### PR TITLE
Move doc site

### DIFF
--- a/docs/publish.sh
+++ b/docs/publish.sh
@@ -3,4 +3,4 @@
 set -euo pipefail
 
 hugo
-gsutil -m rsync -dr public gs://gqlgen.com
+aws-vault exec platform -- aws s3 sync public s3://gqlgen-docs

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,0 +1,23 @@
+Documentation
+====
+
+This directory contains the markdown source files for the static doc site hosted at [gqlgen.com](https://gqlgen.com) 
+
+
+## Install hugo
+
+Before working with these docs you will need to install hugo, see [Quickstart](https://gohugo.io/getting-started/quick-start/) for instructions.
+
+
+## Editing docs
+
+When editing docs run `hugo serve` and a live reload server will start, then navigate to http://localhost:1313 in your browser. Any changes made will be updated in the browser.
+
+
+## Publishing docs
+
+**Requires 99designs aws-vault access**
+
+run `./publish.sh` to make the docs live.
+
+


### PR DESCRIPTION
Moves the doc site to a 99designs owned s3 bucket and update the docs.

Will update the dns records once 0.4.0 drops, for now the new docs can be previewed at http://gqlgen-docs.s3-website-us-east-1.amazonaws.com/