### PR TITLE
 added schema file globbing fixes #631

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -67,9 +68,33 @@ func LoadConfig(filename string) (*Config, error) {
 	preGlobbing := config.SchemaFilename
 	config.SchemaFilename = StringList{}
 	for _, f := range preGlobbing {
-		matches, err := filepath.Glob(f)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to glob schema filename %s", f)
+		var matches []string
+
+		// for ** we want to override default globbing patterns and walk all
+		// subdirectories to match schema files.
+		if strings.Contains(f, "**") {
+			pathParts := strings.SplitN(f, "**", 2)
+			if err := filepath.Walk(pathParts[0], func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+
+				// make sure paths match files
+				// <root>?.*<filename|.+>\.<ext>
+				fileRegex := regexp.MustCompile(pathParts[0] + "?.*" + strings.Replace(strings.Replace(pathParts[1], ".", "\\.", -1), "*", ".+", -1))
+				if fileRegex.MatchString(path) {
+					matches = append(matches, path)
+				}
+
+				return nil
+			}); err != nil {
+				return nil, errors.Wrapf(err, "failed to walk schema at root %s", pathParts[0])
+			}
+		} else {
+			matches, err = filepath.Glob(f)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to glob schema filename %s", f)
+			}
 		}
 
 		for _, m := range matches {

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -81,7 +81,10 @@ func LoadConfig(filename string) (*Config, error) {
 
 				// make sure paths match files
 				// <root>?.*<filename|.+>\.<ext>
-				fileRegex := regexp.MustCompile(pathParts[0] + "?.*" + strings.Replace(strings.Replace(pathParts[1], ".", "\\.", -1), "*", ".+", -1))
+				fileRegex := regexp.MustCompile(
+					pathParts[0] +
+						"?.*" +
+						strings.Replace(strings.Replace(pathParts[1], ".", "\\.", -1), "*", ".+", -1))
 				if fileRegex.MatchString(path) {
 					matches = append(matches, path)
 				}

--- a/codegen/config/config_test.go
+++ b/codegen/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,8 +27,8 @@ func TestLoadConfig(t *testing.T) {
 
 	t.Run("globbed filenames", func(t *testing.T) {
 		c, err := LoadConfig("testdata/cfg/glob.yml")
-		require.NoError(t, err, "")
-		fmt.Printf("%+v\n", c)
+		require.NoError(t, err)
+
 		require.Equal(t, c.SchemaFilename[0], "testdata/cfg/glob/bar/bar with spaces.graphql")
 		require.Equal(t, c.SchemaFilename[1], "testdata/cfg/glob/foo/foo.graphql")
 	})

--- a/codegen/config/config_test.go
+++ b/codegen/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,6 +24,19 @@ func TestLoadConfig(t *testing.T) {
 	t.Run("unknown keys", func(t *testing.T) {
 		_, err := LoadConfig("testdata/cfg/unknownkeys.yml")
 		require.EqualError(t, err, "unable to parse config: yaml: unmarshal errors:\n  line 2: field unknown not found in type config.Config")
+	})
+
+	t.Run("globbed filenames", func(t *testing.T) {
+		c, err := LoadConfig("testdata/cfg/glob.yml")
+		require.NoError(t, err, "")
+		fmt.Printf("%+v\n", c)
+		require.Equal(t, c.SchemaFilename[0], "testdata/cfg/glob/bar/bar with spaces.graphql")
+		require.Equal(t, c.SchemaFilename[1], "testdata/cfg/glob/foo/foo.graphql")
+	})
+
+	t.Run("unwalkable path", func(t *testing.T) {
+		_, err := LoadConfig("testdata/cfg/unwalkable.yml")
+		require.EqualError(t, err, "failed to walk schema at root not_walkable/: lstat not_walkable/: no such file or directory")
 	})
 }
 

--- a/codegen/config/testdata/cfg/glob.yml
+++ b/codegen/config/testdata/cfg/glob.yml
@@ -1,0 +1,9 @@
+schema:
+- testdata/cfg/glob/**/*.graphql
+exec:
+  filename: generated.go
+model:
+  filename: models_gen.go
+resolver:
+  filename: resolver.go
+  type: Resolver

--- a/codegen/config/testdata/cfg/glob/bar/bar with spaces.graphql
+++ b/codegen/config/testdata/cfg/glob/bar/bar with spaces.graphql
@@ -1,0 +1,12 @@
+type Query {
+  todos: [Todo!]!
+}
+
+input NewTodo {
+  text: String!
+  userId: String!
+}
+
+type Mutation {
+  createTodo(input: NewTodo!): Todo!
+}

--- a/codegen/config/testdata/cfg/glob/foo/foo.graphql
+++ b/codegen/config/testdata/cfg/glob/foo/foo.graphql
@@ -1,0 +1,11 @@
+type Todo {
+  id: ID!
+  text: String!
+  done: Boolean!
+  user: User!
+}
+
+type User {
+  id: ID!
+  name: String!
+}

--- a/codegen/config/testdata/cfg/unwalkable.yml
+++ b/codegen/config/testdata/cfg/unwalkable.yml
@@ -1,0 +1,9 @@
+schema:
+- not_walkable/**/*.graphql
+exec:
+  filename: generated.go
+model:
+  filename: models_gen.go
+resolver:
+  filename: resolver.go
+  type: Resolver

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -17,11 +17,15 @@ schema: schema.graphql
 schema:
  - schema.graphql
  - user.graphql
- 
+
 # Or you can use globs
-schema: 
+schema:
  - "*.graphql"
- 
+
+# Or globs from a root directory
+schema:
+ - "schema/**/*.graphql"
+
 # Let gqlgen know where to put the generated server
 exec:
   filename: graph/generated/generated.go


### PR DESCRIPTION
Describe your PR and link to any relevant issues:

This fixes #631 by implementing globbing for schema files. 

Tested with:
```
# schema:
# - schema/schema.graphql
# - schema/models/todo/todo.graphql
# - schema/models/user/user with spaces.graphql

# schema:
# - schema/schema.graphql
# - schema/models/user/*.graphql
# - schema/models/todo/*.graphql

# schema:
# - schema/schema.graphql
# - schema/**/user/*.graphql
# - schema/**/todo/*.graphql

# schema:
# - schema/schema.graphql
# - schema/models/**/todo.graphql
# - schema/models/**/user with spaces.graphql

# schema:
# - schema/schema.graphql
# - schema/models/**/*.graphql

# schema:
# - schema/**/*.graphql
```

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
