### PR TITLE
Use pointers when embedding structs in generated structs

### DIFF
--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -117,6 +117,14 @@ type ComplexityRoot struct {
 		ID func(childComplexity int) int
 	}
 
+	LoopA struct {
+		B func(childComplexity int) int
+	}
+
+	LoopB struct {
+		A func(childComplexity int) int
+	}
+
 	Map struct {
 		ID func(childComplexity int) int
 	}
@@ -452,6 +460,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.It.ID(childComplexity), true
+
+	case "LoopA.b":
+		if e.complexity.LoopA.B == nil {
+			break
+		}
+
+		return e.complexity.LoopA.B(childComplexity), true
+
+	case "LoopB.a":
+		if e.complexity.LoopB.A == nil {
+			break
+		}
+
+		return e.complexity.LoopB.A(childComplexity), true
 
 	case "Map.id":
 		if e.complexity.Map.ID == nil {
@@ -1141,6 +1163,14 @@ type OverlappingFields {
   oldFoo: Int!
   newFoo: Int!
   new_foo: Int!
+}
+`},
+	&ast.Source{Name: "loops.graphql", Input: `type LoopA {
+    b: LoopB!
+}
+
+type LoopB {
+    a: LoopA!
 }
 `},
 	&ast.Source{Name: "maps.graphql", Input: `extend type Query {
@@ -2613,6 +2643,60 @@ func (ec *executionContext) _It_id(ctx context.Context, field graphql.CollectedF
 	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _LoopA_b(ctx context.Context, field graphql.CollectedField, obj *LoopA) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object:   "LoopA",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.B, nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*LoopB)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNLoopB2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐLoopB(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _LoopB_a(ctx context.Context, field graphql.CollectedField, obj *LoopB) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object:   "LoopB",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.A, nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*LoopA)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNLoopA2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐLoopA(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Map_id(ctx context.Context, field graphql.CollectedField, obj *Map) graphql.Marshaler {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
@@ -2808,10 +2892,10 @@ func (ec *executionContext) _OuterObject_inner(ctx context.Context, field graphq
 		}
 		return graphql.Null
 	}
-	res := resTmp.(InnerObject)
+	res := resTmp.(*InnerObject)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNInnerObject2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐInnerObject(ctx, field.Selections, res)
+	return ec.marshalNInnerObject2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐInnerObject(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _OverlappingFields_oneFoo(ctx context.Context, field graphql.CollectedField, obj *OverlappingFields) graphql.Marshaler {
@@ -5410,7 +5494,7 @@ func (ec *executionContext) unmarshalInputInputDirectives(ctx context.Context, v
 			}
 		case "inner":
 			var err error
-			it.Inner, err = ec.unmarshalNInnerDirectives2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐInnerDirectives(ctx, v)
+			it.Inner, err = ec.unmarshalNInnerDirectives2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐInnerDirectives(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -5454,7 +5538,7 @@ func (ec *executionContext) unmarshalInputOuterInput(ctx context.Context, v inte
 		switch k {
 		case "inner":
 			var err error
-			it.Inner, err = ec.unmarshalNInnerInput2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐInnerInput(ctx, v)
+			it.Inner, err = ec.unmarshalNInnerInput2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐInnerInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -6071,6 +6155,60 @@ func (ec *executionContext) _It(ctx context.Context, sel ast.SelectionSet, obj *
 			out.Values[i] = graphql.MarshalString("It")
 		case "id":
 			out.Values[i] = ec._It_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalid = true
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalid {
+		return graphql.Null
+	}
+	return out
+}
+
+var loopAImplementors = []string{"LoopA"}
+
+func (ec *executionContext) _LoopA(ctx context.Context, sel ast.SelectionSet, obj *LoopA) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.RequestContext, sel, loopAImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	invalid := false
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("LoopA")
+		case "b":
+			out.Values[i] = ec._LoopA_b(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalid = true
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalid {
+		return graphql.Null
+	}
+	return out
+}
+
+var loopBImplementors = []string{"LoopB"}
+
+func (ec *executionContext) _LoopB(ctx context.Context, sel ast.SelectionSet, obj *LoopB) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.RequestContext, sel, loopBImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	invalid := false
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("LoopB")
+		case "a":
+			out.Values[i] = ec._LoopB_a(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalid = true
 			}
@@ -7306,12 +7444,38 @@ func (ec *executionContext) unmarshalNInnerDirectives2githubᚗcomᚋ99designs�
 	return ec.unmarshalInputInnerDirectives(ctx, v)
 }
 
+func (ec *executionContext) unmarshalNInnerDirectives2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐInnerDirectives(ctx context.Context, v interface{}) (*InnerDirectives, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalNInnerDirectives2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐInnerDirectives(ctx, v)
+	return &res, err
+}
+
 func (ec *executionContext) unmarshalNInnerInput2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐInnerInput(ctx context.Context, v interface{}) (InnerInput, error) {
 	return ec.unmarshalInputInnerInput(ctx, v)
 }
 
+func (ec *executionContext) unmarshalNInnerInput2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐInnerInput(ctx context.Context, v interface{}) (*InnerInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalNInnerInput2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐInnerInput(ctx, v)
+	return &res, err
+}
+
 func (ec *executionContext) marshalNInnerObject2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐInnerObject(ctx context.Context, sel ast.SelectionSet, v InnerObject) graphql.Marshaler {
 	return ec._InnerObject(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNInnerObject2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐInnerObject(ctx context.Context, sel ast.SelectionSet, v *InnerObject) graphql.Marshaler {
+	if v == nil {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._InnerObject(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNInputDirectives2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐInputDirectives(ctx context.Context, v interface{}) (InputDirectives, error) {
@@ -7340,6 +7504,34 @@ func (ec *executionContext) unmarshalNInt2int64(ctx context.Context, v interface
 
 func (ec *executionContext) marshalNInt2int64(ctx context.Context, sel ast.SelectionSet, v int64) graphql.Marshaler {
 	return graphql.MarshalInt64(v)
+}
+
+func (ec *executionContext) marshalNLoopA2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐLoopA(ctx context.Context, sel ast.SelectionSet, v LoopA) graphql.Marshaler {
+	return ec._LoopA(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNLoopA2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐLoopA(ctx context.Context, sel ast.SelectionSet, v *LoopA) graphql.Marshaler {
+	if v == nil {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._LoopA(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNLoopB2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐLoopB(ctx context.Context, sel ast.SelectionSet, v LoopB) graphql.Marshaler {
+	return ec._LoopB(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNLoopB2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐLoopB(ctx context.Context, sel ast.SelectionSet, v *LoopB) graphql.Marshaler {
+	if v == nil {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._LoopB(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNMarshalPanic2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐMarshalPanic(ctx context.Context, v interface{}) (MarshalPanic, error) {

--- a/codegen/testserver/loops.graphql
+++ b/codegen/testserver/loops.graphql
@@ -1,0 +1,7 @@
+type LoopA {
+    b: LoopB!
+}
+
+type LoopB {
+    a: LoopA!
+}

--- a/codegen/testserver/models-gen.go
+++ b/codegen/testserver/models-gen.go
@@ -51,9 +51,17 @@ type InnerObject struct {
 
 type InputDirectives struct {
 	Text          string           `json:"text"`
-	Inner         InnerDirectives  `json:"inner"`
+	Inner         *InnerDirectives `json:"inner"`
 	InnerNullable *InnerDirectives `json:"innerNullable"`
 	ThirdParty    *ThirdParty      `json:"thirdParty"`
+}
+
+type LoopA struct {
+	B *LoopB `json:"b"`
+}
+
+type LoopB struct {
+	A *LoopA `json:"a"`
 }
 
 // Since gqlgen defines default implementation for a Map scalar, this tests that the builtin is _not_
@@ -63,11 +71,11 @@ type Map struct {
 }
 
 type OuterInput struct {
-	Inner InnerInput `json:"inner"`
+	Inner *InnerInput `json:"inner"`
 }
 
 type OuterObject struct {
-	Inner InnerObject `json:"inner"`
+	Inner *InnerObject `json:"inner"`
 }
 
 type Slices struct {

--- a/example/config/generated.go
+++ b/example/config/generated.go
@@ -572,10 +572,10 @@ func (ec *executionContext) _Todo_user(ctx context.Context, field graphql.Collec
 		}
 		return graphql.Null
 	}
-	res := resTmp.(User)
+	res := resTmp.(*User)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNUser2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋconfigᚐUser(ctx, field.Selections, res)
+	return ec.marshalNUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋconfigᚐUser(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _User_id(ctx context.Context, field graphql.CollectedField, obj *User) graphql.Marshaler {
@@ -1992,6 +1992,16 @@ func (ec *executionContext) marshalNTodo2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ
 
 func (ec *executionContext) marshalNUser2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋconfigᚐUser(ctx context.Context, sel ast.SelectionSet, v User) graphql.Marshaler {
 	return ec._User(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋconfigᚐUser(ctx context.Context, sel ast.SelectionSet, v *User) graphql.Marshaler {
+	if v == nil {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._User(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {

--- a/example/config/models_gen.go
+++ b/example/config/models_gen.go
@@ -12,5 +12,5 @@ type Todo struct {
 	DatabaseID  int    `json:"databaseId"`
 	Description string `json:"text"`
 	Done        bool   `json:"done"`
-	User        User   `json:"user"`
+	User        *User  `json:"user"`
 }

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -1,6 +1,7 @@
 package modelgen
 
 import (
+	"io/ioutil"
 	"testing"
 
 	"github.com/99designs/gqlgen/codegen/config"
@@ -13,8 +14,15 @@ func TestModelGeneration(t *testing.T) {
 	p := Plugin{}
 	require.NoError(t, p.MutateConfig(cfg))
 
-	require.True(t, cfg.Models.UserDefined("MissingType"))
+	require.True(t, cfg.Models.UserDefined("MissingTypeNotNull"))
+	require.True(t, cfg.Models.UserDefined("MissingTypeNullable"))
 	require.True(t, cfg.Models.UserDefined("MissingEnum"))
 	require.True(t, cfg.Models.UserDefined("MissingUnion"))
 	require.True(t, cfg.Models.UserDefined("MissingInterface"))
+
+	t.Run("no pointer pointers", func(t *testing.T) {
+		generated, err := ioutil.ReadFile("./out/generated.go")
+		require.NoError(t, err)
+		require.NotContains(t, string(generated), "**")
+	})
 }

--- a/plugin/modelgen/out/existing.go
+++ b/plugin/modelgen/out/existing.go
@@ -1,5 +1,12 @@
 package out
 
+type ExistingType struct {
+	Name     *string              `json:"name"`
+	Enum     *ExistingEnum        `json:"enum"`
+	Int      ExistingInterface    `json:"int"`
+	Existing *MissingTypeNullable `json:"existing"`
+}
+
 type ExistingModel struct {
 	Name string
 	Enum ExistingEnum

--- a/plugin/modelgen/out/generated.go
+++ b/plugin/modelgen/out/generated.go
@@ -16,34 +16,36 @@ type MissingUnion interface {
 	IsMissingUnion()
 }
 
-type ExistingType struct {
-	Name     *string           `json:"name"`
-	Enum     *ExistingEnum     `json:"enum"`
-	Int      ExistingInterface `json:"int"`
-	Existing *MissingType      `json:"existing"`
-}
-
-func (ExistingType) IsMissingUnion()      {}
-func (ExistingType) IsMissingInterface()  {}
-func (ExistingType) IsExistingInterface() {}
-func (ExistingType) IsExistingUnion()     {}
-
 type MissingInput struct {
 	Name *string      `json:"name"`
 	Enum *MissingEnum `json:"enum"`
 }
 
-type MissingType struct {
-	Name     *string          `json:"name"`
-	Enum     *MissingEnum     `json:"enum"`
-	Int      MissingInterface `json:"int"`
-	Existing *ExistingType    `json:"existing"`
+type MissingTypeNotNull struct {
+	Name     string               `json:"name"`
+	Enum     MissingEnum          `json:"enum"`
+	Int      MissingInterface     `json:"int"`
+	Existing *ExistingType        `json:"existing"`
+	Missing2 *MissingTypeNullable `json:"missing2"`
 }
 
-func (MissingType) IsMissingInterface()  {}
-func (MissingType) IsExistingInterface() {}
-func (MissingType) IsMissingUnion()      {}
-func (MissingType) IsExistingUnion()     {}
+func (MissingTypeNotNull) IsMissingInterface()  {}
+func (MissingTypeNotNull) IsExistingInterface() {}
+func (MissingTypeNotNull) IsMissingUnion()      {}
+func (MissingTypeNotNull) IsExistingUnion()     {}
+
+type MissingTypeNullable struct {
+	Name     *string             `json:"name"`
+	Enum     *MissingEnum        `json:"enum"`
+	Int      MissingInterface    `json:"int"`
+	Existing *ExistingType       `json:"existing"`
+	Missing2 *MissingTypeNotNull `json:"missing2"`
+}
+
+func (MissingTypeNullable) IsMissingInterface()  {}
+func (MissingTypeNullable) IsExistingInterface() {}
+func (MissingTypeNullable) IsMissingUnion()      {}
+func (MissingTypeNullable) IsExistingUnion()     {}
 
 type MissingEnum string
 

--- a/plugin/modelgen/testdata/gqlgen.yml
+++ b/plugin/modelgen/testdata/gqlgen.yml
@@ -17,5 +17,6 @@ models:
     model: github.com/99designs/gqlgen/plugin/modelgen/out.ExistingInterface
   ExistingUnion:
     model: github.com/99designs/gqlgen/plugin/modelgen/out.ExistingUnion
-
+  ExistingType:
+    model: github.com/99designs/gqlgen/plugin/modelgen/out.ExistingType
 

--- a/plugin/modelgen/testdata/schema.graphql
+++ b/plugin/modelgen/testdata/schema.graphql
@@ -10,11 +10,20 @@ type Subscription {
     thisShoudlntGetGenerated: Boolean
 }
 
-type MissingType implements MissingInterface & ExistingInterface {
+type MissingTypeNotNull implements MissingInterface & ExistingInterface {
+    name: String!
+    enum: MissingEnum!
+    int: MissingInterface!
+    existing: ExistingType!
+    missing2: MissingTypeNullable!
+}
+
+type MissingTypeNullable implements MissingInterface & ExistingInterface {
     name: String
     enum: MissingEnum
     int: MissingInterface
     existing: ExistingType
+    missing2: MissingTypeNotNull
 }
 
 input MissingInput {
@@ -31,13 +40,13 @@ interface MissingInterface {
     name: String
 }
 
-union MissingUnion = MissingType | ExistingType
+union MissingUnion = MissingTypeNotNull | MissingTypeNullable | ExistingType
 
 type ExistingType implements MissingInterface & ExistingInterface {
     name: String
     enum: ExistingEnum
     int: ExistingInterface
-    existing: MissingType
+    existing: MissingTypeNullable
 }
 
 input ExistingInput {
@@ -54,5 +63,5 @@ interface ExistingInterface {
     name: String
 }
 
-union ExistingUnion = MissingType | ExistingType
+union ExistingUnion = MissingTypeNotNull | MissingTypeNullable  | ExistingType
 


### PR DESCRIPTION
modelgen currently tries to turn
```graphql
type LoopA {
    b: LoopB!
}

 type LoopB {
    a: LoopA!
}
```

into 
```go
type LoopA struct {
	B LoopB
}

 type LoopB struct {
	A LoopA
}
```
Which is invalid. 

This PR adds pointers whenever embedding a struct in a struct to avoid this.

Fixes #585 #586 #693 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
