### PR TITLE
Fix directives on args with custom type

### DIFF
--- a/codegen/args.gotpl
+++ b/codegen/args.gotpl
@@ -24,7 +24,7 @@ func (ec *executionContext) {{ $name }}(ctx context.Context, rawArgs map[string]
 				if err != nil {
 					return nil, err
 				}
-				if data, ok := tmp.({{ $arg.TypeReference.GO }}) ; ok {
+				if data, ok := tmp.({{ $arg.TypeReference.GO | ref }}) ; ok {
 					arg{{$i}} = data
 				} else {
 					return nil, fmt.Errorf(`unexpected type %T from directive, should be {{ $arg.TypeReference.GO }}`, tmp)

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -101,6 +101,9 @@ func (r *queryResolver) DirectiveInputNullable(ctx context.Context, arg *InputDi
 func (r *queryResolver) DirectiveInput(ctx context.Context, arg InputDirectives) (*string, error) {
 	panic("not implemented")
 }
+func (r *queryResolver) DirectiveInputType(ctx context.Context, arg InnerInput) (*string, error) {
+	panic("not implemented")
+}
 func (r *queryResolver) InputSlice(ctx context.Context, arg []string) (bool, error) {
 	panic("not implemented")
 }

--- a/codegen/testserver/schema.graphql
+++ b/codegen/testserver/schema.graphql
@@ -15,6 +15,7 @@ type Query {
     directiveNullableArg(arg: Int @range(min:0), arg2: Int @range): String
     directiveInputNullable(arg: InputDirectives): String
     directiveInput(arg: InputDirectives!): String
+    directiveInputType(arg: InnerInput! @custom): String
     inputSlice(arg: [String!]!): Boolean!
     shapeUnion: ShapeUnion!
     autobind: Autobind
@@ -126,6 +127,7 @@ type EmbeddedPointer {
 
 directive @length(min: Int!, max: Int) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 directive @range(min: Int = 0, max: Int) on ARGUMENT_DEFINITION
+directive @custom on ARGUMENT_DEFINITION
 
 enum Status {
     OK

--- a/codegen/testserver/stub.go
+++ b/codegen/testserver/stub.go
@@ -37,6 +37,7 @@ type Stub struct {
 		DirectiveNullableArg   func(ctx context.Context, arg *int, arg2 *int) (*string, error)
 		DirectiveInputNullable func(ctx context.Context, arg *InputDirectives) (*string, error)
 		DirectiveInput         func(ctx context.Context, arg InputDirectives) (*string, error)
+		DirectiveInputType     func(ctx context.Context, arg InnerInput) (*string, error)
 		InputSlice             func(ctx context.Context, arg []string) (bool, error)
 		ShapeUnion             func(ctx context.Context) (ShapeUnion, error)
 		Autobind               func(ctx context.Context) (*Autobind, error)
@@ -143,6 +144,9 @@ func (r *stubQuery) DirectiveInputNullable(ctx context.Context, arg *InputDirect
 }
 func (r *stubQuery) DirectiveInput(ctx context.Context, arg InputDirectives) (*string, error) {
 	return r.QueryResolver.DirectiveInput(ctx, arg)
+}
+func (r *stubQuery) DirectiveInputType(ctx context.Context, arg InnerInput) (*string, error) {
+	return r.QueryResolver.DirectiveInputType(ctx, arg)
 }
 func (r *stubQuery) InputSlice(ctx context.Context, arg []string) (bool, error) {
 	return r.QueryResolver.InputSlice(ctx, arg)


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

When generating code with a directive for an argument which is a custom type or input the full identifier of the type is returned, which causes errors.

Example:
```
if data, ok := tmp.(github.com/user/repository/model.MyInput) ; ok {
  arg0 = data
} else {
  return nil, fmt.Errorf(`unexpected type %T from directive, should be github.com/user/repository/model.MyInput`, tmp)
}
```

After applying the change, the code is fixed:
```
if data, ok := tmp.(model.MyInput); ok {
  arg0 = data
} else {
  return nil, fmt.Errorf(`unexpected type %T from directive, should be github.com/user/repository/model.MyInput`, tmp)
}
```