### PR TITLE
add `content-type: text/html` header to playground handler

### DIFF
--- a/handler/playground.go
+++ b/handler/playground.go
@@ -42,6 +42,7 @@ var page = template.Must(template.New("graphiql").Parse(`<!DOCTYPE html>
 
 func Playground(title string, endpoint string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "text/html")
 		err := page.Execute(w, map[string]string{
 			"title":    title,
 			"endpoint": endpoint,


### PR DESCRIPTION
This ensures that the browser doesn't think it should download the page
instead of rendering it, if the handler goes through a gzipping
middleware such as https://github.com/phyber/negroni-gzip.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

(Sorry, not quite sure where relevant docs or tests are)