### PR TITLE
Fix type binding validation for slices of pointers like []*foo

### DIFF
--- a/codegen/util.go
+++ b/codegen/util.go
@@ -337,14 +337,14 @@ func validateTypeBinding(imports *Imports, field *Field, goType types.Type) erro
 	gqlType := normalizeVendor(field.Type.FullSignature())
 	goTypeStr := normalizeVendor(goType.String())
 
-	if goTypeStr == gqlType || "*"+goTypeStr == gqlType || goTypeStr == "*"+gqlType {
+	if equalTypes(goTypeStr, gqlType) {
 		field.Type.Modifiers = modifiersFromGoType(goType)
 		return nil
 	}
 
 	// deal with type aliases
 	underlyingStr := normalizeVendor(goType.Underlying().String())
-	if underlyingStr == gqlType || "*"+underlyingStr == gqlType || underlyingStr == "*"+gqlType {
+	if equalTypes(underlyingStr, gqlType) {
 		field.Type.Modifiers = modifiersFromGoType(goType)
 		pkg, typ := pkgAndType(goType.String())
 		imp := imports.findByPath(pkg)
@@ -381,4 +381,8 @@ func normalizeVendor(pkg string) string {
 	pkg = strings.TrimPrefix(pkg, modifiers)
 	parts := strings.Split(pkg, "/vendor/")
 	return modifiers + parts[len(parts)-1]
+}
+
+func equalTypes(goType string, gqlType string) bool {
+	return goType == gqlType || "*"+goType == gqlType || goType == "*"+gqlType || strings.Replace(goType, "[]*", "[]", -1) == gqlType
 }

--- a/codegen/util_test.go
+++ b/codegen/util_test.go
@@ -16,6 +16,7 @@ func TestNormalizeVendor(t *testing.T) {
 	require.Equal(t, "[]bar/baz", normalizeVendor("[]foo/vendor/bar/baz"))
 	require.Equal(t, "*bar/baz", normalizeVendor("*foo/vendor/bar/baz"))
 	require.Equal(t, "*[]*bar/baz", normalizeVendor("*[]*foo/vendor/bar/baz"))
+	require.Equal(t, "[]*bar/baz", normalizeVendor("[]*foo/vendor/bar/baz"))
 }
 
 func TestFindField(t *testing.T) {
@@ -116,6 +117,27 @@ func TestEqualFieldName(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
 			result := equalFieldName(tc.Source, tc.Target)
+			require.Equal(t, tc.Expected, result)
+		})
+	}
+}
+
+func TestEqualTypes(t *testing.T) {
+	tt := []struct {
+		Name     string
+		Source   string
+		Target   string
+		Expected bool
+	}{
+		{Name: "basic", Source: "bar/baz", Target: "bar/baz", Expected: true},
+		{Name: "basic slice", Source: "[]bar/baz", Target: "[]bar/baz", Expected: true},
+		{Name: "pointer", Source: "*bar/baz", Target: "bar/baz", Expected: true},
+		{Name: "pointer slice", Source: "[]*bar/baz", Target: "[]bar/baz", Expected: true},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := equalTypes(tc.Source, tc.Target)
 			require.Equal(t, tc.Expected, result)
 		})
 	}


### PR DESCRIPTION
I was running into this during `gqlgen -v`:
```
field has wrong type: []github.com/snormore/foobar/pkg/app.Foo is not compatible with []*github.com/snormore/foobar/pkg/app.Foo
```

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
