### PR TITLE
Validate gopath when running gqlgen

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/99designs/gqlgen/internal/gopath"
 	"github.com/spf13/cobra"
 )
 
@@ -39,6 +40,16 @@ var rootCmd = &cobra.Command{
 	Long: `This is a library for quickly creating strictly typed graphql servers in golang.
 			See https://gqlgen.com/ for a getting started guide.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		pwd, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "unable to determine current workding dir: %s\n", err.Error())
+			os.Exit(1)
+		}
+
+		if !gopath.Contains(pwd) {
+			fmt.Fprintf(os.Stderr, "gqlgen must be run from inside your $GOPATH\n")
+			os.Exit(1)
+		}
 		if verbose {
 			log.SetFlags(0)
 		} else {

--- a/codegen/config.go
+++ b/codegen/config.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/99designs/gqlgen/internal/gopath"
 	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/ast"
 	"gopkg.in/yaml.v2"
@@ -107,22 +108,11 @@ func (c *PackageConfig) normalize() error {
 }
 
 func (c *PackageConfig) ImportPath() string {
-	dir := filepath.ToSlash(c.Dir())
-	for _, gopath := range filepath.SplitList(build.Default.GOPATH) {
-		gopath = filepath.ToSlash(gopath) + "/src/"
-		if len(gopath) > len(dir) {
-			continue
-		}
-		if strings.EqualFold(gopath, dir[0:len(gopath)]) {
-			dir = dir[len(gopath):]
-			break
-		}
-	}
-	return dir
+	return gopath.MustDir2Import(c.Dir())
 }
 
 func (c *PackageConfig) Dir() string {
-	return filepath.ToSlash(filepath.Dir(c.Filename))
+	return filepath.Dir(c.Filename)
 }
 
 func (c *PackageConfig) Check() error {

--- a/codegen/config_test.go
+++ b/codegen/config_test.go
@@ -1,12 +1,10 @@
 package codegen
 
 import (
-	"go/build"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,29 +54,5 @@ func TestLoadDefaultConfig(t *testing.T) {
 
 		cfg, err = LoadConfigFromDefaultLocations()
 		require.True(t, os.IsNotExist(err))
-	})
-}
-
-func Test_fullPackageName(t *testing.T) {
-	origBuildContext := build.Default
-	defer func() { build.Default = origBuildContext }()
-
-	t.Run("gopath longer than package name", func(t *testing.T) {
-		p := PackageConfig{Filename: "/b/src/y/foo/bar/baz.go"}
-		build.Default.GOPATH = "/a/src/xxxxxxxxxxxxxxxxxxxxxxxx:/b/src/y"
-		var got string
-		ok := assert.NotPanics(t, func() { got = p.ImportPath() })
-		if ok {
-			assert.Equal(t, "/b/src/y/foo/bar", got)
-		}
-	})
-	t.Run("stop searching on first hit", func(t *testing.T) {
-		p := PackageConfig{Filename: "/a/src/x/foo/bar/baz.go"}
-		build.Default.GOPATH = "/a/src/x:/b/src/y"
-		var got string
-		ok := assert.NotPanics(t, func() { got = p.ImportPath() })
-		if ok {
-			assert.Equal(t, "/a/src/x/foo/bar", got)
-		}
 	})
 }

--- a/codegen/import_build.go
+++ b/codegen/import_build.go
@@ -5,12 +5,11 @@ import (
 	"go/build"
 	"sort"
 	"strconv"
-	"strings"
-
 	// Import and ignore the ambient imports listed below so dependency managers
 	// don't prune unused code for us. Both lists should be kept in sync.
 	_ "github.com/99designs/gqlgen/graphql"
 	_ "github.com/99designs/gqlgen/graphql/introspection"
+	"github.com/99designs/gqlgen/internal/gopath"
 	_ "github.com/vektah/gqlparser"
 	_ "github.com/vektah/gqlparser/ast"
 )
@@ -55,7 +54,8 @@ func (s *Imports) add(path string) *Import {
 		return nil
 	}
 
-	if stringHasSuffixFold(s.destDir, path) {
+	// if we are referencing our own package we dont need an import
+	if gopath.MustDir2Import(s.destDir) == path {
 		return nil
 	}
 
@@ -75,10 +75,6 @@ func (s *Imports) add(path string) *Import {
 	s.imports = append(s.imports, imp)
 
 	return imp
-}
-
-func stringHasSuffixFold(s, suffix string) bool {
-	return len(s) >= len(suffix) && strings.EqualFold(s[len(s)-len(suffix):], suffix)
 }
 
 func (s Imports) finalize() []*Import {

--- a/internal/gopath/gopath.go
+++ b/internal/gopath/gopath.go
@@ -1,0 +1,37 @@
+package gopath
+
+import (
+	"fmt"
+	"go/build"
+	"path/filepath"
+	"strings"
+)
+
+var NotFound = fmt.Errorf("not on GOPATH")
+
+// Contains returns true if the given directory is in the GOPATH
+func Contains(dir string) bool {
+	_, err := Dir2Import(dir)
+	return err == nil
+}
+
+// Dir2Import takes an *absolute* path and returns a golang import path for the package, and returns an error if it isn't on the gopath
+func Dir2Import(dir string) (string, error) {
+	dir = filepath.ToSlash(dir)
+	for _, gopath := range filepath.SplitList(build.Default.GOPATH) {
+		gopath = filepath.ToSlash(filepath.Join(gopath, "src"))
+		if len(gopath) < len(dir) && strings.EqualFold(gopath, dir[0:len(gopath)]) {
+			return dir[len(gopath)+1:], nil
+		}
+	}
+	return "", NotFound
+}
+
+// MustDir2Import takes an *absolute* path and returns a golang import path for the package, and panics if it isn't on the gopath
+func MustDir2Import(dir string) string {
+	pkg, err := Dir2Import(dir)
+	if err != nil {
+		panic(err)
+	}
+	return pkg
+}

--- a/internal/gopath/gopath_test.go
+++ b/internal/gopath/gopath_test.go
@@ -1,0 +1,62 @@
+package gopath
+
+import (
+	"go/build"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContains(t *testing.T) {
+	origBuildContext := build.Default
+	defer func() { build.Default = origBuildContext }()
+
+	if runtime.GOOS == "windows" {
+		build.Default.GOPATH = `C:\go;C:\Users\user\go`
+
+		assert.True(t, Contains(`C:\go\src\github.com\vektah\gqlgen`))
+		assert.True(t, Contains(`C:\go\src\fpp`))
+		assert.True(t, Contains(`C:/go/src/github.com/vektah/gqlgen`))
+		assert.True(t, Contains(`C:\Users\user\go\src\foo`))
+		assert.False(t, Contains(`C:\tmp`))
+		assert.False(t, Contains(`C:\Users\user`))
+		assert.False(t, Contains(`C:\Users\another\go`))
+	} else {
+		build.Default.GOPATH = "/go:/home/user/go"
+
+		assert.True(t, Contains("/go/src/github.com/vektah/gqlgen"))
+		assert.True(t, Contains("/go/src/foo"))
+		assert.True(t, Contains("/home/user/go/src/foo"))
+		assert.False(t, Contains("/tmp"))
+		assert.False(t, Contains("/home/user"))
+		assert.False(t, Contains("/home/another/go"))
+	}
+}
+
+func TestDir2Package(t *testing.T) {
+	origBuildContext := build.Default
+	defer func() { build.Default = origBuildContext }()
+
+	if runtime.GOOS == "windows" {
+		build.Default.GOPATH = "C:/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;C:/a/y;C:/b/"
+
+		assert.Equal(t, "foo/bar", MustDir2Import("C:/a/y/src/foo/bar"))
+		assert.Equal(t, "foo/bar", MustDir2Import(`C:\a\y\src\foo\bar`))
+		assert.Equal(t, "foo/bar", MustDir2Import("C:/b/src/foo/bar"))
+		assert.Equal(t, "foo/bar", MustDir2Import(`C:\b\src\foo\bar`))
+
+		assert.PanicsWithValue(t, NotFound, func() {
+			MustDir2Import("C:/tmp/foo")
+		})
+	} else {
+		build.Default.GOPATH = "/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx:/a/y:/b/"
+
+		assert.Equal(t, "foo/bar", MustDir2Import("/a/y/src/foo/bar"))
+		assert.Equal(t, "foo/bar", MustDir2Import("/b/src/foo/bar"))
+
+		assert.PanicsWithValue(t, NotFound, func() {
+			MustDir2Import("/tmp/foo")
+		})
+	}
+}


### PR DESCRIPTION
When running gqlgen outside of a configured gopath generate an error message:
```
roci :: ~ » gqlgen
gqlgen must be run from inside your $GOPATH
```

Fixes #303 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
