### PR TITLE
Drop old cli flags

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,7 +26,7 @@
   version = "v3.3.2"
 
 [[projects]]
-  digest = "1:f3df613325a793ffb3d0ce7644a3bb6f62db45ac744dafe20172fe999c61cdbf"
+  digest = "1:78907d832e27dbfc6e3fdfc52bd2e5e2e05c1d0e3789d4825b824489fbeab233"
   name = "github.com/gogo/protobuf"
   packages = [
     "io",
@@ -72,14 +72,6 @@
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
-  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
-  name = "github.com/inconshreveable/mousetrap"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
-  version = "v1.0"
-
-[[projects]]
   branch = "master"
   digest = "1:ab9cfaf00fc5db5fd9d8e5f33da52e62bcc977d1976503dcc2a1492f391bd9ed"
   name = "github.com/mitchellh/mapstructure"
@@ -107,7 +99,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:450b7623b185031f3a456801155c8320209f75d0d4c4e633c6b1e59d44d6e392"
+  digest = "1:27af6024faa3c28426a698b8c653be0fd908bc96e25b7d76f2192eb342427db6"
   name = "github.com/opentracing/opentracing-go"
   packages = [
     ".",
@@ -151,23 +143,7 @@
   revision = "ffb13db8def02f545acc58bd288ec6057c2bbfb9"
 
 [[projects]]
-  digest = "1:645cabccbb4fa8aab25a956cbcbdf6a6845ca736b2c64e197ca7cbb9d210b939"
-  name = "github.com/spf13/cobra"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
-  version = "v0.0.3"
-
-[[projects]]
-  digest = "1:9424f440bba8f7508b69414634aef3b2b3a877e522d8a4624692412805407bb7"
-  name = "github.com/spf13/pflag"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
-  version = "v1.0.1"
-
-[[projects]]
-  digest = "1:7e8d267900c7fa7f35129a2a37596e38ed0f11ca746d6d9ba727980ee138f9f6"
+  digest = "1:73697231b93fb74a73ebd8384b68b9a60c57ea6b13c56d2425414566a72c8e6d"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
@@ -176,6 +152,14 @@
   pruneopts = "UT"
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
+
+[[projects]]
+  digest = "1:b24d38b282bacf9791408a080f606370efa3d364e4b5fd9ba0f7b87786d3b679"
+  name = "github.com/urfave/cli"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
+  version = "v1.20.0"
 
 [[projects]]
   branch = "master"
@@ -187,7 +171,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c6b203aeee848da05afba3a2dfaa47bb45668b1511f238e0cf5178e50c9607a2"
+  digest = "1:3e2c3d0b8cb780a09467884bebc032c831ae273d1d993b8f55fa61084e37278c"
   name = "github.com/vektah/gqlparser"
   packages = [
     ".",
@@ -211,7 +195,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3cbc05413b8aac22b1f6d4350ed696b5a83a8515a4136db8f1ec3a0aee3d76e1"
+  digest = "1:77fe642412bfed48743e2b75163e3ab5c430cfe22dd488788647b89b28794635"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
@@ -232,7 +216,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:741ebea9214cc226789d3003baeca9b169e04b5b336fb1a3b2c16e75bd296bb5"
+  digest = "1:7ddb3a7b35cc853fe0db36a1b2473bdff03f28add7d28e4725e692603111266e"
   name = "sourcegraph.com/sourcegraph/appdash"
   packages = [
     ".",
@@ -248,7 +232,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8e0a2957fe342f22d70a543c3fcdf390f7627419c3d82d87ab4fd715a9ef5716"
+  digest = "1:be108b48d79c3b3c345811a57a47ee87fdbe895beb4bb56239da71d4943e5be7"
   name = "sourcegraph.com/sourcegraph/appdash-data"
   packages = ["."]
   pruneopts = "UT"
@@ -267,9 +251,9 @@
     "github.com/opentracing/opentracing-go/ext",
     "github.com/opentracing/opentracing-go/log",
     "github.com/pkg/errors",
-    "github.com/spf13/cobra",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
+    "github.com/urfave/cli",
     "github.com/vektah/dataloaden",
     "github.com/vektah/gqlparser",
     "github.com/vektah/gqlparser/ast",

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -7,21 +7,20 @@ import (
 
 	"github.com/99designs/gqlgen/codegen"
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
+	"github.com/urfave/cli"
 )
 
-func init() {
-	rootCmd.AddCommand(genCmd)
-}
-
-var genCmd = &cobra.Command{
-	Use:   "gen",
-	Short: "Generate models & resolvers .go",
-	Long:  "",
-	Run: func(cmd *cobra.Command, args []string) {
+var genCmd = cli.Command{
+	Name:  "generate",
+	Usage: "generate a graphql server based on schema",
+	Flags: []cli.Flag{
+		cli.BoolFlag{Name: "verbose, v", Usage: "show logs"},
+		cli.StringFlag{Name: "config, c", Usage: "the config filename"},
+	},
+	Action: func(ctx *cli.Context) {
 		var config *codegen.Config
 		var err error
-		if configFilename != "" {
+		if configFilename := ctx.String("config"); configFilename != "" {
 			config, err = codegen.LoadConfig(configFilename)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err.Error())
@@ -35,23 +34,6 @@ var genCmd = &cobra.Command{
 				fmt.Fprintln(os.Stderr, err.Error())
 				os.Exit(1)
 			}
-		}
-
-		// overwrite by commandline options
-		if schemaFilename != "" {
-			config.SchemaFilename = schemaFilename
-		}
-		if models != "" {
-			config.Model.Filename = models
-		}
-		if output != "" {
-			config.Exec.Filename = output
-		}
-		if packageName != "" {
-			config.Exec.Package = packageName
-		}
-		if modelPackageName != "" {
-			config.Model.Package = modelPackageName
 		}
 
 		schemaRaw, err := ioutil.ReadFile(config.SchemaFilename)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -9,13 +9,9 @@ import (
 
 	"github.com/99designs/gqlgen/codegen"
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
+	"github.com/urfave/cli"
 	"gopkg.in/yaml.v2"
 )
-
-func init() {
-	rootCmd.AddCommand(initCmd)
-}
 
 var configComment = `
 # .gqlgen.yml example
@@ -55,19 +51,24 @@ type Mutation {
 }
 `
 
-var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Generate gqlgen skeleton",
-	Long:  "",
-	Run: func(cmd *cobra.Command, args []string) {
-		initSchema()
-		config := initConfig()
+var initCmd = cli.Command{
+	Name:  "init",
+	Usage: "create a new gqlgen project",
+	Flags: []cli.Flag{
+		cli.BoolFlag{Name: "verbose, v", Usage: "show logs"},
+		cli.StringFlag{Name: "config, c", Usage: "the config filename"},
+		cli.StringFlag{Name: "server", Usage: "where to write the server stub to", Value: "server/server.go"},
+		cli.StringFlag{Name: "schema", Usage: "where to write the schema stub to", Value: "schema.graphql"},
+	},
+	Action: func(ctx *cli.Context) {
+		initSchema(ctx.String("schema"))
+		config := initConfig(ctx)
 
-		GenerateGraphServer(config)
+		GenerateGraphServer(config, ctx.String("server"))
 	},
 }
 
-func GenerateGraphServer(config *codegen.Config) {
+func GenerateGraphServer(config *codegen.Config, serverFilename string) {
 	schemaRaw, err := ioutil.ReadFile(config.SchemaFilename)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "unable to open schema: "+err.Error())
@@ -78,10 +79,6 @@ func GenerateGraphServer(config *codegen.Config) {
 	if err = config.Check(); err != nil {
 		fmt.Fprintln(os.Stderr, "invalid config format: "+err.Error())
 		os.Exit(1)
-	}
-
-	if serverFilename == "" {
-		serverFilename = "server/server.go"
 	}
 
 	if err := codegen.Generate(*config); err != nil {
@@ -97,9 +94,10 @@ func GenerateGraphServer(config *codegen.Config) {
 	fmt.Fprintf(os.Stdout, "Exec \"go run ./%s\" to start GraphQL server\n", serverFilename)
 }
 
-func initConfig() *codegen.Config {
+func initConfig(ctx *cli.Context) *codegen.Config {
 	var config *codegen.Config
 	var err error
+	configFilename := ctx.String("config")
 	if configFilename != "" {
 		config, err = codegen.LoadConfig(configFilename)
 	} else {
@@ -126,22 +124,6 @@ func initConfig() *codegen.Config {
 		Type:     "Resolver",
 	}
 
-	if schemaFilename != "" {
-		config.SchemaFilename = schemaFilename
-	}
-	if models != "" {
-		config.Model.Filename = models
-	}
-	if output != "" {
-		config.Exec.Filename = output
-	}
-	if packageName != "" {
-		config.Exec.Package = packageName
-	}
-	if modelPackageName != "" {
-		config.Model.Package = modelPackageName
-	}
-
 	var buf bytes.Buffer
 	buf.WriteString(strings.TrimSpace(configComment))
 	buf.WriteString("\n\n")
@@ -164,11 +146,7 @@ func initConfig() *codegen.Config {
 	return config
 }
 
-func initSchema() {
-	if schemaFilename == "" {
-		schemaFilename = "schema.graphql"
-	}
-
+func initSchema(schemaFilename string) {
 	_, err := os.Stat(schemaFilename)
 	if !os.IsNotExist(err) {
 		return

--- a/example/todo/todo.go
+++ b/example/todo/todo.go
@@ -1,4 +1,4 @@
-//go:generate gorunpkg github.com/99designs/gqlgen --out generated.go
+//go:generate gorunpkg github.com/99designs/gqlgen
 
 package todo
 


### PR DESCRIPTION
Removes all of the poorly named flags (eg `package`, `modelPackage` and `exec`) that now live in config, and switch to [urvaf/cli](https://github.com/urfave/cli) to remove all the nasty global state in flag parsing.

```
gqlgen help
NAME:
   gqlgen - generate a graphql server based on schema

USAGE:
   gqlgen [global options] command [command options] [arguments...]

DESCRIPTION:
   This is a library for quickly creating strictly typed graphql servers in golang. See https://gqlgen.com/ for a getting started guide.

COMMANDS:
     generate  generate a graphql server based on schema
     init      create a new gqlgen project
     help, h   Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --verbose, -v             show logs
   --config value, -c value  the config filename
   --help, -h                show help
```

init has a few extra knobs that were being conflated with gen
```
$ gqlgen help init
NAME:
   gqlgen generate - generate a graphql server based on schema

USAGE:
   gqlgen generate [command options] [arguments...]

OPTIONS:
   --verbose, -v             show logs
   --config value, -c value  the config filename
   
roci :: 99designs/gqlgen » gqlgen init -h    
NAME:
   gqlgen init - create a new gqlgen project

USAGE:
   gqlgen init [command options] [arguments...]

OPTIONS:
   --verbose, -v             show logs
   --config value, -c value  the config filename
   --server value            where to write the server stub to (default: "server/server.go")
   --schema value            where to write the schema stub to (default: "schema.graphql")
```

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md)) - already covered
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content)) - already covered
