### PR TITLE
Fix set header to JSON earlier in GraphQL response

### DIFF
--- a/handler/graphql.go
+++ b/handler/graphql.go
@@ -311,6 +311,7 @@ func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	var reqParams params
 	switch r.Method {
 	case http.MethodGet:
@@ -332,7 +333,6 @@ func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
 
 	ctx := r.Context()
 

--- a/handler/graphql_test.go
+++ b/handler/graphql_test.go
@@ -45,30 +45,35 @@ func TestHandlerPOST(t *testing.T) {
 	t.Run("decode failure", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", "notjson")
 		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, resp.HeaderMap.Get("Content-Type"), "application/json")
 		assert.Equal(t, `{"errors":[{"message":"json body could not be decoded: invalid character 'o' in literal null (expecting 'u')"}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("parse failure", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query": "!"}`)
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+		assert.Equal(t, resp.HeaderMap.Get("Content-Type"), "application/json")
 		assert.Equal(t, `{"errors":[{"message":"Unexpected !","locations":[{"line":1,"column":1}]}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("validation failure", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query": "{ me { title }}"}`)
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+		assert.Equal(t, resp.HeaderMap.Get("Content-Type"), "application/json")
 		assert.Equal(t, `{"errors":[{"message":"Cannot query field \"title\" on type \"User\".","locations":[{"line":1,"column":8}]}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("invalid variable", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query": "query($id:Int!){user(id:$id){name}}","variables":{"id":false}}`)
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+		assert.Equal(t, resp.HeaderMap.Get("Content-Type"), "application/json")
 		assert.Equal(t, `{"errors":[{"message":"cannot use bool as Int","path":["variable","id"]}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("execution failure", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query": "mutation { me { name } }"}`)
 		assert.Equal(t, http.StatusOK, resp.Code)
+		assert.Equal(t, resp.HeaderMap.Get("Content-Type"), "application/json")
 		assert.Equal(t, `{"errors":[{"message":"mutations are not supported"}],"data":null}`, resp.Body.String())
 	})
 }


### PR DESCRIPTION
Update the GraphQL handler to set the Response Header to JSON earlier for
error messages to be returned as JSON and not text/html.

Fixes https://github.com/99designs/gqlgen/issues/519

## Notes:
- Add checks for JSON Content-Type checks in decode bad queries tests
