### PR TITLE
Fix Embedded Pointer

### DIFF
--- a/codegen/testserver/gqlgen.yml
+++ b/codegen/testserver/gqlgen.yml
@@ -31,3 +31,5 @@ models:
       field: { resolver: true }
   Error:
     model: "github.com/99designs/gqlgen/codegen/testserver.Error"
+  EmbeddedPointer:
+    model: "github.com/99designs/gqlgen/codegen/testserver.EmbeddedPointerModel"

--- a/codegen/testserver/models.go
+++ b/codegen/testserver/models.go
@@ -21,3 +21,12 @@ func (Error) ErrorOnNonRequiredField() (string, error) {
 func (Error) NilOnRequiredField() *string {
 	return nil
 }
+
+type EmbeddedPointerModel struct {
+	*EmbeddedPointer
+	ID string
+}
+
+type EmbeddedPointer struct {
+	Title string
+}

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -11,6 +11,9 @@ import (
 
 type Resolver struct{}
 
+func (r *Resolver) EmbeddedPointer() EmbeddedPointerResolver {
+	return &embeddedPointerResolver{r}
+}
 func (r *Resolver) ForcedResolver() ForcedResolverResolver {
 	return &forcedResolverResolver{r}
 }
@@ -19,6 +22,12 @@ func (r *Resolver) Query() QueryResolver {
 }
 func (r *Resolver) Subscription() SubscriptionResolver {
 	return &subscriptionResolver{r}
+}
+
+type embeddedPointerResolver struct{ *Resolver }
+
+func (r *embeddedPointerResolver) Title(ctx context.Context, obj *EmbeddedPointerModel) (*string, error) {
+	panic("not implemented")
 }
 
 type forcedResolverResolver struct{ *Resolver }

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -11,9 +11,6 @@ import (
 
 type Resolver struct{}
 
-func (r *Resolver) EmbeddedPointer() EmbeddedPointerResolver {
-	return &embeddedPointerResolver{r}
-}
 func (r *Resolver) ForcedResolver() ForcedResolverResolver {
 	return &forcedResolverResolver{r}
 }
@@ -22,12 +19,6 @@ func (r *Resolver) Query() QueryResolver {
 }
 func (r *Resolver) Subscription() SubscriptionResolver {
 	return &subscriptionResolver{r}
-}
-
-type embeddedPointerResolver struct{ *Resolver }
-
-func (r *embeddedPointerResolver) Title(ctx context.Context, obj *EmbeddedPointerModel) (*string, error) {
-	panic("not implemented")
 }
 
 type forcedResolverResolver struct{ *Resolver }

--- a/codegen/testserver/schema.graphql
+++ b/codegen/testserver/schema.graphql
@@ -131,3 +131,8 @@ union ShapeUnion = Circle | Rectangle
 type ForcedResolver {
     field: Circle
 }
+
+type EmbeddedPointer {
+    ID: String
+    Title: String
+}

--- a/codegen/util.go
+++ b/codegen/util.go
@@ -132,17 +132,16 @@ func findField(typ *types.Struct, name, structTag string) (*types.Var, error) {
 		}
 
 		if field.Anonymous() {
-			if named, ok := field.Type().(*types.Struct); ok {
-				f, err := findField(named, name, structTag)
-				if err != nil && !strings.HasPrefix(err.Error(), "no field named") {
-					return nil, err
-				}
-				if f != nil && foundField == nil {
-					foundField = f
-				}
+
+			fieldType := field.Type()
+
+			if ptr, ok := fieldType.(*types.Pointer); ok {
+				fieldType = ptr.Elem()
 			}
 
-			if named, ok := field.Type().Underlying().(*types.Struct); ok {
+			// Type.Underlying() returns itself for all types except types.Named, where it returns a struct type.
+			// It should be safe to always call.
+			if named, ok := fieldType.Underlying().(*types.Struct); ok {
 				f, err := findField(named, name, structTag)
 				if err != nil && !strings.HasPrefix(err.Error(), "no field named") {
 					return nil, err


### PR DESCRIPTION
Fixes the first part of #356 

`codegen.findField` was not accounting for anonymous pointer types and was generating a redundant resolver.  This change fixes this so that these pointers are unwrapped and the element type is considered recursively as a match for the field.