### PR TITLE
playground: secure CDN resources with Subresource Integrity

### DIFF
--- a/handler/playground.go
+++ b/handler/playground.go
@@ -11,9 +11,12 @@ var page = template.Must(template.New("graphiql").Parse(`<!DOCTYPE html>
 	<meta charset=utf-8/>
 	<meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
 	<link rel="shortcut icon" href="https://graphcool-playground.netlify.com/favicon.png">
-	<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react@{{ .version }}/build/static/css/index.css"/>
-	<link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react@{{ .version }}/build/favicon.png"/>
-	<script src="//cdn.jsdelivr.net/npm/graphql-playground-react@{{ .version }}/build/static/js/middleware.js"></script>
+	<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react@{{ .version }}/build/static/css/index.css" 
+		integrity="{{ .cssSRI }}" crossorigin="anonymous"/>
+	<link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react@{{ .version }}/build/favicon.png"
+		integrity="{{ .faviconSRI }}" crossorigin="anonymous"/>
+	<script src="//cdn.jsdelivr.net/npm/graphql-playground-react@{{ .version }}/build/static/js/middleware.js"
+		integrity="{{ .jsSRI }}" crossorigin="anonymous"></script>
 	<title>{{.title}}</title>
 </head>
 <body>
@@ -43,9 +46,12 @@ var page = template.Must(template.New("graphiql").Parse(`<!DOCTYPE html>
 func Playground(title string, endpoint string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		err := page.Execute(w, map[string]string{
-			"title":    title,
-			"endpoint": endpoint,
-			"version":  "1.7.8",
+			"title":      title,
+			"endpoint":   endpoint,
+			"version":    "1.7.8",
+			"cssSRI":     "sha256-cS9Vc2OBt9eUf4sykRWukeFYaInL29+myBmFDSa7F/U=",
+			"faviconSRI": "sha256-GhTyE+McTU79R4+pRO6ih+4TfsTOrpPwD8ReKFzb3PM=",
+			"jsSRI":      "sha256-ucQsC5k+XYnUlQia6tMKdAOGBbfbDAquMa+oqIooB5A=",
 		})
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
The current HTTP handler for the playground leave a way to load tampered resources, either with a faulty CDN or through a man-in-the-middle.

This PR add Subresource Integrity for those external resources. If such tampering happen, the browser will simply refuse to load them.

Btw, jsdelivr conveniently provide the SRI hash, so updating the playground will still be easy.

![image](https://user-images.githubusercontent.com/294669/53698154-19b4fd00-3dd9-11e9-9ea5-8f2e74ebcbb6.png)
