### PR TITLE
Handle colliding fields in complexity root gracefully

### DIFF
--- a/codegen/complexity.go
+++ b/codegen/complexity.go
@@ -1,0 +1,11 @@
+package codegen
+
+func (o *Object) UniqueFields() map[string]*Field {
+	m := map[string]*Field{}
+
+	for _, f := range o.Fields {
+		m[f.GoFieldName] = f
+	}
+
+	return m
+}

--- a/codegen/data.go
+++ b/codegen/data.go
@@ -20,6 +20,7 @@ type Data struct {
 	Inputs          Objects
 	Interfaces      map[string]*Interface
 	ReferencedTypes map[string]*config.TypeReference
+	ComplexityRoots map[string]*Object
 
 	QueryRoot        *Object
 	MutationRoot     *Object

--- a/codegen/generated!.gotpl
+++ b/codegen/generated!.gotpl
@@ -46,7 +46,7 @@ type ComplexityRoot struct {
 {{ range $object := .Objects }}
 	{{ if not $object.IsReserved -}}
 		{{ $object.Name|go }} struct {
-		{{ range $field := $object.Fields -}}
+		{{ range $field := $object.UniqueFields -}}
 			{{ if not $field.IsReserved -}}
 				{{ $field.GoFieldName }} {{ $field.ComplexitySignature }}
 			{{ end }}
@@ -84,7 +84,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 	switch typeName + "." + field {
 	{{ range $object := .Objects }}
 		{{ if not $object.IsReserved }}
-			{{ range $field := $object.Fields }}
+			{{ range $field := $object.UniqueFields }}
 				{{ if not $field.IsReserved }}
 					case "{{$object.Name}}.{{$field.GoFieldName}}":
 						if e.complexity.{{$object.Name|go}}.{{$field.GoFieldName}} == nil {

--- a/codegen/testserver/complexity.graphql
+++ b/codegen/testserver/complexity.graphql
@@ -1,0 +1,11 @@
+extend type Query {
+    overlapping: OverlappingFields
+}
+
+type OverlappingFields {
+  oneFoo: Int!
+  twoFoo: Int!
+  oldFoo: Int!
+  newFoo: Int!
+  new_foo: Int!
+}

--- a/codegen/testserver/complexity_test.go
+++ b/codegen/testserver/complexity_test.go
@@ -1,0 +1,46 @@
+package testserver
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/99designs/gqlgen/client"
+	"github.com/99designs/gqlgen/handler"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComplexityCollisions(t *testing.T) {
+	resolvers := &Stub{}
+
+	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
+	c := client.New(srv.URL)
+
+	resolvers.QueryResolver.Overlapping = func(ctx context.Context) (fields *OverlappingFields, e error) {
+		return &OverlappingFields{
+			Foo:    2,
+			NewFoo: 3,
+		}, nil
+	}
+
+	resolvers.OverlappingFieldsResolver.OldFoo = func(ctx context.Context, obj *OverlappingFields) (i int, e error) {
+		return obj.Foo, nil
+	}
+
+	var resp struct {
+		Overlapping struct {
+			OneFoo  int `json:"oneFoo"`
+			TwoFoo  int `json:"twoFoo"`
+			OldFoo  int `json:"oldFoo"`
+			NewFoo  int `json:"newFoo"`
+			New_foo int `json:"new_foo"`
+		}
+	}
+	c.MustPost(`query { overlapping { oneFoo, twoFoo, oldFoo, newFoo, new_foo } }`, &resp)
+	require.Equal(t, 2, resp.Overlapping.OneFoo)
+	require.Equal(t, 2, resp.Overlapping.TwoFoo)
+	require.Equal(t, 2, resp.Overlapping.OldFoo)
+	require.Equal(t, 3, resp.Overlapping.NewFoo)
+	require.Equal(t, 3, resp.Overlapping.New_foo)
+
+}

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -40,6 +40,7 @@ type Config struct {
 type ResolverRoot interface {
 	ForcedResolver() ForcedResolverResolver
 	ModelMethods() ModelMethodsResolver
+	OverlappingFields() OverlappingFieldsResolver
 	Panics() PanicsResolver
 	Query() QueryResolver
 	Subscription() SubscriptionResolver
@@ -64,16 +65,16 @@ type ComplexityRoot struct {
 	}
 
 	Autobind struct {
+		IdInt func(childComplexity int) int
+		IdStr func(childComplexity int) int
 		Int   func(childComplexity int) int
 		Int32 func(childComplexity int) int
 		Int64 func(childComplexity int) int
-		IdStr func(childComplexity int) int
-		IdInt func(childComplexity int) int
 	}
 
 	Circle struct {
-		Radius func(childComplexity int) int
 		Area   func(childComplexity int) int
+		Radius func(childComplexity int) int
 	}
 
 	EmbeddedDefaultScalar struct {
@@ -86,9 +87,9 @@ type ComplexityRoot struct {
 	}
 
 	Error struct {
-		ID                      func(childComplexity int) int
 		ErrorOnNonRequiredField func(childComplexity int) int
 		ErrorOnRequiredField    func(childComplexity int) int
+		ID                      func(childComplexity int) int
 		NilOnRequiredField      func(childComplexity int) int
 	}
 
@@ -114,8 +115,8 @@ type ComplexityRoot struct {
 	}
 
 	ModelMethods struct {
-		ResolverField func(childComplexity int) int
 		NoContext     func(childComplexity int) int
+		ResolverField func(childComplexity int) int
 		WithContext   func(childComplexity int) int
 	}
 
@@ -123,45 +124,52 @@ type ComplexityRoot struct {
 		Inner func(childComplexity int) int
 	}
 
+	OverlappingFields struct {
+		Foo    func(childComplexity int) int
+		NewFoo func(childComplexity int) int
+		OldFoo func(childComplexity int) int
+	}
+
 	Panics struct {
-		FieldScalarMarshal func(childComplexity int) int
-		FieldFuncMarshal   func(childComplexity int, u []MarshalPanic) int
 		ArgUnmarshal       func(childComplexity int, u []MarshalPanic) int
+		FieldFuncMarshal   func(childComplexity int, u []MarshalPanic) int
+		FieldScalarMarshal func(childComplexity int) int
 	}
 
 	Query struct {
-		InvalidIdentifier      func(childComplexity int) int
+		Autobind               func(childComplexity int) int
 		Collision              func(childComplexity int) int
+		DefaultScalar          func(childComplexity int, arg string) int
+		DeprecatedField        func(childComplexity int) int
+		DirectiveArg           func(childComplexity int, arg string) int
+		DirectiveInput         func(childComplexity int, arg InputDirectives) int
+		DirectiveInputNullable func(childComplexity int, arg *InputDirectives) int
+		DirectiveInputType     func(childComplexity int, arg InnerInput) int
+		DirectiveNullableArg   func(childComplexity int, arg *int, arg2 *int) int
+		ErrorBubble            func(childComplexity int) int
+		InputSlice             func(childComplexity int, arg []string) int
+		InvalidIdentifier      func(childComplexity int) int
 		MapInput               func(childComplexity int, input map[string]interface{}) int
-		Recursive              func(childComplexity int, input *RecursiveInputSlice) int
+		MapStringInterface     func(childComplexity int, in map[string]interface{}) int
+		ModelMethods           func(childComplexity int) int
 		NestedInputs           func(childComplexity int, input [][]*OuterInput) int
 		NestedOutputs          func(childComplexity int) int
-		Shapes                 func(childComplexity int) int
-		ErrorBubble            func(childComplexity int) int
-		ModelMethods           func(childComplexity int) int
-		Valid                  func(childComplexity int) int
-		User                   func(childComplexity int, id int) int
 		NullableArg            func(childComplexity int, arg *int) int
-		DirectiveArg           func(childComplexity int, arg string) int
-		DirectiveNullableArg   func(childComplexity int, arg *int, arg2 *int) int
-		DirectiveInputNullable func(childComplexity int, arg *InputDirectives) int
-		DirectiveInput         func(childComplexity int, arg InputDirectives) int
-		DirectiveInputType     func(childComplexity int, arg InnerInput) int
-		InputSlice             func(childComplexity int, arg []string) int
-		ShapeUnion             func(childComplexity int) int
-		Autobind               func(childComplexity int) int
-		DeprecatedField        func(childComplexity int) int
-		MapStringInterface     func(childComplexity int, in map[string]interface{}) int
+		Overlapping            func(childComplexity int) int
 		Panics                 func(childComplexity int) int
-		DefaultScalar          func(childComplexity int, arg string) int
+		Recursive              func(childComplexity int, input *RecursiveInputSlice) int
+		ShapeUnion             func(childComplexity int) int
+		Shapes                 func(childComplexity int) int
 		Slices                 func(childComplexity int) int
+		User                   func(childComplexity int, id int) int
+		Valid                  func(childComplexity int) int
 		ValidType              func(childComplexity int) int
 	}
 
 	Rectangle struct {
+		Area   func(childComplexity int) int
 		Length func(childComplexity int) int
 		Width  func(childComplexity int) int
-		Area   func(childComplexity int) int
 	}
 
 	Slices struct {
@@ -172,22 +180,22 @@ type ComplexityRoot struct {
 	}
 
 	Subscription struct {
-		Updated     func(childComplexity int) int
 		InitPayload func(childComplexity int) int
+		Updated     func(childComplexity int) int
 	}
 
 	User struct {
-		ID      func(childComplexity int) int
-		Friends func(childComplexity int) int
 		Created func(childComplexity int) int
+		Friends func(childComplexity int) int
+		ID      func(childComplexity int) int
 		Updated func(childComplexity int) int
 	}
 
 	ValidType struct {
 		DifferentCase      func(childComplexity int) int
 		DifferentCaseOld   func(childComplexity int) int
-		ValidInputKeywords func(childComplexity int, input *ValidInput) int
 		ValidArgs          func(childComplexity int, breakArg string, defaultArg string, funcArg string, interfaceArg string, selectArg string, caseArg string, deferArg string, goArg string, mapArg string, structArg string, chanArg string, elseArg string, gotoArg string, packageArg string, switchArg string, constArg string, fallthroughArg string, ifArg string, rangeArg string, typeArg string, continueArg string, forArg string, importArg string, returnArg string, varArg string, _Arg string) int
+		ValidInputKeywords func(childComplexity int, input *ValidInput) int
 	}
 
 	XXIt struct {
@@ -212,6 +220,9 @@ type ForcedResolverResolver interface {
 }
 type ModelMethodsResolver interface {
 	ResolverField(ctx context.Context, obj *ModelMethods) (bool, error)
+}
+type OverlappingFieldsResolver interface {
+	OldFoo(ctx context.Context, obj *OverlappingFields) (int, error)
 }
 type PanicsResolver interface {
 	FieldScalarMarshal(ctx context.Context, obj *Panics) ([]MarshalPanic, error)
@@ -240,6 +251,7 @@ type QueryResolver interface {
 	ShapeUnion(ctx context.Context) (ShapeUnion, error)
 	Autobind(ctx context.Context) (*Autobind, error)
 	DeprecatedField(ctx context.Context) (string, error)
+	Overlapping(ctx context.Context) (*OverlappingFields, error)
 	MapStringInterface(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error)
 	Panics(ctx context.Context) (*Panics, error)
 	DefaultScalar(ctx context.Context, arg string) (string, error)
@@ -283,6 +295,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.AbIt.ID(childComplexity), true
 
+	case "Autobind.IdInt":
+		if e.complexity.Autobind.IdInt == nil {
+			break
+		}
+
+		return e.complexity.Autobind.IdInt(childComplexity), true
+
+	case "Autobind.IdStr":
+		if e.complexity.Autobind.IdStr == nil {
+			break
+		}
+
+		return e.complexity.Autobind.IdStr(childComplexity), true
+
 	case "Autobind.Int":
 		if e.complexity.Autobind.Int == nil {
 			break
@@ -304,19 +330,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Autobind.Int64(childComplexity), true
 
-	case "Autobind.IdStr":
-		if e.complexity.Autobind.IdStr == nil {
+	case "Circle.Area":
+		if e.complexity.Circle.Area == nil {
 			break
 		}
 
-		return e.complexity.Autobind.IdStr(childComplexity), true
-
-	case "Autobind.IdInt":
-		if e.complexity.Autobind.IdInt == nil {
-			break
-		}
-
-		return e.complexity.Autobind.IdInt(childComplexity), true
+		return e.complexity.Circle.Area(childComplexity), true
 
 	case "Circle.Radius":
 		if e.complexity.Circle.Radius == nil {
@@ -324,13 +343,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Circle.Radius(childComplexity), true
-
-	case "Circle.Area":
-		if e.complexity.Circle.Area == nil {
-			break
-		}
-
-		return e.complexity.Circle.Area(childComplexity), true
 
 	case "EmbeddedDefaultScalar.Value":
 		if e.complexity.EmbeddedDefaultScalar.Value == nil {
@@ -353,13 +365,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.EmbeddedPointer.Title(childComplexity), true
 
-	case "Error.ID":
-		if e.complexity.Error.ID == nil {
-			break
-		}
-
-		return e.complexity.Error.ID(childComplexity), true
-
 	case "Error.ErrorOnNonRequiredField":
 		if e.complexity.Error.ErrorOnNonRequiredField == nil {
 			break
@@ -373,6 +378,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Error.ErrorOnRequiredField(childComplexity), true
+
+	case "Error.ID":
+		if e.complexity.Error.ID == nil {
+			break
+		}
+
+		return e.complexity.Error.ID(childComplexity), true
 
 	case "Error.NilOnRequiredField":
 		if e.complexity.Error.NilOnRequiredField == nil {
@@ -423,19 +435,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.MapStringInterfaceType.B(childComplexity), true
 
-	case "ModelMethods.ResolverField":
-		if e.complexity.ModelMethods.ResolverField == nil {
-			break
-		}
-
-		return e.complexity.ModelMethods.ResolverField(childComplexity), true
-
 	case "ModelMethods.NoContext":
 		if e.complexity.ModelMethods.NoContext == nil {
 			break
 		}
 
 		return e.complexity.ModelMethods.NoContext(childComplexity), true
+
+	case "ModelMethods.ResolverField":
+		if e.complexity.ModelMethods.ResolverField == nil {
+			break
+		}
+
+		return e.complexity.ModelMethods.ResolverField(childComplexity), true
 
 	case "ModelMethods.WithContext":
 		if e.complexity.ModelMethods.WithContext == nil {
@@ -451,24 +463,26 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.OuterObject.Inner(childComplexity), true
 
-	case "Panics.FieldScalarMarshal":
-		if e.complexity.Panics.FieldScalarMarshal == nil {
+	case "OverlappingFields.Foo":
+		if e.complexity.OverlappingFields.Foo == nil {
 			break
 		}
 
-		return e.complexity.Panics.FieldScalarMarshal(childComplexity), true
+		return e.complexity.OverlappingFields.Foo(childComplexity), true
 
-	case "Panics.FieldFuncMarshal":
-		if e.complexity.Panics.FieldFuncMarshal == nil {
+	case "OverlappingFields.NewFoo":
+		if e.complexity.OverlappingFields.NewFoo == nil {
 			break
 		}
 
-		args, err := ec.field_Panics_fieldFuncMarshal_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
+		return e.complexity.OverlappingFields.NewFoo(childComplexity), true
+
+	case "OverlappingFields.OldFoo":
+		if e.complexity.OverlappingFields.OldFoo == nil {
+			break
 		}
 
-		return e.complexity.Panics.FieldFuncMarshal(childComplexity, args["u"].([]MarshalPanic)), true
+		return e.complexity.OverlappingFields.OldFoo(childComplexity), true
 
 	case "Panics.ArgUnmarshal":
 		if e.complexity.Panics.ArgUnmarshal == nil {
@@ -482,12 +496,31 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Panics.ArgUnmarshal(childComplexity, args["u"].([]MarshalPanic)), true
 
-	case "Query.InvalidIdentifier":
-		if e.complexity.Query.InvalidIdentifier == nil {
+	case "Panics.FieldFuncMarshal":
+		if e.complexity.Panics.FieldFuncMarshal == nil {
 			break
 		}
 
-		return e.complexity.Query.InvalidIdentifier(childComplexity), true
+		args, err := ec.field_Panics_fieldFuncMarshal_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Panics.FieldFuncMarshal(childComplexity, args["u"].([]MarshalPanic)), true
+
+	case "Panics.FieldScalarMarshal":
+		if e.complexity.Panics.FieldScalarMarshal == nil {
+			break
+		}
+
+		return e.complexity.Panics.FieldScalarMarshal(childComplexity), true
+
+	case "Query.Autobind":
+		if e.complexity.Query.Autobind == nil {
+			break
+		}
+
+		return e.complexity.Query.Autobind(childComplexity), true
 
 	case "Query.Collision":
 		if e.complexity.Query.Collision == nil {
@@ -495,6 +528,111 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Collision(childComplexity), true
+
+	case "Query.DefaultScalar":
+		if e.complexity.Query.DefaultScalar == nil {
+			break
+		}
+
+		args, err := ec.field_Query_defaultScalar_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.DefaultScalar(childComplexity, args["arg"].(string)), true
+
+	case "Query.DeprecatedField":
+		if e.complexity.Query.DeprecatedField == nil {
+			break
+		}
+
+		return e.complexity.Query.DeprecatedField(childComplexity), true
+
+	case "Query.DirectiveArg":
+		if e.complexity.Query.DirectiveArg == nil {
+			break
+		}
+
+		args, err := ec.field_Query_directiveArg_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.DirectiveArg(childComplexity, args["arg"].(string)), true
+
+	case "Query.DirectiveInput":
+		if e.complexity.Query.DirectiveInput == nil {
+			break
+		}
+
+		args, err := ec.field_Query_directiveInput_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.DirectiveInput(childComplexity, args["arg"].(InputDirectives)), true
+
+	case "Query.DirectiveInputNullable":
+		if e.complexity.Query.DirectiveInputNullable == nil {
+			break
+		}
+
+		args, err := ec.field_Query_directiveInputNullable_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.DirectiveInputNullable(childComplexity, args["arg"].(*InputDirectives)), true
+
+	case "Query.DirectiveInputType":
+		if e.complexity.Query.DirectiveInputType == nil {
+			break
+		}
+
+		args, err := ec.field_Query_directiveInputType_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.DirectiveInputType(childComplexity, args["arg"].(InnerInput)), true
+
+	case "Query.DirectiveNullableArg":
+		if e.complexity.Query.DirectiveNullableArg == nil {
+			break
+		}
+
+		args, err := ec.field_Query_directiveNullableArg_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.DirectiveNullableArg(childComplexity, args["arg"].(*int), args["arg2"].(*int)), true
+
+	case "Query.ErrorBubble":
+		if e.complexity.Query.ErrorBubble == nil {
+			break
+		}
+
+		return e.complexity.Query.ErrorBubble(childComplexity), true
+
+	case "Query.InputSlice":
+		if e.complexity.Query.InputSlice == nil {
+			break
+		}
+
+		args, err := ec.field_Query_inputSlice_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.InputSlice(childComplexity, args["arg"].([]string)), true
+
+	case "Query.InvalidIdentifier":
+		if e.complexity.Query.InvalidIdentifier == nil {
+			break
+		}
+
+		return e.complexity.Query.InvalidIdentifier(childComplexity), true
 
 	case "Query.MapInput":
 		if e.complexity.Query.MapInput == nil {
@@ -508,17 +646,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.MapInput(childComplexity, args["input"].(map[string]interface{})), true
 
-	case "Query.Recursive":
-		if e.complexity.Query.Recursive == nil {
+	case "Query.MapStringInterface":
+		if e.complexity.Query.MapStringInterface == nil {
 			break
 		}
 
-		args, err := ec.field_Query_recursive_args(context.TODO(), rawArgs)
+		args, err := ec.field_Query_mapStringInterface_args(context.TODO(), rawArgs)
 		if err != nil {
 			return 0, false
 		}
 
-		return e.complexity.Query.Recursive(childComplexity, args["input"].(*RecursiveInputSlice)), true
+		return e.complexity.Query.MapStringInterface(childComplexity, args["in"].(map[string]interface{})), true
+
+	case "Query.ModelMethods":
+		if e.complexity.Query.ModelMethods == nil {
+			break
+		}
+
+		return e.complexity.Query.ModelMethods(childComplexity), true
 
 	case "Query.NestedInputs":
 		if e.complexity.Query.NestedInputs == nil {
@@ -539,6 +684,51 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.NestedOutputs(childComplexity), true
 
+	case "Query.NullableArg":
+		if e.complexity.Query.NullableArg == nil {
+			break
+		}
+
+		args, err := ec.field_Query_nullableArg_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.NullableArg(childComplexity, args["arg"].(*int)), true
+
+	case "Query.Overlapping":
+		if e.complexity.Query.Overlapping == nil {
+			break
+		}
+
+		return e.complexity.Query.Overlapping(childComplexity), true
+
+	case "Query.Panics":
+		if e.complexity.Query.Panics == nil {
+			break
+		}
+
+		return e.complexity.Query.Panics(childComplexity), true
+
+	case "Query.Recursive":
+		if e.complexity.Query.Recursive == nil {
+			break
+		}
+
+		args, err := ec.field_Query_recursive_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Recursive(childComplexity, args["input"].(*RecursiveInputSlice)), true
+
+	case "Query.ShapeUnion":
+		if e.complexity.Query.ShapeUnion == nil {
+			break
+		}
+
+		return e.complexity.Query.ShapeUnion(childComplexity), true
+
 	case "Query.Shapes":
 		if e.complexity.Query.Shapes == nil {
 			break
@@ -546,26 +736,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Shapes(childComplexity), true
 
-	case "Query.ErrorBubble":
-		if e.complexity.Query.ErrorBubble == nil {
+	case "Query.Slices":
+		if e.complexity.Query.Slices == nil {
 			break
 		}
 
-		return e.complexity.Query.ErrorBubble(childComplexity), true
-
-	case "Query.ModelMethods":
-		if e.complexity.Query.ModelMethods == nil {
-			break
-		}
-
-		return e.complexity.Query.ModelMethods(childComplexity), true
-
-	case "Query.Valid":
-		if e.complexity.Query.Valid == nil {
-			break
-		}
-
-		return e.complexity.Query.Valid(childComplexity), true
+		return e.complexity.Query.Slices(childComplexity), true
 
 	case "Query.User":
 		if e.complexity.Query.User == nil {
@@ -579,148 +755,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.User(childComplexity, args["id"].(int)), true
 
-	case "Query.NullableArg":
-		if e.complexity.Query.NullableArg == nil {
+	case "Query.Valid":
+		if e.complexity.Query.Valid == nil {
 			break
 		}
 
-		args, err := ec.field_Query_nullableArg_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.NullableArg(childComplexity, args["arg"].(*int)), true
-
-	case "Query.DirectiveArg":
-		if e.complexity.Query.DirectiveArg == nil {
-			break
-		}
-
-		args, err := ec.field_Query_directiveArg_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.DirectiveArg(childComplexity, args["arg"].(string)), true
-
-	case "Query.DirectiveNullableArg":
-		if e.complexity.Query.DirectiveNullableArg == nil {
-			break
-		}
-
-		args, err := ec.field_Query_directiveNullableArg_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.DirectiveNullableArg(childComplexity, args["arg"].(*int), args["arg2"].(*int)), true
-
-	case "Query.DirectiveInputNullable":
-		if e.complexity.Query.DirectiveInputNullable == nil {
-			break
-		}
-
-		args, err := ec.field_Query_directiveInputNullable_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.DirectiveInputNullable(childComplexity, args["arg"].(*InputDirectives)), true
-
-	case "Query.DirectiveInput":
-		if e.complexity.Query.DirectiveInput == nil {
-			break
-		}
-
-		args, err := ec.field_Query_directiveInput_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.DirectiveInput(childComplexity, args["arg"].(InputDirectives)), true
-
-	case "Query.DirectiveInputType":
-		if e.complexity.Query.DirectiveInputType == nil {
-			break
-		}
-
-		args, err := ec.field_Query_directiveInputType_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.DirectiveInputType(childComplexity, args["arg"].(InnerInput)), true
-
-	case "Query.InputSlice":
-		if e.complexity.Query.InputSlice == nil {
-			break
-		}
-
-		args, err := ec.field_Query_inputSlice_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.InputSlice(childComplexity, args["arg"].([]string)), true
-
-	case "Query.ShapeUnion":
-		if e.complexity.Query.ShapeUnion == nil {
-			break
-		}
-
-		return e.complexity.Query.ShapeUnion(childComplexity), true
-
-	case "Query.Autobind":
-		if e.complexity.Query.Autobind == nil {
-			break
-		}
-
-		return e.complexity.Query.Autobind(childComplexity), true
-
-	case "Query.DeprecatedField":
-		if e.complexity.Query.DeprecatedField == nil {
-			break
-		}
-
-		return e.complexity.Query.DeprecatedField(childComplexity), true
-
-	case "Query.MapStringInterface":
-		if e.complexity.Query.MapStringInterface == nil {
-			break
-		}
-
-		args, err := ec.field_Query_mapStringInterface_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.MapStringInterface(childComplexity, args["in"].(map[string]interface{})), true
-
-	case "Query.Panics":
-		if e.complexity.Query.Panics == nil {
-			break
-		}
-
-		return e.complexity.Query.Panics(childComplexity), true
-
-	case "Query.DefaultScalar":
-		if e.complexity.Query.DefaultScalar == nil {
-			break
-		}
-
-		args, err := ec.field_Query_defaultScalar_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.DefaultScalar(childComplexity, args["arg"].(string)), true
-
-	case "Query.Slices":
-		if e.complexity.Query.Slices == nil {
-			break
-		}
-
-		return e.complexity.Query.Slices(childComplexity), true
+		return e.complexity.Query.Valid(childComplexity), true
 
 	case "Query.ValidType":
 		if e.complexity.Query.ValidType == nil {
@@ -728,6 +768,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.ValidType(childComplexity), true
+
+	case "Rectangle.Area":
+		if e.complexity.Rectangle.Area == nil {
+			break
+		}
+
+		return e.complexity.Rectangle.Area(childComplexity), true
 
 	case "Rectangle.Length":
 		if e.complexity.Rectangle.Length == nil {
@@ -742,13 +789,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Rectangle.Width(childComplexity), true
-
-	case "Rectangle.Area":
-		if e.complexity.Rectangle.Area == nil {
-			break
-		}
-
-		return e.complexity.Rectangle.Area(childComplexity), true
 
 	case "Slices.Test1":
 		if e.complexity.Slices.Test1 == nil {
@@ -778,13 +818,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Slices.Test4(childComplexity), true
 
-	case "Subscription.Updated":
-		if e.complexity.Subscription.Updated == nil {
-			break
-		}
-
-		return e.complexity.Subscription.Updated(childComplexity), true
-
 	case "Subscription.InitPayload":
 		if e.complexity.Subscription.InitPayload == nil {
 			break
@@ -792,12 +825,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Subscription.InitPayload(childComplexity), true
 
-	case "User.ID":
-		if e.complexity.User.ID == nil {
+	case "Subscription.Updated":
+		if e.complexity.Subscription.Updated == nil {
 			break
 		}
 
-		return e.complexity.User.ID(childComplexity), true
+		return e.complexity.Subscription.Updated(childComplexity), true
+
+	case "User.Created":
+		if e.complexity.User.Created == nil {
+			break
+		}
+
+		return e.complexity.User.Created(childComplexity), true
 
 	case "User.Friends":
 		if e.complexity.User.Friends == nil {
@@ -806,12 +846,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.User.Friends(childComplexity), true
 
-	case "User.Created":
-		if e.complexity.User.Created == nil {
+	case "User.ID":
+		if e.complexity.User.ID == nil {
 			break
 		}
 
-		return e.complexity.User.Created(childComplexity), true
+		return e.complexity.User.ID(childComplexity), true
 
 	case "User.Updated":
 		if e.complexity.User.Updated == nil {
@@ -834,18 +874,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ValidType.DifferentCaseOld(childComplexity), true
 
-	case "ValidType.ValidInputKeywords":
-		if e.complexity.ValidType.ValidInputKeywords == nil {
-			break
-		}
-
-		args, err := ec.field_ValidType_validInputKeywords_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.ValidType.ValidInputKeywords(childComplexity, args["input"].(*ValidInput)), true
-
 	case "ValidType.ValidArgs":
 		if e.complexity.ValidType.ValidArgs == nil {
 			break
@@ -857,6 +885,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ValidType.ValidArgs(childComplexity, args["break"].(string), args["default"].(string), args["func"].(string), args["interface"].(string), args["select"].(string), args["case"].(string), args["defer"].(string), args["go"].(string), args["map"].(string), args["struct"].(string), args["chan"].(string), args["else"].(string), args["goto"].(string), args["package"].(string), args["switch"].(string), args["const"].(string), args["fallthrough"].(string), args["if"].(string), args["range"].(string), args["type"].(string), args["continue"].(string), args["for"].(string), args["import"].(string), args["return"].(string), args["var"].(string), args["_"].(string)), true
+
+	case "ValidType.ValidInputKeywords":
+		if e.complexity.ValidType.ValidInputKeywords == nil {
+			break
+		}
+
+		args, err := ec.field_ValidType_validInputKeywords_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ValidType.ValidInputKeywords(childComplexity, args["input"].(*ValidInput)), true
 
 	case "XXIt.ID":
 		if e.complexity.XXIt.ID == nil {
@@ -1017,6 +1057,18 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var parsedSchema = gqlparser.MustLoadSchema(
+	&ast.Source{Name: "complexity.graphql", Input: `extend type Query {
+    overlapping: OverlappingFields
+}
+
+type OverlappingFields {
+  oneFoo: Int!
+  twoFoo: Int!
+  oldFoo: Int!
+  newFoo: Int!
+  new_foo: Int!
+}
+`},
 	&ast.Source{Name: "maps.graphql", Input: `extend type Query {
     mapStringInterface(in: MapStringInterfaceInput): MapStringInterfaceType
 }
@@ -2566,6 +2618,141 @@ func (ec *executionContext) _OuterObject_inner(ctx context.Context, field graphq
 	return ec.marshalNInnerObject2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐInnerObject(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _OverlappingFields_oneFoo(ctx context.Context, field graphql.CollectedField, obj *OverlappingFields) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object:   "OverlappingFields",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Foo, nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _OverlappingFields_twoFoo(ctx context.Context, field graphql.CollectedField, obj *OverlappingFields) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object:   "OverlappingFields",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Foo, nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _OverlappingFields_oldFoo(ctx context.Context, field graphql.CollectedField, obj *OverlappingFields) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object:   "OverlappingFields",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.OverlappingFields().OldFoo(rctx, obj)
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _OverlappingFields_newFoo(ctx context.Context, field graphql.CollectedField, obj *OverlappingFields) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object:   "OverlappingFields",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NewFoo, nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _OverlappingFields_new_foo(ctx context.Context, field graphql.CollectedField, obj *OverlappingFields) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object:   "OverlappingFields",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NewFoo, nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Panics_fieldScalarMarshal(ctx context.Context, field graphql.CollectedField, obj *Panics) graphql.Marshaler {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
@@ -3255,6 +3442,30 @@ func (ec *executionContext) _Query_deprecatedField(ctx context.Context, field gr
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
 	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_overlapping(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object:   "Query",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Overlapping(rctx)
+	})
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*OverlappingFields)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOOverlappingFields2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐOverlappingFields(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_mapStringInterface(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
@@ -5630,6 +5841,62 @@ func (ec *executionContext) _OuterObject(ctx context.Context, sel ast.SelectionS
 	return out
 }
 
+var overlappingFieldsImplementors = []string{"OverlappingFields"}
+
+func (ec *executionContext) _OverlappingFields(ctx context.Context, sel ast.SelectionSet, obj *OverlappingFields) graphql.Marshaler {
+	fields := graphql.CollectFields(ctx, sel, overlappingFieldsImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	invalid := false
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("OverlappingFields")
+		case "oneFoo":
+			out.Values[i] = ec._OverlappingFields_oneFoo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalid = true
+			}
+		case "twoFoo":
+			out.Values[i] = ec._OverlappingFields_twoFoo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalid = true
+			}
+		case "oldFoo":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._OverlappingFields_oldFoo(ctx, field, obj)
+				if res == graphql.Null {
+					invalid = true
+				}
+				return res
+			})
+		case "newFoo":
+			out.Values[i] = ec._OverlappingFields_newFoo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalid = true
+			}
+		case "new_foo":
+			out.Values[i] = ec._OverlappingFields_new_foo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalid = true
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalid {
+		return graphql.Null
+	}
+	return out
+}
+
 var panicsImplementors = []string{"Panics"}
 
 func (ec *executionContext) _Panics(ctx context.Context, sel ast.SelectionSet, obj *Panics) graphql.Marshaler {
@@ -5953,6 +6220,17 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 				if res == graphql.Null {
 					invalid = true
 				}
+				return res
+			})
+		case "overlapping":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_overlapping(ctx, field)
 				return res
 			})
 		case "mapStringInterface":
@@ -7367,6 +7645,17 @@ func (ec *executionContext) marshalOOuterObject2ᚖgithubᚗcomᚋ99designsᚋgq
 		return graphql.Null
 	}
 	return ec._OuterObject(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOOverlappingFields2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐOverlappingFields(ctx context.Context, sel ast.SelectionSet, v OverlappingFields) graphql.Marshaler {
+	return ec._OverlappingFields(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalOOverlappingFields2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐOverlappingFields(ctx context.Context, sel ast.SelectionSet, v *OverlappingFields) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._OverlappingFields(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOPanics2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐPanics(ctx context.Context, sel ast.SelectionSet, v Panics) graphql.Marshaler {

--- a/codegen/testserver/gqlgen.yml
+++ b/codegen/testserver/gqlgen.yml
@@ -60,3 +60,9 @@ models:
     model: "map[string]interface{}"
   MapStringInterfaceType:
     model: "map[string]interface{}"
+  OverlappingFields:
+    model: "github.com/99designs/gqlgen/codegen/testserver.OverlappingFields"
+    fields:
+      oneFoo: { fieldName: foo }
+      twoFoo: { fieldName: foo }
+      oldFoo: { fieldName: foo, resolver: true }

--- a/codegen/testserver/models.go
+++ b/codegen/testserver/models.go
@@ -71,3 +71,8 @@ type Autobind struct {
 	IdStr string
 	IdInt int
 }
+
+type OverlappingFields struct {
+	Foo    int
+	NewFoo int
+}

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -17,6 +17,9 @@ func (r *Resolver) ForcedResolver() ForcedResolverResolver {
 func (r *Resolver) ModelMethods() ModelMethodsResolver {
 	return &modelMethodsResolver{r}
 }
+func (r *Resolver) OverlappingFields() OverlappingFieldsResolver {
+	return &overlappingFieldsResolver{r}
+}
 func (r *Resolver) Panics() PanicsResolver {
 	return &panicsResolver{r}
 }
@@ -39,6 +42,12 @@ func (r *forcedResolverResolver) Field(ctx context.Context, obj *ForcedResolver)
 type modelMethodsResolver struct{ *Resolver }
 
 func (r *modelMethodsResolver) ResolverField(ctx context.Context, obj *ModelMethods) (bool, error) {
+	panic("not implemented")
+}
+
+type overlappingFieldsResolver struct{ *Resolver }
+
+func (r *overlappingFieldsResolver) OldFoo(ctx context.Context, obj *OverlappingFields) (int, error) {
 	panic("not implemented")
 }
 
@@ -114,6 +123,9 @@ func (r *queryResolver) Autobind(ctx context.Context) (*Autobind, error) {
 	panic("not implemented")
 }
 func (r *queryResolver) DeprecatedField(ctx context.Context) (string, error) {
+	panic("not implemented")
+}
+func (r *queryResolver) Overlapping(ctx context.Context) (*OverlappingFields, error) {
 	panic("not implemented")
 }
 func (r *queryResolver) MapStringInterface(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error) {

--- a/codegen/testserver/stub.go
+++ b/codegen/testserver/stub.go
@@ -16,6 +16,9 @@ type Stub struct {
 	ModelMethodsResolver struct {
 		ResolverField func(ctx context.Context, obj *ModelMethods) (bool, error)
 	}
+	OverlappingFieldsResolver struct {
+		OldFoo func(ctx context.Context, obj *OverlappingFields) (int, error)
+	}
 	PanicsResolver struct {
 		FieldScalarMarshal func(ctx context.Context, obj *Panics) ([]MarshalPanic, error)
 		ArgUnmarshal       func(ctx context.Context, obj *Panics, u []MarshalPanic) (bool, error)
@@ -42,6 +45,7 @@ type Stub struct {
 		ShapeUnion             func(ctx context.Context) (ShapeUnion, error)
 		Autobind               func(ctx context.Context) (*Autobind, error)
 		DeprecatedField        func(ctx context.Context) (string, error)
+		Overlapping            func(ctx context.Context) (*OverlappingFields, error)
 		MapStringInterface     func(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error)
 		Panics                 func(ctx context.Context) (*Panics, error)
 		DefaultScalar          func(ctx context.Context, arg string) (string, error)
@@ -62,6 +66,9 @@ func (r *Stub) ForcedResolver() ForcedResolverResolver {
 }
 func (r *Stub) ModelMethods() ModelMethodsResolver {
 	return &stubModelMethods{r}
+}
+func (r *Stub) OverlappingFields() OverlappingFieldsResolver {
+	return &stubOverlappingFields{r}
 }
 func (r *Stub) Panics() PanicsResolver {
 	return &stubPanics{r}
@@ -86,6 +93,12 @@ type stubModelMethods struct{ *Stub }
 
 func (r *stubModelMethods) ResolverField(ctx context.Context, obj *ModelMethods) (bool, error) {
 	return r.ModelMethodsResolver.ResolverField(ctx, obj)
+}
+
+type stubOverlappingFields struct{ *Stub }
+
+func (r *stubOverlappingFields) OldFoo(ctx context.Context, obj *OverlappingFields) (int, error) {
+	return r.OverlappingFieldsResolver.OldFoo(ctx, obj)
 }
 
 type stubPanics struct{ *Stub }
@@ -161,6 +174,9 @@ func (r *stubQuery) Autobind(ctx context.Context) (*Autobind, error) {
 }
 func (r *stubQuery) DeprecatedField(ctx context.Context) (string, error) {
 	return r.QueryResolver.DeprecatedField(ctx)
+}
+func (r *stubQuery) Overlapping(ctx context.Context) (*OverlappingFields, error) {
+	return r.QueryResolver.Overlapping(ctx)
 }
 func (r *stubQuery) MapStringInterface(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error) {
 	return r.QueryResolver.MapStringInterface(ctx, in)

--- a/example/chat/generated.go
+++ b/example/chat/generated.go
@@ -45,15 +45,15 @@ type DirectiveRoot struct {
 
 type ComplexityRoot struct {
 	Chatroom struct {
-		Name     func(childComplexity int) int
 		Messages func(childComplexity int) int
+		Name     func(childComplexity int) int
 	}
 
 	Message struct {
+		CreatedAt func(childComplexity int) int
+		CreatedBy func(childComplexity int) int
 		ID        func(childComplexity int) int
 		Text      func(childComplexity int) int
-		CreatedBy func(childComplexity int) int
-		CreatedAt func(childComplexity int) int
 	}
 
 	Mutation struct {
@@ -94,6 +94,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 	_ = ec
 	switch typeName + "." + field {
 
+	case "Chatroom.Messages":
+		if e.complexity.Chatroom.Messages == nil {
+			break
+		}
+
+		return e.complexity.Chatroom.Messages(childComplexity), true
+
 	case "Chatroom.Name":
 		if e.complexity.Chatroom.Name == nil {
 			break
@@ -101,12 +108,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Chatroom.Name(childComplexity), true
 
-	case "Chatroom.Messages":
-		if e.complexity.Chatroom.Messages == nil {
+	case "Message.CreatedAt":
+		if e.complexity.Message.CreatedAt == nil {
 			break
 		}
 
-		return e.complexity.Chatroom.Messages(childComplexity), true
+		return e.complexity.Message.CreatedAt(childComplexity), true
+
+	case "Message.CreatedBy":
+		if e.complexity.Message.CreatedBy == nil {
+			break
+		}
+
+		return e.complexity.Message.CreatedBy(childComplexity), true
 
 	case "Message.ID":
 		if e.complexity.Message.ID == nil {
@@ -121,20 +135,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Message.Text(childComplexity), true
-
-	case "Message.CreatedBy":
-		if e.complexity.Message.CreatedBy == nil {
-			break
-		}
-
-		return e.complexity.Message.CreatedBy(childComplexity), true
-
-	case "Message.CreatedAt":
-		if e.complexity.Message.CreatedAt == nil {
-			break
-		}
-
-		return e.complexity.Message.CreatedAt(childComplexity), true
 
 	case "Mutation.Post":
 		if e.complexity.Mutation.Post == nil {

--- a/example/config/generated.go
+++ b/example/config/generated.go
@@ -51,16 +51,16 @@ type ComplexityRoot struct {
 	}
 
 	Todo struct {
-		ID          func(childComplexity int) int
 		DatabaseID  func(childComplexity int) int
 		Description func(childComplexity int) int
 		Done        func(childComplexity int) int
+		ID          func(childComplexity int) int
 		User        func(childComplexity int) int
 	}
 
 	User struct {
-		ID       func(childComplexity int) int
 		FullName func(childComplexity int) int
+		ID       func(childComplexity int) int
 	}
 }
 
@@ -108,13 +108,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Todos(childComplexity), true
 
-	case "Todo.ID":
-		if e.complexity.Todo.ID == nil {
-			break
-		}
-
-		return e.complexity.Todo.ID(childComplexity), true
-
 	case "Todo.DatabaseID":
 		if e.complexity.Todo.DatabaseID == nil {
 			break
@@ -136,6 +129,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Todo.Done(childComplexity), true
 
+	case "Todo.ID":
+		if e.complexity.Todo.ID == nil {
+			break
+		}
+
+		return e.complexity.Todo.ID(childComplexity), true
+
 	case "Todo.User":
 		if e.complexity.Todo.User == nil {
 			break
@@ -143,19 +143,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Todo.User(childComplexity), true
 
-	case "User.ID":
-		if e.complexity.User.ID == nil {
-			break
-		}
-
-		return e.complexity.User.ID(childComplexity), true
-
 	case "User.FullName":
 		if e.complexity.User.FullName == nil {
 			break
 		}
 
 		return e.complexity.User.FullName(childComplexity), true
+
+	case "User.ID":
+		if e.complexity.User.ID == nil {
+			break
+		}
+
+		return e.complexity.User.ID(childComplexity), true
 
 	}
 	return 0, false

--- a/example/dataloader/generated.go
+++ b/example/dataloader/generated.go
@@ -44,15 +44,15 @@ type DirectiveRoot struct {
 
 type ComplexityRoot struct {
 	Address struct {
+		Country func(childComplexity int) int
 		ID      func(childComplexity int) int
 		Street  func(childComplexity int) int
-		Country func(childComplexity int) int
 	}
 
 	Customer struct {
+		Address func(childComplexity int) int
 		ID      func(childComplexity int) int
 		Name    func(childComplexity int) int
-		Address func(childComplexity int) int
 		Orders  func(childComplexity int) int
 	}
 
@@ -61,9 +61,9 @@ type ComplexityRoot struct {
 	}
 
 	Order struct {
-		ID     func(childComplexity int) int
-		Date   func(childComplexity int) int
 		Amount func(childComplexity int) int
+		Date   func(childComplexity int) int
+		ID     func(childComplexity int) int
 		Items  func(childComplexity int) int
 	}
 
@@ -102,6 +102,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 	_ = ec
 	switch typeName + "." + field {
 
+	case "Address.Country":
+		if e.complexity.Address.Country == nil {
+			break
+		}
+
+		return e.complexity.Address.Country(childComplexity), true
+
 	case "Address.ID":
 		if e.complexity.Address.ID == nil {
 			break
@@ -116,12 +123,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Address.Street(childComplexity), true
 
-	case "Address.Country":
-		if e.complexity.Address.Country == nil {
+	case "Customer.Address":
+		if e.complexity.Customer.Address == nil {
 			break
 		}
 
-		return e.complexity.Address.Country(childComplexity), true
+		return e.complexity.Customer.Address(childComplexity), true
 
 	case "Customer.ID":
 		if e.complexity.Customer.ID == nil {
@@ -137,13 +144,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Customer.Name(childComplexity), true
 
-	case "Customer.Address":
-		if e.complexity.Customer.Address == nil {
-			break
-		}
-
-		return e.complexity.Customer.Address(childComplexity), true
-
 	case "Customer.Orders":
 		if e.complexity.Customer.Orders == nil {
 			break
@@ -158,12 +158,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Item.Name(childComplexity), true
 
-	case "Order.ID":
-		if e.complexity.Order.ID == nil {
+	case "Order.Amount":
+		if e.complexity.Order.Amount == nil {
 			break
 		}
 
-		return e.complexity.Order.ID(childComplexity), true
+		return e.complexity.Order.Amount(childComplexity), true
 
 	case "Order.Date":
 		if e.complexity.Order.Date == nil {
@@ -172,12 +172,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Order.Date(childComplexity), true
 
-	case "Order.Amount":
-		if e.complexity.Order.Amount == nil {
+	case "Order.ID":
+		if e.complexity.Order.ID == nil {
 			break
 		}
 
-		return e.complexity.Order.Amount(childComplexity), true
+		return e.complexity.Order.ID(childComplexity), true
 
 	case "Order.Items":
 		if e.complexity.Order.Items == nil {

--- a/example/scalars/generated.go
+++ b/example/scalars/generated.go
@@ -50,18 +50,18 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		User   func(childComplexity int, id external.ObjectID) int
 		Search func(childComplexity int, input *model.SearchArgs) int
+		User   func(childComplexity int, id external.ObjectID) int
 	}
 
 	User struct {
-		ID                func(childComplexity int) int
-		Name              func(childComplexity int) int
-		Created           func(childComplexity int) int
-		IsBanned          func(childComplexity int) int
-		PrimitiveResolver func(childComplexity int) int
-		CustomResolver    func(childComplexity int) int
 		Address           func(childComplexity int) int
+		Created           func(childComplexity int) int
+		CustomResolver    func(childComplexity int) int
+		ID                func(childComplexity int) int
+		IsBanned          func(childComplexity int) int
+		Name              func(childComplexity int) int
+		PrimitiveResolver func(childComplexity int) int
 		Tier              func(childComplexity int) int
 	}
 }
@@ -104,18 +104,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Address.Location(childComplexity), true
 
-	case "Query.User":
-		if e.complexity.Query.User == nil {
-			break
-		}
-
-		args, err := ec.field_Query_user_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.User(childComplexity, args["id"].(external.ObjectID)), true
-
 	case "Query.Search":
 		if e.complexity.Query.Search == nil {
 			break
@@ -128,19 +116,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Search(childComplexity, args["input"].(*model.SearchArgs)), true
 
-	case "User.ID":
-		if e.complexity.User.ID == nil {
+	case "Query.User":
+		if e.complexity.Query.User == nil {
 			break
 		}
 
-		return e.complexity.User.ID(childComplexity), true
+		args, err := ec.field_Query_user_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
 
-	case "User.Name":
-		if e.complexity.User.Name == nil {
+		return e.complexity.Query.User(childComplexity, args["id"].(external.ObjectID)), true
+
+	case "User.Address":
+		if e.complexity.User.Address == nil {
 			break
 		}
 
-		return e.complexity.User.Name(childComplexity), true
+		return e.complexity.User.Address(childComplexity), true
 
 	case "User.Created":
 		if e.complexity.User.Created == nil {
@@ -149,20 +142,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.User.Created(childComplexity), true
 
-	case "User.IsBanned":
-		if e.complexity.User.IsBanned == nil {
-			break
-		}
-
-		return e.complexity.User.IsBanned(childComplexity), true
-
-	case "User.PrimitiveResolver":
-		if e.complexity.User.PrimitiveResolver == nil {
-			break
-		}
-
-		return e.complexity.User.PrimitiveResolver(childComplexity), true
-
 	case "User.CustomResolver":
 		if e.complexity.User.CustomResolver == nil {
 			break
@@ -170,12 +149,33 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.User.CustomResolver(childComplexity), true
 
-	case "User.Address":
-		if e.complexity.User.Address == nil {
+	case "User.ID":
+		if e.complexity.User.ID == nil {
 			break
 		}
 
-		return e.complexity.User.Address(childComplexity), true
+		return e.complexity.User.ID(childComplexity), true
+
+	case "User.IsBanned":
+		if e.complexity.User.IsBanned == nil {
+			break
+		}
+
+		return e.complexity.User.IsBanned(childComplexity), true
+
+	case "User.Name":
+		if e.complexity.User.Name == nil {
+			break
+		}
+
+		return e.complexity.User.Name(childComplexity), true
+
+	case "User.PrimitiveResolver":
+		if e.complexity.User.PrimitiveResolver == nil {
+			break
+		}
+
+		return e.complexity.User.PrimitiveResolver(childComplexity), true
 
 	case "User.Tier":
 		if e.complexity.User.Tier == nil {

--- a/example/selection/generated.go
+++ b/example/selection/generated.go
@@ -43,17 +43,17 @@ type DirectiveRoot struct {
 
 type ComplexityRoot struct {
 	Like struct {
-		Reaction  func(childComplexity int) int
-		Sent      func(childComplexity int) int
-		Selection func(childComplexity int) int
 		Collected func(childComplexity int) int
+		Reaction  func(childComplexity int) int
+		Selection func(childComplexity int) int
+		Sent      func(childComplexity int) int
 	}
 
 	Post struct {
-		Message   func(childComplexity int) int
-		Sent      func(childComplexity int) int
-		Selection func(childComplexity int) int
 		Collected func(childComplexity int) int
+		Message   func(childComplexity int) int
+		Selection func(childComplexity int) int
+		Sent      func(childComplexity int) int
 	}
 
 	Query struct {
@@ -80,19 +80,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 	_ = ec
 	switch typeName + "." + field {
 
+	case "Like.Collected":
+		if e.complexity.Like.Collected == nil {
+			break
+		}
+
+		return e.complexity.Like.Collected(childComplexity), true
+
 	case "Like.Reaction":
 		if e.complexity.Like.Reaction == nil {
 			break
 		}
 
 		return e.complexity.Like.Reaction(childComplexity), true
-
-	case "Like.Sent":
-		if e.complexity.Like.Sent == nil {
-			break
-		}
-
-		return e.complexity.Like.Sent(childComplexity), true
 
 	case "Like.Selection":
 		if e.complexity.Like.Selection == nil {
@@ -101,12 +101,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Like.Selection(childComplexity), true
 
-	case "Like.Collected":
-		if e.complexity.Like.Collected == nil {
+	case "Like.Sent":
+		if e.complexity.Like.Sent == nil {
 			break
 		}
 
-		return e.complexity.Like.Collected(childComplexity), true
+		return e.complexity.Like.Sent(childComplexity), true
+
+	case "Post.Collected":
+		if e.complexity.Post.Collected == nil {
+			break
+		}
+
+		return e.complexity.Post.Collected(childComplexity), true
 
 	case "Post.Message":
 		if e.complexity.Post.Message == nil {
@@ -115,13 +122,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Post.Message(childComplexity), true
 
-	case "Post.Sent":
-		if e.complexity.Post.Sent == nil {
-			break
-		}
-
-		return e.complexity.Post.Sent(childComplexity), true
-
 	case "Post.Selection":
 		if e.complexity.Post.Selection == nil {
 			break
@@ -129,12 +129,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Post.Selection(childComplexity), true
 
-	case "Post.Collected":
-		if e.complexity.Post.Collected == nil {
+	case "Post.Sent":
+		if e.complexity.Post.Sent == nil {
 			break
 		}
 
-		return e.complexity.Post.Collected(childComplexity), true
+		return e.complexity.Post.Sent(childComplexity), true
 
 	case "Query.Events":
 		if e.complexity.Query.Events == nil {

--- a/example/starwars/generated/exec.go
+++ b/example/starwars/generated/exec.go
@@ -49,19 +49,19 @@ type DirectiveRoot struct {
 
 type ComplexityRoot struct {
 	Droid struct {
-		ID                func(childComplexity int) int
-		Name              func(childComplexity int) int
+		AppearsIn         func(childComplexity int) int
 		Friends           func(childComplexity int) int
 		FriendsConnection func(childComplexity int, first *int, after *string) int
-		AppearsIn         func(childComplexity int) int
+		ID                func(childComplexity int) int
+		Name              func(childComplexity int) int
 		PrimaryFunction   func(childComplexity int) int
 	}
 
 	FriendsConnection struct {
-		TotalCount func(childComplexity int) int
 		Edges      func(childComplexity int) int
 		Friends    func(childComplexity int) int
 		PageInfo   func(childComplexity int) int
+		TotalCount func(childComplexity int) int
 	}
 
 	FriendsEdge struct {
@@ -70,13 +70,13 @@ type ComplexityRoot struct {
 	}
 
 	Human struct {
-		ID                func(childComplexity int) int
-		Name              func(childComplexity int) int
-		Height            func(childComplexity int, unit models.LengthUnit) int
-		Mass              func(childComplexity int) int
+		AppearsIn         func(childComplexity int) int
 		Friends           func(childComplexity int) int
 		FriendsConnection func(childComplexity int, first *int, after *string) int
-		AppearsIn         func(childComplexity int) int
+		Height            func(childComplexity int, unit models.LengthUnit) int
+		ID                func(childComplexity int) int
+		Mass              func(childComplexity int) int
+		Name              func(childComplexity int) int
 		Starships         func(childComplexity int) int
 	}
 
@@ -85,32 +85,32 @@ type ComplexityRoot struct {
 	}
 
 	PageInfo struct {
-		StartCursor func(childComplexity int) int
 		EndCursor   func(childComplexity int) int
 		HasNextPage func(childComplexity int) int
+		StartCursor func(childComplexity int) int
 	}
 
 	Query struct {
-		Hero      func(childComplexity int, episode *models.Episode) int
-		Reviews   func(childComplexity int, episode models.Episode, since *time.Time) int
-		Search    func(childComplexity int, text string) int
 		Character func(childComplexity int, id string) int
 		Droid     func(childComplexity int, id string) int
+		Hero      func(childComplexity int, episode *models.Episode) int
 		Human     func(childComplexity int, id string) int
+		Reviews   func(childComplexity int, episode models.Episode, since *time.Time) int
+		Search    func(childComplexity int, text string) int
 		Starship  func(childComplexity int, id string) int
 	}
 
 	Review struct {
-		Stars      func(childComplexity int) int
 		Commentary func(childComplexity int) int
+		Stars      func(childComplexity int) int
 		Time       func(childComplexity int) int
 	}
 
 	Starship struct {
-		ID      func(childComplexity int) int
-		Name    func(childComplexity int) int
-		Length  func(childComplexity int, unit *models.LengthUnit) int
 		History func(childComplexity int) int
+		ID      func(childComplexity int) int
+		Length  func(childComplexity int, unit *models.LengthUnit) int
+		Name    func(childComplexity int) int
 	}
 }
 
@@ -159,19 +159,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 	_ = ec
 	switch typeName + "." + field {
 
-	case "Droid.ID":
-		if e.complexity.Droid.ID == nil {
+	case "Droid.AppearsIn":
+		if e.complexity.Droid.AppearsIn == nil {
 			break
 		}
 
-		return e.complexity.Droid.ID(childComplexity), true
-
-	case "Droid.Name":
-		if e.complexity.Droid.Name == nil {
-			break
-		}
-
-		return e.complexity.Droid.Name(childComplexity), true
+		return e.complexity.Droid.AppearsIn(childComplexity), true
 
 	case "Droid.Friends":
 		if e.complexity.Droid.Friends == nil {
@@ -192,12 +185,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Droid.FriendsConnection(childComplexity, args["first"].(*int), args["after"].(*string)), true
 
-	case "Droid.AppearsIn":
-		if e.complexity.Droid.AppearsIn == nil {
+	case "Droid.ID":
+		if e.complexity.Droid.ID == nil {
 			break
 		}
 
-		return e.complexity.Droid.AppearsIn(childComplexity), true
+		return e.complexity.Droid.ID(childComplexity), true
+
+	case "Droid.Name":
+		if e.complexity.Droid.Name == nil {
+			break
+		}
+
+		return e.complexity.Droid.Name(childComplexity), true
 
 	case "Droid.PrimaryFunction":
 		if e.complexity.Droid.PrimaryFunction == nil {
@@ -205,13 +205,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Droid.PrimaryFunction(childComplexity), true
-
-	case "FriendsConnection.TotalCount":
-		if e.complexity.FriendsConnection.TotalCount == nil {
-			break
-		}
-
-		return e.complexity.FriendsConnection.TotalCount(childComplexity), true
 
 	case "FriendsConnection.Edges":
 		if e.complexity.FriendsConnection.Edges == nil {
@@ -234,6 +227,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.FriendsConnection.PageInfo(childComplexity), true
 
+	case "FriendsConnection.TotalCount":
+		if e.complexity.FriendsConnection.TotalCount == nil {
+			break
+		}
+
+		return e.complexity.FriendsConnection.TotalCount(childComplexity), true
+
 	case "FriendsEdge.Cursor":
 		if e.complexity.FriendsEdge.Cursor == nil {
 			break
@@ -248,38 +248,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.FriendsEdge.Node(childComplexity), true
 
-	case "Human.ID":
-		if e.complexity.Human.ID == nil {
+	case "Human.AppearsIn":
+		if e.complexity.Human.AppearsIn == nil {
 			break
 		}
 
-		return e.complexity.Human.ID(childComplexity), true
-
-	case "Human.Name":
-		if e.complexity.Human.Name == nil {
-			break
-		}
-
-		return e.complexity.Human.Name(childComplexity), true
-
-	case "Human.Height":
-		if e.complexity.Human.Height == nil {
-			break
-		}
-
-		args, err := ec.field_Human_height_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Human.Height(childComplexity, args["unit"].(models.LengthUnit)), true
-
-	case "Human.Mass":
-		if e.complexity.Human.Mass == nil {
-			break
-		}
-
-		return e.complexity.Human.Mass(childComplexity), true
+		return e.complexity.Human.AppearsIn(childComplexity), true
 
 	case "Human.Friends":
 		if e.complexity.Human.Friends == nil {
@@ -300,12 +274,38 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Human.FriendsConnection(childComplexity, args["first"].(*int), args["after"].(*string)), true
 
-	case "Human.AppearsIn":
-		if e.complexity.Human.AppearsIn == nil {
+	case "Human.Height":
+		if e.complexity.Human.Height == nil {
 			break
 		}
 
-		return e.complexity.Human.AppearsIn(childComplexity), true
+		args, err := ec.field_Human_height_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Human.Height(childComplexity, args["unit"].(models.LengthUnit)), true
+
+	case "Human.ID":
+		if e.complexity.Human.ID == nil {
+			break
+		}
+
+		return e.complexity.Human.ID(childComplexity), true
+
+	case "Human.Mass":
+		if e.complexity.Human.Mass == nil {
+			break
+		}
+
+		return e.complexity.Human.Mass(childComplexity), true
+
+	case "Human.Name":
+		if e.complexity.Human.Name == nil {
+			break
+		}
+
+		return e.complexity.Human.Name(childComplexity), true
 
 	case "Human.Starships":
 		if e.complexity.Human.Starships == nil {
@@ -326,13 +326,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.CreateReview(childComplexity, args["episode"].(models.Episode), args["review"].(models.Review)), true
 
-	case "PageInfo.StartCursor":
-		if e.complexity.PageInfo.StartCursor == nil {
-			break
-		}
-
-		return e.complexity.PageInfo.StartCursor(childComplexity), true
-
 	case "PageInfo.EndCursor":
 		if e.complexity.PageInfo.EndCursor == nil {
 			break
@@ -347,41 +340,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PageInfo.HasNextPage(childComplexity), true
 
-	case "Query.Hero":
-		if e.complexity.Query.Hero == nil {
+	case "PageInfo.StartCursor":
+		if e.complexity.PageInfo.StartCursor == nil {
 			break
 		}
 
-		args, err := ec.field_Query_hero_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.Hero(childComplexity, args["episode"].(*models.Episode)), true
-
-	case "Query.Reviews":
-		if e.complexity.Query.Reviews == nil {
-			break
-		}
-
-		args, err := ec.field_Query_reviews_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.Reviews(childComplexity, args["episode"].(models.Episode), args["since"].(*time.Time)), true
-
-	case "Query.Search":
-		if e.complexity.Query.Search == nil {
-			break
-		}
-
-		args, err := ec.field_Query_search_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.Search(childComplexity, args["text"].(string)), true
+		return e.complexity.PageInfo.StartCursor(childComplexity), true
 
 	case "Query.Character":
 		if e.complexity.Query.Character == nil {
@@ -407,6 +371,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Droid(childComplexity, args["id"].(string)), true
 
+	case "Query.Hero":
+		if e.complexity.Query.Hero == nil {
+			break
+		}
+
+		args, err := ec.field_Query_hero_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Hero(childComplexity, args["episode"].(*models.Episode)), true
+
 	case "Query.Human":
 		if e.complexity.Query.Human == nil {
 			break
@@ -418,6 +394,30 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Human(childComplexity, args["id"].(string)), true
+
+	case "Query.Reviews":
+		if e.complexity.Query.Reviews == nil {
+			break
+		}
+
+		args, err := ec.field_Query_reviews_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Reviews(childComplexity, args["episode"].(models.Episode), args["since"].(*time.Time)), true
+
+	case "Query.Search":
+		if e.complexity.Query.Search == nil {
+			break
+		}
+
+		args, err := ec.field_Query_search_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Search(childComplexity, args["text"].(string)), true
 
 	case "Query.Starship":
 		if e.complexity.Query.Starship == nil {
@@ -431,19 +431,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Starship(childComplexity, args["id"].(string)), true
 
-	case "Review.Stars":
-		if e.complexity.Review.Stars == nil {
-			break
-		}
-
-		return e.complexity.Review.Stars(childComplexity), true
-
 	case "Review.Commentary":
 		if e.complexity.Review.Commentary == nil {
 			break
 		}
 
 		return e.complexity.Review.Commentary(childComplexity), true
+
+	case "Review.Stars":
+		if e.complexity.Review.Stars == nil {
+			break
+		}
+
+		return e.complexity.Review.Stars(childComplexity), true
 
 	case "Review.Time":
 		if e.complexity.Review.Time == nil {
@@ -452,19 +452,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Review.Time(childComplexity), true
 
+	case "Starship.History":
+		if e.complexity.Starship.History == nil {
+			break
+		}
+
+		return e.complexity.Starship.History(childComplexity), true
+
 	case "Starship.ID":
 		if e.complexity.Starship.ID == nil {
 			break
 		}
 
 		return e.complexity.Starship.ID(childComplexity), true
-
-	case "Starship.Name":
-		if e.complexity.Starship.Name == nil {
-			break
-		}
-
-		return e.complexity.Starship.Name(childComplexity), true
 
 	case "Starship.Length":
 		if e.complexity.Starship.Length == nil {
@@ -478,12 +478,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Starship.Length(childComplexity, args["unit"].(*models.LengthUnit)), true
 
-	case "Starship.History":
-		if e.complexity.Starship.History == nil {
+	case "Starship.Name":
+		if e.complexity.Starship.Name == nil {
 			break
 		}
 
-		return e.complexity.Starship.History(childComplexity), true
+		return e.complexity.Starship.Name(childComplexity), true
 
 	}
 	return 0, false

--- a/example/todo/generated.go
+++ b/example/todo/generated.go
@@ -48,15 +48,15 @@ type ComplexityRoot struct {
 	}
 
 	MyQuery struct {
-		Todo     func(childComplexity int, id int) int
 		LastTodo func(childComplexity int) int
+		Todo     func(childComplexity int, id int) int
 		Todos    func(childComplexity int) int
 	}
 
 	Todo struct {
+		Done func(childComplexity int) int
 		ID   func(childComplexity int) int
 		Text func(childComplexity int) int
-		Done func(childComplexity int) int
 	}
 }
 
@@ -109,6 +109,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.MyMutation.UpdateTodo(childComplexity, args["id"].(int), args["changes"].(map[string]interface{})), true
 
+	case "MyQuery.LastTodo":
+		if e.complexity.MyQuery.LastTodo == nil {
+			break
+		}
+
+		return e.complexity.MyQuery.LastTodo(childComplexity), true
+
 	case "MyQuery.Todo":
 		if e.complexity.MyQuery.Todo == nil {
 			break
@@ -121,19 +128,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.MyQuery.Todo(childComplexity, args["id"].(int)), true
 
-	case "MyQuery.LastTodo":
-		if e.complexity.MyQuery.LastTodo == nil {
-			break
-		}
-
-		return e.complexity.MyQuery.LastTodo(childComplexity), true
-
 	case "MyQuery.Todos":
 		if e.complexity.MyQuery.Todos == nil {
 			break
 		}
 
 		return e.complexity.MyQuery.Todos(childComplexity), true
+
+	case "Todo.Done":
+		if e.complexity.Todo.Done == nil {
+			break
+		}
+
+		return e.complexity.Todo.Done(childComplexity), true
 
 	case "Todo.ID":
 		if e.complexity.Todo.ID == nil {
@@ -148,13 +155,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Todo.Text(childComplexity), true
-
-	case "Todo.Done":
-		if e.complexity.Todo.Done == nil {
-			break
-		}
-
-		return e.complexity.Todo.Done(childComplexity), true
 
 	}
 	return 0, false

--- a/example/type-system-extension/generated.go
+++ b/example/type-system-extension/generated.go
@@ -60,14 +60,14 @@ type ComplexityRoot struct {
 	}
 
 	MyQuery struct {
-		Todos func(childComplexity int) int
 		Todo  func(childComplexity int, id string) int
+		Todos func(childComplexity int) int
 	}
 
 	Todo struct {
 		ID       func(childComplexity int) int
-		Text     func(childComplexity int) int
 		State    func(childComplexity int) int
+		Text     func(childComplexity int) int
 		Verified func(childComplexity int) int
 	}
 }
@@ -107,13 +107,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.MyMutation.CreateTodo(childComplexity, args["todo"].(TodoInput)), true
 
-	case "MyQuery.Todos":
-		if e.complexity.MyQuery.Todos == nil {
-			break
-		}
-
-		return e.complexity.MyQuery.Todos(childComplexity), true
-
 	case "MyQuery.Todo":
 		if e.complexity.MyQuery.Todo == nil {
 			break
@@ -126,6 +119,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.MyQuery.Todo(childComplexity, args["id"].(string)), true
 
+	case "MyQuery.Todos":
+		if e.complexity.MyQuery.Todos == nil {
+			break
+		}
+
+		return e.complexity.MyQuery.Todos(childComplexity), true
+
 	case "Todo.ID":
 		if e.complexity.Todo.ID == nil {
 			break
@@ -133,19 +133,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Todo.ID(childComplexity), true
 
-	case "Todo.Text":
-		if e.complexity.Todo.Text == nil {
-			break
-		}
-
-		return e.complexity.Todo.Text(childComplexity), true
-
 	case "Todo.State":
 		if e.complexity.Todo.State == nil {
 			break
 		}
 
 		return e.complexity.Todo.State(childComplexity), true
+
+	case "Todo.Text":
+		if e.complexity.Todo.Text == nil {
+			break
+		}
+
+		return e.complexity.Todo.Text(childComplexity), true
 
 	case "Todo.Verified":
 		if e.complexity.Todo.Verified == nil {

--- a/integration/generated.go
+++ b/integration/generated.go
@@ -52,16 +52,16 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		Path         func(childComplexity int) int
 		Date         func(childComplexity int, filter models.DateFilter) int
-		Viewer       func(childComplexity int) int
-		JSONEncoding func(childComplexity int) int
 		Error        func(childComplexity int, typeArg *models.ErrorType) int
+		JSONEncoding func(childComplexity int) int
+		Path         func(childComplexity int) int
+		Viewer       func(childComplexity int) int
 	}
 
 	User struct {
-		Name  func(childComplexity int) int
 		Likes func(childComplexity int) int
+		Name  func(childComplexity int) int
 	}
 
 	Viewer struct {
@@ -121,13 +121,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Element.Mismatched(childComplexity), true
 
-	case "Query.Path":
-		if e.complexity.Query.Path == nil {
-			break
-		}
-
-		return e.complexity.Query.Path(childComplexity), true
-
 	case "Query.Date":
 		if e.complexity.Query.Date == nil {
 			break
@@ -139,20 +132,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Date(childComplexity, args["filter"].(models.DateFilter)), true
-
-	case "Query.Viewer":
-		if e.complexity.Query.Viewer == nil {
-			break
-		}
-
-		return e.complexity.Query.Viewer(childComplexity), true
-
-	case "Query.JSONEncoding":
-		if e.complexity.Query.JSONEncoding == nil {
-			break
-		}
-
-		return e.complexity.Query.JSONEncoding(childComplexity), true
 
 	case "Query.Error":
 		if e.complexity.Query.Error == nil {
@@ -166,12 +145,26 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Error(childComplexity, args["type"].(*models.ErrorType)), true
 
-	case "User.Name":
-		if e.complexity.User.Name == nil {
+	case "Query.JSONEncoding":
+		if e.complexity.Query.JSONEncoding == nil {
 			break
 		}
 
-		return e.complexity.User.Name(childComplexity), true
+		return e.complexity.Query.JSONEncoding(childComplexity), true
+
+	case "Query.Path":
+		if e.complexity.Query.Path == nil {
+			break
+		}
+
+		return e.complexity.Query.Path(childComplexity), true
+
+	case "Query.Viewer":
+		if e.complexity.Query.Viewer == nil {
+			break
+		}
+
+		return e.complexity.Query.Viewer(childComplexity), true
 
 	case "User.Likes":
 		if e.complexity.User.Likes == nil {
@@ -179,6 +172,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.User.Likes(childComplexity), true
+
+	case "User.Name":
+		if e.complexity.User.Name == nil {
+			break
+		}
+
+		return e.complexity.User.Name(childComplexity), true
 
 	case "Viewer.User":
 		if e.complexity.Viewer.User == nil {


### PR DESCRIPTION
Theres a bit of history on this one, see https://github.com/99designs/gqlgen/issues/376 and https://github.com/99designs/gqlgen/issues/473.

This PR just makes sure that if multiple complexity fields would collide that only one is added. It does mean we cant specify different complexity functions for each field, but it seems like a reasonable tradeoff.

fixes https://github.com/99designs/gqlgen/issues/600


I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
