### PR TITLE
validate Input Object type must define one or more input fields

### DIFF
--- a/codegen/input_build.go
+++ b/codegen/input_build.go
@@ -47,6 +47,10 @@ func (cfg *Config) buildInput(types NamedTypes, typ *ast.Definition) (*Object, e
 	obj := &Object{NamedType: types[typ.Name]}
 	typeEntry, entryExists := cfg.Models[typ.Name]
 
+	if len(typ.Fields) == 0 {
+		return nil, errors.Errorf("Input Object Type '%s' must define one or more input fields", obj.GQLType)
+	}
+
 	for _, field := range typ.Fields {
 		newField := Field{
 			GQLName: field.Name,

--- a/codegen/input_test.go
+++ b/codegen/input_test.go
@@ -33,12 +33,25 @@ func TestTypeInInput(t *testing.T) {
 	require.EqualError(t, err, "model plan failed: Item cannot be used as a field of BookmarkableInput. only input and scalar types are allowed")
 }
 
+func TestEmptyInputField(t *testing.T) {
+	err := generate("emptyinputfield", `
+		type Query {
+			addBookmark(b: BookmarkableInput!): Boolean!
+		}
+		type Item {}
+		input BookmarkableInput {
+		}
+	`)
+
+	require.EqualError(t, err, "model plan failed: Input Object Type 'BookmarkableInput' must define one or more input fields")
+}
+
 func generate(name string, schema string, typemap ...TypeMap) error {
 	cfg := Config{
 		SchemaFilename: SchemaFilenames{"schema.graphql"},
-		SchemaStr: map[string]string{"schema.graphql": schema},
-		Exec:      PackageConfig{Filename: "gen/" + name + "/exec.go"},
-		Model:     PackageConfig{Filename: "gen/" + name + "/model.go"},
+		SchemaStr:      map[string]string{"schema.graphql": schema},
+		Exec:           PackageConfig{Filename: "gen/" + name + "/exec.go"},
+		Model:          PackageConfig{Filename: "gen/" + name + "/model.go"},
 	}
 
 	if len(typemap) > 0 {


### PR DESCRIPTION
fixes #423

I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
