### PR TITLE
Fix: omit deprecated fields when includeDeprecated=false

### DIFF
--- a/graphql/introspection/type.go
+++ b/graphql/introspection/type.go
@@ -70,6 +70,10 @@ func (t *Type) Fields(includeDeprecated bool) []Field {
 			continue
 		}
 
+		if !includeDeprecated && f.Directives.ForName("deprecated") != nil {
+			continue
+		}
+
 		var args []InputValue
 		for _, arg := range f.Arguments {
 			args = append(args, InputValue{

--- a/graphql/introspection/type_test.go
+++ b/graphql/introspection/type_test.go
@@ -15,6 +15,9 @@ func TestType(t *testing.T) {
 			Fields: ast.FieldList{
 				&ast.FieldDefinition{Name: "__schema"},
 				&ast.FieldDefinition{Name: "test"},
+				&ast.FieldDefinition{Name: "deprecated", Directives: ast.DirectiveList{
+					&ast.Directive{Name: "deprecated"},
+				}},
 			},
 			Kind: ast.Object,
 		},
@@ -28,9 +31,16 @@ func TestType(t *testing.T) {
 		require.Equal(t, "test description", schemaType.Description())
 	})
 
-	t.Run("fields ", func(t *testing.T) {
+	t.Run("fields", func(t *testing.T) {
 		fields := schemaType.Fields(false)
 		require.Len(t, fields, 1)
 		require.Equal(t, "test", fields[0].Name)
+	})
+
+	t.Run("fields includeDepricated", func(t *testing.T) {
+		fields := schemaType.Fields(true)
+		require.Len(t, fields, 2)
+		require.Equal(t, "test", fields[0].Name)
+		require.Equal(t, "deprecated", fields[1].Name)
 	})
 }


### PR DESCRIPTION
Introspection with `includeDeprecated=false` would still return deprecated fields.  In practice this is a small deal because the introspection query typically has `includeDeprecated=true`.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
