### PR TITLE
Updated README: added another alternative for typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a library for quickly creating strictly typed graphql servers in golang.
 
 See the [docs](https://gqlgen.com/) for a getting started guide.
 
-Looking for typescript? Check out [graphqlgen](https://github.com/prisma/graphqlgen)
+Looking for typescript? Check out [graphqlgen](https://github.com/prisma/graphqlgen) or [graphql-code-generator](https://graphql-code-generator.com/)
 
 ### Feature comparison
 


### PR DESCRIPTION
Hi @99designs!

In this PR I updated the README file, pointing to another alternative for generating TypeScript from GraphQL.
GraphQL Code Generator generates output from a GraphQL schema and GraphQL documents (query/mutation/subscription/fragment) for both client and server. And also supports generating TypeScript resolvers similar to this package. 
