### PR TITLE
Take care about commonInitialisms in ToGo

### DIFF
--- a/codegen/generated!.gotpl
+++ b/codegen/generated!.gotpl
@@ -45,7 +45,7 @@ type DirectiveRoot struct {
 type ComplexityRoot struct {
 {{ range $object := .Objects }}
 	{{ if not $object.IsReserved -}}
-		{{ $object.Name|toCamel }} struct {
+		{{ $object.Name|go }} struct {
 		{{ range $field := $object.Fields -}}
 			{{ if not $field.IsReserved -}}
 				{{ $field.GoFieldName }} {{ $field.ComplexitySignature }}
@@ -87,7 +87,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			{{ range $field := $object.Fields }}
 				{{ if not $field.IsReserved }}
 					case "{{$object.Name}}.{{$field.GoFieldName}}":
-						if e.complexity.{{$object.Name|toCamel}}.{{$field.GoFieldName}} == nil {
+						if e.complexity.{{$object.Name|go}}.{{$field.GoFieldName}} == nil {
 							break
 						}
 						{{ if $field.Args }}
@@ -96,7 +96,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 								return 0, false
 							}
 						{{ end }}
-						return e.complexity.{{$object.Name|toCamel}}.{{$field.GoFieldName}}(childComplexity{{if $field.Args}}, {{$field.ComplexityArgs}} {{end}}), true
+						return e.complexity.{{$object.Name|go}}.{{$field.GoFieldName}}(childComplexity{{if $field.Args}}, {{$field.ComplexityArgs}} {{end}}), true
 				{{ end }}
 			{{ end }}
 		{{ end }}

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -269,17 +269,9 @@ type wordInfo struct {
 	HasCommonInitial   bool
 }
 
+// This function is based on the following code.
+// https://github.com/golang/lint/blob/06c8688daad7faa9da5a0c2f163a3d14aac986ca/lint.go#L679
 func wordWalker(str string, f func(*wordInfo)) {
-
-	skipRune := func(r rune) bool {
-		switch r {
-		case '-', '_':
-			return true
-		default:
-			return false
-		}
-	}
-
 	runes := []rune(str)
 	w, i := 0, 0 // index of start of word, scan
 	hasCommonInitial := false
@@ -287,11 +279,11 @@ func wordWalker(str string, f func(*wordInfo)) {
 		eow := false // whether we hit the end of a word
 		if i+1 == len(runes) {
 			eow = true
-		} else if skipRune(runes[i+1]) {
+		} else if isDelimiter(runes[i+1]) {
 			// underscore; shift the remainder forward over any run of underscores
 			eow = true
 			n := 1
-			for i+n+1 < len(runes) && skipRune(runes[i+n+1]) {
+			for i+n+1 < len(runes) && isDelimiter(runes[i+n+1]) {
 				n++
 			}
 
@@ -374,74 +366,6 @@ func sanitizeKeywords(name string) string {
 		}
 	}
 	return name
-}
-
-// copy from https://github.com/golang/lint/blob/06c8688daad7faa9da5a0c2f163a3d14aac986ca/lint.go#L679
-func lintName(name string) string {
-	// Fast path for simple cases: "_" and all lowercase.
-	if name == "_" {
-		return name
-	}
-	allLower := true
-	for _, r := range name {
-		if !unicode.IsLower(r) {
-			allLower = false
-			break
-		}
-	}
-	if allLower {
-		return name
-	}
-
-	// Split camelCase at any lower->upper transition, and split on underscores.
-	// Check each word for common initialisms.
-	runes := []rune(name)
-	w, i := 0, 0 // index of start of word, scan
-	for i+1 <= len(runes) {
-		eow := false // whether we hit the end of a word
-		if i+1 == len(runes) {
-			eow = true
-		} else if runes[i+1] == '_' {
-			// underscore; shift the remainder forward over any run of underscores
-			eow = true
-			n := 1
-			for i+n+1 < len(runes) && runes[i+n+1] == '_' {
-				n++
-			}
-
-			// Leave at most one underscore if the underscore is between two digits
-			if i+n+1 < len(runes) && unicode.IsDigit(runes[i]) && unicode.IsDigit(runes[i+n+1]) {
-				n--
-			}
-
-			copy(runes[i+1:], runes[i+n+1:])
-			runes = runes[:len(runes)-n]
-		} else if unicode.IsLower(runes[i]) && !unicode.IsLower(runes[i+1]) {
-			// lower->non-lower
-			eow = true
-		}
-		i++
-		if !eow {
-			continue
-		}
-
-		// [w,i) is a word.
-		word := string(runes[w:i])
-		if u := strings.ToUpper(word); commonInitialisms[u] {
-			// Keep consistent case, which is lowercase only at the start.
-			if w == 0 && unicode.IsLower(runes[w]) {
-				u = strings.ToLower(u)
-			}
-			// All the common initialisms are ASCII,
-			// so we can replace the bytes exactly.
-			copy(runes[w:], []rune(u))
-		} else if w > 0 && strings.ToLower(word) == word {
-			// already all lowercase, and not the first word, so uppercase the first character.
-			runes[w] = unicode.ToUpper(runes[w])
-		}
-		w = i
-	}
-	return string(runes)
 }
 
 // commonInitialisms is a set of common initialisms.

--- a/codegen/templates/templates_test.go
+++ b/codegen/templates/templates_test.go
@@ -6,12 +6,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestToUpper(t *testing.T) {
+func TestToCamel(t *testing.T) {
 	require.Equal(t, "ToCamel", ToCamel("TO_CAMEL"))
 	require.Equal(t, "ToCamel", ToCamel("to_camel"))
 	require.Equal(t, "ToCamel", ToCamel("toCamel"))
 	require.Equal(t, "ToCamel", ToCamel("ToCamel"))
 	require.Equal(t, "ToCamel", ToCamel("to-camel"))
+
+	require.Equal(t, "RelatedURLs", ToCamel("RelatedURLs"))
+	require.Equal(t, "ImageIDs", ToCamel("ImageIDs"))
+	require.Equal(t, "FooID", ToCamel("FooID"))
+	require.Equal(t, "IDFoo", ToCamel("IDFoo"))
+	require.Equal(t, "FooASCII", ToCamel("FooASCII"))
+	require.Equal(t, "ASCIIFoo", ToCamel("ASCIIFoo"))
+	require.Equal(t, "FooUTF8", ToCamel("FooUTF8"))
+	require.Equal(t, "UTF8Foo", ToCamel("UTF8Foo"))
+
+	require.Equal(t, "A", ToCamel("A"))
+	require.Equal(t, "ID", ToCamel("ID"))
+	require.Equal(t, "", ToCamel(""))
 }
 
 func TestCenter(t *testing.T) {

--- a/codegen/templates/templates_test.go
+++ b/codegen/templates/templates_test.go
@@ -6,25 +6,89 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestToCamel(t *testing.T) {
-	require.Equal(t, "ToCamel", ToCamel("TO_CAMEL"))
-	require.Equal(t, "ToCamel", ToCamel("to_camel"))
-	require.Equal(t, "ToCamel", ToCamel("toCamel"))
-	require.Equal(t, "ToCamel", ToCamel("ToCamel"))
-	require.Equal(t, "ToCamel", ToCamel("to-camel"))
+func TestToGo(t *testing.T) {
+	require.Equal(t, "ToCamel", ToGo("TO_CAMEL"))
+	require.Equal(t, "ToCamel", ToGo("to_camel"))
+	require.Equal(t, "ToCamel", ToGo("toCamel"))
+	require.Equal(t, "ToCamel", ToGo("ToCamel"))
+	require.Equal(t, "ToCamel", ToGo("to-camel"))
 
-	require.Equal(t, "RelatedURLs", ToCamel("RelatedURLs"))
-	require.Equal(t, "ImageIDs", ToCamel("ImageIDs"))
-	require.Equal(t, "FooID", ToCamel("FooID"))
-	require.Equal(t, "IDFoo", ToCamel("IDFoo"))
-	require.Equal(t, "FooASCII", ToCamel("FooASCII"))
-	require.Equal(t, "ASCIIFoo", ToCamel("ASCIIFoo"))
-	require.Equal(t, "FooUTF8", ToCamel("FooUTF8"))
-	require.Equal(t, "UTF8Foo", ToCamel("UTF8Foo"))
+	require.Equal(t, "RelatedURLs", ToGo("RelatedURLs"))
+	require.Equal(t, "ImageIDs", ToGo("ImageIDs"))
+	require.Equal(t, "FooID", ToGo("FooID"))
+	require.Equal(t, "IDFoo", ToGo("IDFoo"))
+	require.Equal(t, "FooASCII", ToGo("FooASCII"))
+	require.Equal(t, "ASCIIFoo", ToGo("ASCIIFoo"))
+	require.Equal(t, "FooUTF8", ToGo("FooUTF8"))
+	require.Equal(t, "UTF8Foo", ToGo("UTF8Foo"))
+	require.Equal(t, "JSONEncoding", ToGo("JSONEncoding"))
 
-	require.Equal(t, "A", ToCamel("A"))
-	require.Equal(t, "ID", ToCamel("ID"))
-	require.Equal(t, "", ToCamel(""))
+	require.Equal(t, "A", ToGo("A"))
+	require.Equal(t, "ID", ToGo("ID"))
+	require.Equal(t, "", ToGo(""))
+
+	require.Equal(t, "RelatedUrls", ToGo("RelatedUrls"))
+}
+
+func TestToGoPrivate(t *testing.T) {
+	require.Equal(t, "toCamel", ToGoPrivate("TO_CAMEL"))
+	require.Equal(t, "toCamel", ToGoPrivate("to_camel"))
+	require.Equal(t, "toCamel", ToGoPrivate("toCamel"))
+	require.Equal(t, "toCamel", ToGoPrivate("ToCamel"))
+	require.Equal(t, "toCamel", ToGoPrivate("to-camel"))
+
+	require.Equal(t, "relatedURLs", ToGoPrivate("RelatedURLs"))
+	require.Equal(t, "imageIDs", ToGoPrivate("ImageIDs"))
+	require.Equal(t, "fooID", ToGoPrivate("FooID"))
+	require.Equal(t, "idFoo", ToGoPrivate("IDFoo"))
+	require.Equal(t, "fooASCII", ToGoPrivate("FooASCII"))
+	require.Equal(t, "asciiFoo", ToGoPrivate("ASCIIFoo"))
+	require.Equal(t, "fooUTF8", ToGoPrivate("FooUTF8"))
+	require.Equal(t, "utf8Foo", ToGoPrivate("UTF8Foo"))
+	require.Equal(t, "jsonEncoding", ToGoPrivate("JSONEncoding"))
+
+	require.Equal(t, "rangeArg", ToGoPrivate("Range"))
+
+	require.Equal(t, "a", ToGoPrivate("A"))
+	require.Equal(t, "id", ToGoPrivate("ID"))
+	require.Equal(t, "", ToGoPrivate(""))
+}
+
+func Test_wordWalker(t *testing.T) {
+
+	type Result struct {
+		Value            string
+		HasCommonInitial bool
+	}
+	helper := func(str string) []*Result {
+		resultList := []*Result{}
+		wordWalker(str, func(word string, hasCommonInitial bool) {
+			resultList = append(resultList, &Result{word, hasCommonInitial})
+		})
+		return resultList
+	}
+
+	require.Equal(t, []*Result{{Value: "TO"}, {Value: "CAMEL"}}, helper("TO_CAMEL"))
+	require.Equal(t, []*Result{{Value: "to"}, {Value: "camel"}}, helper("to_camel"))
+	require.Equal(t, []*Result{{Value: "to"}, {Value: "Camel"}}, helper("toCamel"))
+	require.Equal(t, []*Result{{Value: "To"}, {Value: "Camel"}}, helper("ToCamel"))
+	require.Equal(t, []*Result{{Value: "to"}, {Value: "camel"}}, helper("to-camel"))
+
+	require.Equal(t, []*Result{{Value: "Related"}, {Value: "URLs", HasCommonInitial: true}}, helper("RelatedURLs"))
+	require.Equal(t, []*Result{{Value: "Image"}, {Value: "IDs", HasCommonInitial: true}}, helper("ImageIDs"))
+	require.Equal(t, []*Result{{Value: "Foo"}, {Value: "ID", HasCommonInitial: true}}, helper("FooID"))
+	require.Equal(t, []*Result{{Value: "ID", HasCommonInitial: true}, {Value: "Foo"}}, helper("IDFoo"))
+	require.Equal(t, []*Result{{Value: "Foo"}, {Value: "ASCII", HasCommonInitial: true}}, helper("FooASCII"))
+	require.Equal(t, []*Result{{Value: "ASCII", HasCommonInitial: true}, {Value: "Foo"}}, helper("ASCIIFoo"))
+	require.Equal(t, []*Result{{Value: "Foo"}, {Value: "UTF8", HasCommonInitial: true}}, helper("FooUTF8"))
+	require.Equal(t, []*Result{{Value: "UTF8", HasCommonInitial: true}, {Value: "Foo"}}, helper("UTF8Foo"))
+
+	require.Equal(t, []*Result{{Value: "A"}}, helper("A"))
+	require.Equal(t, []*Result{{Value: "ID", HasCommonInitial: true}}, helper("ID"))
+	require.Equal(t, []*Result{{Value: "ID", HasCommonInitial: true}}, helper("id"))
+	require.Equal(t, []*Result{}, helper(""))
+
+	require.Equal(t, []*Result{{Value: "Related"}, {Value: "Urls"}}, helper("RelatedUrls"))
 }
 
 func TestCenter(t *testing.T) {

--- a/codegen/templates/templates_test.go
+++ b/codegen/templates/templates_test.go
@@ -25,6 +25,7 @@ func TestToGo(t *testing.T) {
 
 	require.Equal(t, "A", ToGo("A"))
 	require.Equal(t, "ID", ToGo("ID"))
+	require.Equal(t, "ID", ToGo("id"))
 	require.Equal(t, "", ToGo(""))
 
 	require.Equal(t, "RelatedUrls", ToGo("RelatedUrls"))
@@ -51,44 +52,41 @@ func TestToGoPrivate(t *testing.T) {
 
 	require.Equal(t, "a", ToGoPrivate("A"))
 	require.Equal(t, "id", ToGoPrivate("ID"))
+	require.Equal(t, "id", ToGoPrivate("id"))
 	require.Equal(t, "", ToGoPrivate(""))
 }
 
 func Test_wordWalker(t *testing.T) {
 
-	type Result struct {
-		Value            string
-		HasCommonInitial bool
-	}
-	helper := func(str string) []*Result {
-		resultList := []*Result{}
-		wordWalker(str, func(word string, hasCommonInitial bool) {
-			resultList = append(resultList, &Result{word, hasCommonInitial})
+	helper := func(str string) []*wordInfo {
+		resultList := []*wordInfo{}
+		wordWalker(str, func(info *wordInfo) {
+			resultList = append(resultList, info)
 		})
 		return resultList
 	}
 
-	require.Equal(t, []*Result{{Value: "TO"}, {Value: "CAMEL"}}, helper("TO_CAMEL"))
-	require.Equal(t, []*Result{{Value: "to"}, {Value: "camel"}}, helper("to_camel"))
-	require.Equal(t, []*Result{{Value: "to"}, {Value: "Camel"}}, helper("toCamel"))
-	require.Equal(t, []*Result{{Value: "To"}, {Value: "Camel"}}, helper("ToCamel"))
-	require.Equal(t, []*Result{{Value: "to"}, {Value: "camel"}}, helper("to-camel"))
+	require.Equal(t, []*wordInfo{{Word: "TO"}, {Word: "CAMEL"}}, helper("TO_CAMEL"))
+	require.Equal(t, []*wordInfo{{Word: "to"}, {Word: "camel"}}, helper("to_camel"))
+	require.Equal(t, []*wordInfo{{Word: "to"}, {Word: "Camel"}}, helper("toCamel"))
+	require.Equal(t, []*wordInfo{{Word: "To"}, {Word: "Camel"}}, helper("ToCamel"))
+	require.Equal(t, []*wordInfo{{Word: "to"}, {Word: "camel"}}, helper("to-camel"))
 
-	require.Equal(t, []*Result{{Value: "Related"}, {Value: "URLs", HasCommonInitial: true}}, helper("RelatedURLs"))
-	require.Equal(t, []*Result{{Value: "Image"}, {Value: "IDs", HasCommonInitial: true}}, helper("ImageIDs"))
-	require.Equal(t, []*Result{{Value: "Foo"}, {Value: "ID", HasCommonInitial: true}}, helper("FooID"))
-	require.Equal(t, []*Result{{Value: "ID", HasCommonInitial: true}, {Value: "Foo"}}, helper("IDFoo"))
-	require.Equal(t, []*Result{{Value: "Foo"}, {Value: "ASCII", HasCommonInitial: true}}, helper("FooASCII"))
-	require.Equal(t, []*Result{{Value: "ASCII", HasCommonInitial: true}, {Value: "Foo"}}, helper("ASCIIFoo"))
-	require.Equal(t, []*Result{{Value: "Foo"}, {Value: "UTF8", HasCommonInitial: true}}, helper("FooUTF8"))
-	require.Equal(t, []*Result{{Value: "UTF8", HasCommonInitial: true}, {Value: "Foo"}}, helper("UTF8Foo"))
+	require.Equal(t, []*wordInfo{{Word: "Related"}, {Word: "URLs", HasCommonInitial: true}}, helper("RelatedURLs"))
+	require.Equal(t, []*wordInfo{{Word: "Image"}, {Word: "IDs", HasCommonInitial: true}}, helper("ImageIDs"))
+	require.Equal(t, []*wordInfo{{Word: "Foo"}, {Word: "ID", HasCommonInitial: true, MatchCommonInitial: true}}, helper("FooID"))
+	require.Equal(t, []*wordInfo{{Word: "ID", HasCommonInitial: true, MatchCommonInitial: true}, {Word: "Foo"}}, helper("IDFoo"))
+	require.Equal(t, []*wordInfo{{Word: "Foo"}, {Word: "ASCII", HasCommonInitial: true, MatchCommonInitial: true}}, helper("FooASCII"))
+	require.Equal(t, []*wordInfo{{Word: "ASCII", HasCommonInitial: true, MatchCommonInitial: true}, {Word: "Foo"}}, helper("ASCIIFoo"))
+	require.Equal(t, []*wordInfo{{Word: "Foo"}, {Word: "UTF8", HasCommonInitial: true, MatchCommonInitial: true}}, helper("FooUTF8"))
+	require.Equal(t, []*wordInfo{{Word: "UTF8", HasCommonInitial: true, MatchCommonInitial: true}, {Word: "Foo"}}, helper("UTF8Foo"))
 
-	require.Equal(t, []*Result{{Value: "A"}}, helper("A"))
-	require.Equal(t, []*Result{{Value: "ID", HasCommonInitial: true}}, helper("ID"))
-	require.Equal(t, []*Result{{Value: "ID", HasCommonInitial: true}}, helper("id"))
-	require.Equal(t, []*Result{}, helper(""))
+	require.Equal(t, []*wordInfo{{Word: "A"}}, helper("A"))
+	require.Equal(t, []*wordInfo{{Word: "ID", HasCommonInitial: true, MatchCommonInitial: true}}, helper("ID"))
+	require.Equal(t, []*wordInfo{{Word: "id", HasCommonInitial: true, MatchCommonInitial: true}}, helper("id"))
+	require.Equal(t, []*wordInfo{}, helper(""))
 
-	require.Equal(t, []*Result{{Value: "Related"}, {Value: "Urls"}}, helper("RelatedUrls"))
+	require.Equal(t, []*wordInfo{{Word: "Related"}, {Word: "Urls"}}, helper("RelatedUrls"))
 }
 
 func TestCenter(t *testing.T) {


### PR DESCRIPTION
in v0.8.0, `RelatedURLs` is convert to `RelatedUrls`, and `ImageIDs` be `ImageIds`.

I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [X] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
