### PR TITLE
Do not try to bind method on input object

### DIFF
--- a/codegen/util.go
+++ b/codegen/util.go
@@ -213,7 +213,12 @@ func bindObject(t types.Type, object *Object, structTag string) BindErrors {
 		}
 
 		// first try binding to a method
-		methodErr := bindMethod(t, field)
+		var methodErr error
+		if object.IsInput {
+			methodErr = fmt.Errorf("can not bind to method on input object")
+		} else {
+			methodErr = bindMethod(t, field)
+		}
 		if methodErr == nil {
 			continue
 		}


### PR DESCRIPTION
Related to #506, it shouldn't be possible to bind a getter method to an input object.