### PR TITLE
[websocket] Add a config to reject initial connection

### DIFF
--- a/handler/graphql.go
+++ b/handler/graphql.go
@@ -30,7 +30,7 @@ type params struct {
 	Variables     map[string]interface{} `json:"variables"`
 }
 
-type websocketInitFunc func(ctx context.Context, initPayload InitPayload) bool
+type websocketInitFunc func(ctx context.Context, initPayload InitPayload) error
 
 type Config struct {
 	cacheSize                       int
@@ -255,7 +255,7 @@ func (tw *tracerWrapper) EndOperationExecution(ctx context.Context) {
 
 // WebsocketInitFunc is called when the server receives connection init message from the client.
 // This can be used to check initial payload to see whether to accept the websocket connection.
-func WebsocketInitFunc(websocketInitFunc func(ctx context.Context, initPayload InitPayload) bool) Option {
+func WebsocketInitFunc(websocketInitFunc func(ctx context.Context, initPayload InitPayload) error) Option {
 	return func(cfg *Config) {
 		cfg.websocketInitFunc = websocketInitFunc
 	}

--- a/handler/graphql.go
+++ b/handler/graphql.go
@@ -40,6 +40,7 @@ type Config struct {
 	tracer                          graphql.Tracer
 	complexityLimit                 int
 	complexityLimitFunc             graphql.ComplexityLimitFunc
+	websocketOnInitFunc             func(ctx context.Context, initPayload InitPayload) bool
 	disableIntrospection            bool
 	connectionKeepAlivePingInterval time.Duration
 	uploadMaxMemory                 int64
@@ -248,6 +249,14 @@ func (tw *tracerWrapper) EndFieldExecution(ctx context.Context) {
 func (tw *tracerWrapper) EndOperationExecution(ctx context.Context) {
 	tw.tracer2.EndOperationExecution(ctx)
 	tw.tracer1.EndOperationExecution(ctx)
+}
+
+// WebsocketOnInitFunc is called when the server receives connection init message from the client.
+// This can be used to check initial payload to see whether to accept the websocket connection.
+func WebsocketOnInitFunc(websocketOnInitFunc func(ctx context.Context, initPayload InitPayload) bool) Option {
+	return func(cfg *Config) {
+		cfg.websocketOnInitFunc = websocketOnInitFunc
+	}
 }
 
 // CacheSize sets the maximum size of the query cache.

--- a/handler/graphql.go
+++ b/handler/graphql.go
@@ -30,6 +30,8 @@ type params struct {
 	Variables     map[string]interface{} `json:"variables"`
 }
 
+type websocketInitFunc func(ctx context.Context, initPayload InitPayload) bool
+
 type Config struct {
 	cacheSize                       int
 	upgrader                        websocket.Upgrader
@@ -40,7 +42,7 @@ type Config struct {
 	tracer                          graphql.Tracer
 	complexityLimit                 int
 	complexityLimitFunc             graphql.ComplexityLimitFunc
-	websocketOnInitFunc             func(ctx context.Context, initPayload InitPayload) bool
+	websocketInitFunc               websocketInitFunc
 	disableIntrospection            bool
 	connectionKeepAlivePingInterval time.Duration
 	uploadMaxMemory                 int64
@@ -251,11 +253,11 @@ func (tw *tracerWrapper) EndOperationExecution(ctx context.Context) {
 	tw.tracer1.EndOperationExecution(ctx)
 }
 
-// WebsocketOnInitFunc is called when the server receives connection init message from the client.
+// WebsocketInitFunc is called when the server receives connection init message from the client.
 // This can be used to check initial payload to see whether to accept the websocket connection.
-func WebsocketOnInitFunc(websocketOnInitFunc func(ctx context.Context, initPayload InitPayload) bool) Option {
+func WebsocketInitFunc(websocketInitFunc func(ctx context.Context, initPayload InitPayload) bool) Option {
 	return func(cfg *Config) {
-		cfg.websocketOnInitFunc = websocketOnInitFunc
+		cfg.websocketInitFunc = websocketInitFunc
 	}
 }
 

--- a/handler/websocket.go
+++ b/handler/websocket.go
@@ -94,9 +94,8 @@ func (c *wsConnection) init() bool {
 			}
 		}
 
-		if c.cfg.websocketOnInitFunc != nil {
-			isValidPayload := c.cfg.websocketOnInitFunc(c.ctx, c.initPayload)
-			if !isValidPayload {
+		if c.cfg.websocketInitFunc != nil {
+			if ok := c.cfg.websocketInitFunc(c.ctx, c.initPayload); !ok {
 				c.sendConnectionError("invalid init payload")
 				c.close(websocket.CloseNormalClosure, "terminated")
 				return false

--- a/handler/websocket.go
+++ b/handler/websocket.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/gorilla/websocket"
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/vektah/gqlparser"
 	"github.com/vektah/gqlparser/ast"
 	"github.com/vektah/gqlparser/gqlerror"
@@ -90,6 +90,15 @@ func (c *wsConnection) init() bool {
 			c.initPayload = make(InitPayload)
 			err := json.Unmarshal(message.Payload, &c.initPayload)
 			if err != nil {
+				return false
+			}
+		}
+
+		if c.cfg.websocketOnInitFunc != nil {
+			isValidPayload := c.cfg.websocketOnInitFunc(c.ctx, c.initPayload)
+			if !isValidPayload {
+				c.sendConnectionError("invalid init payload")
+				c.close(websocket.CloseNormalClosure, "terminated")
 				return false
 			}
 		}

--- a/handler/websocket.go
+++ b/handler/websocket.go
@@ -95,8 +95,8 @@ func (c *wsConnection) init() bool {
 		}
 
 		if c.cfg.websocketInitFunc != nil {
-			if ok := c.cfg.websocketInitFunc(c.ctx, c.initPayload); !ok {
-				c.sendConnectionError("invalid init payload")
+			if err := c.cfg.websocketInitFunc(c.ctx, c.initPayload); err != nil {
+				c.sendConnectionError(err.Error())
 				c.close(websocket.CloseNormalClosure, "terminated")
 				return false
 			}

--- a/handler/websocket_test.go
+++ b/handler/websocket_test.go
@@ -159,10 +159,10 @@ func TestWebsocketWithKeepAlive(t *testing.T) {
 	})
 }
 
-func TestWebsocketOnInitFunc(t *testing.T) {
+func TestWebsocketInitFunc(t *testing.T) {
 	next := make(chan struct{})
 
-	t.Run("accept connection if WebsocketOnInitFunc is NOT provided", func(t *testing.T) {
+	t.Run("accept connection if WebsocketInitFunc is NOT provided", func(t *testing.T) {
 		h := GraphQL(&executableSchemaStub{next})
 		srv := httptest.NewServer(h)
 		defer srv.Close()
@@ -175,8 +175,8 @@ func TestWebsocketOnInitFunc(t *testing.T) {
 		require.Equal(t, connectionAckMsg, readOp(c).Type)
 	})
 
-	t.Run("accept connection if WebsocketOnInitFunc is provided and is accepting connection", func(t *testing.T) {
-		h := GraphQL(&executableSchemaStub{next}, WebsocketOnInitFunc(func(ctx context.Context, initPayload InitPayload) bool {
+	t.Run("accept connection if WebsocketInitFunc is provided and is accepting connection", func(t *testing.T) {
+		h := GraphQL(&executableSchemaStub{next}, WebsocketInitFunc(func(ctx context.Context, initPayload InitPayload) bool {
 			return true
 		}))
 		srv := httptest.NewServer(h)
@@ -190,8 +190,8 @@ func TestWebsocketOnInitFunc(t *testing.T) {
 		require.Equal(t, connectionAckMsg, readOp(c).Type)
 	})
 
-	t.Run("reject connection if WebsocketOnInitFunc is provided and is accepting connection", func(t *testing.T) {
-		h := GraphQL(&executableSchemaStub{next}, WebsocketOnInitFunc(func(ctx context.Context, initPayload InitPayload) bool {
+	t.Run("reject connection if WebsocketInitFunc is provided and is accepting connection", func(t *testing.T) {
+		h := GraphQL(&executableSchemaStub{next}, WebsocketInitFunc(func(ctx context.Context, initPayload InitPayload) bool {
 			return false
 		}))
 		srv := httptest.NewServer(h)

--- a/handler/websocket_test.go
+++ b/handler/websocket_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -176,8 +177,8 @@ func TestWebsocketInitFunc(t *testing.T) {
 	})
 
 	t.Run("accept connection if WebsocketInitFunc is provided and is accepting connection", func(t *testing.T) {
-		h := GraphQL(&executableSchemaStub{next}, WebsocketInitFunc(func(ctx context.Context, initPayload InitPayload) bool {
-			return true
+		h := GraphQL(&executableSchemaStub{next}, WebsocketInitFunc(func(ctx context.Context, initPayload InitPayload) error {
+			return nil
 		}))
 		srv := httptest.NewServer(h)
 		defer srv.Close()
@@ -191,8 +192,8 @@ func TestWebsocketInitFunc(t *testing.T) {
 	})
 
 	t.Run("reject connection if WebsocketInitFunc is provided and is accepting connection", func(t *testing.T) {
-		h := GraphQL(&executableSchemaStub{next}, WebsocketInitFunc(func(ctx context.Context, initPayload InitPayload) bool {
-			return false
+		h := GraphQL(&executableSchemaStub{next}, WebsocketInitFunc(func(ctx context.Context, initPayload InitPayload) error {
+			return errors.New("invalid init payload")
 		}))
 		srv := httptest.NewServer(h)
 		defer srv.Close()


### PR DESCRIPTION
### Problem

Currently, we are allowing clients to always connect to the server unless the message is invalid. Current implementation [here](https://github.com/99designs/gqlgen/blob/694f90aa089c34a80bf3007a6d298a96ba7f132c/handler/websocket.go#L88-L97)

This is not safe as a malicious user can connect to the WebSocket and perform queries/mutations. An example of such message:

![Screen Shot 2019-06-18 at 11 05 15 am](https://user-images.githubusercontent.com/33769523/59646186-21968280-91b9-11e9-81d1-09ce52a88837.png)

We would have to check in every query/mutation/subscription to make sure that a user can perform such action (related PR: https://github.com/99designs/gqlgen/pull/348). 

### Proposal

This PR adds a new function to handler config called `websocketOnInitFunc`. This can be used by the server to check the init payload to decide whether to establish the connection or reject it. If this function is not given, the connection is always established.

### Example workflow

This is an example workflow, different apps may have different approaches:

1. The client sends a WebSocket upgrade request with init payload to the server and a token in cookie
2. The server receives the request, picks out the cookie and put it in context
3. When the init function is called, it will use the init payload and compare with the cookie in context
4a. If they are the same, create the connection
4b. If they are not the same, close the connection and send back a `invalid init payload` message

Accepted connection:
![Screen Shot 2019-06-18 at 10 53 02 am](https://user-images.githubusercontent.com/33769523/59646786-c619c400-91bb-11e9-8b38-d27f2a9f2db1.png)


Rejected connection:
![Screen Shot 2019-06-18 at 10 53 18 am](https://user-images.githubusercontent.com/33769523/59646759-a97d8c00-91bb-11e9-9d1b-cada1da6514c.png)


I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content)) - None
