### PR TITLE
Run generate ./... and test ./... in circle

### DIFF
--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -3,7 +3,7 @@
 set -eu
 
 echo "### go generating"
-go generate $(go list ./... | grep -v codegen/tests)
+go generate ./...
 
 if [[ $(git --no-pager diff) ]] ; then
     echo "you need to run go generate"
@@ -12,7 +12,7 @@ if [[ $(git --no-pager diff) ]] ; then
 fi
 
 echo "### running testsuite"
-go test -race $(go list ./... | grep -v codegen/tests)
+go test -race ./...
 
 echo "### linting"
 gometalinter --vendor ./...


### PR DESCRIPTION
This exclusion used to prevent go generate finding the go generate stanzas automatically added to the generated resolvers. As long as the dir is clean it isn't actually required, but running go generate a second time would error. 

Unfortunately, it's now excluding some actual tests on circle (but not AppVeyor) so lets remove it and see if it is ever actually a problem.