### PR TITLE
Automatic Persisted Queries

### DIFF
--- a/docs/content/reference/apq.md
+++ b/docs/content/reference/apq.md
@@ -1,0 +1,77 @@
+---
+title: "Automatic persisted queries"
+description:   
+linkTitle: "APQ"
+menu: { main: { parent: 'reference' } }
+---
+
+When you work with GraphQL by default your queries are transferred with every request. That can waste significant
+bandwidth. To avoid that you can use Automatic Persisted Queries (APQ).
+
+With APQ you send only query hash to the server. If hash is not found on a server then client makes a second request
+to register query hash with original query on a server.
+
+## Usage
+
+In order to enable Automatic Persisted Queries you need to change your client. For more information see 
+[Automatic Persisted Queries Link](https://github.com/apollographql/apollo-link-persisted-queries) documentation.
+
+For the server you need to implement `PersistedQueryCache` interface and pass instance to 
+`handler.EnablePersistedQueryCache` option.
+
+See example using [go-redis](github.com/go-redis/redis) package below:
+```go
+import (
+	"context"
+	"time"
+
+	"github.com/go-redis/redis"
+	"github.com/pkg/errors"
+)
+
+type Cache struct {
+	client redis.UniversalClient
+	ttl    time.Duration
+}
+
+const apqPrefix = "apq:"
+
+func NewCache(redisAddress string, password string, ttl time.Duration) (*Cache, error) {
+	client := redis.NewClient(&redis.Options{
+		Addr:     redisAddress,
+	})
+
+	err := client.Ping().Err()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return &Cache{client: client, ttl: ttl}, nil
+}
+
+func (c *Cache) Add(ctx context.Context, hash string, query string) {
+	c.client.Set(apqPrefix + hash, query, c.ttl)
+}
+
+func (c *Cache) Get(ctx context.Context, hash string) (string, bool) {
+	s, err := c.client.Get(apqPrefix + hash).Result()
+	if err != nil {
+		return "", false
+	}
+	return s, true
+}
+
+func main() {
+	cache, err := NewCache(cfg.RedisAddress, 24*time.Hour)
+	if err != nil {
+		log.Fatalf("cannot create APQ redis cache: %v", err)
+	}
+	
+	c := Config{ Resolvers: &resolvers{} }
+	gqlHandler := handler.GraphQL(
+		blog.NewExecutableSchema(c),
+		handler.EnablePersistedQueryCache(cache),
+	)
+	http.Handle("/query", gqlHandler)
+}
+```

--- a/handler/graphql.go
+++ b/handler/graphql.go
@@ -358,9 +358,9 @@ func GraphQL(exec graphql.ExecutableSchema, options ...Option) http.HandlerFunc 
 	}
 
 	handler := &graphqlHandler{
-		cfg:      cfg,
-		cache:    cache,
-		exec:     exec,
+		cfg:   cfg,
+		cache: cache,
+		exec:  exec,
 	}
 
 	return handler.ServeHTTP
@@ -369,9 +369,9 @@ func GraphQL(exec graphql.ExecutableSchema, options ...Option) http.HandlerFunc 
 var _ http.Handler = (*graphqlHandler)(nil)
 
 type graphqlHandler struct {
-	cfg      *Config
-	cache    *lru.Cache
-	exec     graphql.ExecutableSchema
+	cfg   *Config
+	cache *lru.Cache
+	exec  graphql.ExecutableSchema
 }
 
 func computeQueryHash(query string) string {

--- a/handler/graphql.go
+++ b/handler/graphql.go
@@ -2,6 +2,8 @@ package handler
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,7 +30,22 @@ type params struct {
 	Query         string                 `json:"query"`
 	OperationName string                 `json:"operationName"`
 	Variables     map[string]interface{} `json:"variables"`
+	Extensions    *extensions            `json:"extensions"`
 }
+
+type extensions struct {
+	PQ *persistedQuery `json:"persistedQuery"`
+}
+
+type persistedQuery struct {
+	Sha256  string `json:"sha256Hash"`
+	Version int64  `json:"version"`
+}
+
+const (
+	errPersistedQueryNotSupported = "PersistedQueryNotSupported"
+	errPersistedQueryNotFound     = "PersistedQueryNotFound"
+)
 
 type Config struct {
 	cacheSize                       int
@@ -44,6 +61,7 @@ type Config struct {
 	connectionKeepAlivePingInterval time.Duration
 	uploadMaxMemory                 int64
 	uploadMaxSize                   int64
+	apqCacheSize                    int
 }
 
 func (c *Config) newRequestContext(es graphql.ExecutableSchema, doc *ast.QueryDocument, op *ast.OperationDefinition, query string, variables map[string]interface{}) *graphql.RequestContext {
@@ -285,6 +303,14 @@ func WebsocketKeepAliveDuration(duration time.Duration) Option {
 	}
 }
 
+// APQCacheSize sets the maximum size of the automatic persisted query cache.
+// If size is less than or equal to 0, the cache is disabled.
+func APQCacheSize(size int) Option {
+	return func(cfg *Config) {
+		cfg.apqCacheSize = size
+	}
+}
+
 const DefaultCacheSize = 1000
 const DefaultConnectionKeepAlivePingInterval = 25 * time.Second
 
@@ -327,10 +353,22 @@ func GraphQL(exec graphql.ExecutableSchema, options ...Option) http.HandlerFunc 
 		cfg.tracer = &graphql.NopTracer{}
 	}
 
+	var apqCache *lru.Cache
+	if cfg.apqCacheSize > 0 {
+		var err error
+		apqCache, err = lru.New(cfg.apqCacheSize)
+		if err != nil {
+			// An error is only returned for non-positive cache size
+			// and we already checked for that.
+			panic("unexpected error creating apq cache: " + err.Error())
+		}
+	}
+
 	handler := &graphqlHandler{
-		cfg:   cfg,
-		cache: cache,
-		exec:  exec,
+		cfg:      cfg,
+		cache:    cache,
+		exec:     exec,
+		apqCache: apqCache,
 	}
 
 	return handler.ServeHTTP
@@ -339,9 +377,15 @@ func GraphQL(exec graphql.ExecutableSchema, options ...Option) http.HandlerFunc 
 var _ http.Handler = (*graphqlHandler)(nil)
 
 type graphqlHandler struct {
-	cfg   *Config
-	cache *lru.Cache
-	exec  graphql.ExecutableSchema
+	cfg      *Config
+	cache    *lru.Cache
+	exec     graphql.ExecutableSchema
+	apqCache *lru.Cache
+}
+
+func computeQueryHash(query string) string {
+	b := sha256.Sum256([]byte(query))
+	return hex.EncodeToString(b[:])
 }
 
 func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -409,6 +453,39 @@ func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
+	var queryHash string
+	apq := reqParams.Extensions != nil && reqParams.Extensions.PQ != nil
+	if apq {
+		// client has enabled apq
+		queryHash = reqParams.Extensions.PQ.Sha256
+		if gh.apqCache == nil {
+			// server has disabled apq
+			sendErrorf(w, http.StatusOK, errPersistedQueryNotSupported)
+			return
+		}
+		if reqParams.Extensions.PQ.Version != 1 {
+			sendErrorf(w, http.StatusOK, "Unsupported persisted query version")
+			return
+		}
+		if reqParams.Query == "" {
+			// client sent optimistic query hash without query string
+			query, ok := gh.apqCache.Get(queryHash)
+			if !ok {
+				sendErrorf(w, http.StatusOK, errPersistedQueryNotFound)
+				return
+			}
+			reqParams.Query = query.(string)
+		} else {
+			if computeQueryHash(reqParams.Query) != queryHash {
+				sendErrorf(w, http.StatusOK, "provided sha does not match query")
+				return
+			}
+		}
+	} else if reqParams.Query == "" {
+		sendErrorf(w, http.StatusUnprocessableEntity, "Must provide query string")
+		return
+	}
+
 	var doc *ast.QueryDocument
 	var cacheHit bool
 	if gh.cache != nil {
@@ -461,6 +538,11 @@ func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if reqCtx.ComplexityLimit > 0 && reqCtx.OperationComplexity > reqCtx.ComplexityLimit {
 		sendErrorf(w, http.StatusUnprocessableEntity, "operation has complexity %d, which exceeds the limit of %d", reqCtx.OperationComplexity, reqCtx.ComplexityLimit)
 		return
+	}
+
+	if apq && gh.apqCache != nil {
+		// Add to persisted query cache
+		gh.apqCache.Add(queryHash, reqParams.Query)
 	}
 
 	switch op.Operation {

--- a/handler/graphql.go
+++ b/handler/graphql.go
@@ -413,6 +413,13 @@ func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
+
+		if extensions := r.URL.Query().Get("extensions"); extensions != "" {
+			if err := jsonDecode(strings.NewReader(extensions), &reqParams.Extensions); err != nil {
+				sendErrorf(w, http.StatusBadRequest, "extensions could not be decoded")
+				return
+			}
+		}
 	case http.MethodPost:
 		mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if err != nil {

--- a/handler/graphql_test.go
+++ b/handler/graphql_test.go
@@ -767,7 +767,7 @@ func TestBytesRead(t *testing.T) {
 
 func TestAutomaticPersistedQuery(t *testing.T) {
 	h := GraphQL(&executableSchemaStub{}, APQCacheSize(1000))
-	t.Run("automatic persisted query", func(t *testing.T) {
+	t.Run("automatic persisted query POST", func(t *testing.T) {
 		// normal queries should be unaffected
 		resp := doRequest(h, "POST", "/graphql", `{"query":"{ me { name } }"}`)
 		assert.Equal(t, http.StatusOK, resp.Code)
@@ -783,6 +783,26 @@ func TestAutomaticPersistedQuery(t *testing.T) {
 		assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
 		// future requests without query string
 		resp = doRequest(h, "POST", "/graphql", `{"extensions":{"persistedQuery":{"sha256Hash":"b8d9506e34c83b0e53c2aa463624fcea354713bc38f95276e6f0bd893ffb5b88","version":1}}}`)
+		assert.Equal(t, http.StatusOK, resp.Code)
+		assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+	})
+
+	t.Run("automatic persisted query GET", func(t *testing.T) {
+		// normal queries should be unaffected
+		resp := doRequest(h, "GET", "/graphql?query={me{name}}", "")
+		assert.Equal(t, http.StatusOK, resp.Code)
+		assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+
+		// first pass: optimistic hash without query string
+		resp = doRequest(h, "GET", `/graphql?extensions={"persistedQuery":{"version":1,"sha256Hash":"b58723c4fd7ce18043ae53635b304ba6cee765a67009645b04ca01e80ce1c065"}}`, "")
+		assert.Equal(t, http.StatusOK, resp.Code)
+		assert.Equal(t, `{"errors":[{"message":"PersistedQueryNotFound"}],"data":null}`, resp.Body.String())
+		// second pass: query with query string and query hash
+		resp = doRequest(h, "GET", `/graphql?query={me{name}}&extensions={"persistedQuery":{"sha256Hash":"b58723c4fd7ce18043ae53635b304ba6cee765a67009645b04ca01e80ce1c065","version":1}}}`, "")
+		assert.Equal(t, http.StatusOK, resp.Code)
+		assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+		// future requests without query string
+		resp = doRequest(h, "GET", `/graphql?extensions={"persistedQuery":{"version":1,"sha256Hash":"b58723c4fd7ce18043ae53635b304ba6cee765a67009645b04ca01e80ce1c065"}}`, "")
 		assert.Equal(t, http.StatusOK, resp.Code)
 		assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
 	})


### PR DESCRIPTION
This PR implements automatic persisted queries as described [here](https://blog.apollographql.com/improve-graphql-performance-with-automatic-persisted-queries-c31d27b8e6ea)

It follows apollo server implementation [here](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-server-core/src/requestPipeline.ts) to make sure it is compatible with apollo clients.

This have been running in our production environment for a few weeks and works well with Apollo client with APQ enabled.

This implements #401 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
