### PR TITLE
Allow user to supply path to gqlerror

### DIFF
--- a/graphql/error.go
+++ b/graphql/error.go
@@ -14,7 +14,9 @@ type ExtendedError interface {
 
 func DefaultErrorPresenter(ctx context.Context, err error) *gqlerror.Error {
 	if gqlerr, ok := err.(*gqlerror.Error); ok {
-		gqlerr.Path = GetResolverContext(ctx).Path()
+		if gqlerr.Path == nil {
+			gqlerr.Path = GetResolverContext(ctx).Path()
+		}
 		return gqlerr
 	}
 


### PR DESCRIPTION
Fixes #596 by only adding path to a `gqlerror` in the case when the user did not already set one.


I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))

