### PR TITLE
Union Fragment Bug Fix

### DIFF
--- a/codegen/object.go
+++ b/codegen/object.go
@@ -84,8 +84,8 @@ type Objects []*Object
 
 func (o *Object) Implementors() string {
 	satisfiedBy := strconv.Quote(o.Name)
-	for _, s := range o.Definition.Interfaces {
-		satisfiedBy += ", " + strconv.Quote(s)
+	for _, s := range o.Implements {
+		satisfiedBy += ", " + strconv.Quote(s.Name)
 	}
 	return "[]string{" + satisfiedBy + "}"
 }

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -3657,7 +3657,7 @@ func (ec *executionContext) _ShapeUnion(ctx context.Context, sel ast.SelectionSe
 
 // region    **************************** object.gotpl ****************************
 
-var circleImplementors = []string{"Circle", "Shape"}
+var circleImplementors = []string{"Circle", "Shape", "ShapeUnion"}
 
 func (ec *executionContext) _Circle(ctx context.Context, sel ast.SelectionSet, obj *Circle) graphql.Marshaler {
 	fields := graphql.CollectFields(ctx, sel, circleImplementors)
@@ -4097,7 +4097,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 	return out
 }
 
-var rectangleImplementors = []string{"Rectangle", "Shape"}
+var rectangleImplementors = []string{"Rectangle", "Shape", "ShapeUnion"}
 
 func (ec *executionContext) _Rectangle(ctx context.Context, sel ast.SelectionSet, obj *Rectangle) graphql.Marshaler {
 	fields := graphql.CollectFields(ctx, sel, rectangleImplementors)

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -113,6 +113,7 @@ type ComplexityRoot struct {
 		DirectiveInputNullable func(childComplexity int, arg *InputDirectives) int
 		DirectiveInput         func(childComplexity int, arg InputDirectives) int
 		InputSlice             func(childComplexity int, arg []string) int
+		ShapeUnion             func(childComplexity int) int
 		KeywordArgs            func(childComplexity int, breakArg string, defaultArg string, funcArg string, interfaceArg string, selectArg string, caseArg string, deferArg string, goArg string, mapArg string, structArg string, chanArg string, elseArg string, gotoArg string, packageArg string, switchArg string, constArg string, fallthroughArg string, ifArg string, rangeArg string, typeArg string, continueArg string, forArg string, importArg string, returnArg string, varArg string) int
 	}
 
@@ -158,6 +159,7 @@ type QueryResolver interface {
 	DirectiveInputNullable(ctx context.Context, arg *InputDirectives) (*string, error)
 	DirectiveInput(ctx context.Context, arg InputDirectives) (*string, error)
 	InputSlice(ctx context.Context, arg []string) (bool, error)
+	ShapeUnion(ctx context.Context) (ShapeUnion, error)
 	KeywordArgs(ctx context.Context, breakArg string, defaultArg string, funcArg string, interfaceArg string, selectArg string, caseArg string, deferArg string, goArg string, mapArg string, structArg string, chanArg string, elseArg string, gotoArg string, packageArg string, switchArg string, constArg string, fallthroughArg string, ifArg string, rangeArg string, typeArg string, continueArg string, forArg string, importArg string, returnArg string, varArg string) (bool, error)
 }
 type SubscriptionResolver interface {
@@ -476,6 +478,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.InputSlice(childComplexity, args["arg"].([]string)), true
 
+	case "Query.shapeUnion":
+		if e.complexity.Query.ShapeUnion == nil {
+			break
+		}
+
+		return e.complexity.Query.ShapeUnion(childComplexity), true
+
 	case "Query.keywordArgs":
 		if e.complexity.Query.KeywordArgs == nil {
 			break
@@ -680,6 +689,7 @@ var parsedSchema = gqlparser.MustLoadSchema(
     directiveInputNullable(arg: InputDirectives): String
     directiveInput(arg: InputDirectives!): String
     inputSlice(arg: [String!]!): Boolean!
+    shapeUnion: ShapeUnion!
 }
 
 type Subscription {
@@ -2236,6 +2246,32 @@ func (ec *executionContext) _Query_inputSlice(ctx context.Context, field graphql
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
 	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_shapeUnion(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object: "Query",
+		Field:  field,
+		Args:   nil,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().ShapeUnion(rctx)
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(ShapeUnion)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNShapeUnion2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐShapeUnion(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_keywordArgs(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
@@ -4028,6 +4064,15 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 				}
 				return res
 			})
+		case "shapeUnion":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				res = ec._Query_shapeUnion(ctx, field)
+				if res == graphql.Null {
+					invalid = true
+				}
+				return res
+			})
 		case "keywordArgs":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {
@@ -4425,6 +4470,10 @@ func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.Selecti
 
 func (ec *executionContext) unmarshalNRecursiveInputSlice2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐRecursiveInputSlice(ctx context.Context, v interface{}) (RecursiveInputSlice, error) {
 	return ec.unmarshalInputRecursiveInputSlice(ctx, v)
+}
+
+func (ec *executionContext) marshalNShapeUnion2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐShapeUnion(ctx context.Context, sel ast.SelectionSet, v ShapeUnion) graphql.Marshaler {
+	return ec._ShapeUnion(ctx, sel, &v)
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v interface{}) (string, error) {

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -95,6 +95,9 @@ func (r *queryResolver) DirectiveInput(ctx context.Context, arg InputDirectives)
 func (r *queryResolver) InputSlice(ctx context.Context, arg []string) (bool, error) {
 	panic("not implemented")
 }
+func (r *queryResolver) ShapeUnion(ctx context.Context) (ShapeUnion, error) {
+	panic("not implemented")
+}
 func (r *queryResolver) KeywordArgs(ctx context.Context, breakArg string, defaultArg string, funcArg string, interfaceArg string, selectArg string, caseArg string, deferArg string, goArg string, mapArg string, structArg string, chanArg string, elseArg string, gotoArg string, packageArg string, switchArg string, constArg string, fallthroughArg string, ifArg string, rangeArg string, typeArg string, continueArg string, forArg string, importArg string, returnArg string, varArg string) (bool, error) {
 	panic("not implemented")
 }

--- a/codegen/testserver/schema.graphql
+++ b/codegen/testserver/schema.graphql
@@ -17,6 +17,7 @@ type Query {
     directiveInputNullable(arg: InputDirectives): String
     directiveInput(arg: InputDirectives!): String
     inputSlice(arg: [String!]!): Boolean!
+    shapeUnion: ShapeUnion!
 }
 
 type Subscription {

--- a/codegen/testserver/stub.go
+++ b/codegen/testserver/stub.go
@@ -35,6 +35,7 @@ type Stub struct {
 		DirectiveInputNullable func(ctx context.Context, arg *InputDirectives) (*string, error)
 		DirectiveInput         func(ctx context.Context, arg InputDirectives) (*string, error)
 		InputSlice             func(ctx context.Context, arg []string) (bool, error)
+		ShapeUnion             func(ctx context.Context) (ShapeUnion, error)
 		KeywordArgs            func(ctx context.Context, breakArg string, defaultArg string, funcArg string, interfaceArg string, selectArg string, caseArg string, deferArg string, goArg string, mapArg string, structArg string, chanArg string, elseArg string, gotoArg string, packageArg string, switchArg string, constArg string, fallthroughArg string, ifArg string, rangeArg string, typeArg string, continueArg string, forArg string, importArg string, returnArg string, varArg string) (bool, error)
 	}
 	SubscriptionResolver struct {
@@ -129,6 +130,9 @@ func (r *stubQuery) DirectiveInput(ctx context.Context, arg InputDirectives) (*s
 }
 func (r *stubQuery) InputSlice(ctx context.Context, arg []string) (bool, error) {
 	return r.QueryResolver.InputSlice(ctx, arg)
+}
+func (r *stubQuery) ShapeUnion(ctx context.Context) (ShapeUnion, error) {
+	return r.QueryResolver.ShapeUnion(ctx)
 }
 func (r *stubQuery) KeywordArgs(ctx context.Context, breakArg string, defaultArg string, funcArg string, interfaceArg string, selectArg string, caseArg string, deferArg string, goArg string, mapArg string, structArg string, chanArg string, elseArg string, gotoArg string, packageArg string, switchArg string, constArg string, fallthroughArg string, ifArg string, rangeArg string, typeArg string, continueArg string, forArg string, importArg string, returnArg string, varArg string) (bool, error) {
 	return r.QueryResolver.KeywordArgs(ctx, breakArg, defaultArg, funcArg, interfaceArg, selectArg, caseArg, deferArg, goArg, mapArg, structArg, chanArg, elseArg, gotoArg, packageArg, switchArg, constArg, fallthroughArg, ifArg, rangeArg, typeArg, continueArg, forArg, importArg, returnArg, varArg)

--- a/example/starwars/generated.go
+++ b/example/starwars/generated.go
@@ -2897,7 +2897,7 @@ func (ec *executionContext) _SearchResult(ctx context.Context, sel ast.Selection
 
 // region    **************************** object.gotpl ****************************
 
-var droidImplementors = []string{"Droid", "Character"}
+var droidImplementors = []string{"Droid", "Character", "SearchResult"}
 
 func (ec *executionContext) _Droid(ctx context.Context, sel ast.SelectionSet, obj *Droid) graphql.Marshaler {
 	fields := graphql.CollectFields(ctx, sel, droidImplementors)
@@ -3024,7 +3024,7 @@ func (ec *executionContext) _FriendsEdge(ctx context.Context, sel ast.SelectionS
 	return out
 }
 
-var humanImplementors = []string{"Human", "Character"}
+var humanImplementors = []string{"Human", "Character", "SearchResult"}
 
 func (ec *executionContext) _Human(ctx context.Context, sel ast.SelectionSet, obj *Human) graphql.Marshaler {
 	fields := graphql.CollectFields(ctx, sel, humanImplementors)
@@ -3263,7 +3263,7 @@ func (ec *executionContext) _Review(ctx context.Context, sel ast.SelectionSet, o
 	return out
 }
 
-var starshipImplementors = []string{"Starship"}
+var starshipImplementors = []string{"Starship", "SearchResult"}
 
 func (ec *executionContext) _Starship(ctx context.Context, sel ast.SelectionSet, obj *Starship) graphql.Marshaler {
 	fields := graphql.CollectFields(ctx, sel, starshipImplementors)

--- a/example/type-system-extension/generated.go
+++ b/example/type-system-extension/generated.go
@@ -1613,7 +1613,7 @@ func (ec *executionContext) _MyQuery(ctx context.Context, sel ast.SelectionSet) 
 	return out
 }
 
-var todoImplementors = []string{"Todo", "Node"}
+var todoImplementors = []string{"Todo", "Node", "Data"}
 
 func (ec *executionContext) _Todo(ctx context.Context, sel ast.SelectionSet, obj *Todo) graphql.Marshaler {
 	fields := graphql.CollectFields(ctx, sel, todoImplementors)

--- a/graphql/exec.go
+++ b/graphql/exec.go
@@ -35,7 +35,10 @@ func collectFields(reqCtx *RequestContext, selSet ast.SelectionSet, satisfies []
 
 			f.Selections = append(f.Selections, sel.SelectionSet...)
 		case *ast.InlineFragment:
-			if !shouldIncludeNode(sel.Directives, reqCtx.Variables) || !instanceOf(sel.TypeCondition, satisfies) {
+			if !shouldIncludeNode(sel.Directives, reqCtx.Variables) {
+				continue
+			}
+			if !instanceOf(sel.TypeCondition, satisfies) {
 				continue
 			}
 			for _, childField := range collectFields(reqCtx, sel.SelectionSet, satisfies, visited) {


### PR DESCRIPTION
Closes #399

The issue that is being run into is that union types delegate their field collection to the concrete type that is resolved.  The problem occurs when the selection is on a Union type, which is not listed in the concrete implementors, and thus is skipped during field collection.

The solution is to include Unions in the list of implementors for each concrete type.  This can be retrieved with `ast.Schema.GetImplements`.

~~@vektah has already fixed this issue in https://github.com/99designs/gqlgen/tree/multiple-bind-types which will merge prior to next release.~~

Not quite, a small fix is still required in this PR.