### PR TITLE
Fix broken links in docs

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -14,7 +14,7 @@ The aim for this tutorial is to build a "todo" graphql server that can:
  - create new todos
  - mark off todos as they are completed
 
-You can find the finished code for this tutorial [here](https://github.com/99designs/gqlgen-tutorials/tree/master/gettingstarted)
+You can find the finished code for this tutorial [here](https://github.com/vektah/gqlgen-tutorials/tree/master/gettingstarted)
 
 ## Install gqlgen
 
@@ -92,13 +92,13 @@ And then tell gqlgen to use this new struct by adding this to the gqlgen.yml:
 ```yaml
 models:
   Todo:
-    model: github.com/99designs/gqlgen-tutorials/gettingstarted.Todo
+    model: github.com/vektah/gqlgen-tutorials/gettingstarted.Todo
 ```
 
 and regenerate by running
 ```bash
-$ gqlgen -v 
-Unable to bind Todo.user to github.com/99designs/gqlgen-tutorials/gettingstarted.Todo
+$ gqlgen -v
+Unable to bind Todo.user to github.com/vektah/gqlgen-tutorials/gettingstarted.Todo
 	no method named user
 	no field named user
 	Adding resolver method

--- a/docs/content/reference/dataloaders.md
+++ b/docs/content/reference/dataloaders.md
@@ -152,4 +152,4 @@ The generated UserLoader has a few other useful methods on it:
  - `LoadAll(keys)`: If you know up front you want a bunch users
  - `Prime(key, user)`: Used to sync state between similar loaders (usersById, usersByNote)
 
-You can see the full working example [here](https://github.com/99designs/gqlgen-tutorials/tree/master/dataloader) 
+You can see the full working example [here](https://github.com/vektah/gqlgen-tutorials/tree/master/dataloader)


### PR DESCRIPTION
`gqlgen-tutorials` repository is moved 
from https://github.com/99designs/gqlgen-tutorials
to https://github.com/vektah/gqlgen-tutorials