### PR TITLE
Autobind models

### DIFF
--- a/codegen/data.go
+++ b/codegen/data.go
@@ -51,6 +51,11 @@ func BuildData(cfg *config.Config) (*Data, error) {
 		return nil, err
 	}
 
+	err = cfg.Autobind(b.Schema)
+	if err != nil {
+		return nil, err
+	}
+
 	cfg.InjectBuiltins(b.Schema)
 
 	b.Binder, err = b.Config.NewBinder(b.Schema)

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -44,6 +44,11 @@ resolver:
 # Optional, turns on binding to field names by tag provided
 struct_tag: json
 
+# Instead of listing out every model like below, you can automatically bind to any matching types
+# within the given path. EXPERIMENTAL in v0.9.1
+autobind:
+ - github.com/my/app/models
+
 # Tell gqlgen about any existing models you want to reuse for
 # graphql. These normally come from the db or a remote api.
 models:

--- a/example/starwars/.gqlgen.yml
+++ b/example/starwars/.gqlgen.yml
@@ -3,15 +3,10 @@ exec:
 model:
   filename: models/generated.go
 
+autobind:
+  - github.com/99designs/gqlgen/example/starwars/models
+
 models:
-  Droid:
-    model: github.com/99designs/gqlgen/example/starwars/models.Droid
-  FriendsConnection:
-    model: github.com/99designs/gqlgen/example/starwars/models.FriendsConnection
-  Human:
-    model: github.com/99designs/gqlgen/example/starwars/models.Human
-  Review:
-    model: github.com/99designs/gqlgen/example/starwars/models.Review
   ReviewInput:
     model: github.com/99designs/gqlgen/example/starwars/models.Review
   Starship:

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -72,6 +72,11 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 		return err
 	}
 
+	err = cfg.Autobind(schema)
+	if err != nil {
+		return err
+	}
+
 	cfg.InjectBuiltins(schema)
 
 	binder, err := cfg.NewBinder(schema)


### PR DESCRIPTION
This PR adds a new config key `autobind` which is a list of packages to search for GraphQL names in. If they are found they will automatically be added to models for you. This should avoid a bunch of boilerplate.

Fixes #621 

It probably only works with `go modules`, sorry, you should update.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
