### PR TITLE
add extra builtin types only when not defined

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -368,7 +368,7 @@ func (c *Config) InjectBuiltins(s *ast.Schema) {
 	}
 
 	for typeName, entry := range extraBuiltins {
-		if t, ok := s.Types[typeName]; ok && t.Kind == ast.Scalar {
+		if t, ok := s.Types[typeName]; !c.Models.Exists(typeName) && ok && t.Kind == ast.Scalar {
 			c.Models[typeName] = entry
 		}
 	}


### PR DESCRIPTION
In 0.8.1 you could override the builtin types (eg `Time`) in config, this beaviour was lost in https://github.com/99designs/gqlgen/pull/635.

