### PR TITLE
Load the playground sources from HTTPS by default

### DIFF
--- a/handler/playground.go
+++ b/handler/playground.go
@@ -11,11 +11,11 @@ var page = template.Must(template.New("graphiql").Parse(`<!DOCTYPE html>
 	<meta charset=utf-8/>
 	<meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
 	<link rel="shortcut icon" href="https://graphcool-playground.netlify.com/favicon.png">
-	<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react@{{ .version }}/build/static/css/index.css" 
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphql-playground-react@{{ .version }}/build/static/css/index.css" 
 		integrity="{{ .cssSRI }}" crossorigin="anonymous"/>
-	<link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react@{{ .version }}/build/favicon.png"
+	<link rel="shortcut icon" href="https://cdn.jsdelivr.net/npm/graphql-playground-react@{{ .version }}/build/favicon.png"
 		integrity="{{ .faviconSRI }}" crossorigin="anonymous"/>
-	<script src="//cdn.jsdelivr.net/npm/graphql-playground-react@{{ .version }}/build/static/js/middleware.js"
+	<script src="https://cdn.jsdelivr.net/npm/graphql-playground-react@{{ .version }}/build/static/js/middleware.js"
 		integrity="{{ .jsSRI }}" crossorigin="anonymous"></script>
 	<title>{{.title}}</title>
 </head>


### PR DESCRIPTION
For some browsers on non-secure domains resources from CDN doesn't loads, so I made all cdn.jsdelivr.net resources of the playground by HTTPS by default

Here is no need to add any tests or documentation updates
