### PR TITLE
sort directives by name when gen

### DIFF
--- a/codegen/directive_build.go
+++ b/codegen/directive_build.go
@@ -1,6 +1,10 @@
 package codegen
 
-import "github.com/pkg/errors"
+import (
+	"sort"
+
+	"github.com/pkg/errors"
+)
 
 func (cfg *Config) buildDirectives(types NamedTypes) ([]*Directive, error) {
 	var directives []*Directive
@@ -38,5 +42,8 @@ func (cfg *Config) buildDirectives(types NamedTypes) ([]*Directive, error) {
 			Args: args,
 		})
 	}
+
+	sort.Slice(directives, func(i, j int) bool { return directives[i].Name < directives[j].Name })
+
 	return directives, nil
 }


### PR DESCRIPTION
`ast.Schema` use map to store directives parsed from schema file, and map iteration order is random in Golang. The result is that `buildDirectives` will return random order directives when gen for the same schema file.

This pr sort directives by name, it will solve issue #295