### PR TITLE
Replaced "encoding/json" by "github.com/json-iterator/go"

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -8,8 +8,11 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/mitchellh/mapstructure"
 )
+
+var jsonIterator = jsoniter.ConfigCompatibleWithStandardLibrary
 
 // Client for graphql requests
 type Client struct {
@@ -96,7 +99,7 @@ func (p *Client) Post(query string, response interface{}, options ...Option) (re
 
 func (p *Client) RawPost(query string, options ...Option) (*ResponseData, error) {
 	r := p.mkRequest(query, options...)
-	requestBody, err := json.Marshal(r)
+	requestBody, err := jsonIterator.Marshal(r)
 	if err != nil {
 		return nil, fmt.Errorf("encode: %s", err.Error())
 	}
@@ -122,7 +125,7 @@ func (p *Client) RawPost(query string, options ...Option) (*ResponseData, error)
 	// decode it into map string first, let mapstructure do the final decode
 	// because it can be much stricter about unknown fields.
 	respDataRaw := &ResponseData{}
-	err = json.Unmarshal(responseBody, &respDataRaw)
+	err = jsonIterator.Unmarshal(responseBody, &respDataRaw)
 	if err != nil {
 		return nil, fmt.Errorf("decode: %s", err.Error())
 	}

--- a/client/websocket.go
+++ b/client/websocket.go
@@ -43,7 +43,7 @@ func (p *Client) Websocket(query string, options ...Option) *Subscription {
 
 func (p *Client) WebsocketWithPayload(query string, initPayload map[string]interface{}, options ...Option) *Subscription {
 	r := p.mkRequest(query, options...)
-	requestBody, err := json.Marshal(r)
+	requestBody, err := jsonIterator.Marshal(r)
 	if err != nil {
 		return errorSubscription(fmt.Errorf("encode: %s", err.Error()))
 	}
@@ -58,7 +58,7 @@ func (p *Client) WebsocketWithPayload(query string, initPayload map[string]inter
 
 	initMessage := operationMessage{Type: connectionInitMsg}
 	if initPayload != nil {
-		initMessage.Payload, err = json.Marshal(initPayload)
+		initMessage.Payload, err = jsonIterator.Marshal(initPayload)
 		if err != nil {
 			return errorSubscription(fmt.Errorf("parse payload: %s", err.Error()))
 		}
@@ -94,7 +94,7 @@ func (p *Client) WebsocketWithPayload(query string, initPayload map[string]inter
 			}
 
 			respDataRaw := map[string]interface{}{}
-			err = json.Unmarshal(op.Payload, &respDataRaw)
+			err = jsonIterator.Unmarshal(op.Payload, &respDataRaw)
 			if err != nil {
 				return fmt.Errorf("decode: %s", err.Error())
 			}

--- a/handler/graphql.go
+++ b/handler/graphql.go
@@ -12,11 +12,14 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/gorilla/websocket"
 	"github.com/hashicorp/golang-lru"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/vektah/gqlparser/ast"
 	"github.com/vektah/gqlparser/gqlerror"
 	"github.com/vektah/gqlparser/parser"
 	"github.com/vektah/gqlparser/validator"
 )
+
+var jsonIterator = jsoniter.ConfigCompatibleWithStandardLibrary
 
 type params struct {
 	Query         string                 `json:"query"`
@@ -365,13 +368,13 @@ func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch op.Operation {
 	case ast.Query:
-		b, err := json.Marshal(gh.exec.Query(ctx, op))
+		b, err := jsonIterator.Marshal(gh.exec.Query(ctx, op))
 		if err != nil {
 			panic(err)
 		}
 		w.Write(b)
 	case ast.Mutation:
-		b, err := json.Marshal(gh.exec.Mutation(ctx, op))
+		b, err := jsonIterator.Marshal(gh.exec.Mutation(ctx, op))
 		if err != nil {
 			panic(err)
 		}
@@ -446,7 +449,7 @@ func jsonDecode(r io.Reader, val interface{}) error {
 
 func sendError(w http.ResponseWriter, code int, errors ...*gqlerror.Error) {
 	w.WriteHeader(code)
-	b, err := json.Marshal(&graphql.Response{Errors: errors})
+	b, err := jsonIterator.Marshal(&graphql.Response{Errors: errors})
 	if err != nil {
 		panic(err)
 	}

--- a/handler/websocket.go
+++ b/handler/websocket.go
@@ -83,7 +83,7 @@ func (c *wsConnection) init() bool {
 	case connectionInitMsg:
 		if len(message.Payload) > 0 {
 			c.initPayload = make(InitPayload)
-			err := json.Unmarshal(message.Payload, &c.initPayload)
+			err := jsonIterator.Unmarshal(message.Payload, &c.initPayload)
 			if err != nil {
 				return false
 			}
@@ -213,7 +213,7 @@ func (c *wsConnection) subscribe(message *operationMessage) bool {
 }
 
 func (c *wsConnection) sendData(id string, response *graphql.Response) {
-	b, err := json.Marshal(response)
+	b, err := jsonIterator.Marshal(response)
 	if err != nil {
 		c.sendError(id, gqlerror.Errorf("unable to encode json response: %s", err.Error()))
 		return
@@ -227,7 +227,7 @@ func (c *wsConnection) sendError(id string, errors ...*gqlerror.Error) {
 	for _, err := range errors {
 		errs = append(errs, err)
 	}
-	b, err := json.Marshal(errs)
+	b, err := jsonIterator.Marshal(errs)
 	if err != nil {
 		panic(err)
 	}
@@ -235,7 +235,7 @@ func (c *wsConnection) sendError(id string, errors ...*gqlerror.Error) {
 }
 
 func (c *wsConnection) sendConnectionError(format string, args ...interface{}) {
-	b, err := json.Marshal(&gqlerror.Error{Message: fmt.Sprintf(format, args...)})
+	b, err := jsonIterator.Marshal(&gqlerror.Error{Message: fmt.Sprintf(format, args...)})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Replace encoding/json by a faster library

Replaced the default Marshal/Unmarshal operations from the standard library to the similar operations from a faster library: [github.com/json-iterator/go](https://github.com/json-iterator/go).

As you can see, according to THEIR benchmark, it might help improve the performance of gqlgen as it relies heavily on json marshalling/unmarshalling.

![Benchmark results](https://camo.githubusercontent.com/9f07f16d9d489005278c9722c785b2595b01c59e/687474703a2f2f6a736f6e697465722e636f6d2f62656e63686d61726b732f676f2d62656e63686d61726b2e706e67)

I haven't tried doing a solid benchmark using gqlgen as I haven't had the occasion yet. But if you feel like doing it, go for it.
