### PR TITLE
Update Getting Started for 0.8 and Go Modules

### DIFF
--- a/ambient.go
+++ b/ambient.go
@@ -1,4 +1,4 @@
-package gqlgen
+package main
 
 import (
 	// Import and ignore the ambient imports listed below so dependency managers

--- a/api/generate.go
+++ b/api/generate.go
@@ -1,4 +1,4 @@
-package gqlgen
+package api
 
 import (
 	"syscall"

--- a/api/option.go
+++ b/api/option.go
@@ -1,4 +1,4 @@
-package gqlgen
+package api
 
 import (
 	"github.com/99designs/gqlgen/codegen/config"

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/99designs/gqlgen"
+	"github.com/99designs/gqlgen/api"
 	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
@@ -36,7 +36,7 @@ var genCmd = cli.Command{
 			}
 		}
 
-		if err = gqlgen.Generate(cfg); err != nil {
+		if err = api.Generate(cfg); err != nil {
 			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(3)
 		}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -7,9 +7,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/99designs/gqlgen/api"
 	"github.com/99designs/gqlgen/plugin/servergen"
-
-	"github.com/99designs/gqlgen"
 
 	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/pkg/errors"
@@ -73,7 +72,7 @@ var initCmd = cli.Command{
 }
 
 func GenerateGraphServer(cfg *config.Config, serverFilename string) {
-	err := gqlgen.Generate(cfg, gqlgen.AddPlugin(servergen.New(serverFilename)))
+	err := api.Generate(cfg, api.AddPlugin(servergen.New(serverFilename)))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 	}

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -3,7 +3,7 @@ linkTitle: Configuration
 title: How to configure gqlgen using gqlgen.yml
 description: How to configure gqlgen using gqlgen.yml
 menu: main
-weight: -7
+weight: -5
 ---
 
 gqlgen can be configured using a `gqlgen.yml` file, by default it will be loaded from the current directory, or any parent directory.

--- a/docs/content/getting-started-dep.md
+++ b/docs/content/getting-started-dep.md
@@ -195,8 +195,6 @@ $ go run scripts/gqlgen.go
 Now we just need to fill in the `not implemented` parts.  Update `resolver.go`
 
 ```go
-//go:generate go run ./scripts/gqlgen.go
-
 package gettingstarted
 
 import (
@@ -205,7 +203,7 @@ import (
 	"math/rand"
 )
 
-type Resolver struct{
+type Resolver struct {
 	todos []Todo
 }
 
@@ -221,13 +219,13 @@ func (r *Resolver) Todo() TodoResolver {
 
 type mutationResolver struct{ *Resolver }
 
-func (r *mutationResolver) CreateTodo(ctx context.Context, input NewTodo) (Todo, error) {
-	todo := Todo{
+func (r *mutationResolver) CreateTodo(ctx context.Context, input NewTodo) (*Todo, error) {
+	todo := &Todo{
 		Text:   input.Text,
 		ID:     fmt.Sprintf("T%d", rand.Int()),
 		UserID: input.UserID,
 	}
-	r.todos = append(r.todos, todo)
+	r.todos = append(r.todos, *todo)
 	return todo, nil
 }
 
@@ -239,8 +237,8 @@ func (r *queryResolver) Todos(ctx context.Context) ([]Todo, error) {
 
 type todoResolver struct{ *Resolver }
 
-func (r *todoResolver) User(ctx context.Context, obj *Todo) (User, error) {
-	return User{ID: obj.UserID, Name: "user " + obj.UserID}, nil
+func (r *todoResolver) User(ctx context.Context, obj *Todo) (*User, error) {
+	return &User{ID: obj.UserID, Name: "user " + obj.UserID}, nil
 }
 
 ```

--- a/docs/content/getting-started-dep.md
+++ b/docs/content/getting-started-dep.md
@@ -1,10 +1,14 @@
 ---
-linkTitle: Getting Started
+linkTitle: Getting Started Using dep
 title: Building GraphQL servers in golang
-description: Get started building type-safe GraphQL servers in Golang using gqlgen  
-menu: main
+description: Get started building type-safe GraphQL servers in Golang using gqlgen
 weight: -7
+hidden: true
 ---
+
+> Deprecated
+>
+> This tutorial uses the `dep` tool to manage dependencies instead of Go Modules and should be considered a deprecated way to use gqlgen.  Read out new [Getting Started]({{< ref "getting-started.md" >}}) guide for instructions for using Go Modules.
 
 This tutorial will take you through the process of building a GraphQL server with gqlgen that can:
 
@@ -14,18 +18,34 @@ This tutorial will take you through the process of building a GraphQL server wit
 
 You can find the finished code for this tutorial [here](https://github.com/vektah/gqlgen-tutorials/tree/master/gettingstarted)
 
-> Note
->
-> This tutorial uses Go Modules and requires Go 1.11+.  If you want to use this tutorial without Go Modules, take a look at our [Getting Started Using dep]({{< ref "getting-started-dep.md" >}}) guide instead.
+## Install gqlgen
 
-## Setup Project
+This article uses [`dep`](https://github.com/golang/dep) to install gqlgen.  [Follow the instructions for your environment](https://github.com/golang/dep) to install.
 
-Create a directory for your project, and initialise it as a Go Module:
+Assuming you already have a working [Go environment](https://golang.org/doc/install), create a directory for the project in your `$GOPATH`:
 
 ```sh
-mkdir gqlgen-todos
-cd gqlgen-todos
-go mod init gqlgen-todos
+$ mkdir -p $GOPATH/src/github.com/[username]/gqlgen-todos
+```
+
+Add the following file to your project under `scripts/gqlgen.go`:
+
+```go
+// +build ignore
+
+package main
+
+import "github.com/99designs/gqlgen/cmd"
+
+func main() {
+	cmd.Execute()
+}
+```
+
+Lastly, initialise dep.  This will inspect any imports you have in your project, and pull down the latest tagged release.
+
+```sh
+$ dep init
 ```
 
 ## Building the server
@@ -65,7 +85,7 @@ type Mutation {
 ### Create the project skeleton
 
 ```bash
-$ go run github.com/99designs/gqlgen init
+$ go run scripts/gqlgen.go init
 ```
 
 This has created an empty skeleton with all files you need:
@@ -75,6 +95,12 @@ This has created an empty skeleton with all files you need:
  - `models_gen.go` — Generated models required to build the graph. Often you will override these with your own models. Still very useful for input types.
  - `resolver.go` — This is where your application code lives. `generated.go` will call into this to get the data the user has requested. 
  - `server/server.go` — This is a minimal entry point that sets up an `http.Handler` to the generated GraphQL server.
+
+ Now run dep ensure, so that we can ensure that the newly generated code's dependencies are all present:
+
+ ```sh
+ $ dep ensure
+ ```
  
 ### Create the database models
 
@@ -102,7 +128,7 @@ models:
 Regenerate by running:
 
 ```bash
-$ go run github.com/99designs/gqlgen -v
+$ go run scripts/gqlgen.go -v
 Unable to bind Todo.user to github.com/[username]/gqlgen-todos/gettingstarted.Todo
 	no method named user
 	no field named user
@@ -163,12 +189,14 @@ This is a work in progress, we have a way to generate resolver stubs, but it can
 
 ```bash
 $ rm resolver.go
-$ go run github.com/99designs/gqlgen
+$ go run scripts/gqlgen.go
 ```
 
 Now we just need to fill in the `not implemented` parts.  Update `resolver.go`
 
 ```go
+//go:generate go run ./scripts/gqlgen.go
+
 package gettingstarted
 
 import (
@@ -250,7 +278,7 @@ query findTodos {
 At the top of our `resolver.go` add the following line:
 
 ```go
-//go:generate go run github.com/99designs/gqlgen
+//go:generate go run scripts/gqlgen.go -v
 ```
 
 This magic comment tells `go generate` what command to run when we want to regenerate our code.  To run go generate recursively over your entire project, use this command:
@@ -258,3 +286,7 @@ This magic comment tells `go generate` what command to run when we want to regen
 ```go
 go generate ./...
 ```
+
+> Note
+>
+> Ensure that the path to your `gqlgen` binary is relative to the file the generate command is added to.

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -3,7 +3,7 @@ linkTitle: Getting Started
 title: Building GraphQL servers in golang
 description: Get started building type-safe GraphQL servers in Golang using gqlgen  
 menu: main
-weight: -5
+weight: -7
 ---
 
 This tutorial will take you through the process of building a GraphQL server with gqlgen that can:

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -9,7 +9,7 @@
 
 	<title>{{ if not .IsHome }}{{ .Title }} &mdash;{{ end }} {{ .Site.Title }}</title>
 
-	<link href="https://fonts.googleapis.com/css?family=Roboto:400,400i,700|Source+Code+Pro:400,700|Work+Sans:600,700" rel="stylesheet">
+	<link href="https://fonts.googleapis.com/css?family=Roboto:400,400i,700|Source+Code+Pro:400,700|Work+Sans:500,700" rel="stylesheet">
 	<link rel="stylesheet" href="{{ .Site.BaseURL }}main.css?v=3" type="text/css" />
 	<link rel="stylesheet" href="{{ .Site.BaseURL }}syntax.css?v=2" type="text/css" />
 

--- a/docs/static/main.css
+++ b/docs/static/main.css
@@ -221,10 +221,6 @@ ul.submenu span {
     padding: 5px 10px;
 }
 
-ul.menu li {
-    font-weight: 400;
-}
-
 ul.menu li.active,
 ul.menu a:hover {
     background-color: var(--color-nav-active);
@@ -389,7 +385,6 @@ em {
         color: var(--color-heading-text);
         background-color: var(--color-heading-background);
         font-family: var(--font-heading);
-        font-weight: 500;
 
         list-style-type: none;
         -webkit-font-smoothing: antialiased;

--- a/internal/code/imports_test.go
+++ b/internal/code/imports_test.go
@@ -14,7 +14,7 @@ func TestImportPathForDir(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "github.com/99designs/gqlgen/internal/code", ImportPathForDir(wd))
-	assert.Equal(t, "github.com/99designs/gqlgen", ImportPathForDir(filepath.Join(wd, "..", "..")))
+	assert.Equal(t, "github.com/99designs/gqlgen/api", ImportPathForDir(filepath.Join(wd, "..", "..", "api")))
 
 	// doesnt contain go code, but should still give a valid import path
 	assert.Equal(t, "github.com/99designs/gqlgen/docs", ImportPathForDir(filepath.Join(wd, "..", "..", "docs")))
@@ -24,7 +24,7 @@ func TestImportPathForDir(t *testing.T) {
 }
 
 func TestNameForPackage(t *testing.T) {
-	assert.Equal(t, "gqlgen", NameForPackage("github.com/99designs/gqlgen"))
+	assert.Equal(t, "api", NameForPackage("github.com/99designs/gqlgen/api"))
 
 	// does not contain go code, should still give a valid name
 	assert.Equal(t, "docs", NameForPackage("github.com/99designs/gqlgen/docs"))

--- a/main.go
+++ b/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/99designs/gqlgen/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/testdata/gqlgen.go
+++ b/testdata/gqlgen.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/99designs/gqlgen"
+	"github.com/99designs/gqlgen/api"
 	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/99designs/gqlgen/plugin/stubgen"
 )
@@ -27,12 +27,12 @@ func main() {
 		os.Exit(2)
 	}
 
-	var options []gqlgen.Option
+	var options []api.Option
 	if *stub != "" {
-		options = append(options, gqlgen.AddPlugin(stubgen.New(*stub, "Stub")))
+		options = append(options, api.AddPlugin(stubgen.New(*stub, "Stub")))
 	}
 
-	err = gqlgen.Generate(cfg, options...)
+	err = api.Generate(cfg, options...)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(3)


### PR DESCRIPTION
This updates the Getting Started documentation to work with Go Modules and the 0.8 release in general.

We decided to keep the `dep` documentation around for now in case people aren't ready to upgrade to Go Modules.  But the addition of Go Modules simplifies the setup and execution a lot, however it now makes less sense to deprecate the binary, so it is reintroduced here.