### PR TITLE
copy complexity to RequestContext

### DIFF
--- a/graphql/context.go
+++ b/graphql/context.go
@@ -17,6 +17,10 @@ type RequestContext struct {
 	RawQuery  string
 	Variables map[string]interface{}
 	Doc       *ast.QueryDocument
+
+	ComplexityLimit     int
+	OperationComplexity int
+
 	// ErrorPresenter will be used to generate the error
 	// message from errors given to Error().
 	ErrorPresenter      ErrorPresenterFunc


### PR DESCRIPTION
I want to get access to operation complexity on Tracing.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
