### PR TITLE
Move ambient imports into cmd package

### DIFF
--- a/cmd/ambient.go
+++ b/cmd/ambient.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	// Import and ignore the ambient imports listed below so dependency managers


### PR DESCRIPTION
The getting started docs for `dep` suggest creating a local gqlgen script, however these ambient import are in the root package, so `dep` misses them and introspection (and probably other required packages) are missed and fail during codegen.

This was due to changes between 0.7 and 0.8 where the binary was re-added, but the ambient imports weren't moved.
