### PR TITLE
Fixing init command

### DIFF
--- a/codegen/config_test.go
+++ b/codegen/config_test.go
@@ -36,7 +36,7 @@ func TestLoadDefaultConfig(t *testing.T) {
 		err = os.Chdir(filepath.Join(testDir, "tests", "cfg", "subdir"))
 		require.NoError(t, err)
 
-		cfg, err = LoadDefaultConfig()
+		cfg, err = LoadConfigFromDefaultLocations()
 		require.NoError(t, err)
 		require.Equal(t, cfg.SchemaFilename, "inner")
 	})
@@ -45,18 +45,17 @@ func TestLoadDefaultConfig(t *testing.T) {
 		err = os.Chdir(filepath.Join(testDir, "tests", "cfg", "otherdir"))
 		require.NoError(t, err)
 
-		cfg, err = LoadDefaultConfig()
+		cfg, err = LoadConfigFromDefaultLocations()
 		require.NoError(t, err)
 		require.Equal(t, cfg.SchemaFilename, "outer")
 	})
 
-	t.Run("will fallback to defaults", func(t *testing.T) {
+	t.Run("will return error if config doesn't exist", func(t *testing.T) {
 		err = os.Chdir(testDir)
 		require.NoError(t, err)
 
-		cfg, err = LoadDefaultConfig()
-		require.NoError(t, err)
-		require.Equal(t, cfg.SchemaFilename, "schema.graphql")
+		cfg, err = LoadConfigFromDefaultLocations()
+		require.True(t, os.IsNotExist(err))
 	})
 }
 


### PR DESCRIPTION
The init command always return "file already exists" error if there are no
configFilename specified

This is caused by `codegen.LoadDefaultConfig()` hiding the loading details
and always return the default config with no error while the init
command code expects it to tell us if config doesn't exists in default
locations.

To avoid confusion I have split out the loading config code into its own function so we can handle different cases easier.

Additionally I also moved default config into its own function so we always
generating new a config instead of passing it around and potentially
mutating the default config.