### PR TITLE
Handling queries with partial path errors

### DIFF
--- a/integration/integration-test.js
+++ b/integration/integration-test.js
@@ -70,4 +70,13 @@ describe('Errors', () => {
 
         expect(res.errors[0].message).toEqual('Normal error');
     });
+
+    it('should return errors only for failed resolvers', async () => {
+        let res = await client.query({
+            query: gql`{ viewer { user { name } } error(type: NORMAL) }`,
+        });
+
+        expect(res.errors[0].message).toEqual('Normal error');
+        expect(res.data.viewer.user.name).toEqual('Bob');
+    });
 });


### PR DESCRIPTION
Opening this as a PR since I felt like providing a diff adding a test was the simplest way to convey my question.

In the case where only part of the query path fails, we currently only receive the error without also receiving the data from the paths that successfully resolved. E.g. for a query like:

```
{
  user {
    name
  }
  organization {
    name
  }
}
```

Where resolving `user` fails, but resolving `organization` is successful, we currently get a response like:

```
{
  "errors": [
    {
      "message": "Some error",
      "path": [
        "user"
      ]
    }
  ],
  "data": null
}
```

Where `organization` is not returned.

My expected behavior would have been:

```
{
  "errors": [
    {
      "message": "Some error",
      "path": [
        "user"
      ]
    }
  ],
  "data": {
    "organization": {
      "name": "Bob"
    }
  }
}
```

I've added an integration test here that currently fails, but would pass with my desired behavior.

If this current behavior is unintentional, I can take a shot at completing this PR to return the expected result (errors only for the paths that fail to resolve and the data for the rest).