### PR TITLE
accept an optional ctx parameter on model methods

### DIFF
--- a/codegen/object.go
+++ b/codegen/object.go
@@ -33,16 +33,17 @@ type Object struct {
 
 type Field struct {
 	*Type
-	Description    string          // Description of a field
-	GQLName        string          // The name of the field in graphql
-	GoFieldType    GoFieldType     // The field type in go, if any
-	GoReceiverName string          // The name of method & var receiver in go, if any
-	GoFieldName    string          // The name of the method or var in go, if any
-	Args           []FieldArgument // A list of arguments to be passed to this field
-	ForceResolver  bool            // Should be emit Resolver method
-	NoErr          bool            // If this is bound to a go method, does that method have an error as the second argument
-	Object         *Object         // A link back to the parent object
-	Default        interface{}     // The default value
+	Description      string          // Description of a field
+	GQLName          string          // The name of the field in graphql
+	GoFieldType      GoFieldType     // The field type in go, if any
+	GoReceiverName   string          // The name of method & var receiver in go, if any
+	GoFieldName      string          // The name of the method or var in go, if any
+	Args             []FieldArgument // A list of arguments to be passed to this field
+	ForceResolver    bool            // Should be emit Resolver method
+	MethodHasContext bool            // If this is bound to a go method, does the method also take a context
+	NoErr            bool            // If this is bound to a go method, does that method have an error as the second argument
+	Object           *Object         // A link back to the parent object
+	Default          interface{}     // The default value
 }
 
 type FieldArgument struct {
@@ -208,6 +209,10 @@ func (f *Field) CallArgs() string {
 
 		if !f.Object.Root {
 			args = append(args, "obj")
+		}
+	} else {
+		if f.MethodHasContext {
+			args = append(args, "ctx")
 		}
 	}
 

--- a/codegen/object.go
+++ b/codegen/object.go
@@ -104,7 +104,10 @@ func (f *Field) IsVariable() bool {
 }
 
 func (f *Field) IsConcurrent() bool {
-	return f.IsResolver() && !f.Object.DisableConcurrency
+	if f.Object.DisableConcurrency {
+		return false
+	}
+	return f.MethodHasContext || f.IsResolver()
 }
 
 func (f *Field) GoNameExported() string {

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -1524,7 +1524,7 @@ func (ec *executionContext) _ModelMethods(ctx context.Context, sel ast.Selection
 // nolint: vetshadow
 func (ec *executionContext) _ModelMethods_resolverField(ctx context.Context, field graphql.CollectedField, obj *ModelMethods) graphql.Marshaler {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer ec.Tracer.EndFieldExecution(ctx)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
 	rctx := &graphql.ResolverContext{
 		Object: "ModelMethods",
 		Args:   nil,
@@ -1551,7 +1551,7 @@ func (ec *executionContext) _ModelMethods_resolverField(ctx context.Context, fie
 // nolint: vetshadow
 func (ec *executionContext) _ModelMethods_noContext(ctx context.Context, field graphql.CollectedField, obj *ModelMethods) graphql.Marshaler {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer ec.Tracer.EndFieldExecution(ctx)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
 	rctx := &graphql.ResolverContext{
 		Object: "ModelMethods",
 		Args:   nil,
@@ -1578,7 +1578,7 @@ func (ec *executionContext) _ModelMethods_noContext(ctx context.Context, field g
 // nolint: vetshadow
 func (ec *executionContext) _ModelMethods_withContext(ctx context.Context, field graphql.CollectedField, obj *ModelMethods) graphql.Marshaler {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer ec.Tracer.EndFieldExecution(ctx)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
 	rctx := &graphql.ResolverContext{
 		Object: "ModelMethods",
 		Args:   nil,
@@ -2168,7 +2168,7 @@ func (ec *executionContext) _Query_errorBubble(ctx context.Context, field graphq
 // nolint: vetshadow
 func (ec *executionContext) _Query_modelMethods(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer ec.Tracer.EndFieldExecution(ctx)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
 	rctx := &graphql.ResolverContext{
 		Object: "Query",
 		Args:   nil,

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -34,6 +34,7 @@ type Config struct {
 
 type ResolverRoot interface {
 	ForcedResolver() ForcedResolverResolver
+	ModelMethods() ModelMethodsResolver
 	Query() QueryResolver
 	Subscription() SubscriptionResolver
 	User() UserResolver
@@ -76,6 +77,12 @@ type ComplexityRoot struct {
 		Id func(childComplexity int) int
 	}
 
+	ModelMethods struct {
+		ResolverField func(childComplexity int) int
+		NoContext     func(childComplexity int) int
+		WithContext   func(childComplexity int) int
+	}
+
 	OuterObject struct {
 		Inner func(childComplexity int) int
 	}
@@ -90,6 +97,7 @@ type ComplexityRoot struct {
 		Keywords          func(childComplexity int, input *Keywords) int
 		Shapes            func(childComplexity int) int
 		ErrorBubble       func(childComplexity int) int
+		ModelMethods      func(childComplexity int) int
 		Valid             func(childComplexity int) int
 		User              func(childComplexity int, id int) int
 		NullableArg       func(childComplexity int, arg *int) int
@@ -116,6 +124,9 @@ type ComplexityRoot struct {
 type ForcedResolverResolver interface {
 	Field(ctx context.Context, obj *ForcedResolver) (*Circle, error)
 }
+type ModelMethodsResolver interface {
+	ResolverField(ctx context.Context, obj *ModelMethods) (bool, error)
+}
 type QueryResolver interface {
 	InvalidIdentifier(ctx context.Context) (*invalid_packagename.InvalidIdentifier, error)
 	Collision(ctx context.Context) (*introspection1.It, error)
@@ -126,6 +137,7 @@ type QueryResolver interface {
 	Keywords(ctx context.Context, input *Keywords) (bool, error)
 	Shapes(ctx context.Context) ([]*Shape, error)
 	ErrorBubble(ctx context.Context) (*Error, error)
+	ModelMethods(ctx context.Context) (*ModelMethods, error)
 	Valid(ctx context.Context) (string, error)
 	User(ctx context.Context, id int) (User, error)
 	NullableArg(ctx context.Context, arg *int) (*string, error)
@@ -648,6 +660,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.It.Id(childComplexity), true
 
+	case "ModelMethods.resolverField":
+		if e.complexity.ModelMethods.ResolverField == nil {
+			break
+		}
+
+		return e.complexity.ModelMethods.ResolverField(childComplexity), true
+
+	case "ModelMethods.noContext":
+		if e.complexity.ModelMethods.NoContext == nil {
+			break
+		}
+
+		return e.complexity.ModelMethods.NoContext(childComplexity), true
+
+	case "ModelMethods.withContext":
+		if e.complexity.ModelMethods.WithContext == nil {
+			break
+		}
+
+		return e.complexity.ModelMethods.WithContext(childComplexity), true
+
 	case "OuterObject.inner":
 		if e.complexity.OuterObject.Inner == nil {
 			break
@@ -737,6 +770,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.ErrorBubble(childComplexity), true
+
+	case "Query.modelMethods":
+		if e.complexity.Query.ModelMethods == nil {
+			break
+		}
+
+		return e.complexity.Query.ModelMethods(childComplexity), true
 
 	case "Query.valid":
 		if e.complexity.Query.Valid == nil {
@@ -1432,6 +1472,136 @@ func (ec *executionContext) _It_id(ctx context.Context, field graphql.CollectedF
 	return graphql.MarshalID(res)
 }
 
+var modelMethodsImplementors = []string{"ModelMethods"}
+
+// nolint: gocyclo, errcheck, gas, goconst
+func (ec *executionContext) _ModelMethods(ctx context.Context, sel ast.SelectionSet, obj *ModelMethods) graphql.Marshaler {
+	fields := graphql.CollectFields(ctx, sel, modelMethodsImplementors)
+
+	var wg sync.WaitGroup
+	out := graphql.NewOrderedMap(len(fields))
+	invalid := false
+	for i, field := range fields {
+		out.Keys[i] = field.Alias
+
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ModelMethods")
+		case "resolverField":
+			wg.Add(1)
+			go func(i int, field graphql.CollectedField) {
+				out.Values[i] = ec._ModelMethods_resolverField(ctx, field, obj)
+				if out.Values[i] == graphql.Null {
+					invalid = true
+				}
+				wg.Done()
+			}(i, field)
+		case "noContext":
+			out.Values[i] = ec._ModelMethods_noContext(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalid = true
+			}
+		case "withContext":
+			wg.Add(1)
+			go func(i int, field graphql.CollectedField) {
+				out.Values[i] = ec._ModelMethods_withContext(ctx, field, obj)
+				if out.Values[i] == graphql.Null {
+					invalid = true
+				}
+				wg.Done()
+			}(i, field)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	wg.Wait()
+	if invalid {
+		return graphql.Null
+	}
+	return out
+}
+
+// nolint: vetshadow
+func (ec *executionContext) _ModelMethods_resolverField(ctx context.Context, field graphql.CollectedField, obj *ModelMethods) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer ec.Tracer.EndFieldExecution(ctx)
+	rctx := &graphql.ResolverContext{
+		Object: "ModelMethods",
+		Args:   nil,
+		Field:  field,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ModelMethods().ResolverField(rctx, obj)
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return graphql.MarshalBoolean(res)
+}
+
+// nolint: vetshadow
+func (ec *executionContext) _ModelMethods_noContext(ctx context.Context, field graphql.CollectedField, obj *ModelMethods) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer ec.Tracer.EndFieldExecution(ctx)
+	rctx := &graphql.ResolverContext{
+		Object: "ModelMethods",
+		Args:   nil,
+		Field:  field,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NoContext(), nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return graphql.MarshalBoolean(res)
+}
+
+// nolint: vetshadow
+func (ec *executionContext) _ModelMethods_withContext(ctx context.Context, field graphql.CollectedField, obj *ModelMethods) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer ec.Tracer.EndFieldExecution(ctx)
+	rctx := &graphql.ResolverContext{
+		Object: "ModelMethods",
+		Args:   nil,
+		Field:  field,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.WithContext(ctx), nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return graphql.MarshalBoolean(res)
+}
+
 var outerObjectImplementors = []string{"OuterObject"}
 
 // nolint: gocyclo, errcheck, gas, goconst
@@ -1564,6 +1734,12 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			wg.Add(1)
 			go func(i int, field graphql.CollectedField) {
 				out.Values[i] = ec._Query_errorBubble(ctx, field)
+				wg.Done()
+			}(i, field)
+		case "modelMethods":
+			wg.Add(1)
+			go func(i int, field graphql.CollectedField) {
+				out.Values[i] = ec._Query_modelMethods(ctx, field)
 				wg.Done()
 			}(i, field)
 		case "valid":
@@ -1987,6 +2163,35 @@ func (ec *executionContext) _Query_errorBubble(ctx context.Context, field graphq
 	}
 
 	return ec._Error(ctx, field.Selections, res)
+}
+
+// nolint: vetshadow
+func (ec *executionContext) _Query_modelMethods(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer ec.Tracer.EndFieldExecution(ctx)
+	rctx := &graphql.ResolverContext{
+		Object: "Query",
+		Args:   nil,
+		Field:  field,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().ModelMethods(rctx)
+	})
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*ModelMethods)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+
+	if res == nil {
+		return graphql.Null
+	}
+
+	return ec._ModelMethods(ctx, field.Selections, res)
 }
 
 // nolint: vetshadow
@@ -4204,6 +4409,7 @@ var parsedSchema = gqlparser.MustLoadSchema(
     keywords(input: Keywords): Boolean!
     shapes: [Shape]
     errorBubble: Error
+    modelMethods: ModelMethods
     valid: String!
     user(id: Int!): User!
     nullableArg(arg: Int = 123): String
@@ -4224,6 +4430,12 @@ type Error {
     errorOnNonRequiredField: String
     errorOnRequiredField: String!
     nilOnRequiredField: String!
+}
+
+type ModelMethods {
+    resolverField: Boolean!
+    noContext: Boolean!
+    withContext: Boolean!
 }
 
 type InvalidIdentifier {

--- a/codegen/testserver/generated_test.go
+++ b/codegen/testserver/generated_test.go
@@ -521,6 +521,12 @@ func TestTracer(t *testing.T) {
 	})
 
 	t.Run("model methods", func(t *testing.T) {
+		srv := httptest.NewServer(
+			handler.GraphQL(
+				NewExecutableSchema(Config{Resolvers: &testResolver{}}),
+			))
+		defer srv.Close()
+		c := client.New(srv.URL)
 		t.Run("without context", func(t *testing.T) {
 			var resp struct {
 				ModelMethods struct {

--- a/codegen/testserver/generated_test.go
+++ b/codegen/testserver/generated_test.go
@@ -519,6 +519,29 @@ func TestTracer(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, called)
 	})
+
+	t.Run("model methods", func(t *testing.T) {
+		t.Run("without context", func(t *testing.T) {
+			var resp struct {
+				ModelMethods struct {
+					NoContext bool
+				}
+			}
+			err := c.Post(`query { modelMethods{ noContext } }`, &resp)
+			require.NoError(t, err)
+			require.True(t, resp.ModelMethods.NoContext)
+		})
+		t.Run("with context", func(t *testing.T) {
+			var resp struct {
+				ModelMethods struct {
+					WithContext bool
+				}
+			}
+			err := c.Post(`query { modelMethods{ withContext } }`, &resp)
+			require.NoError(t, err)
+			require.True(t, resp.ModelMethods.WithContext)
+		})
+	})
 }
 
 func TestResponseExtension(t *testing.T) {
@@ -555,6 +578,9 @@ func (r *testResolver) User() UserResolver {
 
 func (r *testResolver) Query() QueryResolver {
 	return &testQueryResolver{}
+}
+func (r *testResolver) ModelMethods() ModelMethodsResolver {
+	return &modelMethodsResolver{}
 }
 
 type testQueryResolver struct{ queryResolver }

--- a/codegen/testserver/generated_test.go
+++ b/codegen/testserver/generated_test.go
@@ -580,7 +580,13 @@ func (r *testResolver) Query() QueryResolver {
 	return &testQueryResolver{}
 }
 func (r *testResolver) ModelMethods() ModelMethodsResolver {
-	return &modelMethodsResolver{}
+	return &testModelMethodsResolver{}
+}
+
+type testModelMethodsResolver struct{}
+
+func (r *testModelMethodsResolver) ResolverField(ctx context.Context, obj *ModelMethods) (bool, error) {
+	return true, nil
 }
 
 type testQueryResolver struct{ queryResolver }
@@ -600,6 +606,10 @@ func (r *testQueryResolver) User(ctx context.Context, id int) (User, error) {
 func (r *testQueryResolver) NullableArg(ctx context.Context, arg *int) (*string, error) {
 	s := "Ok"
 	return &s, nil
+}
+
+func (r *testQueryResolver) ModelMethods(ctx context.Context) (*ModelMethods, error) {
+	return &ModelMethods{}, nil
 }
 
 func (r *testResolver) Subscription() SubscriptionResolver {

--- a/codegen/testserver/gqlgen.yml
+++ b/codegen/testserver/gqlgen.yml
@@ -11,6 +11,8 @@ resolver:
 models:
   It:
     model: "github.com/99designs/gqlgen/codegen/testserver/introspection.It"
+  ModelMethods:
+    model: "github.com/99designs/gqlgen/codegen/testserver.ModelMethods"
   InvalidIdentifier:
     model: "github.com/99designs/gqlgen/codegen/testserver/invalid-packagename.InvalidIdentifier"
   Changes:

--- a/codegen/testserver/models.go
+++ b/codegen/testserver/models.go
@@ -1,9 +1,23 @@
 package testserver
 
-import "fmt"
+import (
+	context "context"
+	"fmt"
+)
 
 type ForcedResolver struct {
 	Field Circle
+}
+
+type ModelMethods struct {
+}
+
+func (m ModelMethods) NoContext() bool {
+	return true
+}
+
+func (m ModelMethods) WithContext(_ context.Context) bool {
+	return true
 }
 
 type Error struct {

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -14,6 +14,9 @@ type Resolver struct{}
 func (r *Resolver) ForcedResolver() ForcedResolverResolver {
 	return &forcedResolverResolver{r}
 }
+func (r *Resolver) ModelMethods() ModelMethodsResolver {
+	return &modelMethodsResolver{r}
+}
 func (r *Resolver) Query() QueryResolver {
 	return &queryResolver{r}
 }
@@ -23,19 +26,16 @@ func (r *Resolver) Subscription() SubscriptionResolver {
 func (r *Resolver) User() UserResolver {
 	return &userResolver{r}
 }
-func (r *Resolver) ModelMethods() ModelMethodsResolver {
-	return &modelMethodsResolver{}
-}
-
-type modelMethodsResolver struct{}
-
-func (r *modelMethodsResolver) ResolverField(ctx context.Context, obj *ModelMethods) (bool, error) {
-	return true, nil
-}
 
 type forcedResolverResolver struct{ *Resolver }
 
 func (r *forcedResolverResolver) Field(ctx context.Context, obj *ForcedResolver) (*Circle, error) {
+	panic("not implemented")
+}
+
+type modelMethodsResolver struct{ *Resolver }
+
+func (r *modelMethodsResolver) ResolverField(ctx context.Context, obj *ModelMethods) (bool, error) {
 	panic("not implemented")
 }
 
@@ -68,6 +68,9 @@ func (r *queryResolver) Shapes(ctx context.Context) ([]*Shape, error) {
 func (r *queryResolver) ErrorBubble(ctx context.Context) (*Error, error) {
 	panic("not implemented")
 }
+func (r *queryResolver) ModelMethods(ctx context.Context) (*ModelMethods, error) {
+	panic("not implemented")
+}
 func (r *queryResolver) Valid(ctx context.Context) (string, error) {
 	panic("not implemented")
 }
@@ -76,9 +79,6 @@ func (r *queryResolver) User(ctx context.Context, id int) (User, error) {
 }
 func (r *queryResolver) NullableArg(ctx context.Context, arg *int) (*string, error) {
 	panic("not implemented")
-}
-func (r *queryResolver) ModelMethods(ctx context.Context) (*ModelMethods, error) {
-	return &ModelMethods{}, nil
 }
 func (r *queryResolver) KeywordArgs(ctx context.Context, breakArg string, defaultArg string, funcArg string, interfaceArg string, selectArg string, caseArg string, deferArg string, goArg string, mapArg string, structArg string, chanArg string, elseArg string, gotoArg string, packageArg string, switchArg string, constArg string, fallthroughArg string, ifArg string, rangeArg string, typeArg string, continueArg string, forArg string, importArg string, returnArg string, varArg string) (bool, error) {
 	panic("not implemented")

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -23,6 +23,15 @@ func (r *Resolver) Subscription() SubscriptionResolver {
 func (r *Resolver) User() UserResolver {
 	return &userResolver{r}
 }
+func (r *Resolver) ModelMethods() ModelMethodsResolver {
+	return &modelMethodsResolver{}
+}
+
+type modelMethodsResolver struct{}
+
+func (r *modelMethodsResolver) ResolverField(ctx context.Context, obj *ModelMethods) (bool, error) {
+	return true, nil
+}
 
 type forcedResolverResolver struct{ *Resolver }
 
@@ -67,6 +76,9 @@ func (r *queryResolver) User(ctx context.Context, id int) (User, error) {
 }
 func (r *queryResolver) NullableArg(ctx context.Context, arg *int) (*string, error) {
 	panic("not implemented")
+}
+func (r *queryResolver) ModelMethods(ctx context.Context) (*ModelMethods, error) {
+	return &ModelMethods{}, nil
 }
 func (r *queryResolver) KeywordArgs(ctx context.Context, breakArg string, defaultArg string, funcArg string, interfaceArg string, selectArg string, caseArg string, deferArg string, goArg string, mapArg string, structArg string, chanArg string, elseArg string, gotoArg string, packageArg string, switchArg string, constArg string, fallthroughArg string, ifArg string, rangeArg string, typeArg string, continueArg string, forArg string, importArg string, returnArg string, varArg string) (bool, error) {
 	panic("not implemented")

--- a/codegen/testserver/schema.graphql
+++ b/codegen/testserver/schema.graphql
@@ -8,6 +8,7 @@ type Query {
     keywords(input: Keywords): Boolean!
     shapes: [Shape]
     errorBubble: Error
+    modelMethods: ModelMethods
     valid: String!
     user(id: Int!): User!
     nullableArg(arg: Int = 123): String
@@ -28,6 +29,12 @@ type Error {
     errorOnNonRequiredField: String
     errorOnRequiredField: String!
     nilOnRequiredField: String!
+}
+
+type ModelMethods {
+    resolverField: Boolean!
+    noContext: Boolean!
+    withContext: Boolean!
 }
 
 type InvalidIdentifier {

--- a/docs/content/reference/resolvers.md
+++ b/docs/content/reference/resolvers.md
@@ -87,7 +87,10 @@ models:
 ```
 
 Here, we see that there is a method on car with the name ```Owner```, thus the ```Owner``` function will be called if
-a graphQL request includes that field to be resolved
+a graphQL request includes that field to be resolved.
+
+Model methods can optionally take a context as their first argument. If a
+context is required, the model method will also be run in parallel.
 
 ## Bind when the field names do not match
 


### PR DESCRIPTION
This PR allows you to take a context on model methods. This makes it much easier to transition from graph-gophers/graphql-go to this library. By configuring all of your graph-gophers resolvers as "models" in gqlgen, you can reuse existing code and migrate gradually instead of having to rewrite all resolvers in order to migrate.

Testing and docs coming up after I get some initial feedback on the concept and implementation.

Edit: I ran into one more thing that prevents me from being able to transition gradually. Models can't be returned from resolvers as pointers unless they are optional. All of my graph-gophers resolvers are pointers. I'm considering a temporary hack to make all models passed as pointers or converting all graph-gophers resolvers to non-pointers (there was no real reason for them to be pointers). I'd love some tips if anyone has done this before. 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
