### PR TITLE
Adds default custom scalar of interface{}

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -363,8 +363,9 @@ func (c *Config) InjectBuiltins(s *ast.Schema) {
 
 	// These are additional types that are injected if defined in the schema as scalars.
 	extraBuiltins := TypeMap{
-		"Time": {Model: StringList{"github.com/99designs/gqlgen/graphql.Time"}},
-		"Map":  {Model: StringList{"github.com/99designs/gqlgen/graphql.Map"}},
+		"Time":      {Model: StringList{"github.com/99designs/gqlgen/graphql.Time"}},
+		"Map":       {Model: StringList{"github.com/99designs/gqlgen/graphql.Map"}},
+		"Interface": {Model: StringList{"github.com/99designs/gqlgen/graphql.Interface"}},
 	}
 
 	for typeName, entry := range extraBuiltins {

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -363,9 +363,9 @@ func (c *Config) InjectBuiltins(s *ast.Schema) {
 
 	// These are additional types that are injected if defined in the schema as scalars.
 	extraBuiltins := TypeMap{
-		"Time":      {Model: StringList{"github.com/99designs/gqlgen/graphql.Time"}},
-		"Map":       {Model: StringList{"github.com/99designs/gqlgen/graphql.Map"}},
-		"Interface": {Model: StringList{"github.com/99designs/gqlgen/graphql.Interface"}},
+		"Time": {Model: StringList{"github.com/99designs/gqlgen/graphql.Time"}},
+		"Map":  {Model: StringList{"github.com/99designs/gqlgen/graphql.Map"}},
+		"Any":  {Model: StringList{"github.com/99designs/gqlgen/graphql.Any"}},
 	}
 
 	for typeName, entry := range extraBuiltins {

--- a/docs/content/reference/scalars.md
+++ b/docs/content/reference/scalars.md
@@ -7,7 +7,7 @@ menu: { main: { parent: 'reference' } }
 
 ## Built-in helpers
 
-gqlgen ships with three built-in helpers for common custom scalar use-cases, `Time`, `Interface` and `Map`.  Adding any of these to a schema will automatically add the marshalling behaviour to Go types.
+gqlgen ships with three built-in helpers for common custom scalar use-cases, `Time`, `Any` and `Map`.  Adding any of these to a schema will automatically add the marshalling behaviour to Go types.
 
 ### Time
 
@@ -25,10 +25,10 @@ scalar Map
 
 Maps an arbitrary GraphQL value to a `map[string]{interface}` Go type.
 
-### Interface
+### Any
 
 ```graphql
-scalar Interface
+scalar Any
 ```
 
 Maps an arbitrary GraphQL value to a `interface{}` Go type.

--- a/docs/content/reference/scalars.md
+++ b/docs/content/reference/scalars.md
@@ -7,7 +7,7 @@ menu: { main: { parent: 'reference' } }
 
 ## Built-in helpers
 
-gqlgen ships with two built-in helpers for common custom scalar use-cases, `Time` `Interface` and `Map`.  Adding either of these to a schema will automatically add the marshalling behaviour to Go types.
+gqlgen ships with three built-in helpers for common custom scalar use-cases, `Time`, `Interface` and `Map`.  Adding any of these to a schema will automatically add the marshalling behaviour to Go types.
 
 ### Time
 

--- a/docs/content/reference/scalars.md
+++ b/docs/content/reference/scalars.md
@@ -7,7 +7,7 @@ menu: { main: { parent: 'reference' } }
 
 ## Built-in helpers
 
-gqlgen ships with two built-in helpers for common custom scalar use-cases, `Time` and `Map`.  Adding either of these to a schema will automatically add the marshalling behaviour to Go types.
+gqlgen ships with two built-in helpers for common custom scalar use-cases, `Time` `Interface` and `Map`.  Adding either of these to a schema will automatically add the marshalling behaviour to Go types.
 
 ### Time
 
@@ -24,6 +24,14 @@ scalar Map
 ```
 
 Maps an arbitrary GraphQL value to a `map[string]{interface}` Go type.
+
+### Interface
+
+```graphql
+scalar Interface
+```
+
+Maps an arbitrary GraphQL value to a `interface{}` Go type.
 
 ##  Custom scalars with user defined types
 
@@ -75,7 +83,7 @@ models:
 
 ## Custom scalars with third party types
 
-Sometimes you cant add methods to a type because its in another repo, part of the standard 
+Sometimes you cant add methods to a type because its in another repo, part of the standard
 library (eg string or time.Time). To do this we can build an external marshaler:
 
 ```go
@@ -85,7 +93,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	
+
 	"github.com/99designs/gqlgen/graphql"
 )
 

--- a/graphql/any.go
+++ b/graphql/any.go
@@ -5,7 +5,7 @@ import (
 	"io"
 )
 
-func MarshalInterface(v interface{}) Marshaler {
+func MarshalAny(v interface{}) Marshaler {
 	return WriterFunc(func(w io.Writer) {
 		err := json.NewEncoder(w).Encode(v)
 		if err != nil {
@@ -14,6 +14,6 @@ func MarshalInterface(v interface{}) Marshaler {
 	})
 }
 
-func UnmarshalInterface(v interface{}) (interface{}, error) {
+func UnmarshalAny(v interface{}) (interface{}, error) {
 	return v, nil
 }

--- a/graphql/interface.go
+++ b/graphql/interface.go
@@ -3,13 +3,11 @@ package graphql
 import (
 	"encoding/json"
 	"io"
-
-	"github.com/qhenkart/gqlgen/graphql"
 )
 
 func MarshalInterface(v interface{}) Marshaler {
-	return graphql.WriterFunc(func(w io.Writer) {
-		err := json.NewEncoder(w).Encode(val)
+	return WriterFunc(func(w io.Writer) {
+		err := json.NewEncoder(w).Encode(v)
 		if err != nil {
 			panic(err)
 		}

--- a/graphql/interface.go
+++ b/graphql/interface.go
@@ -1,0 +1,21 @@
+package graphql
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/qhenkart/gqlgen/graphql"
+)
+
+func MarshalInterface(v interface{}) Marshaler {
+	return graphql.WriterFunc(func(w io.Writer) {
+		err := json.NewEncoder(w).Encode(val)
+		if err != nil {
+			panic(err)
+		}
+	})
+}
+
+func UnmarshalInterface(v interface{}) (interface{}, error) {
+	return v, nil
+}


### PR DESCRIPTION
Given that the Map default custom scalar is automatically provided of map[string]interface{}, it seemed strange to me that interface{} itself has no scalar. These seems like a common (albeit not optimal) enough design pattern in Go that it should be included. At first I thought it might push people not to strictly type their schema, but since Map is supported, I don't see any reason why this shouldn't be.

I didn't add and link an issue because of the simplicity of this PR

I have:
 - [] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
I can add tests if they are deemed necessary, but the other custom scalars don't have any, and this particular scalar is much simpler
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
