### PR TITLE
use json.Decoder.UseNumber() when unmarshalling vars

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -176,7 +176,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:07b9c7ab78ec48004cf88b4d93c10cad32c7e21b49f99db418fb0ebee0f98b90"
+  digest = "1:7acc3d2f02aed0095986646435472af4c2e2db42ad730aa78cae780aba5b59f9"
   name = "github.com/vektah/gqlparser"
   packages = [
     ".",
@@ -188,7 +188,7 @@
     "validator/rules",
   ]
   pruneopts = "UT"
-  revision = "8dd97c3c1c0357d7602ca9435a8a6cb5e57b4171"
+  revision = "6298a7d57d3de59879b323d6a8cb66280826906f"
 
 [[projects]]
   branch = "master"

--- a/example/todo/todo_test.go
+++ b/example/todo/todo_test.go
@@ -14,20 +14,23 @@ func TestTodo(t *testing.T) {
 	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(New())))
 	c := client.New(srv.URL)
 
-	t.Run("create a new todo", func(t *testing.T) {
-		var resp struct {
-			CreateTodo struct{ ID int }
-		}
-		c.MustPost(`mutation { createTodo(todo:{text:"Fery important"}) { id } }`, &resp)
+	var resp struct {
+		CreateTodo struct{ ID int }
+	}
+	c.MustPost(`mutation { createTodo(todo:{text:"Fery important"}) { id } }`, &resp)
 
-		require.Equal(t, 4, resp.CreateTodo.ID)
-	})
+	require.Equal(t, 4, resp.CreateTodo.ID)
 
 	t.Run("update the todo text", func(t *testing.T) {
 		var resp struct {
 			UpdateTodo struct{ Text string }
 		}
-		c.MustPost(`mutation { updateTodo(id: 4, changes:{text:"Very important"}) { text } }`, &resp)
+		c.MustPost(
+			`mutation($id: Int!, $text: String!) { updateTodo(id: $id, changes:{text:$text}) { text } }`,
+			&resp,
+			client.Var("id", 4),
+			client.Var("text", "Very important"),
+		)
 
 		require.Equal(t, "Very important", resp.UpdateTodo.Text)
 	})

--- a/graphql/float.go
+++ b/graphql/float.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -18,8 +19,12 @@ func UnmarshalFloat(v interface{}) (float64, error) {
 		return strconv.ParseFloat(v, 64)
 	case int:
 		return float64(v), nil
+	case int64:
+		return float64(v), nil
 	case float64:
 		return v, nil
+	case json.Number:
+		return strconv.ParseFloat(string(v), 64)
 	default:
 		return 0, fmt.Errorf("%T is not an float", v)
 	}

--- a/graphql/id.go
+++ b/graphql/id.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -15,6 +16,8 @@ func UnmarshalID(v interface{}) (string, error) {
 	switch v := v.(type) {
 	case string:
 		return v, nil
+	case json.Number:
+		return string(v), nil
 	case int:
 		return strconv.Itoa(v), nil
 	case float64:

--- a/graphql/int.go
+++ b/graphql/int.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -20,8 +21,8 @@ func UnmarshalInt(v interface{}) (int, error) {
 		return v, nil
 	case int64:
 		return int(v), nil
-	case float64:
-		return int(v), nil
+	case json.Number:
+		return strconv.Atoi(string(v))
 	default:
 		return 0, fmt.Errorf("%T is not an int", v)
 	}


### PR DESCRIPTION
The new stricter variable validation rules uncovered a bug where json unmarshalling ints would get converted to floats, then coerced back to ints. 

This is obviously a lossy process for large int numbers (52 bit mantissa means numbers up to 4,503,599,627,370,496 should be OK).

I've removed the coercion from float -> int and opted into json.Decoder.UseNumber which keeps all numbers as strings until we go to decode them, giving us back the full 64 bits.