### PR TITLE
Increase float precision

### DIFF
--- a/graphql/float.go
+++ b/graphql/float.go
@@ -9,7 +9,7 @@ import (
 
 func MarshalFloat(f float64) Marshaler {
 	return WriterFunc(func(w io.Writer) {
-		io.WriteString(w, fmt.Sprintf("%f", f))
+		io.WriteString(w, fmt.Sprintf("%g", f))
 	})
 }
 

--- a/graphql/float_test.go
+++ b/graphql/float_test.go
@@ -1,0 +1,22 @@
+package graphql
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFloat(t *testing.T) {
+	assert.Equal(t, "123", m2s(MarshalFloat(123)))
+	assert.Equal(t, "1.2345678901", m2s(MarshalFloat(1.2345678901)))
+	assert.Equal(t, "1.2345678901234567", m2s(MarshalFloat(1.234567890123456789)))
+	assert.Equal(t, "1.2e+20", m2s(MarshalFloat(1.2e+20)))
+	assert.Equal(t, "1.2e-20", m2s(MarshalFloat(1.2e-20)))
+}
+
+func m2s(m Marshaler) string {
+	var b bytes.Buffer
+	m.MarshalGQL(&b)
+	return b.String()
+}

--- a/graphql/jsonw_test.go
+++ b/graphql/jsonw_test.go
@@ -34,5 +34,5 @@ func TestJsonWriter(t *testing.T) {
 	b := &bytes.Buffer{}
 	obj.MarshalGQL(b)
 
-	require.Equal(t, `{"test":10,"array":[1,"2",true,false,null,1.300000,true],"emptyArray":[],"child":{"child":{"child":null}}}`, b.String())
+	require.Equal(t, `{"test":10,"array":[1,"2",true,false,null,1.3,true],"emptyArray":[],"child":{"child":{"child":null}}}`, b.String())
 }


### PR DESCRIPTION
Even though floats internally were being stored as float64, they were being encoded using "%f", which limits the outgoing precision to 6 decimal places.

This swaps over to use "%g" which will show up to 17 decimal places, and fall back to scientific notation when the exponent gets large.

Fix #424

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
