### PR TITLE
Fix autocasing modelgen bugs

### DIFF
--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -53,6 +53,14 @@ type DirectiveRoot struct {
 }
 
 type ComplexityRoot struct {
+	Ait struct {
+		ID func(childComplexity int) int
+	}
+
+	AbIt struct {
+		ID func(childComplexity int) int
+	}
+
 	Autobind struct {
 		Int   func(childComplexity int) int
 		Int32 func(childComplexity int) int
@@ -160,6 +168,22 @@ type ComplexityRoot struct {
 		ValidInputKeywords func(childComplexity int, input *ValidInput) int
 		ValidArgs          func(childComplexity int, breakArg string, defaultArg string, funcArg string, interfaceArg string, selectArg string, caseArg string, deferArg string, goArg string, mapArg string, structArg string, chanArg string, elseArg string, gotoArg string, packageArg string, switchArg string, constArg string, fallthroughArg string, ifArg string, rangeArg string, typeArg string, continueArg string, forArg string, importArg string, returnArg string, varArg string, _Arg string) int
 	}
+
+	Xxit struct {
+		ID func(childComplexity int) int
+	}
+
+	XxIt struct {
+		ID func(childComplexity int) int
+	}
+
+	AsdfIt struct {
+		ID func(childComplexity int) int
+	}
+
+	IIt struct {
+		ID func(childComplexity int) int
+	}
 }
 
 type ForcedResolverResolver interface {
@@ -220,6 +244,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 	ec := executionContext{nil, e}
 	_ = ec
 	switch typeName + "." + field {
+
+	case "AIt.ID":
+		if e.complexity.Ait.ID == nil {
+			break
+		}
+
+		return e.complexity.Ait.ID(childComplexity), true
+
+	case "AbIt.ID":
+		if e.complexity.AbIt.ID == nil {
+			break
+		}
+
+		return e.complexity.AbIt.ID(childComplexity), true
 
 	case "Autobind.Int":
 		if e.complexity.Autobind.Int == nil {
@@ -716,6 +754,34 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ValidType.ValidArgs(childComplexity, args["break"].(string), args["default"].(string), args["func"].(string), args["interface"].(string), args["select"].(string), args["case"].(string), args["defer"].(string), args["go"].(string), args["map"].(string), args["struct"].(string), args["chan"].(string), args["else"].(string), args["goto"].(string), args["package"].(string), args["switch"].(string), args["const"].(string), args["fallthrough"].(string), args["if"].(string), args["range"].(string), args["type"].(string), args["continue"].(string), args["for"].(string), args["import"].(string), args["return"].(string), args["var"].(string), args["_"].(string)), true
 
+	case "XXIt.ID":
+		if e.complexity.Xxit.ID == nil {
+			break
+		}
+
+		return e.complexity.Xxit.ID(childComplexity), true
+
+	case "XxIt.ID":
+		if e.complexity.XxIt.ID == nil {
+			break
+		}
+
+		return e.complexity.XxIt.ID(childComplexity), true
+
+	case "asdfIt.ID":
+		if e.complexity.AsdfIt.ID == nil {
+			break
+		}
+
+		return e.complexity.AsdfIt.ID(childComplexity), true
+
+	case "iIt.ID":
+		if e.complexity.IIt.ID == nil {
+			break
+		}
+
+		return e.complexity.IIt.ID(childComplexity), true
+
 	}
 	return 0, false
 }
@@ -1064,6 +1130,15 @@ input ValidInput {
     _:           String!
 }
 
+`},
+	&ast.Source{Name: "weird_type_cases.graphql", Input: `# regression test for https://github.com/99designs/gqlgen/issues/583
+
+type asdfIt { id: ID! }
+type iIt { id: ID! }
+type AIt { id: ID! }
+type XXIt { id: ID! }
+type AbIt { id: ID! }
+type XxIt { id: ID! }
 `},
 )
 
@@ -1614,6 +1689,58 @@ func (ec *executionContext) field___Type_fields_args(ctx context.Context, rawArg
 // endregion ***************************** args.gotpl *****************************
 
 // region    **************************** field.gotpl *****************************
+
+func (ec *executionContext) _AIt_id(ctx context.Context, field graphql.CollectedField, obj *Ait) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object: "AIt",
+		Field:  field,
+		Args:   nil,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _AbIt_id(ctx context.Context, field graphql.CollectedField, obj *AbIt) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object: "AbIt",
+		Field:  field,
+		Args:   nil,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
 
 func (ec *executionContext) _Autobind_int(ctx context.Context, field graphql.CollectedField, obj *Autobind) graphql.Marshaler {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
@@ -3256,6 +3383,58 @@ func (ec *executionContext) _ValidType_validArgs(ctx context.Context, field grap
 	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _XXIt_id(ctx context.Context, field graphql.CollectedField, obj *Xxit) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object: "XXIt",
+		Field:  field,
+		Args:   nil,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _XxIt_id(ctx context.Context, field graphql.CollectedField, obj *XxIt) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object: "XxIt",
+		Field:  field,
+		Args:   nil,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql.CollectedField, obj *introspection.Directive) graphql.Marshaler {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
@@ -4051,6 +4230,58 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 	return ec.marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _asdfIt_id(ctx context.Context, field graphql.CollectedField, obj *AsdfIt) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object: "asdfIt",
+		Field:  field,
+		Args:   nil,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _iIt_id(ctx context.Context, field graphql.CollectedField, obj *IIt) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object: "iIt",
+		Field:  field,
+		Args:   nil,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
 // endregion **************************** field.gotpl *****************************
 
 // region    **************************** input.gotpl *****************************
@@ -4401,6 +4632,60 @@ func (ec *executionContext) _ShapeUnion(ctx context.Context, sel ast.SelectionSe
 // endregion ************************** interface.gotpl ***************************
 
 // region    **************************** object.gotpl ****************************
+
+var aItImplementors = []string{"AIt"}
+
+func (ec *executionContext) _AIt(ctx context.Context, sel ast.SelectionSet, obj *Ait) graphql.Marshaler {
+	fields := graphql.CollectFields(ctx, sel, aItImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	invalid := false
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AIt")
+		case "id":
+			out.Values[i] = ec._AIt_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalid = true
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalid {
+		return graphql.Null
+	}
+	return out
+}
+
+var abItImplementors = []string{"AbIt"}
+
+func (ec *executionContext) _AbIt(ctx context.Context, sel ast.SelectionSet, obj *AbIt) graphql.Marshaler {
+	fields := graphql.CollectFields(ctx, sel, abItImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	invalid := false
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AbIt")
+		case "id":
+			out.Values[i] = ec._AbIt_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalid = true
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalid {
+		return graphql.Null
+	}
+	return out
+}
 
 var autobindImplementors = []string{"Autobind"}
 
@@ -5241,6 +5526,60 @@ func (ec *executionContext) _ValidType(ctx context.Context, sel ast.SelectionSet
 	return out
 }
 
+var xXItImplementors = []string{"XXIt"}
+
+func (ec *executionContext) _XXIt(ctx context.Context, sel ast.SelectionSet, obj *Xxit) graphql.Marshaler {
+	fields := graphql.CollectFields(ctx, sel, xXItImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	invalid := false
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("XXIt")
+		case "id":
+			out.Values[i] = ec._XXIt_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalid = true
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalid {
+		return graphql.Null
+	}
+	return out
+}
+
+var xxItImplementors = []string{"XxIt"}
+
+func (ec *executionContext) _XxIt(ctx context.Context, sel ast.SelectionSet, obj *XxIt) graphql.Marshaler {
+	fields := graphql.CollectFields(ctx, sel, xxItImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	invalid := false
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("XxIt")
+		case "id":
+			out.Values[i] = ec._XxIt_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalid = true
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalid {
+		return graphql.Null
+	}
+	return out
+}
+
 var __DirectiveImplementors = []string{"__Directive"}
 
 func (ec *executionContext) ___Directive(ctx context.Context, sel ast.SelectionSet, obj *introspection.Directive) graphql.Marshaler {
@@ -5471,6 +5810,60 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 			out.Values[i] = ec.___Type_inputFields(ctx, field, obj)
 		case "ofType":
 			out.Values[i] = ec.___Type_ofType(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalid {
+		return graphql.Null
+	}
+	return out
+}
+
+var asdfItImplementors = []string{"asdfIt"}
+
+func (ec *executionContext) _asdfIt(ctx context.Context, sel ast.SelectionSet, obj *AsdfIt) graphql.Marshaler {
+	fields := graphql.CollectFields(ctx, sel, asdfItImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	invalid := false
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("asdfIt")
+		case "id":
+			out.Values[i] = ec._asdfIt_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalid = true
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalid {
+		return graphql.Null
+	}
+	return out
+}
+
+var iItImplementors = []string{"iIt"}
+
+func (ec *executionContext) _iIt(ctx context.Context, sel ast.SelectionSet, obj *IIt) graphql.Marshaler {
+	fields := graphql.CollectFields(ctx, sel, iItImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	invalid := false
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("iIt")
+		case "id":
+			out.Values[i] = ec._iIt_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalid = true
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/codegen/testserver/models-gen.go
+++ b/codegen/testserver/models-gen.go
@@ -9,6 +9,14 @@ import (
 	"time"
 )
 
+type Ait struct {
+	ID string `json:"id"`
+}
+
+type AbIt struct {
+	ID string `json:"id"`
+}
+
 type InnerDirectives struct {
 	Message string `json:"message"`
 }
@@ -78,6 +86,22 @@ type ValidType struct {
 	DifferentCaseOld   string `json:"different_case"`
 	ValidInputKeywords bool   `json:"validInputKeywords"`
 	ValidArgs          bool   `json:"validArgs"`
+}
+
+type Xxit struct {
+	ID string `json:"id"`
+}
+
+type XxIt struct {
+	ID string `json:"id"`
+}
+
+type AsdfIt struct {
+	ID string `json:"id"`
+}
+
+type IIt struct {
+	ID string `json:"id"`
 }
 
 type Status string

--- a/codegen/testserver/weird_type_cases.graphql
+++ b/codegen/testserver/weird_type_cases.graphql
@@ -1,0 +1,8 @@
+# regression test for https://github.com/99designs/gqlgen/issues/583
+
+type asdfIt { id: ID! }
+type iIt { id: ID! }
+type AIt { id: ID! }
+type XXIt { id: ID! }
+type AbIt { id: ID! }
+type XxIt { id: ID! }

--- a/plugin/modelgen/models.gotpl
+++ b/plugin/modelgen/models.gotpl
@@ -14,71 +14,71 @@
 
 {{- range $model := .Interfaces }}
 	{{ with .Description }} {{.|prefixLines "// "}} {{ end }}
-	type {{.Name }} interface {
-		Is{{.Name }}()
+	type {{.Name|go }} interface {
+		Is{{.Name|go }}()
 	}
 {{- end }}
 
 {{ range $model := .Models }}
 	{{with .Description }} {{.|prefixLines "// "}} {{end}}
-	type {{ .Name }} struct {
+	type {{ .Name|go }} struct {
 		{{- range $field := .Fields }}
 			{{- with .Description }}
 				{{.|prefixLines "// "}}
 			{{- end}}
-			{{ $field.Name }} {{$field.Type | ref}} `{{$field.Tag}}`
+			{{ $field.Name|go }} {{$field.Type | ref}} `{{$field.Tag}}`
 		{{- end }}
 	}
 
 	{{- range $iface := .Implements }}
-		func ({{ $model.Name }}) Is{{ $iface }}() {}
+		func ({{ $model.Name|go }}) Is{{ $iface }}() {}
 	{{- end }}
 {{- end}}
 
 {{ range $enum := .Enums }}
-	{{ with .Description }} {{.|prefixLines "// "}} {{end}}
-	type {{.Name }} string
+	{{ with .Description|go }} {{.|prefixLines "// "}} {{end}}
+	type {{.Name|go }} string
 	const (
 	{{- range $value := .Values}}
 		{{- with .Description}}
 			{{.|prefixLines "// "}}
 		{{- end}}
-		{{ $enum.Name }}{{ .Name }} {{$enum.Name }} = {{.Value|quote}}
+		{{ $enum.Name|go }}{{ .Name|go }} {{$enum.Name|go }} = {{.Name|quote}}
 	{{- end }}
 	)
 
-	var All{{.Name }} = []{{ .Name }}{
+	var All{{.Name|go }} = []{{ .Name|go }}{
 	{{- range $value := .Values}}
-		{{$enum.Name }}{{ .Name }},
+		{{$enum.Name|go }}{{ .Name|go }},
 	{{- end }}
 	}
 
-	func (e {{.Name }}) IsValid() bool {
+	func (e {{.Name|go }}) IsValid() bool {
 		switch e {
-		case {{ range $index, $element := .Values}}{{if $index}},{{end}}{{ $enum.Name }}{{ $element.Name }}{{end}}:
+		case {{ range $index, $element := .Values}}{{if $index}},{{end}}{{ $enum.Name|go }}{{ $element.Name|go }}{{end}}:
 			return true
 		}
 		return false
 	}
 
-	func (e {{.Name }}) String() string {
+	func (e {{.Name|go }}) String() string {
 		return string(e)
 	}
 
-	func (e *{{.Name }}) UnmarshalGQL(v interface{}) error {
+	func (e *{{.Name|go }}) UnmarshalGQL(v interface{}) error {
 		str, ok := v.(string)
 		if !ok {
 			return fmt.Errorf("enums must be strings")
 		}
 
-		*e = {{ .Name }}(str)
+		*e = {{ .Name|go }}(str)
 		if !e.IsValid() {
-			return fmt.Errorf("%s is not a valid {{ .Raw }}", str)
+			return fmt.Errorf("%s is not a valid {{ .Name }}", str)
 		}
 		return nil
 	}
 
-	func (e {{.Name }}) MarshalGQL(w io.Writer) {
+	func (e {{.Name|go }}) MarshalGQL(w io.Writer) {
 		fmt.Fprint(w, strconv.Quote(e.String()))
 	}
 


### PR DESCRIPTION
modelgen was applying the go caseifier to name directly, which was causing some undefined type errors whenever it disagreed with the original case. 

Now it only does it where it needs to.

Fixes #583

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
