### PR TITLE
Fix Gin installation instruction

### DIFF
--- a/docs/content/recipes/gin.md
+++ b/docs/content/recipes/gin.md
@@ -13,7 +13,7 @@ Here are the steps to setup Gin and gqlgen together:
 
 Install Gin:
 ```bash
-$ go get gin
+$ go get github.com/gin-gonic/gin
 ```
 
 In your router file, define the handlers for the GraphQL and Playground endpoints in two different methods and tie then together in the Gin router:


### PR DESCRIPTION
Current `go get gin` instruction results in an error from Go: `package gin: unrecognized import path "gin" (import path does not begin with hostname)`

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [X] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
