### PR TITLE
Use value type if default value

### DIFF
--- a/codegen/input_build.go
+++ b/codegen/input_build.go
@@ -63,6 +63,9 @@ func (cfg *Config) buildInput(types NamedTypes, typ *ast.Definition) (*Object, e
 		if field.DefaultValue != nil {
 			var err error
 			newField.Default, err = field.DefaultValue.Value(nil)
+			if newField.Type.IsPtr() {
+				newField.Type.StripPtr()
+			}
 			if err != nil {
 				return nil, errors.Errorf("default value for %s.%s is not valid: %s", typ.Name, field.Name, err.Error())
 			}

--- a/codegen/object_build.go
+++ b/codegen/object_build.go
@@ -163,6 +163,9 @@ func (cfg *Config) buildObject(types NamedTypes, typ *ast.Definition, imports *I
 			if arg.DefaultValue != nil {
 				var err error
 				newArg.Default, err = arg.DefaultValue.Value(nil)
+				if newArg.Type.IsPtr() {
+					newArg.Type.StripPtr()
+				}
 				if err != nil {
 					return nil, errors.Errorf("default value for %s.%s is not valid: %s", typ.Name, field.Name, err.Error())
 				}


### PR DESCRIPTION
Hi,

If a default value is present, I'd like it to use a value type:

```graphql
type Query {
    items(limit: Int = 10): ItemList!
}
```
to generate:

```go
func (r *queryResolver) Items(ctx context.Context, limit int) (ItemList, error) {
// ...
```

I was hoping doing ```limit: Int! = 10``` (required type with default value) would suffice, and it sort of did, but the playground web UI returned errors when I didn't explicitly provide a limit value.

I believe I've used other go code generators that switch to value types when default values are present.

Also it looks like the original request for default values implied that the type would switch to a value type: https://github.com/99designs/gqlgen/issues/25 "Generates code that has limit as ```*int``` but I would expect it to be an ```int```"

This is more of a feature request that I implemented. I am new to this project and I'm not sure if this change is correct, though it appears to be doing what I expect. Feel free to reject/close it.
This would be a breaking change, so I understand any hesitation, however maybe now is the time to do such changes.

Thanks,
-Chris
