### PR TITLE
doc: fix mistake on introspection doc page

### DIFF
--- a/docs/content/reference/introspection.md
+++ b/docs/content/reference/introspection.md
@@ -29,7 +29,7 @@ srv := httptest.NewServer(
 	handler.GraphQL(
 		NewExecutableSchema(Config{Resolvers: resolvers}),
 		handler.RequestMiddleware(func(ctx context.Context, next func(ctx context.Context) []byte) []byte {
-			if userForContext(ctx).IsAdmin {
+			if !userForContext(ctx).IsAdmin {
 				graphql.GetRequestContext(ctx).DisableIntrospection = true
 			}
 


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 
This PR fixes a small mistake in the documentation page of `introspection`

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
