### PR TITLE
Fix for Trailing Slash in GOPATH

### DIFF
--- a/codegen/config.go
+++ b/codegen/config.go
@@ -109,7 +109,7 @@ func (c *PackageConfig) normalize() error {
 func (c *PackageConfig) ImportPath() string {
 	dir := filepath.ToSlash(c.Dir())
 	for _, gopath := range filepath.SplitList(build.Default.GOPATH) {
-		gopath = filepath.ToSlash(gopath) + "/src/"
+		gopath = filepath.Clean(filepath.ToSlash(gopath)) + "/src/"
 		if len(gopath) > len(dir) {
 			continue
 		}


### PR DESCRIPTION
If there is trailing slash in GOPATH, double slash causes the `EqualFold` matching to fail and `dir` variable to be incorrectly set.  If `/home/user/go/` is GOPATH, the string that is created is `/home/user/go//src/`.  This PR cleans up the original GOPATH before appending `/src/`.

Example:
`GOPATH=/home/user/go/` causes a "cannot import absolute path" error.
`GOPATH=/home/user/go` runs normally.