### PR TITLE
Fix cli config getters

### DIFF
--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -20,7 +20,7 @@ var genCmd = cli.Command{
 	Action: func(ctx *cli.Context) {
 		var cfg *config.Config
 		var err error
-		if configFilename := ctx.String("gen"); configFilename != "" {
+		if configFilename := ctx.String("config"); configFilename != "" {
 			cfg, err = config.LoadConfig(configFilename)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err.Error())

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -83,7 +83,7 @@ func GenerateGraphServer(cfg *config.Config, serverFilename string) {
 func initConfig(ctx *cli.Context) *config.Config {
 	var cfg *config.Config
 	var err error
-	configFilename := ctx.String("cfg")
+	configFilename := ctx.String("config")
 	if configFilename != "" {
 		cfg, err = config.LoadConfig(configFilename)
 	} else {


### PR DESCRIPTION
Fix #560 by using the correct cli flag `"config"`

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

Maybe some tests would be good but it may be easier to just create a `const config = "config"` but I wasn't sure on how to integrate it with urfave/cli because that uses `"config, c"` as the flag name.