### PR TITLE
Allow configuring the complexity limit dynamically per request

### DIFF
--- a/docs/content/reference/complexity.md
+++ b/docs/content/reference/complexity.md
@@ -56,7 +56,7 @@ func main() {
 }
 ```
 
-Now any query with complexity greater than 5 is rejected by the API. By default, each field and level of depth adds one to the overall query complexity.
+Now any query with complexity greater than 5 is rejected by the API. By default, each field and level of depth adds one to the overall query complexity. You can also use `handler.ComplexityLimitFunc` to dynamically configure the complexity limit per request.
 
 This helps, but we still have a problem: the `posts` and `related` fields, which return arrays, are much more expensive to resolve than the scalar `title` and `text` fields. However, the default complexity calculation weights them equally. It would make more sense to apply a higher cost to the array fields.
 

--- a/graphql/context.go
+++ b/graphql/context.go
@@ -12,6 +12,7 @@ import (
 type Resolver func(ctx context.Context) (res interface{}, err error)
 type FieldMiddleware func(ctx context.Context, next Resolver) (res interface{}, err error)
 type RequestMiddleware func(ctx context.Context, next func(ctx context.Context) []byte) []byte
+type ComplexityLimitFunc func(ctx context.Context) int
 
 type RequestContext struct {
 	RawQuery  string

--- a/handler/graphql_test.go
+++ b/handler/graphql_test.go
@@ -1,10 +1,13 @@
 package handler
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/99designs/gqlgen/graphql"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -125,6 +128,52 @@ func TestHandlerHead(t *testing.T) {
 
 	resp := doRequest(h, "HEAD", "/graphql?query={me{name}}", ``)
 	assert.Equal(t, http.StatusMethodNotAllowed, resp.Code)
+}
+
+func TestHandlerComplexity(t *testing.T) {
+	t.Run("static complexity", func(t *testing.T) {
+		h := GraphQL(&executableSchemaStub{}, ComplexityLimit(2))
+
+		t.Run("below complexity limit", func(t *testing.T) {
+			resp := doRequest(h, "POST", "/graphql", `{"query":"{ me { name } }"}`)
+			assert.Equal(t, http.StatusOK, resp.Code)
+			assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+		})
+
+		t.Run("above complexity limit", func(t *testing.T) {
+			resp := doRequest(h, "POST", "/graphql", `{"query":"{ a: me { name } b: me { name } }"}`)
+			assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+			assert.Equal(t, `{"errors":[{"message":"operation has complexity 4, which exceeds the limit of 2"}],"data":null}`, resp.Body.String())
+		})
+	})
+
+	t.Run("dynamic complexity", func(t *testing.T) {
+		h := GraphQL(&executableSchemaStub{}, ComplexityLimitFunc(func(ctx context.Context) int {
+			reqCtx := graphql.GetRequestContext(ctx)
+			if strings.Contains(reqCtx.RawQuery, "dummy") {
+				return 4
+			}
+			return 2
+		}))
+
+		t.Run("below complexity limit", func(t *testing.T) {
+			resp := doRequest(h, "POST", "/graphql", `{"query":"{ me { name } }"}`)
+			assert.Equal(t, http.StatusOK, resp.Code)
+			assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+		})
+
+		t.Run("above complexity limit", func(t *testing.T) {
+			resp := doRequest(h, "POST", "/graphql", `{"query":"{ a: me { name } b: me { name } }"}`)
+			assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+			assert.Equal(t, `{"errors":[{"message":"operation has complexity 4, which exceeds the limit of 2"}],"data":null}`, resp.Body.String())
+		})
+
+		t.Run("within dynamic complexity limit", func(t *testing.T) {
+			resp := doRequest(h, "POST", "/graphql", `{"query":"{ a: me { name } dummy: me { name } }"}`)
+			assert.Equal(t, http.StatusOK, resp.Code)
+			assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+		})
+	})
 }
 
 func doRequest(handler http.Handler, method string, target string, body string) *httptest.ResponseRecorder {


### PR DESCRIPTION
This can be useful if you have different types of clients (internal, 3rd party), or if you want to allowed authorized users to query for more data. `ComplexityLimitFunc` only takes a context now, under the assumption that all data relevant for computing the limit can be fetched from there. Similar to how other middleware works.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
