### PR TITLE
Fix directives on fields with custom scalars

### DIFF
--- a/codegen/input.gotpl
+++ b/codegen/input.gotpl
@@ -35,7 +35,7 @@
 					if err != nil {
 						return it, err
 					}
-					if data, ok := tmp.({{ $field.TypeReference.GO }}) ; ok {
+					if data, ok := tmp.({{ $field.TypeReference.GO | ref }}) ; ok {
 						it.{{$field.GoFieldName}} = data
 					} else {
 						return it, fmt.Errorf(`unexpected type %T from directive, should be {{ $field.TypeReference.GO }}`, tmp)

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -759,10 +759,13 @@ input OuterInput {
     inner: InnerInput!
 }
 
+scalar ThirdParty
+
 input InputDirectives {
     text: String! @length(min: 0, max: 7, message: "not valid")
     inner: InnerDirectives!
     innerNullable: InnerDirectives
+    thirdParty: ThirdParty @length(min: 0, max: 7, message: "not valid")
 }
 
 input InnerDirectives {
@@ -3489,6 +3492,26 @@ func (ec *executionContext) unmarshalInputInputDirectives(ctx context.Context, v
 			if err != nil {
 				return it, err
 			}
+		case "thirdParty":
+			var err error
+			getField0 := func(ctx context.Context) (interface{}, error) {
+				return ec.unmarshalOThirdParty2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐThirdParty(ctx, v)
+			}
+			getField1 := func(ctx context.Context) (res interface{}, err error) {
+				max := 7
+				n := getField0
+				return ec.directives.Length(ctx, it, n, 0, &max)
+			}
+
+			tmp, err := getField1(ctx)
+			if err != nil {
+				return it, err
+			}
+			if data, ok := tmp.(*ThirdParty); ok {
+				it.ThirdParty = data
+			} else {
+				return it, fmt.Errorf(`unexpected type %T from directive, should be *github.com/99designs/gqlgen/codegen/testserver.ThirdParty`, tmp)
+			}
 		}
 	}
 
@@ -5209,6 +5232,29 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 		return graphql.Null
 	}
 	return ec.marshalOString2string(ctx, sel, *v)
+}
+
+func (ec *executionContext) unmarshalOThirdParty2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐThirdParty(ctx context.Context, v interface{}) (ThirdParty, error) {
+	return UnmarshalThirdParty(v)
+}
+
+func (ec *executionContext) marshalOThirdParty2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐThirdParty(ctx context.Context, sel ast.SelectionSet, v ThirdParty) graphql.Marshaler {
+	return MarshalThirdParty(v)
+}
+
+func (ec *executionContext) unmarshalOThirdParty2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐThirdParty(ctx context.Context, v interface{}) (*ThirdParty, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalOThirdParty2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐThirdParty(ctx, v)
+	return &res, err
+}
+
+func (ec *executionContext) marshalOThirdParty2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐThirdParty(ctx context.Context, sel ast.SelectionSet, v *ThirdParty) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec.marshalOThirdParty2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐThirdParty(ctx, sel, *v)
 }
 
 func (ec *executionContext) unmarshalOTime2timeᚐTime(ctx context.Context, v interface{}) (time.Time, error) {

--- a/codegen/testserver/gqlgen.yml
+++ b/codegen/testserver/gqlgen.yml
@@ -38,3 +38,5 @@ models:
     model: "github.com/99designs/gqlgen/codegen/testserver.Error"
   EmbeddedPointer:
     model: "github.com/99designs/gqlgen/codegen/testserver.EmbeddedPointerModel"
+  ThirdParty:
+    model: "github.com/99designs/gqlgen/codegen/testserver.ThirdParty"

--- a/codegen/testserver/models-gen.go
+++ b/codegen/testserver/models-gen.go
@@ -25,6 +25,7 @@ type InputDirectives struct {
 	Text          string           `json:"text"`
 	Inner         InnerDirectives  `json:"inner"`
 	InnerNullable *InnerDirectives `json:"innerNullable"`
+	ThirdParty    *ThirdParty      `json:"thirdParty"`
 }
 
 type Keywords struct {

--- a/codegen/testserver/schema.graphql
+++ b/codegen/testserver/schema.graphql
@@ -70,10 +70,13 @@ input OuterInput {
     inner: InnerInput!
 }
 
+scalar ThirdParty
+
 input InputDirectives {
     text: String! @length(min: 0, max: 7, message: "not valid")
     inner: InnerDirectives!
     innerNullable: InnerDirectives
+    thirdParty: ThirdParty @length(min: 0, max: 7, message: "not valid")
 }
 
 input InnerDirectives {

--- a/codegen/testserver/thirdparty.go
+++ b/codegen/testserver/thirdparty.go
@@ -1,0 +1,30 @@
+package testserver
+
+import (
+	"fmt"
+	"github.com/99designs/gqlgen/graphql"
+	"io"
+	"strconv"
+)
+
+type ThirdParty struct {
+	str string
+}
+
+func MarshalThirdParty(tp ThirdParty) graphql.Marshaler {
+	return graphql.WriterFunc(func(w io.Writer) {
+		_, err := io.WriteString(w, strconv.Quote(tp.str))
+		if err != nil {
+			panic(err)
+		}
+	})
+}
+
+func UnmarshalThirdParty(input interface{}) (ThirdParty, error) {
+	switch input := input.(type) {
+	case string:
+		return ThirdParty{str: input}, nil
+	default:
+		return ThirdParty{}, fmt.Errorf("unknown type for input: %s", input)
+	}
+}


### PR DESCRIPTION
The bug occurs when using a custom defined scalar, an input type, and  directive together.
E.g.
```gql
#schema.gql
scalar UUID
directive @direc(s: String!) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
input CustomInput {
    stuff:[UUID]  @direc(s:"stuff")
}
```
```go
// custom models
import "github.com/gofrs/uuid"
func MarshalUUID(id uuid.UUID) graphql.Marshaler{ /* ... */ }
func UnmarshalUUID(input interface{}) (uuid.UUID, error) { /* ... */ }
```

would generate:
```go
// ...
// shouldn't be whole path of github.com/gofrs/...
if data, ok := tmp.([]*github.com/gofrs/uuid.UUID) ; ok {
    it.Stuff = data
} else {
    return it, fmt.Errorf(`unexpected type %T from directive, should be []*github.com/gofrs/uuid.UUID`, tmp)
}
```
now: 

```go
if data, ok := tmp.([]*uuid.UUID); ok {
    it.Stuff = data
} else {
    return it, fmt.Errorf(`unexpected type %T from directive, should be []*github.com/gofrs/uuid.UUID`, tmp)
}

```