### PR TITLE
Handle enum slices as directive parameter

### DIFF
--- a/codegen/directive.go
+++ b/codegen/directive.go
@@ -130,6 +130,11 @@ func (d *Directive) ResolveArgs(obj string, next string) string {
 			} else {
 				dArg = templates.Dump(arg.Default)
 			}
+			// for enum slices replace interface{} with actual type to match directive function signature
+			if arg.TypeReference.IsSlice() && arg.TypeReference.Definition.Kind == ast.Enum {
+				t := templates.CurrentImports.LookupType(arg.TypeReference.GO)
+				dArg = strings.Replace(dArg, "[]interface{}", t, 1)
+			}
 		} else if arg.Value == nil && arg.Default == nil {
 			dArg = "nil"
 		}

--- a/codegen/testserver/directive_test.go
+++ b/codegen/testserver/directive_test.go
@@ -39,6 +39,16 @@ func TestDirectives(t *testing.T) {
 		return &s, nil
 	}
 
+	resolvers.QueryResolver.DirectiveInputEnum = func(ctx context.Context, arg InnerInput) (i *string, e error) {
+		s := "Ok"
+		return &s, nil
+	}
+
+	resolvers.QueryResolver.DirectiveInputEnumSlice = func(ctx context.Context, arg InnerInput) (i *string, e error) {
+		s := "Ok"
+		return &s, nil
+	}
+
 	srv := httptest.NewServer(
 		handler.GraphQL(
 			NewExecutableSchema(Config{
@@ -96,6 +106,12 @@ func TestDirectives(t *testing.T) {
 						return nil, fmt.Errorf("unsupported type %T", res)
 					},
 					Custom: func(ctx context.Context, obj interface{}, next graphql.Resolver) (interface{}, error) {
+						return next(ctx)
+					},
+					Permissions: func(ctx context.Context, obj interface{}, next graphql.Resolver, roles Role) (interface{}, error) {
+						return next(ctx)
+					},
+					PermissionsSlice: func(ctx context.Context, obj interface{}, next graphql.Resolver, roles []Role) (interface{}, error) {
 						return next(ctx)
 					},
 				},
@@ -223,6 +239,26 @@ func TestDirectives(t *testing.T) {
 
 			require.Nil(t, err)
 			require.Equal(t, "Ok", *resp.DirectiveInputType)
+		})
+		t.Run("when directive params has enum", func(t *testing.T) {
+			var resp struct {
+				DirectiveInputEnum *string
+			}
+
+			err := c.Post(`query { directiveInputEnum(arg: {id: 1}) }`, &resp)
+
+			require.Nil(t, err)
+			require.Equal(t, "Ok", *resp.DirectiveInputEnum)
+		})
+		t.Run("when directive params has enum slice", func(t *testing.T) {
+			var resp struct {
+				DirectiveInputEnumSlice *string
+			}
+
+			err := c.Post(`query { directiveInputEnumSlice(arg: {id: 1}) }`, &resp)
+
+			require.Nil(t, err)
+			require.Equal(t, "Ok", *resp.DirectiveInputEnumSlice)
 		})
 	})
 }

--- a/codegen/testserver/models-gen.go
+++ b/codegen/testserver/models-gen.go
@@ -104,6 +104,47 @@ type IIt struct {
 	ID string `json:"id"`
 }
 
+type Role string
+
+const (
+	RoleAdmin Role = "ADMIN"
+	RoleUser  Role = "USER"
+)
+
+var AllRole = []Role{
+	RoleAdmin,
+	RoleUser,
+}
+
+func (e Role) IsValid() bool {
+	switch e {
+	case RoleAdmin, RoleUser:
+		return true
+	}
+	return false
+}
+
+func (e Role) String() string {
+	return string(e)
+}
+
+func (e *Role) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = Role(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid Role", str)
+	}
+	return nil
+}
+
+func (e Role) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 type Status string
 
 const (

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -104,6 +104,12 @@ func (r *queryResolver) DirectiveInput(ctx context.Context, arg InputDirectives)
 func (r *queryResolver) DirectiveInputType(ctx context.Context, arg InnerInput) (*string, error) {
 	panic("not implemented")
 }
+func (r *queryResolver) DirectiveInputEnum(ctx context.Context, arg InnerInput) (*string, error) {
+	panic("not implemented")
+}
+func (r *queryResolver) DirectiveInputEnumSlice(ctx context.Context, arg InnerInput) (*string, error) {
+	panic("not implemented")
+}
 func (r *queryResolver) InputSlice(ctx context.Context, arg []string) (bool, error) {
 	panic("not implemented")
 }

--- a/codegen/testserver/schema.graphql
+++ b/codegen/testserver/schema.graphql
@@ -16,6 +16,8 @@ type Query {
     directiveInputNullable(arg: InputDirectives): String
     directiveInput(arg: InputDirectives!): String
     directiveInputType(arg: InnerInput! @custom): String
+    directiveInputEnum(arg: InnerInput! @permissions(roles: ADMIN)): String
+    directiveInputEnumSlice(arg: InnerInput! @permissionsSlice(roles: [ADMIN])): String
     inputSlice(arg: [String!]!): Boolean!
     shapeUnion: ShapeUnion!
     autobind: Autobind
@@ -128,10 +130,17 @@ type EmbeddedPointer {
 directive @length(min: Int!, max: Int) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 directive @range(min: Int = 0, max: Int) on ARGUMENT_DEFINITION
 directive @custom on ARGUMENT_DEFINITION
+directive @permissionsSlice(roles: [Role!]!) on ARGUMENT_DEFINITION
+directive @permissions(roles: Role!) on ARGUMENT_DEFINITION
 
 enum Status {
     OK
     ERROR
+}
+
+enum Role {
+    ADMIN
+    USER
 }
 
 scalar Time

--- a/codegen/testserver/stub.go
+++ b/codegen/testserver/stub.go
@@ -21,30 +21,32 @@ type Stub struct {
 		ArgUnmarshal       func(ctx context.Context, obj *Panics, u []MarshalPanic) (bool, error)
 	}
 	QueryResolver struct {
-		InvalidIdentifier      func(ctx context.Context) (*invalid_packagename.InvalidIdentifier, error)
-		Collision              func(ctx context.Context) (*introspection1.It, error)
-		MapInput               func(ctx context.Context, input map[string]interface{}) (*bool, error)
-		Recursive              func(ctx context.Context, input *RecursiveInputSlice) (*bool, error)
-		NestedInputs           func(ctx context.Context, input [][]*OuterInput) (*bool, error)
-		NestedOutputs          func(ctx context.Context) ([][]*OuterObject, error)
-		Shapes                 func(ctx context.Context) ([]Shape, error)
-		ErrorBubble            func(ctx context.Context) (*Error, error)
-		ModelMethods           func(ctx context.Context) (*ModelMethods, error)
-		Valid                  func(ctx context.Context) (string, error)
-		User                   func(ctx context.Context, id int) (*User, error)
-		NullableArg            func(ctx context.Context, arg *int) (*string, error)
-		DirectiveArg           func(ctx context.Context, arg string) (*string, error)
-		DirectiveNullableArg   func(ctx context.Context, arg *int, arg2 *int) (*string, error)
-		DirectiveInputNullable func(ctx context.Context, arg *InputDirectives) (*string, error)
-		DirectiveInput         func(ctx context.Context, arg InputDirectives) (*string, error)
-		DirectiveInputType     func(ctx context.Context, arg InnerInput) (*string, error)
-		InputSlice             func(ctx context.Context, arg []string) (bool, error)
-		ShapeUnion             func(ctx context.Context) (ShapeUnion, error)
-		Autobind               func(ctx context.Context) (*Autobind, error)
-		DeprecatedField        func(ctx context.Context) (string, error)
-		Panics                 func(ctx context.Context) (*Panics, error)
-		DefaultScalar          func(ctx context.Context, arg string) (string, error)
-		ValidType              func(ctx context.Context) (*ValidType, error)
+		InvalidIdentifier       func(ctx context.Context) (*invalid_packagename.InvalidIdentifier, error)
+		Collision               func(ctx context.Context) (*introspection1.It, error)
+		MapInput                func(ctx context.Context, input map[string]interface{}) (*bool, error)
+		Recursive               func(ctx context.Context, input *RecursiveInputSlice) (*bool, error)
+		NestedInputs            func(ctx context.Context, input [][]*OuterInput) (*bool, error)
+		NestedOutputs           func(ctx context.Context) ([][]*OuterObject, error)
+		Shapes                  func(ctx context.Context) ([]Shape, error)
+		ErrorBubble             func(ctx context.Context) (*Error, error)
+		ModelMethods            func(ctx context.Context) (*ModelMethods, error)
+		Valid                   func(ctx context.Context) (string, error)
+		User                    func(ctx context.Context, id int) (*User, error)
+		NullableArg             func(ctx context.Context, arg *int) (*string, error)
+		DirectiveArg            func(ctx context.Context, arg string) (*string, error)
+		DirectiveNullableArg    func(ctx context.Context, arg *int, arg2 *int) (*string, error)
+		DirectiveInputNullable  func(ctx context.Context, arg *InputDirectives) (*string, error)
+		DirectiveInput          func(ctx context.Context, arg InputDirectives) (*string, error)
+		DirectiveInputType      func(ctx context.Context, arg InnerInput) (*string, error)
+		DirectiveInputEnum      func(ctx context.Context, arg InnerInput) (*string, error)
+		DirectiveInputEnumSlice func(ctx context.Context, arg InnerInput) (*string, error)
+		InputSlice              func(ctx context.Context, arg []string) (bool, error)
+		ShapeUnion              func(ctx context.Context) (ShapeUnion, error)
+		Autobind                func(ctx context.Context) (*Autobind, error)
+		DeprecatedField         func(ctx context.Context) (string, error)
+		Panics                  func(ctx context.Context) (*Panics, error)
+		DefaultScalar           func(ctx context.Context, arg string) (string, error)
+		ValidType               func(ctx context.Context) (*ValidType, error)
 	}
 	SubscriptionResolver struct {
 		Updated     func(ctx context.Context) (<-chan string, error)
@@ -147,6 +149,12 @@ func (r *stubQuery) DirectiveInput(ctx context.Context, arg InputDirectives) (*s
 }
 func (r *stubQuery) DirectiveInputType(ctx context.Context, arg InnerInput) (*string, error) {
 	return r.QueryResolver.DirectiveInputType(ctx, arg)
+}
+func (r *stubQuery) DirectiveInputEnum(ctx context.Context, arg InnerInput) (*string, error) {
+	return r.QueryResolver.DirectiveInputEnum(ctx, arg)
+}
+func (r *stubQuery) DirectiveInputEnumSlice(ctx context.Context, arg InnerInput) (*string, error) {
+	return r.QueryResolver.DirectiveInputEnumSlice(ctx, arg)
 }
 func (r *stubQuery) InputSlice(ctx context.Context, arg []string) (bool, error) {
 	return r.QueryResolver.InputSlice(ctx, arg)


### PR DESCRIPTION
When an enum is defined as an parameter of an directive, the code that is generated contains `[]interface{}` for example `[]interface{}{"ADMIN", "USER"}` instead of the actual type of the enum. This is incompatible with the generated directive function signature which has the explicit type of the enum slice. (see #603)

This change checks after the argument is dumped if the arg is a slice and enum. If this is the case it will replace `[]interface{}` by the actual type.

To me this seems to be a little hacky, but I couldn't find a better place to implement it. I cannot be done in `dump` as there is no reference to the actual type. But there might be a better way to solve this?

I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [X] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

Fixes: #603 
