### PR TITLE
Fix for @deprecated directive not appearing

### DIFF
--- a/codegen/data.go
+++ b/codegen/data.go
@@ -62,9 +62,16 @@ func BuildData(cfg *config.Config) (*Data, error) {
 		return nil, err
 	}
 
+	dataDirectives := make(map[string]*Directive)
+	for name, d := range b.Directives {
+		if !d.Builtin {
+			dataDirectives[name] = d
+		}
+	}
+
 	s := Data{
 		Config:     cfg,
-		Directives: b.Directives,
+		Directives: dataDirectives,
 		Schema:     b.Schema,
 		SchemaStr:  b.SchemaStr,
 		Interfaces: map[string]*Interface{},

--- a/codegen/directive.go
+++ b/codegen/directive.go
@@ -11,8 +11,9 @@ import (
 )
 
 type Directive struct {
-	Name string
-	Args []*FieldArgument
+	Name    string
+	Args    []*FieldArgument
+	Builtin bool
 }
 
 func (b *builder) buildDirectives() (map[string]*Directive, error) {
@@ -22,8 +23,10 @@ func (b *builder) buildDirectives() (map[string]*Directive, error) {
 		if _, ok := directives[name]; ok {
 			return nil, errors.Errorf("directive with name %s already exists", name)
 		}
+
+		var builtin bool
 		if name == "skip" || name == "include" || name == "deprecated" {
-			continue
+			builtin = true
 		}
 
 		var args []*FieldArgument
@@ -50,8 +53,9 @@ func (b *builder) buildDirectives() (map[string]*Directive, error) {
 		}
 
 		directives[name] = &Directive{
-			Name: name,
-			Args: args,
+			Name:    name,
+			Args:    args,
+			Builtin: builtin,
 		}
 	}
 

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -110,6 +110,9 @@ func (r *queryResolver) ShapeUnion(ctx context.Context) (ShapeUnion, error) {
 func (r *queryResolver) Autobind(ctx context.Context) (*Autobind, error) {
 	panic("not implemented")
 }
+func (r *queryResolver) DeprecatedField(ctx context.Context) (string, error) {
+	panic("not implemented")
+}
 func (r *queryResolver) Panics(ctx context.Context) (*Panics, error) {
 	panic("not implemented")
 }

--- a/codegen/testserver/schema.graphql
+++ b/codegen/testserver/schema.graphql
@@ -18,6 +18,7 @@ type Query {
     inputSlice(arg: [String!]!): Boolean!
     shapeUnion: ShapeUnion!
     autobind: Autobind
+    deprecatedField: String! @deprecated(reason: "test deprecated directive")
 }
 
 type Subscription {

--- a/codegen/testserver/stub.go
+++ b/codegen/testserver/stub.go
@@ -40,6 +40,7 @@ type Stub struct {
 		InputSlice             func(ctx context.Context, arg []string) (bool, error)
 		ShapeUnion             func(ctx context.Context) (ShapeUnion, error)
 		Autobind               func(ctx context.Context) (*Autobind, error)
+		DeprecatedField        func(ctx context.Context) (string, error)
 		Panics                 func(ctx context.Context) (*Panics, error)
 		ValidType              func(ctx context.Context) (*ValidType, error)
 	}
@@ -150,6 +151,9 @@ func (r *stubQuery) ShapeUnion(ctx context.Context) (ShapeUnion, error) {
 }
 func (r *stubQuery) Autobind(ctx context.Context) (*Autobind, error) {
 	return r.QueryResolver.Autobind(ctx)
+}
+func (r *stubQuery) DeprecatedField(ctx context.Context) (string, error) {
+	return r.QueryResolver.DeprecatedField(ctx)
 }
 func (r *stubQuery) Panics(ctx context.Context) (*Panics, error) {
 	return r.QueryResolver.Panics(ctx)


### PR DESCRIPTION
Fixes #580

During `buildDirectives` in codegen, the builtin directives `skip`, `include`, and `deprecated` are skipped over.  This causes them to not be registered with the builder later when building objects.  It seems like `deprecated` is definitely needed, since it's a schema directive.  `skip` and `include` I'm not so sure about.  @vektah what's the reason for skipping these in build?