### PR TITLE
Fix typo in README

### DIFF
--- a/example/selection/readme.md
+++ b/example/selection/readme.md
@@ -1,10 +1,10 @@
-### todo app
+### selection app
 
 This is the simplest example of a graphql server.
 
 to run this server
 ```bash
-go run ./example/todo/server/server.go
+go run ./example/selection/server/server.go
 ```
 
-and open http://localhost:8081 in your browser
+and open http://localhost:8086 in your browser


### PR DESCRIPTION
Fix typo in README in selection example directory to point to the selection example, not the todo example.

I have:
 - [X] Updated typos in an example's documentation