### PR TITLE
Automatically convert IsZero to null

### DIFF
--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -196,6 +196,25 @@ func (t *TypeReference) IsScalar() bool {
 	return t.Definition.Kind == ast.Scalar
 }
 
+func (t *TypeReference) HasIsZero() bool {
+	it := t.GO
+	if ptr, isPtr := it.(*types.Pointer); isPtr {
+		it = ptr.Elem()
+	}
+	namedType, ok := it.(*types.Named)
+	if !ok {
+		return false
+	}
+
+	for i := 0; i < namedType.NumMethods(); i++ {
+		switch namedType.Method(i).Name() {
+		case "IsZero":
+			return true
+		}
+	}
+	return false
+}
+
 func (t *TypeReference) SelfMarshalling() bool {
 	it := t.GO
 	if ptr, isPtr := it.(*types.Pointer); isPtr {

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"strconv"
 	"sync"
+	"time"
 
 	introspection1 "github.com/99designs/gqlgen/codegen/testserver/introspection"
 	"github.com/99designs/gqlgen/codegen/testserver/invalid-packagename"
@@ -130,6 +131,8 @@ type ComplexityRoot struct {
 	User struct {
 		Id      func(childComplexity int) int
 		Friends func(childComplexity int) int
+		Created func(childComplexity int) int
+		Updated func(childComplexity int) int
 	}
 }
 
@@ -537,6 +540,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.User.Friends(childComplexity), true
 
+	case "User.created":
+		if e.complexity.User.Created == nil {
+			break
+		}
+
+		return e.complexity.User.Created(childComplexity), true
+
+	case "User.updated":
+		if e.complexity.User.Updated == nil {
+			break
+		}
+
+		return e.complexity.User.Updated(childComplexity), true
+
 	}
 	return 0, false
 }
@@ -690,6 +707,8 @@ type Subscription {
 type User {
     id: Int!
     friends: [User!]!
+    created: Time!
+    updated: Time
 }
 
 type Error {
@@ -836,6 +855,8 @@ enum Status {
     OK
     ERROR
 }
+
+scalar Time
 `},
 )
 
@@ -2501,6 +2522,55 @@ func (ec *executionContext) _User_friends(ctx context.Context, field graphql.Col
 	return ec.marshalNUser2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐUser(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _User_created(ctx context.Context, field graphql.CollectedField, obj *User) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object: "User",
+		Field:  field,
+		Args:   nil,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Created, nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _User_updated(ctx context.Context, field graphql.CollectedField, obj *User) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object: "User",
+		Field:  field,
+		Args:   nil,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Updated, nil
+	})
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql.CollectedField, obj *introspection.Directive) graphql.Marshaler {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
@@ -4127,6 +4197,13 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 				}
 				return res
 			})
+		case "created":
+			out.Values[i] = ec._User_created(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalid = true
+			}
+		case "updated":
+			out.Values[i] = ec._User_updated(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -4480,6 +4557,20 @@ func (ec *executionContext) marshalNString2ᚖstring(ctx context.Context, sel as
 		return graphql.Null
 	}
 	return ec.marshalNString2string(ctx, sel, *v)
+}
+
+func (ec *executionContext) unmarshalNTime2timeᚐTime(ctx context.Context, v interface{}) (time.Time, error) {
+	return graphql.UnmarshalTime(v)
+}
+
+func (ec *executionContext) marshalNTime2timeᚐTime(ctx context.Context, sel ast.SelectionSet, v time.Time) graphql.Marshaler {
+	if v.IsZero() {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return graphql.MarshalTime(v)
 }
 
 func (ec *executionContext) marshalNUser2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐUser(ctx context.Context, sel ast.SelectionSet, v User) graphql.Marshaler {
@@ -5069,6 +5160,32 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 		return graphql.Null
 	}
 	return ec.marshalOString2string(ctx, sel, *v)
+}
+
+func (ec *executionContext) unmarshalOTime2timeᚐTime(ctx context.Context, v interface{}) (time.Time, error) {
+	return graphql.UnmarshalTime(v)
+}
+
+func (ec *executionContext) marshalOTime2timeᚐTime(ctx context.Context, sel ast.SelectionSet, v time.Time) graphql.Marshaler {
+	if v.IsZero() {
+		return graphql.Null
+	}
+	return graphql.MarshalTime(v)
+}
+
+func (ec *executionContext) unmarshalOTime2ᚖtimeᚐTime(ctx context.Context, v interface{}) (*time.Time, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalOTime2timeᚐTime(ctx, v)
+	return &res, err
+}
+
+func (ec *executionContext) marshalOTime2ᚖtimeᚐTime(ctx context.Context, sel ast.SelectionSet, v *time.Time) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec.marshalOTime2timeᚐTime(ctx, sel, *v)
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {

--- a/codegen/testserver/models-gen.go
+++ b/codegen/testserver/models-gen.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"time"
 )
 
 type InnerDirectives struct {
@@ -63,8 +64,10 @@ type OuterObject struct {
 }
 
 type User struct {
-	ID      int    `json:"id"`
-	Friends []User `json:"friends"`
+	ID      int        `json:"id"`
+	Friends []User     `json:"friends"`
+	Created time.Time  `json:"created"`
+	Updated *time.Time `json:"updated"`
 }
 
 type Status string

--- a/codegen/testserver/schema.graphql
+++ b/codegen/testserver/schema.graphql
@@ -27,6 +27,8 @@ type Subscription {
 type User {
     id: Int!
     friends: [User!]!
+    created: Time!
+    updated: Time
 }
 
 type Error {
@@ -173,3 +175,5 @@ enum Status {
     OK
     ERROR
 }
+
+scalar Time

--- a/codegen/testserver/time_test.go
+++ b/codegen/testserver/time_test.go
@@ -1,0 +1,70 @@
+package testserver
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/99designs/gqlgen/client"
+	"github.com/99designs/gqlgen/handler"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTime(t *testing.T) {
+	resolvers := &Stub{}
+
+	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
+	c := client.New(srv.URL)
+
+	resolvers.QueryResolver.User = func(ctx context.Context, id int) (user User, e error) {
+		return User{}, nil
+	}
+
+	t.Run("zero value in nullable field", func(t *testing.T) {
+		var resp struct {
+			User struct {
+				Updated *string
+			}
+		}
+
+		err := c.Post(`query { user(id: 1) { updated } }`, &resp)
+		require.NoError(t, err)
+
+		require.Nil(t, resp.User.Updated)
+	})
+
+	t.Run("zero value in non nullable field", func(t *testing.T) {
+		var resp struct {
+			User struct {
+				Created *string
+			}
+		}
+
+		err := c.Post(`query { user(id: 1) { created } }`, &resp)
+		require.EqualError(t, err, `[{"message":"must not be null","path":["user","created"]}]`)
+	})
+
+	t.Run("with values", func(t *testing.T) {
+		resolvers.QueryResolver.User = func(ctx context.Context, id int) (user User, e error) {
+			updated := time.Date(2010, 1, 1, 0, 0, 20, 0, time.UTC)
+			return User{
+				Created: time.Date(2010, 1, 1, 0, 0, 10, 0, time.UTC),
+				Updated: &updated,
+			}, nil
+		}
+
+		var resp struct {
+			User struct {
+				Created string
+				Updated string
+			}
+		}
+
+		err := c.Post(`query { user(id: 1) { created, updated } }`, &resp)
+		require.NoError(t, err)
+
+		require.Equal(t, "2010-01-01T00:00:10Z", resp.User.Created)
+		require.Equal(t, "2010-01-01T00:00:20Z", resp.User.Updated)
+	})
+}

--- a/codegen/type.gotpl
+++ b/codegen/type.gotpl
@@ -49,6 +49,15 @@
 					{{- end }}
 					return graphql.Null
 				}
+			{{- else if $type.HasIsZero }}
+				if v.IsZero() {
+					{{- if $type.GQL.NonNull }}
+						if !ec.HasError(graphql.GetResolverContext(ctx)) {
+							ec.Errorf(ctx, "must not be null")
+						}
+					{{- end }}
+					return graphql.Null
+				}
 			{{- end }}
 
 			{{- if $type.SelfMarshalling }}

--- a/example/chat/generated.go
+++ b/example/chat/generated.go
@@ -1997,6 +1997,12 @@ func (ec *executionContext) unmarshalNTime2timeᚐTime(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalNTime2timeᚐTime(ctx context.Context, sel ast.SelectionSet, v time.Time) graphql.Marshaler {
+	if v.IsZero() {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
 	return graphql.MarshalTime(v)
 }
 

--- a/example/dataloader/generated.go
+++ b/example/dataloader/generated.go
@@ -2133,6 +2133,12 @@ func (ec *executionContext) unmarshalNTime2timeᚐTime(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalNTime2timeᚐTime(ctx context.Context, sel ast.SelectionSet, v time.Time) graphql.Marshaler {
+	if v.IsZero() {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
 	return graphql.MarshalTime(v)
 }
 

--- a/example/scalars/generated.go
+++ b/example/scalars/generated.go
@@ -2322,6 +2322,9 @@ func (ec *executionContext) unmarshalOTimestamp2timeᚐTime(ctx context.Context,
 }
 
 func (ec *executionContext) marshalOTimestamp2timeᚐTime(ctx context.Context, sel ast.SelectionSet, v time.Time) graphql.Marshaler {
+	if v.IsZero() {
+		return graphql.Null
+	}
 	return model.MarshalTimestamp(v)
 }
 

--- a/example/selection/generated.go
+++ b/example/selection/generated.go
@@ -1758,6 +1758,12 @@ func (ec *executionContext) unmarshalNTime2timeᚐTime(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalNTime2timeᚐTime(ctx context.Context, sel ast.SelectionSet, v time.Time) graphql.Marshaler {
+	if v.IsZero() {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
 	return graphql.MarshalTime(v)
 }
 

--- a/example/starwars/generated.go
+++ b/example/starwars/generated.go
@@ -4290,6 +4290,9 @@ func (ec *executionContext) unmarshalOTime2timeᚐTime(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalOTime2timeᚐTime(ctx context.Context, sel ast.SelectionSet, v time.Time) graphql.Marshaler {
+	if v.IsZero() {
+		return graphql.Null
+	}
 	return graphql.MarshalTime(v)
 }
 


### PR DESCRIPTION
Its often awkward to use times as pointers because time.Now() and friends all return a `time.Time`, not a `*time.Time`. This leads to code that looks like this:

```go
t := time.Now()
return Thing{
   Created: &t,
}
```

This PR lets the runtime check IsZero,  and instead of returning "0000-00-00 00:00:00Z" we return a null. For NotNull fields we get errors.

I've seen pop up a lot in UIs, its pretty much never whats wanted. Even worse when its dropped into a relative time and shows up as 2019 years ago

Closes #76