### PR TITLE
Include OperationDefinition in RequestContext

### DIFF
--- a/graphql/context.go
+++ b/graphql/context.go
@@ -17,6 +17,7 @@ type RequestContext struct {
 	RawQuery  string
 	Variables map[string]interface{}
 	Doc       *ast.QueryDocument
+	Op        *ast.OperationDefinition
 
 	ComplexityLimit      int
 	OperationComplexity  int
@@ -49,9 +50,10 @@ func DefaultRequestMiddleware(ctx context.Context, next func(ctx context.Context
 	return next(ctx)
 }
 
-func NewRequestContext(doc *ast.QueryDocument, query string, variables map[string]interface{}) *RequestContext {
+func NewRequestContext(doc *ast.QueryDocument, op *ast.OperationDefinition, query string, variables map[string]interface{}) *RequestContext {
 	return &RequestContext{
 		Doc:                 doc,
+		Op:                  op,
 		RawQuery:            query,
 		Variables:           variables,
 		ResolverMiddleware:  DefaultResolverMiddleware,

--- a/handler/graphql.go
+++ b/handler/graphql.go
@@ -37,7 +37,7 @@ type Config struct {
 }
 
 func (c *Config) newRequestContext(es graphql.ExecutableSchema, doc *ast.QueryDocument, op *ast.OperationDefinition, query string, variables map[string]interface{}) *graphql.RequestContext {
-	reqCtx := graphql.NewRequestContext(doc, query, variables)
+	reqCtx := graphql.NewRequestContext(doc, op, query, variables)
 	reqCtx.DisableIntrospection = c.disableIntrospection
 
 	if hook := c.recover; hook != nil {


### PR DESCRIPTION
A motivating example is where you have a query doc with multiple definitions and you wish to know which one is executed.

E.g. Given the following query doc, which is common when using graphiql or another explorer:
```
query apiOp {
  # ...
}

query apiOpTwo {
 # ...
}
```
And the request is executed with:

```
{"query":"...", operationName":"apiOpTwo"}
```
You want to log the operation name in logs tracing, etc.  But without the specific operation definition parsed from the request you don't know which one. 

By including this PR, the following becomes possible
```
func OperationNameFromCtx(ctx context.Context) string {
	requestContext := graphql.GetRequestContext(ctx)
	// we use the potentially added Op to find the name of the query being executed
	if requestContext.Op != nil && requestContext.Op.Name != "" {
		return requestContext.Op.Name // => apiOpTwo
	}
	return "nameless-operation"
}
```
