### PR TITLE
Update to latest gqlparser

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -163,7 +163,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7fa8a2105f0b0853395a85d3dd8ef1475c44919374c6496dba7b987586edaced"
+  digest = "1:8124fec00b7f3d03b4971bfa9d5da9f0b03f442dd323d4297abf9a1e6883357d"
   name = "github.com/vektah/gqlparser"
   packages = [
     ".",
@@ -175,7 +175,7 @@
     "validator/rules",
   ]
   pruneopts = "UT"
-  revision = "f119686bf1d4d1a68c7ed6afe35f183625443c41"
+  revision = "8d495d2fd057d1c734159ee3795905e8f162f78a"
 
 [[projects]]
   branch = "master"

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -12,7 +12,7 @@ func TestGenerateServer(t *testing.T) {
 	name := "graphserver"
 	schema := `
 	type Query {
-		user(): User
+		user: User
 	}
 	type User {
 		id: Int

--- a/codegen/input_test.go
+++ b/codegen/input_test.go
@@ -12,7 +12,7 @@ func TestTypeUnionAsInput(t *testing.T) {
 		type Query {
 			addBookmark(b: Bookmarkable!): Boolean!
 		}
-		type Item {}
+		type Item {name: String}
 		union Bookmarkable = Item
 	`)
 
@@ -24,7 +24,7 @@ func TestTypeInInput(t *testing.T) {
 		type Query {
 			addBookmark(b: BookmarkableInput!): Boolean!
 		}
-		type Item {}
+		type Item {name: String}
 		input BookmarkableInput {
 			item: Item
 		}


### PR DESCRIPTION
# Fixed
 - Fixed improperly quoted object default values - https://github.com/vektah/gqlparser/pull/70
 - Fixed inaccurate validation paths - https://github.com/vektah/gqlparser/pull/77
 - Fixed an infinite recursion issue with unterminated types - https://github.com/vektah/gqlparser/pull/79
 - Fixed a panic when dealing with solo carriage returns - https://github.com/vektah/gqlparser/pull/80

# Changed
 - Additional validation for __ types - https://github.com/vektah/gqlparser/pull/76
 - Additional validation for duplicate fields - https://github.com/vektah/gqlparser/pull/75
 - Additional validation for empty types / inputs / enums / interfaces - https://github.com/vektah/gqlparser/pull/71

