### PR TITLE
stop pickup "github.com/vektah/gqlgen/handler" from GOPATH

### DIFF
--- a/codegen/build.go
+++ b/codegen/build.go
@@ -86,6 +86,7 @@ func (cfg *Config) resolver() (*ResolverBuild, error) {
 	namedTypes := cfg.buildNamedTypes()
 	imports := buildImports(namedTypes, destDir)
 	imports.add(cfg.Exec.ImportPath())
+	imports.add("github.com/99designs/gqlgen/handler") // avoid import github.com/vektah/gqlgen/handler
 
 	cfg.bindTypes(imports, namedTypes, destDir, prog)
 

--- a/codegen/import_build.go
+++ b/codegen/import_build.go
@@ -23,6 +23,7 @@ var ambientImports = []string{
 	"github.com/vektah/gqlparser",
 	"github.com/vektah/gqlparser/ast",
 	"github.com/99designs/gqlgen/graphql",
+	"github.com/99designs/gqlgen/handler",
 	"github.com/99designs/gqlgen/graphql/introspection",
 }
 

--- a/codegen/import_build.go
+++ b/codegen/import_build.go
@@ -23,7 +23,6 @@ var ambientImports = []string{
 	"github.com/vektah/gqlparser",
 	"github.com/vektah/gqlparser/ast",
 	"github.com/99designs/gqlgen/graphql",
-	"github.com/99designs/gqlgen/handler",
 	"github.com/99designs/gqlgen/graphql/introspection",
 }
 


### PR DESCRIPTION
```
$ gqlgen init
Exec "go run ./server/server.go" to start GraphQL server

$ cat server/server.go
package main

import (
	"log"
	"net/http"
	"os"

	"github.com/vektah/gqlgen/handler"
	gqlgen_implements "github.com/vvakame/til/graphql/gqlgen-implements"
)

const defaultPort = "8080"

func main() {
	port := os.Getenv("PORT")
	if port == "" {
		port = defaultPort
	}

	http.Handle("/", handler.Playground("GraphQL playground", "/query"))
	http.Handle("/query", handler.GraphQL(gqlgen_implements.NewExecutableSchema(gqlgen_implements.Config{Resolvers: &gqlgen_implements.Resolver{}})))

	log.Printf("connect to http://localhost:%s/ for GraphQL playground", port)
	log.Fatal(http.ListenAndServe(":"+port, nil))
}
```
