### PR TITLE
Init Config Improvement

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -105,28 +105,23 @@ func initConfig() *codegen.Config {
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
-		} else if config != nil {
-			fmt.Fprintln(os.Stderr, "config file already exists")
-			os.Exit(0)
 		}
-	} else {
-		config, err = codegen.LoadConfigFromDefaultLocations()
-		if os.IsNotExist(errors.Cause(err)) {
-			if configFilename == "" {
-				configFilename = "gqlgen.yml"
-			}
-			config = codegen.DefaultConfig()
-			config.Resolver = codegen.PackageConfig{
-				Filename: "resolver.go",
-				Type:     "Resolver",
-			}
-		} else if config != nil {
-			fmt.Fprintln(os.Stderr, "config file already exists")
-			os.Exit(0)
-		} else if err != nil {
-			fmt.Fprintln(os.Stderr, err.Error())
-			os.Exit(1)
-		}
+		return config
+	}
+
+	config, err = codegen.LoadConfigFromDefaultLocations()
+	if config != nil {
+		return config
+	} else if !os.IsNotExist(errors.Cause(err)) {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
+	configFilename = "gqlgen.yml"
+	config = codegen.DefaultConfig()
+	config.Resolver = codegen.PackageConfig{
+		Filename: "resolver.go",
+		Type:     "Resolver",
 	}
 
 	if schemaFilename != "" {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -102,23 +102,25 @@ func initConfig() *codegen.Config {
 	var err error
 	if configFilename != "" {
 		config, err = codegen.LoadConfig(configFilename)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err.Error())
-			os.Exit(1)
-		}
-		return config
+	} else {
+		config, err = codegen.LoadConfigFromDefaultLocations()
 	}
 
-	config, err = codegen.LoadConfigFromDefaultLocations()
 	if config != nil {
-		return config
-	} else if !os.IsNotExist(errors.Cause(err)) {
+		fmt.Fprintf(os.Stderr, "init failed: a configuration file already exists at %s\n", config.FilePath)
+		os.Exit(1)
+	}
+
+	if !os.IsNotExist(errors.Cause(err)) {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 
-	configFilename = "gqlgen.yml"
+	if configFilename == "" {
+		configFilename = "gqlgen.yml"
+	}
 	config = codegen.DefaultConfig()
+
 	config.Resolver = codegen.PackageConfig{
 		Filename: "resolver.go",
 		Type:     "Resolver",

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -94,7 +94,7 @@ func GenerateGraphServer(config *codegen.Config) {
 		os.Exit(1)
 	}
 
-	fmt.Fprintln(os.Stdout, `Exec "go run ./server/server.go" to start GraphQL server`)
+	fmt.Fprintf(os.Stdout, `Exec "go run ./%s" to start GraphQL server`, serverFilename)
 }
 
 func initConfig() *codegen.Config {

--- a/codegen/config.go
+++ b/codegen/config.go
@@ -52,6 +52,8 @@ func LoadConfig(filename string) (*Config, error) {
 		return nil, errors.Wrap(err, "unable to parse config")
 	}
 
+	config.FilePath = filename
+
 	return config, nil
 }
 
@@ -62,6 +64,8 @@ type Config struct {
 	Model          PackageConfig `yaml:"model"`
 	Resolver       PackageConfig `yaml:"resolver,omitempty"`
 	Models         TypeMap       `yaml:"models,omitempty"`
+
+	FilePath string `yaml:"-"`
 
 	schema *ast.Schema `yaml:"-"`
 }


### PR DESCRIPTION
Init will currently fail with an obscure error message if a config file is found.  This change fixes a couple of issues with the codepath, and outputs a better error message if a config file is located:

```
init failed: a configuration file already exists at /Users/mathew/Projects/go/src/github.com/99designs/example/gqlgen.yml
```

Also fixed a minor issue outputting the server filename.