### PR TITLE
Fix: support configured resolver type in server and resolver plugins

### DIFF
--- a/plugin/resolvergen/resolver.gotpl
+++ b/plugin/resolvergen/resolver.gotpl
@@ -27,7 +27,7 @@ type {{.ResolverType}} struct {}
 
 {{ range $object := .Objects -}}
 	{{- if $object.HasResolvers -}}
-		type {{lcFirst $object.Name}}Resolver struct { *Resolver }
+		type {{lcFirst $object.Name}}Resolver struct { *{{$.ResolverType}} }
 
 		{{ range $field := $object.Fields -}}
 			{{- if $field.IsResolver -}}

--- a/plugin/servergen/server.go
+++ b/plugin/servergen/server.go
@@ -27,6 +27,7 @@ func (m *Plugin) GenerateCode(data *codegen.Data) error {
 	serverBuild := &ServerBuild{
 		ExecPackageName:     data.Config.Exec.ImportPath(),
 		ResolverPackageName: data.Config.Resolver.ImportPath(),
+		ResolverType:        data.Config.Resolver.Type,
 	}
 
 	if _, err := os.Stat(m.filename); os.IsNotExist(errors.Cause(err)) {
@@ -46,4 +47,5 @@ type ServerBuild struct {
 
 	ExecPackageName     string
 	ResolverPackageName string
+	ResolverType        string
 }

--- a/plugin/servergen/server.gotpl
+++ b/plugin/servergen/server.gotpl
@@ -13,7 +13,7 @@ func main() {
 	}
 
 	http.Handle("/", handler.Playground("GraphQL playground", "/query"))
-	http.Handle("/query", handler.GraphQL({{ lookupImport .ExecPackageName }}.NewExecutableSchema({{ lookupImport .ExecPackageName}}.Config{Resolvers: &{{ lookupImport .ResolverPackageName}}.Resolver{}})))
+	http.Handle("/query", handler.GraphQL({{ lookupImport .ExecPackageName }}.NewExecutableSchema({{ lookupImport .ExecPackageName}}.Config{Resolvers: &{{ lookupImport .ResolverPackageName}}.{{.ResolverType}}{}})))
 
 	log.Printf("connect to http://localhost:%s/ for GraphQL playground", port)
 	log.Fatal(http.ListenAndServe(":" + port, nil))


### PR DESCRIPTION
Fixes: https://github.com/99designs/gqlgen/issues/747

Generated code now compiles when specifying a custom Resolver type.