### PR TITLE
Fix default scalar implementation regression

### DIFF
--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -116,6 +116,9 @@ func (r *queryResolver) DeprecatedField(ctx context.Context) (string, error) {
 func (r *queryResolver) Panics(ctx context.Context) (*Panics, error) {
 	panic("not implemented")
 }
+func (r *queryResolver) DefaultScalar(ctx context.Context, arg string) (string, error) {
+	panic("not implemented")
+}
 func (r *queryResolver) ValidType(ctx context.Context) (*ValidType, error) {
 	panic("not implemented")
 }

--- a/codegen/testserver/scalar_default.graphql
+++ b/codegen/testserver/scalar_default.graphql
@@ -1,0 +1,6 @@
+extend type Query {
+    defaultScalar(arg: DefaultScalarImplementation! = "default"): DefaultScalarImplementation!
+}
+
+""" This doesnt have an implementation in the typemap, so it should act like a string """
+scalar DefaultScalarImplementation

--- a/codegen/testserver/scalar_default_test.go
+++ b/codegen/testserver/scalar_default_test.go
@@ -1,0 +1,34 @@
+package testserver
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/99designs/gqlgen/client"
+	"github.com/99designs/gqlgen/handler"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultScalarImplementation(t *testing.T) {
+	resolvers := &Stub{}
+
+	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
+	c := client.New(srv.URL)
+
+	resolvers.QueryResolver.DefaultScalar = func(ctx context.Context, arg string) (i string, e error) {
+		return arg, nil
+	}
+
+	t.Run("with arg value", func(t *testing.T) {
+		var resp struct{ DefaultScalar string }
+		c.MustPost(`query { defaultScalar(arg: "fff") }`, &resp)
+		require.Equal(t, "fff", resp.DefaultScalar)
+	})
+
+	t.Run("with default value", func(t *testing.T) {
+		var resp struct{ DefaultScalar string }
+		c.MustPost(`query { defaultScalar  }`, &resp)
+		require.Equal(t, "default", resp.DefaultScalar)
+	})
+}

--- a/codegen/testserver/stub.go
+++ b/codegen/testserver/stub.go
@@ -42,6 +42,7 @@ type Stub struct {
 		Autobind               func(ctx context.Context) (*Autobind, error)
 		DeprecatedField        func(ctx context.Context) (string, error)
 		Panics                 func(ctx context.Context) (*Panics, error)
+		DefaultScalar          func(ctx context.Context, arg string) (string, error)
 		ValidType              func(ctx context.Context) (*ValidType, error)
 	}
 	SubscriptionResolver struct {
@@ -157,6 +158,9 @@ func (r *stubQuery) DeprecatedField(ctx context.Context) (string, error) {
 }
 func (r *stubQuery) Panics(ctx context.Context) (*Panics, error) {
 	return r.QueryResolver.Panics(ctx)
+}
+func (r *stubQuery) DefaultScalar(ctx context.Context, arg string) (string, error) {
+	return r.QueryResolver.DefaultScalar(ctx, arg)
 }
 func (r *stubQuery) ValidType(ctx context.Context) (*ValidType, error) {
 	return r.QueryResolver.ValidType(ctx)

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -4,10 +4,9 @@ import (
 	"go/types"
 	"sort"
 
-	"github.com/99designs/gqlgen/internal/code"
-
 	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/99designs/gqlgen/codegen/templates"
+	"github.com/99designs/gqlgen/internal/code"
 	"github.com/99designs/gqlgen/plugin"
 	"github.com/vektah/gqlparser/ast"
 )
@@ -17,6 +16,7 @@ type ModelBuild struct {
 	Interfaces  []*Interface
 	Models      []*Object
 	Enums       []*Enum
+	Scalars     []string
 }
 
 type Interface struct {
@@ -159,6 +159,8 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 			}
 
 			b.Enums = append(b.Enums, it)
+		case ast.Scalar:
+			b.Scalars = append(b.Scalars, schemaType.Name)
 		}
 	}
 
@@ -174,6 +176,9 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 	}
 	for _, it := range b.Interfaces {
 		cfg.Models.Add(it.Name, cfg.Model.ImportPath()+"."+it.Name)
+	}
+	for _, it := range b.Scalars {
+		cfg.Models.Add(it, "github.com/99designs/gqlgen/graphql.String")
 	}
 
 	if len(b.Models) == 0 && len(b.Enums) == 0 {


### PR DESCRIPTION
As of 0.8 modelgen ensures that all models have a backing implementation before the codegen phase runs... Except for default scalars, which we apparently we don't use anywhere in gqlgen either.

Fixes #575

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
