### PR TITLE
Fix Todo Example Directive

### DIFF
--- a/example/todo/todo.go
+++ b/example/todo/todo.go
@@ -33,10 +33,6 @@ func New() Config {
 			// No admin for you!
 			return nil, nil
 		case RoleOwner:
-			// This is also available in context
-			if obj != graphql.GetResolverContext(ctx).Parent.Result {
-				return nil, fmt.Errorf("parent type mismatch")
-			}
 			ownable, isOwnable := obj.(Ownable)
 			if !isOwnable {
 				return nil, fmt.Errorf("obj cant be owned")


### PR DESCRIPTION
This closes #483 — a minor issue in the Todo example where the directive is checking for a pointer type, but breaks when the return type is a struct.

This will change anyway when is implemented #375, but this fixes the issue for now.
