### PR TITLE
Add middleware to intercept sendError

### DIFF
--- a/docs/content/reference/errors.md
+++ b/docs/content/reference/errors.md
@@ -106,3 +106,22 @@ server := handler.GraphQL(MakeExecutableSchema(resolvers),
 }
 ```
 
+
+### The send error middleware
+
+To get full control over all errors sent to the client, including when the client-sent GraphQL query is invalid, you can
+pass in a send error handler.
+
+Example:
+
+```go
+server := handler.GraphQL(MakeExecutableSchema(resolvers),
+	handler.SendErrorMiddleware(
+		func(ctx context.Context, errors []*gqlerror.Error) []*gqlerror.Error {
+			fmt.Printf("%v\n", errors)
+			return errors
+		}
+	),
+)
+```
+

--- a/graphql/context.go
+++ b/graphql/context.go
@@ -13,6 +13,7 @@ type Resolver func(ctx context.Context) (res interface{}, err error)
 type FieldMiddleware func(ctx context.Context, next Resolver) (res interface{}, err error)
 type RequestMiddleware func(ctx context.Context, next func(ctx context.Context) []byte) []byte
 type ComplexityLimitFunc func(ctx context.Context) int
+type SendErrorMiddleware func(ctx context.Context, errors []*gqlerror.Error) []*gqlerror.Error
 
 type RequestContext struct {
 	RawQuery  string

--- a/handler/websocket.go
+++ b/handler/websocket.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/gorilla/websocket"
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/vektah/gqlparser"
 	"github.com/vektah/gqlparser/ast"
 	"github.com/vektah/gqlparser/gqlerror"
@@ -57,7 +57,7 @@ func connectWs(exec graphql.ExecutableSchema, w http.ResponseWriter, r *http.Req
 	})
 	if err != nil {
 		log.Printf("unable to upgrade %T to websocket %s: ", w, err.Error())
-		sendErrorf(w, http.StatusBadRequest, "unable to upgrade")
+		sendErrorf(r.Context(), cfg, w, http.StatusBadRequest, "unable to upgrade")
 		return
 	}
 


### PR DESCRIPTION
The reason for this PR is so that the server can easily log errors whenever clients send invalid queries (e.g. not valid GraphQL query, or doesn't conform to the schema). Currently this is short-circuited in the handler, with no easy way to access those errors.

Services can of course send in a wrapper of the response writer to the gqlgen handler, and in that wrapper intercept response writes, and log them if the status code is a 4xx. That's more general, but it seems more complicated that necessary (especially if you want to handle the Hijacker interface for websocket connections).

Therefore, I think this PR is a good start. I'm not at all attached to the names I've come up with, feedback much appreciated.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
