### PR TITLE
Fix Mapping Custom Scalar to Slice

### DIFF
--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -193,9 +193,9 @@ func (ref *TypeReference) Elem() *TypeReference {
 		}
 	}
 
-	if s, isSlice := ref.GO.(*types.Slice); isSlice {
+	if ref.IsSlice() {
 		return &TypeReference{
-			GO:          s.Elem(),
+			GO:          ref.GO.(*types.Slice).Elem(),
 			GQL:         ref.GQL.Elem,
 			CastType:    ref.CastType,
 			Definition:  ref.Definition,
@@ -221,7 +221,7 @@ func (t *TypeReference) IsNilable() bool {
 
 func (t *TypeReference) IsSlice() bool {
 	_, isSlice := t.GO.(*types.Slice)
-	return isSlice
+	return t.GQL.Elem != nil && isSlice
 }
 
 func (t *TypeReference) IsNamed() bool {

--- a/codegen/testserver/bytes.go
+++ b/codegen/testserver/bytes.go
@@ -1,0 +1,27 @@
+package testserver
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/99designs/gqlgen/graphql"
+)
+
+func MarshalBytes(b []byte) graphql.Marshaler {
+	return graphql.WriterFunc(func(w io.Writer) {
+		_, _ = fmt.Fprintf(w, "%q", string(b))
+	})
+}
+
+func UnmarshalBytes(v interface{}) ([]byte, error) {
+	switch v := v.(type) {
+	case string:
+		return []byte(v), nil
+	case *string:
+		return []byte(*v), nil
+	case []byte:
+		return v, nil
+	default:
+		return nil, fmt.Errorf("%T is not []byte", v)
+	}
+}

--- a/codegen/testserver/gqlgen.yml
+++ b/codegen/testserver/gqlgen.yml
@@ -68,3 +68,5 @@ models:
       oldFoo: { fieldName: foo, resolver: true }
   FallbackToStringEncoding:
     model: "github.com/99designs/gqlgen/codegen/testserver.FallbackToStringEncoding"
+  Bytes:
+    model: "github.com/99designs/gqlgen/codegen/testserver.Bytes"

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -140,6 +140,9 @@ func (r *queryResolver) DefaultScalar(ctx context.Context, arg string) (string, 
 func (r *queryResolver) Slices(ctx context.Context) (*Slices, error) {
 	panic("not implemented")
 }
+func (r *queryResolver) ScalarSlice(ctx context.Context) ([]byte, error) {
+	panic("not implemented")
+}
 func (r *queryResolver) Fallback(ctx context.Context, arg FallbackToStringEncoding) (FallbackToStringEncoding, error) {
 	panic("not implemented")
 }

--- a/codegen/testserver/slices.graphql
+++ b/codegen/testserver/slices.graphql
@@ -1,5 +1,6 @@
 extend type Query {
     slices: Slices
+    scalarSlice: Bytes!
 }
 
 type Slices {
@@ -8,3 +9,5 @@ type Slices {
   test3: [String]!
   test4: [String!]!
 }
+
+scalar Bytes

--- a/codegen/testserver/slices_test.go
+++ b/codegen/testserver/slices_test.go
@@ -30,4 +30,16 @@ func TestSlices(t *testing.T) {
 		require.NotNil(t, resp.Slices.Test3)
 		require.NotNil(t, resp.Slices.Test4)
 	})
+
+	t.Run("custom scalars to slices work", func(t *testing.T) {
+		resolvers.QueryResolver.ScalarSlice = func(ctx context.Context) ([]byte, error) {
+			return []byte("testing"), nil
+		}
+
+		var resp struct {
+			ScalarSlice string
+		}
+		c.MustPost(`query { scalarSlice }`, &resp)
+		require.Equal(t, "testing", resp.ScalarSlice)
+	})
 }

--- a/codegen/testserver/stub.go
+++ b/codegen/testserver/stub.go
@@ -50,6 +50,7 @@ type Stub struct {
 		Panics                 func(ctx context.Context) (*Panics, error)
 		DefaultScalar          func(ctx context.Context, arg string) (string, error)
 		Slices                 func(ctx context.Context) (*Slices, error)
+		ScalarSlice            func(ctx context.Context) ([]byte, error)
 		Fallback               func(ctx context.Context, arg FallbackToStringEncoding) (FallbackToStringEncoding, error)
 		OptionalUnion          func(ctx context.Context) (TestUnion, error)
 		ValidType              func(ctx context.Context) (*ValidType, error)
@@ -191,6 +192,9 @@ func (r *stubQuery) DefaultScalar(ctx context.Context, arg string) (string, erro
 }
 func (r *stubQuery) Slices(ctx context.Context) (*Slices, error) {
 	return r.QueryResolver.Slices(ctx)
+}
+func (r *stubQuery) ScalarSlice(ctx context.Context) ([]byte, error) {
+	return r.QueryResolver.ScalarSlice(ctx)
 }
 func (r *stubQuery) Fallback(ctx context.Context, arg FallbackToStringEncoding) (FallbackToStringEncoding, error) {
 	return r.QueryResolver.Fallback(ctx, arg)


### PR DESCRIPTION
Fixes #597

This updates the `TypeReference.IsSlice` logic to also look at the GraphQL type.  Previously this was only looking at the Go type, which was breaking for types whose return is not a slice.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] ~~Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))~~
