### PR TITLE
Only Inject Builtin Scalars if Defined in Schema

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -342,8 +342,6 @@ func (c *Config) InjectBuiltins(s *ast.Schema) {
 		"Float":               {Model: StringList{"github.com/99designs/gqlgen/graphql.Float"}},
 		"String":              {Model: StringList{"github.com/99designs/gqlgen/graphql.String"}},
 		"Boolean":             {Model: StringList{"github.com/99designs/gqlgen/graphql.Boolean"}},
-		"Time":                {Model: StringList{"github.com/99designs/gqlgen/graphql.Time"}},
-		"Map":                 {Model: StringList{"github.com/99designs/gqlgen/graphql.Map"}},
 		"Int": {Model: StringList{
 			"github.com/99designs/gqlgen/graphql.Int",
 			"github.com/99designs/gqlgen/graphql.Int32",
@@ -359,6 +357,18 @@ func (c *Config) InjectBuiltins(s *ast.Schema) {
 
 	for typeName, entry := range builtins {
 		if !c.Models.Exists(typeName) {
+			c.Models[typeName] = entry
+		}
+	}
+
+	// These are additional types that are injected if defined in the schema as scalars.
+	extraBuiltins := TypeMap{
+		"Time": {Model: StringList{"github.com/99designs/gqlgen/graphql.Time"}},
+		"Map":  {Model: StringList{"github.com/99designs/gqlgen/graphql.Map"}},
+	}
+
+	for typeName, entry := range extraBuiltins {
+		if t, ok := s.Types[typeName]; ok && t.Kind == ast.Scalar {
 			c.Models[typeName] = entry
 		}
 	}

--- a/codegen/testserver/builtinscalar.graphql
+++ b/codegen/testserver/builtinscalar.graphql
@@ -1,0 +1,8 @@
+
+"""
+Since gqlgen defines default implementation for a Map scalar, this tests that the builtin is _not_
+added to the TypeMap
+"""
+type Map {
+    id: ID!
+}

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -117,6 +117,10 @@ type ComplexityRoot struct {
 		ID func(childComplexity int) int
 	}
 
+	Map struct {
+		ID func(childComplexity int) int
+	}
+
 	MapStringInterfaceType struct {
 		A func(childComplexity int) int
 		B func(childComplexity int) int
@@ -444,6 +448,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.It.ID(childComplexity), true
+
+	case "Map.ID":
+		if e.complexity.Map.ID == nil {
+			break
+		}
+
+		return e.complexity.Map.ID(childComplexity), true
 
 	case "MapStringInterfaceType.A":
 		if e.complexity.MapStringInterfaceType.A == nil {
@@ -1088,6 +1099,15 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var parsedSchema = gqlparser.MustLoadSchema(
+	&ast.Source{Name: "builtinscalar.graphql", Input: `
+"""
+Since gqlgen defines default implementation for a Map scalar, this tests that the builtin is _not_
+added to the TypeMap
+"""
+type Map {
+    id: ID!
+}
+`},
 	&ast.Source{Name: "complexity.graphql", Input: `extend type Query {
     overlapping: OverlappingFields
 }
@@ -2521,6 +2541,33 @@ func (ec *executionContext) _It_id(ctx context.Context, field graphql.CollectedF
 	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
 	rctx := &graphql.ResolverContext{
 		Object:   "It",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Map_id(ctx context.Context, field graphql.CollectedField, obj *Map) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object:   "Map",
 		Field:    field,
 		Args:     nil,
 		IsMethod: false,
@@ -5913,6 +5960,33 @@ func (ec *executionContext) _It(ctx context.Context, sel ast.SelectionSet, obj *
 			out.Values[i] = graphql.MarshalString("It")
 		case "id":
 			out.Values[i] = ec._It_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalid = true
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalid {
+		return graphql.Null
+	}
+	return out
+}
+
+var mapImplementors = []string{"Map"}
+
+func (ec *executionContext) _Map(ctx context.Context, sel ast.SelectionSet, obj *Map) graphql.Marshaler {
+	fields := graphql.CollectFields(ctx, sel, mapImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	invalid := false
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Map")
+		case "id":
+			out.Values[i] = ec._Map_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalid = true
 			}

--- a/codegen/testserver/models-gen.go
+++ b/codegen/testserver/models-gen.go
@@ -56,6 +56,12 @@ type InputDirectives struct {
 	ThirdParty    *ThirdParty      `json:"thirdParty"`
 }
 
+// Since gqlgen defines default implementation for a Map scalar, this tests that the builtin is _not_
+// added to the TypeMap
+type Map struct {
+	ID string `json:"id"`
+}
+
 type OuterInput struct {
 	Inner InnerInput `json:"inner"`
 }

--- a/docs/content/reference/scalars.md
+++ b/docs/content/reference/scalars.md
@@ -1,14 +1,32 @@
 ---
-linkTitle: Custom Scalars
-title: Using custom graphql types in golang
-description: Defining custom GraphQL scalar types using gqlgen
+linkTitle: Scalars
+title: Mapping GraphQL scalar types to Go types
+description: Mapping GraphQL scalar types to Go types
 menu: { main: { parent: 'reference' } }
 ---
 
-There are two different ways to implement scalars in gqlgen, depending on your need.
+## Built-in helpers
 
+gqlgen ships with two built-in helpers for common custom scalar use-cases, `Time` and `Map`.  Adding either of these to a schema will automatically add the marshalling behaviour to Go types.
 
-## With user defined types
+### Time
+
+```graphql
+scalar Time
+```
+
+Maps a `Time` GraphQL scalar to a Go `time.Time` struct.
+
+### Map
+
+```graphql
+scalar Map
+```
+
+Maps an arbitrary GraphQL value to a `map[string]{interface}` Go type.
+
+##  Custom scalars with user defined types
+
 For user defined types you can implement the graphql.Marshal and graphql.Unmarshal interfaces and they will be called.
 
 ```go
@@ -55,7 +73,7 @@ models:
 ```
 
 
-## Custom scalars for types you don't control
+## Custom scalars with third party types
 
 Sometimes you cant add methods to a type because its in another repo, part of the standard 
 library (eg string or time.Time). To do this we can build an external marshaler:


### PR DESCRIPTION
Fixes #629

There was an issue where defining `Time` (and `Map`) in the schema as object types caused a panic.  This was due to `InjectBuiltins` attempting to inject a scalar type into the `TypeMap`.  This updates the injection to only happen if the scalar types are defined.

Worth noting that `InjectBuiltins` is called twice, once in modelgen and again in `BuildData` shortly after.  May be worth fixing this so that there is only a single call.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
