### PR TITLE
Workaround for using packages with vendored code

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -249,7 +249,7 @@ func (tm TypeMap) ReferencedPackages() []string {
 			if pkg == "" || inStrSlice(pkgs, pkg) {
 				continue
 			}
-			pkgs = append(pkgs, pkg)
+			pkgs = append(pkgs, code.QualifyPackagePath(pkg))
 		}
 	}
 

--- a/internal/code/imports.go
+++ b/internal/code/imports.go
@@ -33,6 +33,7 @@ func NameForPackage(importPath string) string {
 	if v, ok := nameForPackageCache.Load(importPath); ok {
 		return v.(string)
 	}
+	importPath = QualifyPackagePath(importPath)
 	p, _ := packages.Load(nil, importPath)
 
 	if len(p) != 1 || p[0].Name == "" {

--- a/internal/code/util.go
+++ b/internal/code/util.go
@@ -1,6 +1,8 @@
 package code
 
 import (
+	"go/build"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -13,16 +15,38 @@ func PkgAndType(name string) (string, string) {
 		return "", name
 	}
 
-	return NormalizeVendor(strings.Join(parts[:len(parts)-1], ".")), parts[len(parts)-1]
+	return strings.Join(parts[:len(parts)-1], "."), parts[len(parts)-1]
 }
 
 var modsRegex = regexp.MustCompile(`^(\*|\[\])*`)
 
+// NormalizeVendor takes a qualified package path and turns it into normal one.
+// eg .
+// github.com/foo/vendor/github.com/99designs/gqlgen/graphql becomes
+// github.com/99designs/gqlgen/graphql
 func NormalizeVendor(pkg string) string {
 	modifiers := modsRegex.FindAllString(pkg, 1)[0]
 	pkg = strings.TrimPrefix(pkg, modifiers)
 	parts := strings.Split(pkg, "/vendor/")
 	return modifiers + parts[len(parts)-1]
+}
+
+// QualifyPackagePath takes an import and fully qualifies it with a vendor dir, if one is required.
+// eg .
+// github.com/99designs/gqlgen/graphql becomes
+// github.com/foo/vendor/github.com/99designs/gqlgen/graphql
+//
+// x/tools/packages only supports 'qualified package paths' so this will need to be done prior to calling it
+// See https://github.com/golang/go/issues/30289
+func QualifyPackagePath(importPath string) string {
+	wd, _ := os.Getwd()
+
+	pkg, err := build.Import(importPath, wd, 0)
+	if err != nil {
+		return importPath
+	}
+
+	return pkg.ImportPath
 }
 
 var invalidPackageNameChar = regexp.MustCompile(`[^\w]`)


### PR DESCRIPTION
Workaround for https://github.com/golang/go/issues/30289 by consulting go/build to get full path names for x/packages to use.
