### PR TITLE
Fix unstable external marshaler funcs with same name as type

### DIFF
--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -122,13 +122,26 @@ func (b *Binder) FindObject(pkgName string, typeName string) (types.Object, erro
 		return nil, errors.Errorf("required package was not loaded: %s", fullName)
 	}
 
+	// function based marshalers take precedence
 	for astNode, def := range pkg.TypesInfo.Defs {
 		// only look at defs in the top scope
 		if def == nil || def.Parent() == nil || def.Parent() != pkg.Types.Scope() {
 			continue
 		}
 
-		if astNode.Name == typeName || astNode.Name == "Marshal"+typeName {
+		if astNode.Name == "Marshal"+typeName {
+			return def, nil
+		}
+	}
+
+	// then look for types directly
+	for astNode, def := range pkg.TypesInfo.Defs {
+		// only look at defs in the top scope
+		if def == nil || def.Parent() == nil || def.Parent() != pkg.Types.Scope() {
+			continue
+		}
+
+		if astNode.Name == typeName {
 			return def, nil
 		}
 	}


### PR DESCRIPTION
#544 uncovered a bug when a marshaler func returns a type with the same name which would cause codegen to randomly ignore the func.

Fixes a sometimes failing test in #544.