### PR TITLE
Add more validation checks on .yml config file

### DIFF
--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -46,11 +46,6 @@ var genCmd = cli.Command{
 			config.SchemaStr[filename] = string(schemaRaw)
 		}
 
-		if err = config.Check(); err != nil {
-			fmt.Fprintln(os.Stderr, "invalid config format: "+err.Error())
-			os.Exit(1)
-		}
-
 		err = codegen.Generate(*config)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err.Error())

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -78,11 +78,6 @@ func GenerateGraphServer(config *codegen.Config, serverFilename string) {
 		config.SchemaStr[filename] = string(schemaRaw)
 	}
 
-	if err := config.Check(); err != nil {
-		fmt.Fprintln(os.Stderr, "invalid config format: "+err.Error())
-		os.Exit(1)
-	}
-
 	if err := codegen.Generate(*config); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -1,6 +1,7 @@
 package codegen
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -19,6 +20,9 @@ func Generate(cfg Config) error {
 		return err
 	}
 
+	if err := cfg.check(); err != nil {
+		return fmt.Errorf("invalid config format: " + err.Error())
+	}
 	_ = syscall.Unlink(cfg.Exec.Filename)
 	_ = syscall.Unlink(cfg.Model.Filename)
 

--- a/codegen/config.go
+++ b/codegen/config.go
@@ -216,10 +216,10 @@ func (cfg *Config) Check() error {
 		if inSameDir {
 			for _, previous := range prevPkgList {
 				if current.Package != previous.Package {
-					eitherPackageEmpty := previous.Package != "" || current.Package != "";
+					eitherPackageEmpty := previous.Package != "" || current.Package != ""
 					if eitherPackageEmpty {
 						if current.Package == filepath.Base(current.Dir()) && previous.Package == "" {
-							break;
+							break
 						}
 						if previous.Package == filepath.Base(previous.Dir()) && current.Package == "" {
 							break

--- a/codegen/config.go
+++ b/codegen/config.go
@@ -191,6 +191,47 @@ func (cfg *Config) Check() error {
 	if err := cfg.Resolver.Check(); err != nil {
 		return errors.Wrap(err, "config.resolver")
 	}
+
+	// check packages names against conflict, if present in the same dir
+	// and check filenames for uniqueness
+	packageConfigList := []PackageConfig{
+		cfg.Model,
+		cfg.Exec,
+		cfg.Resolver,
+	}
+	filesMap := make(map[string]bool)
+	pkgConfigsByDir := make(map[string][]PackageConfig)
+	for i, current := range packageConfigList {
+		if i == 0 {
+			filesMap[current.Filename] = true
+			pkgConfigsByDir[current.Dir()] = []PackageConfig{current}
+			continue
+		}
+		_, fileFound := filesMap[current.Filename]
+		if fileFound {
+			return fmt.Errorf("filename %s defined more than once", current.Filename)
+		}
+		filesMap[current.Filename] = true
+		prevPkgList, inSameDir := pkgConfigsByDir[current.Dir()]
+		if inSameDir {
+			for _, previous := range prevPkgList {
+				if current.Package != previous.Package {
+					eitherPackageEmpty := previous.Package != "" || current.Package != "";
+					if eitherPackageEmpty {
+						if current.Package == filepath.Base(current.Dir()) && previous.Package == "" {
+							break;
+						}
+						if previous.Package == filepath.Base(previous.Dir()) && current.Package == "" {
+							break
+						}
+						return fmt.Errorf("filenames %s and %s are in the same directory but have different package definitions", current.Filename, previous.Filename)
+					}
+				}
+			}
+		}
+		pkgConfigsByDir[current.Dir()] = append(pkgConfigsByDir[current.Dir()], current)
+	}
+
 	return nil
 }
 

--- a/codegen/config_test.go
+++ b/codegen/config_test.go
@@ -79,3 +79,16 @@ func TestReferencedPackages(t *testing.T) {
 	})
 
 }
+
+func TestConfigCheck(t *testing.T) {
+	t.Run("invalid config format due to conflicting package names", func(t *testing.T) {
+		config, err := LoadConfig("testdata/cfg/conflictedPackages.yml")
+		require.NoError(t, err)
+
+		err = config.normalize()
+		require.NoError(t, err)
+
+		err = config.check()
+		require.EqualError(t, err, "filenames exec.go and models.go are in the same directory but have different package definitions")
+	})
+}

--- a/codegen/testdata/cfg/conflictedPackages.yml
+++ b/codegen/testdata/cfg/conflictedPackages.yml
@@ -1,0 +1,10 @@
+schema:
+  - schema.graphql
+exec:
+  filename: generated/exec.go
+  package: graphql
+model:
+  filename: generated/models.go
+resolver:
+  filename: generated/resolver.go
+  type: Resolver


### PR DESCRIPTION
This PR adds two validation checks after parsing gqlgen.yml:

- Check if the config file has two package names defined in the same directory
- Check if the same filename has been used twice. For instance using **gql/gen.go** for both _exec_ and _model_ fields.

Although this may seem intuitive, but it can get tricky in a few cases.
For instance, the following gqlgen.yml config file:
```yml
schema:
- schema.graphql
exec:
  filename: generated/exec.go
  package: graphql
model:
  filename: generated/models.go
resolver:
  filename: generated/resolver.go
  type: Resolver
```
When generating the code, the following error message shows up:
```bash
generating resolver failed: resolver build failed: required package was not loaded: github.com/elgarni/project/generated.User
exit status 2
```
The message could be more descriptive. Moreover, the code was generated for exec.go and models.go, which will not compile anyways since they have different package names.

After this PR, the error message becomes:
```bash
invalid config format: filenames generated/exec.go and generated/models.go are in the same directory but have different package definitions
exit status 1
```
And no code was generated.

The objective of this PR is to stop execution early on, if there are errors in the config file, and not generating any code unless everything is defined correctly in gqlgen.yml

