### PR TITLE
types.NewInterfaceType -> types.NewInterface

### DIFF
--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -83,8 +83,8 @@ func (b *Binder) getPkg(find string) *packages.Package {
 	return nil
 }
 
-var MapType = types.NewMap(types.Typ[types.String], types.NewInterfaceType(nil, nil).Complete())
-var InterfaceType = types.NewInterfaceType(nil, nil)
+var MapType = types.NewMap(types.Typ[types.String], types.NewInterface(nil, nil).Complete())
+var InterfaceType = types.NewInterface(nil, nil)
 
 func (b *Binder) DefaultUserObject(name string) (types.Type, error) {
 	models := b.cfg.Models[name].Model


### PR DESCRIPTION
Changing types.NewInterfaceType to types.NewInterface, because there is no function named NewInterfaceType that causes error when running `go get github.com/99designs/gqlgen/cmd` to the following 
github.com/99designs/gqlgen/codegen/config
# github.com/99designs/gqlgen/codegen/config
../../../99designs/gqlgen/codegen/config/binder.go:86:53: undefined: types.NewInterfaceType
../../../99designs/gqlgen/codegen/config/binder.go:87:21: undefined: types.NewInterfaceType

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
