### PR TITLE
Put newline at end of `gqlgen init` output

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -94,7 +94,7 @@ func GenerateGraphServer(config *codegen.Config) {
 		os.Exit(1)
 	}
 
-	fmt.Fprintf(os.Stdout, `Exec "go run ./%s" to start GraphQL server`, serverFilename)
+	fmt.Fprintf(os.Stdout, "Exec \"go run ./%s\" to start GraphQL server\n", serverFilename)
 }
 
 func initConfig() *codegen.Config {


### PR DESCRIPTION
There is a newline missing at the end of the `gqlgen init` response:

![image](https://user-images.githubusercontent.com/1373315/44436053-e232e180-a567-11e8-9680-47d74e19abe4.png)

This adds it