### PR TITLE
Explicitly import ambient imports so dep doesn't prune them

### DIFF
--- a/codegen/import_build.go
+++ b/codegen/import_build.go
@@ -6,6 +6,13 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	// Import and ignore the ambient imports listed below so dependency managers
+	// don't prune unused code for us. Both lists should be kept in sync.
+	_ "github.com/99designs/gqlgen/graphql"
+	_ "github.com/99designs/gqlgen/graphql/introspection"
+	_ "github.com/vektah/gqlparser"
+	_ "github.com/vektah/gqlparser/ast"
 )
 
 // These imports are referenced by the generated code, and are assumed to have the


### PR DESCRIPTION
installing gqlgen into a new project with dep will result in a bunch of important stuff getting helpfully pruned, as it's not referenced. Fixes https://github.com/99designs/gqlgen/issues/288.