### PR TITLE
Remove 404s from sitemap

### DIFF
--- a/docs/content/introduction.md
+++ b/docs/content/introduction.md
@@ -1,6 +1,7 @@
 ---
 linkTitle: Introduction
 title: Type-safe graphql for golang
+description: Generating GraphQL servers in golang with type safety
 type: homepage
 date: 2018-03-17T13:06:47+11:00
 ---

--- a/docs/layouts/sitemap.xml
+++ b/docs/layouts/sitemap.xml
@@ -1,0 +1,13 @@
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+    {{ range .Data.Pages }}
+        {{ if or .Description (eq .Kind "home") }}
+            <url>
+                <loc>{{ .Permalink }}</loc>
+                {{ if not .Lastmod.IsZero }}<lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}
+                {{ with .Sitemap.ChangeFreq }}<changefreq>{{ . }}</changefreq>{{ end }}
+                {{ if ge .Sitemap.Priority 0.0 }}<priority>{{ .Sitemap.Priority }}</priority>{{ end }}
+            </url>
+        {{ end }}
+    {{ end }}
+</urlset>
+


### PR DESCRIPTION
The sitemap was including links to pages that didn't exist, like https://gqlgen.com/recipes/

This filters them out by only publishing pages with a description.