### PR TITLE
bump version of graphql playground

### DIFF
--- a/handler/playground.go
+++ b/handler/playground.go
@@ -45,7 +45,7 @@ func Playground(title string, endpoint string) http.HandlerFunc {
 		err := page.Execute(w, map[string]string{
 			"title":    title,
 			"endpoint": endpoint,
-			"version":  "1.7.8",
+			"version":  "1.8.5",
 		})
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Just updates the version of the graphql playground used. You can see the diff at https://github.com/prisma/graphql-playground/compare/v1.7.0...v1.8.5
