### PR TITLE
Use graphql.String for types wrapping a basic string

### DIFF
--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -158,9 +158,11 @@ func (b *Binder) PointerTo(ref *TypeReference) *TypeReference {
 	newRef := &TypeReference{
 		GO:          types.NewPointer(ref.GO),
 		GQL:         ref.GQL,
+		CastType:    ref.CastType,
 		Definition:  ref.Definition,
 		Unmarshaler: ref.Unmarshaler,
 		Marshaler:   ref.Marshaler,
+		IsMarshaler: ref.IsMarshaler,
 	}
 
 	b.References = append(b.References, newRef)
@@ -172,8 +174,10 @@ type TypeReference struct {
 	Definition  *ast.Definition
 	GQL         *ast.Type
 	GO          types.Type
+	CastType    types.Type  // Before calling marshalling functions cast from/to this base type
 	Marshaler   *types.Func // When using external marshalling functions this will point to the Marshal function
 	Unmarshaler *types.Func // When using external marshalling functions this will point to the Unmarshal function
+	IsMarshaler bool        // Does the type implement graphql.Marshaler and graphql.Unmarshaler
 }
 
 func (ref *TypeReference) Elem() *TypeReference {
@@ -181,9 +185,11 @@ func (ref *TypeReference) Elem() *TypeReference {
 		return &TypeReference{
 			GO:          p.Elem(),
 			GQL:         ref.GQL,
+			CastType:    ref.CastType,
 			Definition:  ref.Definition,
 			Unmarshaler: ref.Unmarshaler,
 			Marshaler:   ref.Marshaler,
+			IsMarshaler: ref.IsMarshaler,
 		}
 	}
 
@@ -191,9 +197,11 @@ func (ref *TypeReference) Elem() *TypeReference {
 		return &TypeReference{
 			GO:          s.Elem(),
 			GQL:         ref.GQL.Elem,
+			CastType:    ref.CastType,
 			Definition:  ref.Definition,
 			Unmarshaler: ref.Unmarshaler,
 			Marshaler:   ref.Marshaler,
+			IsMarshaler: ref.IsMarshaler,
 		}
 	}
 	return nil
@@ -243,44 +251,6 @@ func (t *TypeReference) HasIsZero() bool {
 	for i := 0; i < namedType.NumMethods(); i++ {
 		switch namedType.Method(i).Name() {
 		case "IsZero":
-			return true
-		}
-	}
-	return false
-}
-
-func (t *TypeReference) SelfMarshalling() bool {
-	it := t.GO
-	if ptr, isPtr := it.(*types.Pointer); isPtr {
-		it = ptr.Elem()
-	}
-	namedType, ok := it.(*types.Named)
-	if !ok {
-		return false
-	}
-
-	for i := 0; i < namedType.NumMethods(); i++ {
-		switch namedType.Method(i).Name() {
-		case "MarshalGQL":
-			return true
-		}
-	}
-	return false
-}
-
-func (t *TypeReference) SelfUnmarshalling() bool {
-	it := t.GO
-	if ptr, isPtr := it.(*types.Pointer); isPtr {
-		it = ptr.Elem()
-	}
-	namedType, ok := it.(*types.Named)
-	if !ok {
-		return false
-	}
-
-	for i := 0; i < namedType.NumMethods(); i++ {
-		switch namedType.Method(i).Name() {
-		case "UnmarshalGQL":
 			return true
 		}
 	}
@@ -395,6 +365,22 @@ func (b *Binder) TypeReference(schemaType *ast.Type, bindTarget types.Type) (ret
 			ref.GO = fun.Type().(*types.Signature).Params().At(0).Type()
 			ref.Marshaler = fun
 			ref.Unmarshaler = types.NewFunc(0, fun.Pkg(), "Unmarshal"+typeName, nil)
+		} else if hasMethod(obj.Type(), "MarshalGQL") && hasMethod(obj.Type(), "UnmarshalGQL") {
+			ref.GO = obj.Type()
+			ref.IsMarshaler = true
+		} else if underlying := basicUnderlying(obj.Type()); underlying != nil && underlying.Kind() == types.String {
+			// Special case for named types wrapping strings. Used by default enum implementations.
+
+			ref.GO = obj.Type()
+			ref.CastType = underlying
+
+			underlyingRef, err := b.TypeReference(&ast.Type{NamedType: "String"}, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			ref.Marshaler = underlyingRef.Marshaler
+			ref.Unmarshaler = underlyingRef.Unmarshaler
 		} else {
 			ref.GO = obj.Type()
 		}
@@ -429,4 +415,37 @@ func (b *Binder) CopyModifiersFromAst(t *ast.Type, base types.Type) types.Type {
 	}
 
 	return base
+}
+
+func hasMethod(it types.Type, name string) bool {
+	if ptr, isPtr := it.(*types.Pointer); isPtr {
+		it = ptr.Elem()
+	}
+	namedType, ok := it.(*types.Named)
+	if !ok {
+		return false
+	}
+
+	for i := 0; i < namedType.NumMethods(); i++ {
+		if namedType.Method(i).Name() == name {
+			return true
+		}
+	}
+	return false
+}
+
+func basicUnderlying(it types.Type) *types.Basic {
+	if ptr, isPtr := it.(*types.Pointer); isPtr {
+		it = ptr.Elem()
+	}
+	namedType, ok := it.(*types.Named)
+	if !ok {
+		return nil
+	}
+
+	if basic, ok := namedType.Underlying().(*types.Basic); ok {
+		return basic
+	}
+
+	return nil
 }

--- a/codegen/testserver/gqlgen.yml
+++ b/codegen/testserver/gqlgen.yml
@@ -66,3 +66,5 @@ models:
       oneFoo: { fieldName: foo }
       twoFoo: { fieldName: foo }
       oldFoo: { fieldName: foo, resolver: true }
+  FallbackToStringEncoding:
+    model: "github.com/99designs/gqlgen/codegen/testserver.FallbackToStringEncoding"

--- a/codegen/testserver/models.go
+++ b/codegen/testserver/models.go
@@ -76,3 +76,11 @@ type OverlappingFields struct {
 	Foo    int
 	NewFoo int
 }
+
+type FallbackToStringEncoding string
+
+const (
+	FallbackToStringEncodingA FallbackToStringEncoding = "A"
+	FallbackToStringEncodingB FallbackToStringEncoding = "B"
+	FallbackToStringEncodingC FallbackToStringEncoding = "C"
+)

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -140,6 +140,9 @@ func (r *queryResolver) DefaultScalar(ctx context.Context, arg string) (string, 
 func (r *queryResolver) Slices(ctx context.Context) (*Slices, error) {
 	panic("not implemented")
 }
+func (r *queryResolver) Fallback(ctx context.Context, arg FallbackToStringEncoding) (FallbackToStringEncoding, error) {
+	panic("not implemented")
+}
 func (r *queryResolver) OptionalUnion(ctx context.Context) (TestUnion, error) {
 	panic("not implemented")
 }

--- a/codegen/testserver/stub.go
+++ b/codegen/testserver/stub.go
@@ -50,6 +50,7 @@ type Stub struct {
 		Panics                 func(ctx context.Context) (*Panics, error)
 		DefaultScalar          func(ctx context.Context, arg string) (string, error)
 		Slices                 func(ctx context.Context) (*Slices, error)
+		Fallback               func(ctx context.Context, arg FallbackToStringEncoding) (FallbackToStringEncoding, error)
 		OptionalUnion          func(ctx context.Context) (TestUnion, error)
 		ValidType              func(ctx context.Context) (*ValidType, error)
 	}
@@ -190,6 +191,9 @@ func (r *stubQuery) DefaultScalar(ctx context.Context, arg string) (string, erro
 }
 func (r *stubQuery) Slices(ctx context.Context) (*Slices, error) {
 	return r.QueryResolver.Slices(ctx)
+}
+func (r *stubQuery) Fallback(ctx context.Context, arg FallbackToStringEncoding) (FallbackToStringEncoding, error) {
+	return r.QueryResolver.Fallback(ctx, arg)
 }
 func (r *stubQuery) OptionalUnion(ctx context.Context) (TestUnion, error) {
 	return r.QueryResolver.OptionalUnion(ctx)

--- a/codegen/testserver/typefallback.graphql
+++ b/codegen/testserver/typefallback.graphql
@@ -1,0 +1,9 @@
+extend type Query {
+    fallback(arg: FallbackToStringEncoding!): FallbackToStringEncoding!
+}
+
+enum FallbackToStringEncoding {
+    A
+    B
+    C
+}

--- a/codegen/testserver/typefallback_test.go
+++ b/codegen/testserver/typefallback_test.go
@@ -1,0 +1,30 @@
+package testserver
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/99designs/gqlgen/client"
+	"github.com/99designs/gqlgen/handler"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTypeFallback(t *testing.T) {
+	resolvers := &Stub{}
+
+	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
+	c := client.New(srv.URL)
+
+	resolvers.QueryResolver.Fallback = func(ctx context.Context, arg FallbackToStringEncoding) (FallbackToStringEncoding, error) {
+		return arg, nil
+	}
+
+	t.Run("fallback to string passthrough", func(t *testing.T) {
+		var resp struct {
+			Fallback string
+		}
+		c.MustPost(`query { fallback(arg: A) }`, &resp)
+		require.Equal(t, "A", resp.Fallback)
+	})
+}

--- a/codegen/type.gotpl
+++ b/codegen/type.gotpl
@@ -27,10 +27,15 @@
 				return res, nil
 			{{- else }}
 				{{- if $type.Unmarshaler }}
-					return {{ $type.Unmarshaler | call }}(v)
+					{{- if $type.CastType }}
+						tmp, err := {{ $type.Unmarshaler | call }}(v)
+						return {{ $type.GO | ref }}(tmp), err
+					{{- else}}
+						return {{ $type.Unmarshaler | call }}(v)
+					{{- end }}
 				{{- else if eq ($type.GO | ref) "map[string]interface{}" }}
 					return v.(map[string]interface{}), nil
-				{{- else if $type.SelfUnmarshalling -}}
+				{{- else if $type.IsMarshaler -}}
 					var res {{ $type.GO | ref }}
 					return res, res.UnmarshalGQL(v)
 				{{- else }}
@@ -62,9 +67,7 @@
 				}
 			{{- end }}
 
-			{{- if $type.SelfMarshalling }}
-				return v
-			{{- else if $type.IsSlice }}
+			{{- if $type.IsSlice }}
 				{{- if not $type.GQL.NonNull }}
 					if v == nil {
 						return graphql.Null
@@ -111,11 +114,13 @@
 				return ret
 			{{- else }}
 
-				{{- if $type.Marshaler }}
+				{{- if $type.IsMarshaler }}
+					return v
+				{{- else if $type.Marshaler }}
 					{{- if $type.IsPtr }}
 						return ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, *v)
 					{{- else }}
-						return {{ $type.Marshaler | call }}(v)
+						return {{ $type.Marshaler | call }}({{- if $type.CastType }}{{ $type.CastType | ref }}(v){{else}}v{{- end }})
 					{{- end }}
 				{{- else }}
 					return ec._{{$type.Definition.Name}}(ctx, sel, {{ if not $type.IsNilable}}&{{end}} v)


### PR DESCRIPTION
Adds a special case that allows `type Foo string` to fallback to calling whatever marshaler is defined for String.

Not the cleanest approach, but it closes out the regression until we have a better solution.

Fixes #595 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
