### PR TITLE
Remove support for the old json typemap

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -141,9 +141,6 @@ func initConfig() *codegen.Config {
 	if modelPackageName != "" {
 		config.Model.Package = modelPackageName
 	}
-	if typemap != "" {
-		config.Models = loadModelMap()
-	}
 
 	var buf bytes.Buffer
 	buf.WriteString(strings.TrimSpace(configComment))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,6 @@ var verbose bool
 var output string
 var models string
 var schemaFilename string
-var typemap string
 var packageName string
 var modelPackageName string
 var serverFilename string
@@ -29,7 +28,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&output, "out", "", "the file to write to")
 	rootCmd.PersistentFlags().StringVar(&models, "models", "", "the file to write the models to")
 	rootCmd.PersistentFlags().StringVar(&schemaFilename, "schema", "", "the graphql schema to generate types from")
-	rootCmd.PersistentFlags().StringVar(&typemap, "typemap", "", "a json map going from graphql to golang types")
 	rootCmd.PersistentFlags().StringVar(&packageName, "package", "", "the package name")
 	rootCmd.PersistentFlags().StringVar(&modelPackageName, "modelpackage", "", "the package name to use for models")
 }


### PR DESCRIPTION
We've maintained support for the json format for 2 months, time to drop it in preparation for 0.5.0

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
