### PR TITLE
Allow disabling generation

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -182,7 +182,7 @@ func (c *PackageConfig) Check() error {
 	if strings.ContainsAny(c.Package, "./\\") {
 		return fmt.Errorf("package should be the output package name only, do not include the output filename")
 	}
-	if c.Filename != "" && !strings.HasSuffix(c.Filename, ".go") {
+	if c.Filename != "" && c.Filename != os.DevNull && !strings.HasSuffix(c.Filename, ".go") {
 		return fmt.Errorf("filename should be path to a go source file")
 	}
 

--- a/codegen/config/config_test.go
+++ b/codegen/config/config_test.go
@@ -93,6 +93,17 @@ func TestReferencedPackages(t *testing.T) {
 }
 
 func TestConfigCheck(t *testing.T) {
+	t.Run("allow disabling generation", func(t *testing.T) {
+		config := DefaultConfig()
+		config.Exec.Filename = os.DevNull
+
+		err := config.normalize()
+		require.NoError(t, err)
+
+		err = config.Check()
+		require.NoError(t, err)
+	})
+
 	t.Run("invalid config format due to conflicting package names", func(t *testing.T) {
 		config, err := LoadConfig("testdata/cfg/conflictedPackages.yml")
 		require.NoError(t, err)


### PR DESCRIPTION
I'm using this package for a server implementation and would like to also use it to generate typed models for a client library.

I can ignore the generated.go and either remove it or avoid checking it in but with this small change, I can have gqlgen output only the file I care about.

I realize this is irrelevant "for building GraphQL servers" so I won't mind if you decide to close the pull request.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] ~Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))~

(I'm not sure this option should be documented so let me know if you think so.)