### PR TITLE
Add version const

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -eu
+
+if ! [ $# -eq 1 ] ; then
+    echo "usage: ./bin/release [version]"
+    exit 1
+fi
+
+VERSION=$1
+
+if ! git diff-index --quiet HEAD -- ; then
+    echo "uncommited changes on HEAD, aborting"
+    exit 1
+fi
+
+if [[ ${VERSION:0:1} != "v" ]] ; then
+    echo "version strings must start with v"
+    exit 1
+fi
+
+git fetch origin
+git checkout origin/master
+
+cat > graphql/version.go <<EOF
+package graphql
+
+const Version = "$VERSION"
+EOF
+
+git add .
+git commit -m "release $VERSION"
+git tag $VERSION
+git push origin $VERSION
+
+
+echo "Now go write some release notes! https://github.com/99designs/gqlgen/releases"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/internal/gopath"
 	"github.com/urfave/cli"
 )
@@ -17,6 +18,7 @@ func Execute() {
 	app.Description = "This is a library for quickly creating strictly typed graphql servers in golang. See https://gqlgen.com/ for a getting started guide."
 	app.HideVersion = true
 	app.Flags = genCmd.Flags
+	app.Version = graphql.Version
 	app.Before = func(context *cli.Context) error {
 		pwd, err := os.Getwd()
 		if err != nil {
@@ -38,6 +40,7 @@ func Execute() {
 	app.Commands = []cli.Command{
 		genCmd,
 		initCmd,
+		versionCmd,
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/urfave/cli"
+)
+
+var versionCmd = cli.Command{
+	Name:  "version",
+	Usage: "print the version string",
+	Action: func(ctx *cli.Context) {
+		fmt.Println(graphql.Version)
+	},
+}

--- a/graphql/version.go
+++ b/graphql/version.go
@@ -1,0 +1,3 @@
+package graphql
+
+const Version = "dev"


### PR DESCRIPTION
Adds a constant that has the version in it, and a release script that pushes tags with the right version string committed.

Can be fetched using `gqlgen version`. Will always report `dev` for not tagged releases.

Fixes #182 