### PR TITLE
Add Deprecation Warning to Binary

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,13 @@
 package main
 
-import "github.com/99designs/gqlgen/cmd"
+import (
+	"fmt"
+	"os"
+
+	"github.com/99designs/gqlgen/cmd"
+)
 
 func main() {
+	fmt.Fprintf(os.Stderr, "warning: running gqlgen from this binary is deprecated and may be removed in a future release. See https://github.com/99designs/gqlgen/issues/415\n")
 	cmd.Execute()
 }


### PR DESCRIPTION
Adds a deprecation notice when running gqlgen as a binary.  Closes #415 

I'll update #415 to include migration notes.