### PR TITLE
Only allow query operations on GET requests

### DIFF
--- a/handler/graphql.go
+++ b/handler/graphql.go
@@ -206,6 +206,11 @@ func GraphQL(exec graphql.ExecutableSchema, options ...Option) http.HandlerFunc 
 			return
 		}
 
+		if op.Operation != ast.Query && r.Method == http.MethodGet {
+			sendErrorf(w, http.StatusUnprocessableEntity, "GET requests only allow query operations")
+			return
+		}
+
 		vars, err := validator.VariableValues(exec.Schema(), op, reqParams.Variables)
 		if err != nil {
 			sendError(w, http.StatusUnprocessableEntity, err)

--- a/handler/graphql_test.go
+++ b/handler/graphql_test.go
@@ -75,6 +75,12 @@ func TestHandlerGET(t *testing.T) {
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
 		assert.Equal(t, `{"data":null,"errors":[{"message":"Unexpected !","locations":[{"line":1,"column":1}]}]}`, resp.Body.String())
 	})
+
+	t.Run("no mutations", func(t *testing.T) {
+		resp := doRequest(h, "GET", "/graphql?query=mutation{me{name}}", "")
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+		assert.Equal(t, `{"data":null,"errors":[{"message":"GET requests only allow query operations"}]}`, resp.Body.String())
+	})
 }
 
 func TestHandlerOptions(t *testing.T) {


### PR DESCRIPTION
This mitigates the risk of CSRF attacks.

Closes #317.