### PR TITLE
Always return *Thing from resolvers for structs

### DIFF
--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -149,6 +149,19 @@ func (b *Binder) FindObject(pkgName string, typeName string) (types.Object, erro
 	return nil, errors.Errorf("unable to find type %s\n", fullName)
 }
 
+func (b *Binder) PointerTo(ref *TypeReference) *TypeReference {
+	newRef := &TypeReference{
+		GO:          types.NewPointer(ref.GO),
+		GQL:         ref.GQL,
+		Definition:  ref.Definition,
+		Unmarshaler: ref.Unmarshaler,
+		Marshaler:   ref.Marshaler,
+	}
+
+	b.References = append(b.References, newRef)
+	return newRef
+}
+
 var modsRegex = regexp.MustCompile(`^(\*|\[\])*`)
 
 func normalizeVendor(pkg string) string {
@@ -203,6 +216,11 @@ func (t *TypeReference) IsSlice() bool {
 func (t *TypeReference) IsNamed() bool {
 	_, isSlice := t.GO.(*types.Named)
 	return isSlice
+}
+
+func (t *TypeReference) IsStruct() bool {
+	_, isStruct := t.GO.Underlying().(*types.Struct)
+	return isStruct
 }
 
 func (t *TypeReference) IsScalar() bool {

--- a/codegen/field.go
+++ b/codegen/field.go
@@ -77,7 +77,12 @@ func (b *builder) bindField(obj *Object, f *Field) error {
 			}
 			f.TypeReference = tr
 		}
+
+		if f.IsResolver && !f.TypeReference.IsPtr() && f.TypeReference.IsStruct() {
+			f.TypeReference = b.Binder.PointerTo(f.TypeReference)
+		}
 	}()
+
 	switch {
 	case f.Name == "__schema":
 		f.GoFieldType = GoFieldMethod

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -160,7 +160,7 @@ type QueryResolver interface {
 	ErrorBubble(ctx context.Context) (*Error, error)
 	ModelMethods(ctx context.Context) (*ModelMethods, error)
 	Valid(ctx context.Context) (string, error)
-	User(ctx context.Context, id int) (User, error)
+	User(ctx context.Context, id int) (*User, error)
 	NullableArg(ctx context.Context, arg *int) (*string, error)
 	DirectiveArg(ctx context.Context, arg string) (*string, error)
 	DirectiveNullableArg(ctx context.Context, arg *int, arg2 *int) (*string, error)
@@ -2094,10 +2094,10 @@ func (ec *executionContext) _Query_user(ctx context.Context, field graphql.Colle
 		}
 		return graphql.Null
 	}
-	res := resTmp.(User)
+	res := resTmp.(*User)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNUser2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐUser(ctx, field.Selections, res)
+	return ec.marshalNUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐUser(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_nullableArg(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
@@ -4833,6 +4833,16 @@ func (ec *executionContext) marshalNUser2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ
 	}
 	wg.Wait()
 	return ret
+}
+
+func (ec *executionContext) marshalNUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐUser(ctx context.Context, sel ast.SelectionSet, v *User) graphql.Marshaler {
+	if v == nil {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._User(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {

--- a/codegen/testserver/middleware_test.go
+++ b/codegen/testserver/middleware_test.go
@@ -19,8 +19,8 @@ func TestMiddleware(t *testing.T) {
 		return &Error{ID: "E1234"}, nil
 	}
 
-	resolvers.QueryResolver.User = func(ctx context.Context, id int) (user User, e error) {
-		return User{ID: 1}, nil
+	resolvers.QueryResolver.User = func(ctx context.Context, id int) (user *User, e error) {
+		return &User{ID: 1}, nil
 	}
 
 	resolvers.UserResolver.Friends = func(ctx context.Context, obj *User) (users []User, e error) {

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -71,7 +71,7 @@ func (r *queryResolver) ModelMethods(ctx context.Context) (*ModelMethods, error)
 func (r *queryResolver) Valid(ctx context.Context) (string, error) {
 	panic("not implemented")
 }
-func (r *queryResolver) User(ctx context.Context, id int) (User, error) {
+func (r *queryResolver) User(ctx context.Context, id int) (*User, error) {
 	panic("not implemented")
 }
 func (r *queryResolver) NullableArg(ctx context.Context, arg *int) (*string, error) {

--- a/codegen/testserver/stub.go
+++ b/codegen/testserver/stub.go
@@ -27,7 +27,7 @@ type Stub struct {
 		ErrorBubble            func(ctx context.Context) (*Error, error)
 		ModelMethods           func(ctx context.Context) (*ModelMethods, error)
 		Valid                  func(ctx context.Context) (string, error)
-		User                   func(ctx context.Context, id int) (User, error)
+		User                   func(ctx context.Context, id int) (*User, error)
 		NullableArg            func(ctx context.Context, arg *int) (*string, error)
 		DirectiveArg           func(ctx context.Context, arg string) (*string, error)
 		DirectiveNullableArg   func(ctx context.Context, arg *int, arg2 *int) (*string, error)
@@ -106,7 +106,7 @@ func (r *stubQuery) ModelMethods(ctx context.Context) (*ModelMethods, error) {
 func (r *stubQuery) Valid(ctx context.Context) (string, error) {
 	return r.QueryResolver.Valid(ctx)
 }
-func (r *stubQuery) User(ctx context.Context, id int) (User, error) {
+func (r *stubQuery) User(ctx context.Context, id int) (*User, error) {
 	return r.QueryResolver.User(ctx, id)
 }
 func (r *stubQuery) NullableArg(ctx context.Context, arg *int) (*string, error) {

--- a/codegen/testserver/time_test.go
+++ b/codegen/testserver/time_test.go
@@ -17,8 +17,8 @@ func TestTime(t *testing.T) {
 	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
 	c := client.New(srv.URL)
 
-	resolvers.QueryResolver.User = func(ctx context.Context, id int) (user User, e error) {
-		return User{}, nil
+	resolvers.QueryResolver.User = func(ctx context.Context, id int) (user *User, e error) {
+		return &User{}, nil
 	}
 
 	t.Run("zero value in nullable field", func(t *testing.T) {
@@ -46,9 +46,9 @@ func TestTime(t *testing.T) {
 	})
 
 	t.Run("with values", func(t *testing.T) {
-		resolvers.QueryResolver.User = func(ctx context.Context, id int) (user User, e error) {
+		resolvers.QueryResolver.User = func(ctx context.Context, id int) (user *User, e error) {
 			updated := time.Date(2010, 1, 1, 0, 0, 20, 0, time.UTC)
-			return User{
+			return &User{
 				Created: time.Date(2010, 1, 1, 0, 0, 10, 0, time.UTC),
 				Updated: &updated,
 			}, nil

--- a/codegen/testserver/tracer_test.go
+++ b/codegen/testserver/tracer_test.go
@@ -16,8 +16,8 @@ import (
 
 func TestTracer(t *testing.T) {
 	resolvers := &Stub{}
-	resolvers.QueryResolver.User = func(ctx context.Context, id int) (user User, e error) {
-		return User{ID: 1}, nil
+	resolvers.QueryResolver.User = func(ctx context.Context, id int) (user *User, e error) {
+		return &User{ID: 1}, nil
 	}
 	t.Run("called in the correct order", func(t *testing.T) {
 		var tracerLog []string

--- a/example/chat/generated.go
+++ b/example/chat/generated.go
@@ -70,13 +70,13 @@ type ComplexityRoot struct {
 }
 
 type MutationResolver interface {
-	Post(ctx context.Context, text string, username string, roomName string) (Message, error)
+	Post(ctx context.Context, text string, username string, roomName string) (*Message, error)
 }
 type QueryResolver interface {
 	Room(ctx context.Context, name string) (*Chatroom, error)
 }
 type SubscriptionResolver interface {
-	MessageAdded(ctx context.Context, roomName string) (<-chan Message, error)
+	MessageAdded(ctx context.Context, roomName string) (<-chan *Message, error)
 }
 
 type executableSchema struct {
@@ -597,10 +597,10 @@ func (ec *executionContext) _Mutation_post(ctx context.Context, field graphql.Co
 		}
 		return graphql.Null
 	}
-	res := resTmp.(Message)
+	res := resTmp.(*Message)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNMessage2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋchatᚐMessage(ctx, field.Selections, res)
+	return ec.marshalNMessage2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋchatᚐMessage(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_room(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
@@ -714,7 +714,7 @@ func (ec *executionContext) _Subscription_messageAdded(ctx context.Context, fiel
 			w.Write([]byte{'{'})
 			graphql.MarshalString(field.Alias).MarshalGQL(w)
 			w.Write([]byte{':'})
-			ec.marshalNMessage2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋchatᚐMessage(ctx, field.Selections, res).MarshalGQL(w)
+			ec.marshalNMessage2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋchatᚐMessage(ctx, field.Selections, res).MarshalGQL(w)
 			w.Write([]byte{'}'})
 		})
 	}
@@ -1982,6 +1982,16 @@ func (ec *executionContext) marshalNMessage2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 	}
 	wg.Wait()
 	return ret
+}
+
+func (ec *executionContext) marshalNMessage2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋchatᚐMessage(ctx context.Context, sel ast.SelectionSet, v *Message) graphql.Marshaler {
+	if v == nil {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._Message(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v interface{}) (string, error) {

--- a/example/config/generated.go
+++ b/example/config/generated.go
@@ -65,7 +65,7 @@ type ComplexityRoot struct {
 }
 
 type MutationResolver interface {
-	CreateTodo(ctx context.Context, input NewTodo) (Todo, error)
+	CreateTodo(ctx context.Context, input NewTodo) (*Todo, error)
 }
 type QueryResolver interface {
 	Todos(ctx context.Context) ([]Todo, error)
@@ -354,10 +354,10 @@ func (ec *executionContext) _Mutation_createTodo(ctx context.Context, field grap
 		}
 		return graphql.Null
 	}
-	res := resTmp.(Todo)
+	res := resTmp.(*Todo)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNTodo2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋconfigᚐTodo(ctx, field.Selections, res)
+	return ec.marshalNTodo2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋconfigᚐTodo(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_todos(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
@@ -1919,6 +1919,16 @@ func (ec *executionContext) marshalNTodo2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ
 	}
 	wg.Wait()
 	return ret
+}
+
+func (ec *executionContext) marshalNTodo2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋconfigᚐTodo(ctx context.Context, sel ast.SelectionSet, v *Todo) graphql.Marshaler {
+	if v == nil {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._Todo(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNUser2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋconfigᚐUser(ctx context.Context, sel ast.SelectionSet, v User) graphql.Marshaler {

--- a/example/config/resolver.go
+++ b/example/config/resolver.go
@@ -38,7 +38,7 @@ func (r *Resolver) Todo() TodoResolver {
 
 type mutationResolver struct{ *Resolver }
 
-func (r *mutationResolver) CreateTodo(ctx context.Context, input NewTodo) (Todo, error) {
+func (r *mutationResolver) CreateTodo(ctx context.Context, input NewTodo) (*Todo, error) {
 	newID := r.nextID
 	r.nextID++
 
@@ -49,7 +49,7 @@ func (r *mutationResolver) CreateTodo(ctx context.Context, input NewTodo) (Todo,
 
 	r.todos = append(r.todos, newTodo)
 
-	return newTodo, nil
+	return &newTodo, nil
 }
 
 type queryResolver struct{ *Resolver }

--- a/example/scalars/generated.go
+++ b/example/scalars/generated.go
@@ -72,7 +72,7 @@ type QueryResolver interface {
 }
 type UserResolver interface {
 	PrimitiveResolver(ctx context.Context, obj *model.User) (string, error)
-	CustomResolver(ctx context.Context, obj *model.User) (model.Point, error)
+	CustomResolver(ctx context.Context, obj *model.User) (*model.Point, error)
 }
 
 type executableSchema struct {
@@ -677,10 +677,10 @@ func (ec *executionContext) _User_customResolver(ctx context.Context, field grap
 		}
 		return graphql.Null
 	}
-	res := resTmp.(model.Point)
+	res := resTmp.(*model.Point)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNPoint2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋscalarsᚋmodelᚐPoint(ctx, field.Selections, res)
+	return ec.marshalNPoint2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋscalarsᚋmodelᚐPoint(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _User_address(ctx context.Context, field graphql.CollectedField, obj *model.User) graphql.Marshaler {
@@ -1977,6 +1977,24 @@ func (ec *executionContext) unmarshalNPoint2githubᚗcomᚋ99designsᚋgqlgenᚋ
 }
 
 func (ec *executionContext) marshalNPoint2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋscalarsᚋmodelᚐPoint(ctx context.Context, sel ast.SelectionSet, v model.Point) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) unmarshalNPoint2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋscalarsᚋmodelᚐPoint(ctx context.Context, v interface{}) (*model.Point, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalNPoint2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋscalarsᚋmodelᚐPoint(ctx, v)
+	return &res, err
+}
+
+func (ec *executionContext) marshalNPoint2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋscalarsᚋmodelᚐPoint(ctx context.Context, sel ast.SelectionSet, v *model.Point) graphql.Marshaler {
+	if v == nil {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
 	return v
 }
 

--- a/example/scalars/resolvers.go
+++ b/example/scalars/resolvers.go
@@ -69,6 +69,6 @@ func (r *userResolver) PrimitiveResolver(ctx context.Context, obj *model.User) (
 	return "test", nil
 }
 
-func (r *userResolver) CustomResolver(ctx context.Context, obj *model.User) (model.Point, error) {
-	return model.Point{X: 5, Y: 1}, nil
+func (r *userResolver) CustomResolver(ctx context.Context, obj *model.User) (*model.Point, error) {
+	return &model.Point{X: 5, Y: 1}, nil
 }

--- a/example/starwars/generated.go
+++ b/example/starwars/generated.go
@@ -115,7 +115,7 @@ type ComplexityRoot struct {
 
 type DroidResolver interface {
 	Friends(ctx context.Context, obj *Droid) ([]Character, error)
-	FriendsConnection(ctx context.Context, obj *Droid, first *int, after *string) (FriendsConnection, error)
+	FriendsConnection(ctx context.Context, obj *Droid, first *int, after *string) (*FriendsConnection, error)
 }
 type FriendsConnectionResolver interface {
 	Edges(ctx context.Context, obj *FriendsConnection) ([]FriendsEdge, error)
@@ -123,7 +123,7 @@ type FriendsConnectionResolver interface {
 }
 type HumanResolver interface {
 	Friends(ctx context.Context, obj *Human) ([]Character, error)
-	FriendsConnection(ctx context.Context, obj *Human, first *int, after *string) (FriendsConnection, error)
+	FriendsConnection(ctx context.Context, obj *Human, first *int, after *string) (*FriendsConnection, error)
 
 	Starships(ctx context.Context, obj *Human) ([]Starship, error)
 }
@@ -1047,10 +1047,10 @@ func (ec *executionContext) _Droid_friendsConnection(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.(FriendsConnection)
+	res := resTmp.(*FriendsConnection)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNFriendsConnection2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋstarwarsᚐFriendsConnection(ctx, field.Selections, res)
+	return ec.marshalNFriendsConnection2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋstarwarsᚐFriendsConnection(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Droid_appearsIn(ctx context.Context, field graphql.CollectedField, obj *Droid) graphql.Marshaler {
@@ -1407,10 +1407,10 @@ func (ec *executionContext) _Human_friendsConnection(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.(FriendsConnection)
+	res := resTmp.(*FriendsConnection)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNFriendsConnection2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋstarwarsᚐFriendsConnection(ctx, field.Selections, res)
+	return ec.marshalNFriendsConnection2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋstarwarsᚐFriendsConnection(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Human_appearsIn(ctx context.Context, field graphql.CollectedField, obj *Human) graphql.Marshaler {
@@ -3636,6 +3636,16 @@ func (ec *executionContext) marshalNFloat2float64(ctx context.Context, sel ast.S
 
 func (ec *executionContext) marshalNFriendsConnection2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋstarwarsᚐFriendsConnection(ctx context.Context, sel ast.SelectionSet, v FriendsConnection) graphql.Marshaler {
 	return ec._FriendsConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNFriendsConnection2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋstarwarsᚐFriendsConnection(ctx context.Context, sel ast.SelectionSet, v *FriendsConnection) graphql.Marshaler {
+	if v == nil {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._FriendsConnection(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNFriendsEdge2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋstarwarsᚐFriendsEdge(ctx context.Context, sel ast.SelectionSet, v FriendsEdge) graphql.Marshaler {

--- a/example/starwars/model.go
+++ b/example/starwars/model.go
@@ -51,16 +51,16 @@ type Droid struct {
 func (Droid) IsCharacter()    {}
 func (Droid) IsSearchResult() {}
 
-func (r *Resolver) resolveFriendConnection(ctx context.Context, ids []string, first *int, after *string) (FriendsConnection, error) {
+func (r *Resolver) resolveFriendConnection(ctx context.Context, ids []string, first *int, after *string) (*FriendsConnection, error) {
 	from := 0
 	if after != nil {
 		b, err := base64.StdEncoding.DecodeString(*after)
 		if err != nil {
-			return FriendsConnection{}, err
+			return nil, err
 		}
 		i, err := strconv.Atoi(strings.TrimPrefix(string(b), "cursor"))
 		if err != nil {
-			return FriendsConnection{}, err
+			return nil, err
 		}
 		from = i
 	}
@@ -73,7 +73,7 @@ func (r *Resolver) resolveFriendConnection(ctx context.Context, ids []string, fi
 		}
 	}
 
-	return FriendsConnection{
+	return &FriendsConnection{
 		ids:  ids,
 		from: from,
 		to:   to,

--- a/example/starwars/resolvers.go
+++ b/example/starwars/resolvers.go
@@ -58,7 +58,7 @@ func (r *droidResolver) Friends(ctx context.Context, obj *Droid) ([]Character, e
 	return r.resolveCharacters(ctx, obj.FriendIds)
 }
 
-func (r *droidResolver) FriendsConnection(ctx context.Context, obj *Droid, first *int, after *string) (FriendsConnection, error) {
+func (r *droidResolver) FriendsConnection(ctx context.Context, obj *Droid, first *int, after *string) (*FriendsConnection, error) {
 	return r.resolveFriendConnection(ctx, obj.FriendIds, first, after)
 }
 
@@ -90,7 +90,7 @@ func (r *humanResolver) Friends(ctx context.Context, obj *Human) ([]Character, e
 	return r.resolveCharacters(ctx, obj.FriendIds)
 }
 
-func (r *humanResolver) FriendsConnection(ctx context.Context, obj *Human, first *int, after *string) (FriendsConnection, error) {
+func (r *humanResolver) FriendsConnection(ctx context.Context, obj *Human, first *int, after *string) (*FriendsConnection, error) {
 	return r.resolveFriendConnection(ctx, obj.FriendIds, first, after)
 }
 

--- a/example/todo/generated.go
+++ b/example/todo/generated.go
@@ -61,7 +61,7 @@ type ComplexityRoot struct {
 }
 
 type MyMutationResolver interface {
-	CreateTodo(ctx context.Context, todo TodoInput) (Todo, error)
+	CreateTodo(ctx context.Context, todo TodoInput) (*Todo, error)
 	UpdateTodo(ctx context.Context, id int, changes map[string]interface{}) (*Todo, error)
 }
 type MyQueryResolver interface {
@@ -434,10 +434,10 @@ func (ec *executionContext) _MyMutation_createTodo(ctx context.Context, field gr
 		}
 		return graphql.Null
 	}
-	res := resTmp.(Todo)
+	res := resTmp.(*Todo)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNTodo2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋtodoᚐTodo(ctx, field.Selections, res)
+	return ec.marshalNTodo2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋtodoᚐTodo(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _MyMutation_updateTodo(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
@@ -1951,6 +1951,16 @@ func (ec *executionContext) marshalNTodo2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ
 	}
 	wg.Wait()
 	return ret
+}
+
+func (ec *executionContext) marshalNTodo2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋtodoᚐTodo(ctx context.Context, sel ast.SelectionSet, v *Todo) graphql.Marshaler {
+	if v == nil {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._Todo(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNTodoInput2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋtodoᚐTodoInput(ctx context.Context, v interface{}) (TodoInput, error) {

--- a/example/todo/todo.go
+++ b/example/todo/todo.go
@@ -91,7 +91,7 @@ func (r *QueryResolver) Todos(ctx context.Context) ([]Todo, error) {
 
 type MutationResolver resolvers
 
-func (r *MutationResolver) CreateTodo(ctx context.Context, todo TodoInput) (Todo, error) {
+func (r *MutationResolver) CreateTodo(ctx context.Context, todo TodoInput) (*Todo, error) {
 	newID := r.id()
 
 	newTodo := Todo{
@@ -106,7 +106,7 @@ func (r *MutationResolver) CreateTodo(ctx context.Context, todo TodoInput) (Todo
 
 	r.todos = append(r.todos, newTodo)
 
-	return newTodo, nil
+	return &newTodo, nil
 }
 
 func (r *MutationResolver) UpdateTodo(ctx context.Context, id int, changes map[string]interface{}) (*Todo, error) {

--- a/example/type-system-extension/generated.go
+++ b/example/type-system-extension/generated.go
@@ -73,7 +73,7 @@ type ComplexityRoot struct {
 }
 
 type MyMutationResolver interface {
-	CreateTodo(ctx context.Context, todo TodoInput) (Todo, error)
+	CreateTodo(ctx context.Context, todo TodoInput) (*Todo, error)
 }
 type MyQueryResolver interface {
 	Todos(ctx context.Context) ([]Todo, error)
@@ -467,10 +467,10 @@ func (ec *executionContext) _MyMutation_createTodo(ctx context.Context, field gr
 		}
 		return graphql.Null
 	}
-	res := resTmp.(Todo)
+	res := resTmp.(*Todo)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNTodo2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋtypeᚑsystemᚑextensionᚐTodo(ctx, field.Selections, res)
+	return ec.marshalNTodo2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋtypeᚑsystemᚑextensionᚐTodo(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _MyQuery_todos(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
@@ -1966,6 +1966,16 @@ func (ec *executionContext) marshalNTodo2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ
 	}
 	wg.Wait()
 	return ret
+}
+
+func (ec *executionContext) marshalNTodo2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋtypeᚑsystemᚑextensionᚐTodo(ctx context.Context, sel ast.SelectionSet, v *Todo) graphql.Marshaler {
+	if v == nil {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._Todo(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNTodoInput2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋtypeᚑsystemᚑextensionᚐTodoInput(ctx context.Context, v interface{}) (TodoInput, error) {

--- a/example/type-system-extension/resolver.go
+++ b/example/type-system-extension/resolver.go
@@ -65,7 +65,7 @@ func (r *queryResolver) Todo(ctx context.Context, id string) (*Todo, error) {
 
 type mutationResolver struct{ *resolver }
 
-func (r *mutationResolver) CreateTodo(ctx context.Context, todoInput TodoInput) (Todo, error) {
+func (r *mutationResolver) CreateTodo(ctx context.Context, todoInput TodoInput) (*Todo, error) {
 	newID := fmt.Sprintf("Todo:%d", len(r.todos)+1)
 	newTodo := &Todo{
 		ID:    newID,
@@ -74,5 +74,5 @@ func (r *mutationResolver) CreateTodo(ctx context.Context, todoInput TodoInput) 
 	}
 	r.todos = append(r.todos, newTodo)
 
-	return *newTodo, nil
+	return newTodo, nil
 }

--- a/integration/generated.go
+++ b/integration/generated.go
@@ -70,7 +70,7 @@ type ComplexityRoot struct {
 }
 
 type ElementResolver interface {
-	Child(ctx context.Context, obj *models.Element) (models.Element, error)
+	Child(ctx context.Context, obj *models.Element) (*models.Element, error)
 	Error(ctx context.Context, obj *models.Element) (bool, error)
 }
 type QueryResolver interface {
@@ -433,10 +433,10 @@ func (ec *executionContext) _Element_child(ctx context.Context, field graphql.Co
 		}
 		return graphql.Null
 	}
-	res := resTmp.(models.Element)
+	res := resTmp.(*models.Element)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNElement2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋmodelsᚑgoᚐElement(ctx, field.Selections, res)
+	return ec.marshalNElement2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋmodelsᚑgoᚐElement(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Element_error(ctx context.Context, field graphql.CollectedField, obj *models.Element) graphql.Marshaler {
@@ -2028,6 +2028,16 @@ func (ec *executionContext) unmarshalNDateFilter2githubᚗcomᚋ99designsᚋgqlg
 
 func (ec *executionContext) marshalNElement2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋmodelsᚑgoᚐElement(ctx context.Context, sel ast.SelectionSet, v models.Element) graphql.Marshaler {
 	return ec._Element(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNElement2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋmodelsᚑgoᚐElement(ctx context.Context, sel ast.SelectionSet, v *models.Element) graphql.Marshaler {
+	if v == nil {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._Element(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v interface{}) (string, error) {

--- a/integration/resolver.go
+++ b/integration/resolver.go
@@ -47,8 +47,8 @@ func (r *elementResolver) Mismatched(ctx context.Context, obj *models.Element) (
 	return []bool{true}, nil
 }
 
-func (r *elementResolver) Child(ctx context.Context, obj *models.Element) (models.Element, error) {
-	return models.Element{ID: obj.ID * 10}, nil
+func (r *elementResolver) Child(ctx context.Context, obj *models.Element) (*models.Element, error) {
+	return &models.Element{ID: obj.ID * 10}, nil
 }
 
 type queryResolver struct{ *Resolver }


### PR DESCRIPTION
This makes the return type from resolvers always return a pointer, even for NotNull fields.  see #375 for rationale.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
