### PR TITLE
Don't let goimports guess import paths

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -9,5 +9,6 @@
       "PartitionStrategy": "packages"
     }
   },
+  "Skip": ["internal/imports/testdata"],
   "Disable": ["gas","golint","gocyclo","goconst", "gotype", "maligned", "gosec"]
 }

--- a/codegen/build.go
+++ b/codegen/build.go
@@ -112,6 +112,13 @@ func (cfg *Config) server(destDir string) *ServerBuild {
 	imports.add(cfg.Exec.ImportPath())
 	imports.add(cfg.Resolver.ImportPath())
 
+	// extra imports only used by the server template
+	imports.add("context")
+	imports.add("log")
+	imports.add("net/http")
+	imports.add("os")
+	imports.add("github.com/99designs/gqlgen/handler")
+
 	return &ServerBuild{
 		PackageName:         cfg.Resolver.Package,
 		Imports:             imports.finalize(),

--- a/codegen/import_build.go
+++ b/codegen/import_build.go
@@ -26,6 +26,7 @@ var ambientImports = []string{
 	"time",
 	"sync",
 	"errors",
+	"bytes",
 
 	"github.com/vektah/gqlparser",
 	"github.com/vektah/gqlparser/ast",

--- a/codegen/templates/inliner/inliner.go
+++ b/codegen/templates/inliner/inliner.go
@@ -2,11 +2,10 @@ package main
 
 import (
 	"bytes"
+	"go/format"
 	"io/ioutil"
 	"strconv"
 	"strings"
-
-	"golang.org/x/tools/imports"
 )
 
 func main() {
@@ -39,7 +38,7 @@ func main() {
 
 	out.WriteString("}\n")
 
-	formatted, err2 := imports.Process(dir+"data.go", out.Bytes(), nil)
+	formatted, err2 := format.Source(out.Bytes())
 	if err2 != nil {
 		panic(err2)
 	}

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -14,10 +15,8 @@ import (
 	"text/template"
 	"unicode"
 
-	"log"
-
+	"github.com/99designs/gqlgen/internal/imports"
 	"github.com/pkg/errors"
-	"golang.org/x/tools/imports"
 )
 
 func Run(name string, tpldata interface{}) (*bytes.Buffer, error) {
@@ -164,23 +163,15 @@ func RenderToFile(tpl string, filename string, data interface{}) error {
 	return nil
 }
 
-func gofmt(filename string, b []byte) ([]byte, error) {
-	out, err := imports.Process(filename, b, nil)
-	if err != nil {
-		return b, errors.Wrap(err, "unable to gofmt")
-	}
-	return out, nil
-}
-
 func write(filename string, b []byte) error {
 	err := os.MkdirAll(filepath.Dir(filename), 0755)
 	if err != nil {
 		return errors.Wrap(err, "failed to create directory")
 	}
 
-	formatted, err := gofmt(filename, b)
+	formatted, err := imports.Prune(filename, b)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "gofmt failed: %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "gofmt failed on %s: %s\n", filepath.Base(filename), err.Error())
 		formatted = b
 	}
 

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -3,7 +3,7 @@
 package testserver
 
 import (
-	"bytes"
+	bytes "bytes"
 	context "context"
 	fmt "fmt"
 	strconv "strconv"

--- a/example/chat/generated.go
+++ b/example/chat/generated.go
@@ -3,7 +3,7 @@
 package chat
 
 import (
-	"bytes"
+	bytes "bytes"
 	context "context"
 	strconv "strconv"
 	sync "sync"

--- a/example/config/generated.go
+++ b/example/config/generated.go
@@ -3,7 +3,7 @@
 package config
 
 import (
-	"bytes"
+	bytes "bytes"
 	context "context"
 	strconv "strconv"
 	sync "sync"

--- a/example/dataloader/generated.go
+++ b/example/dataloader/generated.go
@@ -3,7 +3,7 @@
 package dataloader
 
 import (
-	"bytes"
+	bytes "bytes"
 	context "context"
 	strconv "strconv"
 	sync "sync"

--- a/example/scalars/generated.go
+++ b/example/scalars/generated.go
@@ -3,7 +3,7 @@
 package scalars
 
 import (
-	"bytes"
+	bytes "bytes"
 	context "context"
 	external "external"
 	strconv "strconv"

--- a/example/selection/generated.go
+++ b/example/selection/generated.go
@@ -3,7 +3,7 @@
 package selection
 
 import (
-	"bytes"
+	bytes "bytes"
 	context "context"
 	fmt "fmt"
 	strconv "strconv"

--- a/example/starwars/generated.go
+++ b/example/starwars/generated.go
@@ -3,7 +3,7 @@
 package starwars
 
 import (
-	"bytes"
+	bytes "bytes"
 	context "context"
 	fmt "fmt"
 	strconv "strconv"

--- a/example/todo/generated.go
+++ b/example/todo/generated.go
@@ -3,7 +3,7 @@
 package todo
 
 import (
-	"bytes"
+	bytes "bytes"
 	context "context"
 	strconv "strconv"
 	sync "sync"

--- a/integration/generated.go
+++ b/integration/generated.go
@@ -3,7 +3,7 @@
 package integration
 
 import (
-	"bytes"
+	bytes "bytes"
 	context "context"
 	remote_api "remote_api"
 	strconv "strconv"

--- a/internal/imports/prune.go
+++ b/internal/imports/prune.go
@@ -1,0 +1,119 @@
+// Wrapper around x/tools/imports that only removes imports, never adds new ones.
+
+package imports
+
+import (
+	"bytes"
+	"go/ast"
+	"go/build"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/tools/imports"
+
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+type visitFn func(node ast.Node)
+
+func (fn visitFn) Visit(node ast.Node) ast.Visitor {
+	fn(node)
+	return fn
+}
+
+// Prune removes any unused imports
+func Prune(filename string, src []byte) ([]byte, error) {
+	fset := token.NewFileSet()
+
+	file, err := parser.ParseFile(fset, filename, src, parser.ParseComments|parser.AllErrors)
+	if err != nil {
+		return nil, err
+	}
+
+	unused, err := getUnusedImports(file, filename)
+	if err != nil {
+		return nil, err
+	}
+	for ipath, name := range unused {
+		astutil.DeleteNamedImport(fset, file, name, ipath)
+	}
+	printConfig := &printer.Config{Mode: printer.TabIndent, Tabwidth: 8}
+
+	var buf bytes.Buffer
+	if err := printConfig.Fprint(&buf, fset, file); err != nil {
+		return nil, err
+	}
+
+	return imports.Process(filename, buf.Bytes(), &imports.Options{FormatOnly: true, Comments: true, TabIndent: true, TabWidth: 8})
+}
+
+func getUnusedImports(file ast.Node, filename string) (map[string]string, error) {
+	imported := map[string]*ast.ImportSpec{}
+	used := map[string]bool{}
+
+	abs, err := filepath.Abs(filename)
+	if err != nil {
+		return nil, err
+	}
+	srcDir := filepath.Dir(abs)
+
+	ast.Walk(visitFn(func(node ast.Node) {
+		if node == nil {
+			return
+		}
+		switch v := node.(type) {
+		case *ast.ImportSpec:
+			if v.Name != nil {
+				imported[v.Name.Name] = v
+				break
+			}
+			ipath := strings.Trim(v.Path.Value, `"`)
+			if ipath == "C" {
+				break
+			}
+
+			local := importPathToName(ipath, srcDir)
+
+			imported[local] = v
+		case *ast.SelectorExpr:
+			xident, ok := v.X.(*ast.Ident)
+			if !ok {
+				break
+			}
+			if xident.Obj != nil {
+				// if the parser can resolve it, it's not a package ref
+				break
+			}
+			used[xident.Name] = true
+		}
+	}), file)
+
+	for pkg := range used {
+		delete(imported, pkg)
+	}
+
+	unusedImport := map[string]string{}
+	for pkg, is := range imported {
+		if !used[pkg] && pkg != "_" && pkg != "." {
+			name := ""
+			if is.Name != nil {
+				name = is.Name.Name
+			}
+			unusedImport[strings.Trim(is.Path.Value, `"`)] = name
+		}
+	}
+
+	return unusedImport, nil
+}
+
+func importPathToName(importPath, srcDir string) (packageName string) {
+	pkg, err := build.Default.Import(importPath, srcDir, 0)
+	if err != nil {
+		return ""
+	}
+
+	return pkg.Name
+}

--- a/internal/imports/prune_test.go
+++ b/internal/imports/prune_test.go
@@ -1,0 +1,22 @@
+package imports
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrune(t *testing.T) {
+	b, err := Prune("testdata/unused.go", mustReadFile("testdata/unused.go"))
+	require.NoError(t, err)
+	require.Equal(t, string(mustReadFile("testdata/unused.expected.go")), string(b))
+}
+
+func mustReadFile(filename string) []byte {
+	b, err := ioutil.ReadFile(filename)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/internal/imports/testdata/unused.expected.go
+++ b/internal/imports/testdata/unused.expected.go
@@ -1,0 +1,20 @@
+package testdata
+
+import _ "underscore"
+import a "fmt"
+import "time"
+
+type foo struct {
+	Time time.Time `json:"text"`
+}
+
+func fn() {
+	a.Println("hello")
+}
+
+type Message struct {
+	ID        string    `json:"id"`
+	Text      string    `json:"text"`
+	CreatedBy string    `json:"createdBy"`
+	CreatedAt time.Time `json:"createdAt"`
+}

--- a/internal/imports/testdata/unused.go
+++ b/internal/imports/testdata/unused.go
@@ -1,0 +1,21 @@
+package testdata
+
+import "unused"
+import _ "underscore"
+import a "fmt"
+import "time"
+
+type foo struct {
+	Time time.Time `json:"text"`
+}
+
+func fn() {
+	a.Println("hello")
+}
+
+type Message struct {
+	ID string `json:"id"`
+	Text string `json:"text"`
+	CreatedBy string `json:"createdBy"`
+	CreatedAt time.Time `json:"createdAt"`
+}


### PR DESCRIPTION
gqlgen internally tracks all the imports used in a file and adds them to the import block, handling duplicate imports by appending names.

There are two sources of imports:
 - imports for user generated models, types in graphql, etc. These are all tracked as they are added, with the required deduping behaviours etc.
 - `ambientImports`: these are referenced in the templates and must keep the name they were given in the templates, eg `fmt.Println(` must get the import name `fmt`. Often these are in conditional parts of the templates and may not be used in a particular generated output.

Currently we run the generated code through `goimports`, this does a few things for us:
 - format the code: same as gofmt
 - group and sort imports: this makes our output a little more robust to changes
 - remove unused imports: required for ambient imports that don't actually get used.
 - add missing imports: **DANGER** This adds in any missing imports, these often end up being ambient imports that were forgotten about. This leads to subtle and hard to reproduce issues like #207 when a user imported package grabs the name used in by the import in the template.

This PR removes the "add missing imports" feature of goimports, while maintaining the other 3 by reimplementing the import removal logic and calling goimports with "Format only" to get grouping and sorting. 

Fixes #207