### PR TITLE
Close body after use

### DIFF
--- a/handler/graphql.go
+++ b/handler/graphql.go
@@ -185,6 +185,7 @@ func GraphQL(exec graphql.ExecutableSchema, options ...Option) http.HandlerFunc 
 				sendErrorf(w, http.StatusBadRequest, "json body could not be decoded: "+err.Error())
 				return
 			}
+			defer r.Body.Close()
 		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return


### PR DESCRIPTION
This adds a defer to closing the request body after we read the graphql post body.

I'm not sure how to test this, but I'm seeing a memory leak and my theory is this the reason, although I haven't tried this fix in prod.

<img width="424" alt="screen shot 2018-10-06 at 1 20 08 pm" src="https://user-images.githubusercontent.com/20201/46574995-b5e9ed80-c97a-11e8-873f-368ee41172ef.png">


I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
