### PR TITLE
Stop GetResolverContext from panicking when missing

### DIFF
--- a/graphql/context.go
+++ b/graphql/context.go
@@ -71,12 +71,10 @@ const (
 )
 
 func GetRequestContext(ctx context.Context) *RequestContext {
-	val := ctx.Value(request)
-	if val == nil {
-		return nil
+	if val, ok := ctx.Value(request).(*RequestContext); ok {
+		return val
 	}
-
-	return val.(*RequestContext)
+	return nil
 }
 
 func WithRequestContext(ctx context.Context, rc *RequestContext) context.Context {
@@ -117,8 +115,10 @@ func (r *ResolverContext) Path() []interface{} {
 }
 
 func GetResolverContext(ctx context.Context) *ResolverContext {
-	val, _ := ctx.Value(resolver).(*ResolverContext)
-	return val
+	if val, ok := ctx.Value(resolver).(*ResolverContext); ok {
+		return val
+	}
+	return nil
 }
 
 func WithResolverContext(ctx context.Context, rc *ResolverContext) context.Context {

--- a/graphql/context_test.go
+++ b/graphql/context_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/ast"
 )
 
@@ -62,4 +63,18 @@ func TestRequestContext_GetErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetRequestContext(t *testing.T) {
+	require.Nil(t, GetRequestContext(context.Background()))
+
+	rc := &RequestContext{}
+	require.Equal(t, rc, GetRequestContext(WithRequestContext(context.Background(), rc)))
+}
+
+func TestGetResolverContext(t *testing.T) {
+	require.Nil(t, GetResolverContext(context.Background()))
+
+	rc := &ResolverContext{}
+	require.Equal(t, rc, GetResolverContext(WithResolverContext(context.Background(), rc)))
 }


### PR DESCRIPTION
Fixes https://github.com/99designs/gqlgen/issues/510

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] ~Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))~ no docs apply
