### PR TITLE
Switch to hosting docs on render.com

### DIFF
--- a/docs/publish.sh
+++ b/docs/publish.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-hugo
-aws-vault exec platform -- aws s3 sync public s3://gqlgen.com

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -16,8 +16,5 @@ When editing docs run `hugo serve` and a live reload server will start, then nav
 
 ## Publishing docs
 
-**Requires 99designs aws-vault access**
-
-run `./publish.sh` to make the docs live.
-
+Docs are hosted using [render.com](https://render.com/) and will be automatically deployed when merging to master.
 


### PR DESCRIPTION
[Render.com](https://render.com) has offered to host our static site for free, and have a pretty simple setup for rebuilding on merge to master. I've switched the DNS records and updated the docs.
