### PR TITLE
Adds support for go modules outside of GOPATH

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,6 +18,13 @@
   version = "v1.1.0"
 
 [[projects]]
+  name = "github.com/fortytw2/leaktest"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9a23578d06a26ec1b47bfc8965bf5e7011df8bd6"
+  version = "v1.3.0"
+
+[[projects]]
   digest = "1:66ddebb274faa160a4a23394a17ad3c8e15fee9bf5408d13f77d22b61bc7f072"
   name = "github.com/go-chi/chi"
   packages = ["."]
@@ -242,6 +249,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/fortytw2/leaktest",
     "github.com/go-chi/chi",
     "github.com/gorilla/websocket",
     "github.com/hashicorp/golang-lru",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,3 +27,7 @@ required = ["github.com/vektah/dataloaden"]
 [[constraint]]
   name = "github.com/rs/cors"
   version = "1.6.0"
+
+[[constraint]]
+  name = "github.com/fortytw2/leaktest"
+  version = "1.3.0"

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -21,6 +21,7 @@ Assuming you already have a working [Go environment](https://golang.org/doc/inst
 ```sh
 $ mkdir -p ~/github.com/[username]/gqlgen-todos
 $ cd ~/github.com/[username]/gqlgen-todos
+$ go mod init github.com/[username]/gqlgen-todos
 ```
 
 Add the following file to your project under `scripts/gqlgen.go`:

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -16,17 +16,12 @@ You can find the finished code for this tutorial [here](https://github.com/vekta
 
 ## Install gqlgen
 
-This article uses [`dep`](https://github.com/golang/dep) to install gqlgen.  [Follow the instructions for your environment](https://github.com/golang/dep) to install.
-
-Assuming you already have a working [Go environment](https://golang.org/doc/install), create a directory for the project in your `$GOPATH`:
+Assuming you already have a working [Go environment](https://golang.org/doc/install) using Go 1.11 or higher, create a directory for the project:
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/[username]/gqlgen-todos
+$ mkdir -p ~/github.com/[username]/gqlgen-todos
+$ cd ~/github.com/[username]/gqlgen-todos
 ```
-
-> Go Modules
->
-> Currently `gqlgen` does not support Go Modules.  This is due to the [`loader`](https://godoc.org/golang.org/x/tools/go/loader) package, that also does not yet support Go Modules.  We are looking at solutions to this and the issue is tracked in Github.
 
 Add the following file to your project under `scripts/gqlgen.go`:
 
@@ -40,12 +35,6 @@ import "github.com/99designs/gqlgen/cmd"
 func main() {
 	cmd.Execute()
 }
-```
-
-Lastly, initialise dep.  This will inspect any imports you have in your project, and pull down the latest tagged release.
-
-```sh
-$ dep init
 ```
 
 ## Building the server
@@ -85,6 +74,7 @@ type Mutation {
 ### Create the project skeleton
 
 ```bash
+$ mkdir server
 $ go run scripts/gqlgen.go init
 ```
 
@@ -96,11 +86,6 @@ This has created an empty skeleton with all files you need:
  - `resolver.go` — This is where your application code lives. `generated.go` will call into this to get the data the user has requested. 
  - `server/server.go` — This is a minimal entry point that sets up an `http.Handler` to the generated GraphQL server.
 
- Now run dep ensure, so that we can ensure that the newly generated code's dependencies are all present:
-
- ```sh
- $ dep ensure
- ```
  
 ### Create the database models
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,29 @@
+module github.com/99designs/gqlgen
+
+require (
+	github.com/agnivade/levenshtein v0.0.0-20180303095733-1787a73e302c
+	github.com/davecgh/go-spew v1.1.0
+	github.com/go-chi/chi v3.3.2+incompatible
+	github.com/gogo/protobuf v1.0.0
+	github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f
+	github.com/gorilla/mux v1.6.1
+	github.com/gorilla/websocket v1.2.0
+	github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47
+	github.com/mitchellh/mapstructure v0.0.0-20180203102830-a4e142e9c047
+	github.com/opentracing/basictracer-go v1.0.0
+	github.com/opentracing/opentracing-go v1.0.2
+	github.com/pkg/errors v0.8.0
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/rs/cors v1.6.0
+	github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371
+	github.com/shurcooL/vfsgen v0.0.0-20180121065927-ffb13db8def0
+	github.com/stretchr/testify v1.2.1
+	github.com/urfave/cli v1.20.0
+	github.com/vektah/dataloaden v0.0.0-20180713105249-314ac81052ee
+	github.com/vektah/gqlparser v1.1.0
+	golang.org/x/net v0.0.0-20180404174746-b3c676e531a6
+	golang.org/x/tools v0.0.0-20180215025520-ce871d178848
+	gopkg.in/yaml.v2 v2.2.1
+	sourcegraph.com/sourcegraph/appdash v0.0.0-20180110180208-2cc67fd64755
+	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
+)

--- a/internal/gopath/gopath.go
+++ b/internal/gopath/gopath.go
@@ -3,11 +3,15 @@ package gopath
 import (
 	"fmt"
 	"go/build"
+	"io/ioutil"
+	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
 var NotFound = fmt.Errorf("not on GOPATH")
+var ModuleNameRegexp = regexp.MustCompile(`module\s+(.*)`)
 
 // Contains returns true if the given directory is in the GOPATH
 func Contains(dir string) bool {
@@ -24,7 +28,32 @@ func Dir2Import(dir string) (string, error) {
 			return dir[len(gopath)+1:], nil
 		}
 	}
-	return "", NotFound
+
+	// The following code handles the go modules in a manner that does not break existing code. However, it is not
+	// efficient because it requires several round trips to the filesystem. It also should technically be the first
+	// method we try (before GOPATH) because if someone creates a 'go mod' project that also happens to be in the
+	// GOPATH, the import path will be calculated from GOPATH and not from the go.mod file.
+	//
+	// Possible Fixes:
+	// 1) Cache the results of scanning the filesystem. The code is typically called at compile-time, so its unlikely
+	//    for a go.mod file to be added or altered during compile.
+	// 2) Add an optional switch that turns off GOPATH checks entirely when go.mod is used on a project.
+	// 3) Rewrite gqlgen to make use of 'golang.org/x/tools/go/packages' for determining import paths instead.
+
+	// Scan the path tree for a directory that contains a 'go.mod' file and read the module name from it
+	modDirectory := findGoMod(dir)
+	if 0 == len(modDirectory) {
+		return "", NotFound
+	}
+	modName := moduleName(filepath.Join(modDirectory, "go.mod"))
+	if 0 == len(modName) {
+		return "", NotFound
+	}
+
+	// At this point 'dir' looks something like '/root/path/to/some/dir', 'modDirectory' looks like '/root/path',
+	// and 'modName' looks like 'grabhub.com/myname/vunderprojekt'. The correct import path is:
+	// 'grabhub.com/myname/vunderprojekt/to/some/dir'
+	return fmt.Sprintf("%s%s", modName, strings.TrimPrefix(dir, filepath.ToSlash(modDirectory))), nil
 }
 
 // MustDir2Import takes an *absolute* path and returns a golang import path for the package, and panics if it isn't on the gopath
@@ -34,4 +63,42 @@ func MustDir2Import(dir string) string {
 		panic(err)
 	}
 	return pkg
+}
+
+// Returns the path to the first go.mod file in the parent tree starting with the specified directory. Returns "" if not found
+func findGoMod(srcDir string) string {
+	abs, err := filepath.Abs(srcDir)
+	if err != nil {
+		return ""
+	}
+	for {
+		info, err := os.Stat(filepath.Join(abs, "go.mod"))
+		if err == nil && !info.IsDir() {
+			break
+		}
+		d := filepath.Dir(abs)
+		if len(d) >= len(abs) {
+			return "" // reached top of file system, no go.mod
+		}
+		abs = d
+	}
+
+	return abs
+}
+
+// Returns the main module name from a go.mod file. Returns "" if it cannot be found
+func moduleName(file string) string {
+	data, err := ioutil.ReadFile(file)
+	if nil != err {
+		return ""
+	}
+
+	// Search for `module some/name`
+	matches := ModuleNameRegexp.FindSubmatch(data)
+	if len(matches) < 2 {
+		return ""
+	}
+
+	// The first element is the whole line, the second is the capture group we specified for the module name.
+	return string(matches[1])
 }

--- a/internal/gopath/gopath_test.go
+++ b/internal/gopath/gopath_test.go
@@ -18,7 +18,7 @@ func TestContains(t *testing.T) {
 	// Make a temporary directory and add a go.mod file for the package 'foo'
 	fooDir, err := ioutil.TempDir("", "gopath")
 	assert.Nil(t, err)
-	defer func() { err := os.RemoveAll(fooDir); assert.Nil(t, err) }()
+	defer func() { e := os.RemoveAll(fooDir); assert.Nil(t, e) }()
 	err = ioutil.WriteFile(filepath.Join(fooDir, "go.mod"), []byte("module foo\n\nrequire ()"), 0644)
 	assert.Nil(t, err)
 
@@ -58,7 +58,7 @@ func TestDir2Package(t *testing.T) {
 	// Make a temporary directory and add a go.mod file for the package 'foo'
 	fooDir, err := ioutil.TempDir("", "gopath")
 	assert.Nil(t, err)
-	defer func() { err := os.RemoveAll(fooDir); assert.Nil(t, err) }()
+	defer func() { e := os.RemoveAll(fooDir); assert.Nil(t, e) }()
 	err = ioutil.WriteFile(filepath.Join(fooDir, "go.mod"), []byte("module foo\n\nrequire ()"), 0644)
 	assert.Nil(t, err)
 

--- a/internal/gopath/gopath_test.go
+++ b/internal/gopath/gopath_test.go
@@ -18,7 +18,7 @@ func TestContains(t *testing.T) {
 	// Make a temporary directory and add a go.mod file for the package 'foo'
 	fooDir, err := ioutil.TempDir("", "gopath")
 	assert.Nil(t, err)
-	defer os.RemoveAll(fooDir)
+	defer func() { err := os.RemoveAll(fooDir); assert.Nil(t, err) }()
 	err = ioutil.WriteFile(filepath.Join(fooDir, "go.mod"), []byte("module foo\n\nrequire ()"), 0644)
 	assert.Nil(t, err)
 
@@ -58,7 +58,7 @@ func TestDir2Package(t *testing.T) {
 	// Make a temporary directory and add a go.mod file for the package 'foo'
 	fooDir, err := ioutil.TempDir("", "gopath")
 	assert.Nil(t, err)
-	defer os.RemoveAll(fooDir)
+	defer func() { err := os.RemoveAll(fooDir); assert.Nil(t, err) }()
 	err = ioutil.WriteFile(filepath.Join(fooDir, "go.mod"), []byte("module foo\n\nrequire ()"), 0644)
 	assert.Nil(t, err)
 


### PR DESCRIPTION
Fixes #547

I have:
 - [*] Added tests covering the bug / feature
 - [*] Updated any relevant documentation
The 'Getting Started' guide needed a few touch-ups to remove 'dep' and use 'go mod'

If you follow the steps in the Getting Started guide, or the Steps to Reproduce listed in #547, be aware that you will need to add the following command after running `go mod init`
```
go get github.com/99designs/gqlgen@[commit ID of this PR]
```

Otherwise `go mod` will pull in the latest release of gqlgen that doesn't have the fix! Once this PR is merged and released, that extra step should no longer be necessary.

Also I added a line to 'Getting Started' to `mkdir server`. If that directory did not exist, the generator would panic. I fixed it in the documentation because I wasn't sure if that was the desired behavior or if the template system should be creating the directory if it doesn't exist.