### PR TITLE
fix field schema directives applied to roots

### DIFF
--- a/codegen/field.go
+++ b/codegen/field.go
@@ -288,6 +288,9 @@ func (f *Field) HasDirectives() bool {
 }
 
 func (f *Field) DirectiveObjName() string {
+	if f.Object.Root {
+		return "nil"
+	}
 	return f.GoReceiverName
 }
 

--- a/codegen/testserver/directive.graphql
+++ b/codegen/testserver/directive.graphql
@@ -1,0 +1,25 @@
+directive @length(min: Int!, max: Int, message: String) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+directive @range(min: Int = 0, max: Int) on ARGUMENT_DEFINITION
+directive @custom on ARGUMENT_DEFINITION
+directive @logged(id: UUID!) on FIELD
+
+extend type Query {
+    directiveArg(arg: String! @length(min:1, max: 255, message: "invalid length")): String
+    directiveNullableArg(arg: Int @range(min:0), arg2: Int @range): String
+    directiveInputNullable(arg: InputDirectives): String
+    directiveInput(arg: InputDirectives!): String
+    directiveInputType(arg: InnerInput! @custom): String
+    directiveFieldDef(ret: String!): String! @length(min: 1, message: "not valid")
+    directiveField: String
+}
+
+input InputDirectives {
+    text: String! @length(min: 0, max: 7, message: "not valid")
+    inner: InnerDirectives!
+    innerNullable: InnerDirectives
+    thirdParty: ThirdParty @length(min: 0, max: 7)
+}
+
+input InnerDirectives {
+    message: String! @length(min: 1, message: "not valid")
+}

--- a/codegen/testserver/directive_test.go
+++ b/codegen/testserver/directive_test.go
@@ -180,6 +180,31 @@ func TestDirectives(t *testing.T) {
 			require.Equal(t, "Ok", *resp.DirectiveArg)
 		})
 	})
+	t.Run("field definition directives", func(t *testing.T) {
+		resolvers.QueryResolver.DirectiveFieldDef = func(ctx context.Context, ret string) (i string, e error) {
+			return ret, nil
+		}
+
+		t.Run("too short", func(t *testing.T) {
+			var resp struct {
+				DirectiveFieldDef string
+			}
+
+			err := c.Post(`query { directiveFieldDef(ret: "") }`, &resp)
+
+			require.EqualError(t, err, `[{"message":"not valid","path":["directiveFieldDef"]}]`)
+		})
+
+		t.Run("ok", func(t *testing.T) {
+			var resp struct {
+				DirectiveFieldDef string
+			}
+
+			c.MustPost(`query { directiveFieldDef(ret: "aaa") }`, &resp)
+
+			require.Equal(t, "aaa", resp.DirectiveFieldDef)
+		})
+	})
 	t.Run("field directives", func(t *testing.T) {
 		t.Run("add field directive", func(t *testing.T) {
 			var resp struct {

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -134,6 +134,21 @@ func (r *queryResolver) User(ctx context.Context, id int) (*User, error) {
 func (r *queryResolver) NullableArg(ctx context.Context, arg *int) (*string, error) {
 	panic("not implemented")
 }
+func (r *queryResolver) InputSlice(ctx context.Context, arg []string) (bool, error) {
+	panic("not implemented")
+}
+func (r *queryResolver) ShapeUnion(ctx context.Context) (ShapeUnion, error) {
+	panic("not implemented")
+}
+func (r *queryResolver) Autobind(ctx context.Context) (*Autobind, error) {
+	panic("not implemented")
+}
+func (r *queryResolver) DeprecatedField(ctx context.Context) (string, error) {
+	panic("not implemented")
+}
+func (r *queryResolver) Overlapping(ctx context.Context) (*OverlappingFields, error) {
+	panic("not implemented")
+}
 func (r *queryResolver) DirectiveArg(ctx context.Context, arg string) (*string, error) {
 	panic("not implemented")
 }
@@ -149,22 +164,10 @@ func (r *queryResolver) DirectiveInput(ctx context.Context, arg InputDirectives)
 func (r *queryResolver) DirectiveInputType(ctx context.Context, arg InnerInput) (*string, error) {
 	panic("not implemented")
 }
+func (r *queryResolver) DirectiveFieldDef(ctx context.Context, ret string) (string, error) {
+	panic("not implemented")
+}
 func (r *queryResolver) DirectiveField(ctx context.Context) (*string, error) {
-	panic("not implemented")
-}
-func (r *queryResolver) InputSlice(ctx context.Context, arg []string) (bool, error) {
-	panic("not implemented")
-}
-func (r *queryResolver) ShapeUnion(ctx context.Context) (ShapeUnion, error) {
-	panic("not implemented")
-}
-func (r *queryResolver) Autobind(ctx context.Context) (*Autobind, error) {
-	panic("not implemented")
-}
-func (r *queryResolver) DeprecatedField(ctx context.Context) (string, error) {
-	panic("not implemented")
-}
-func (r *queryResolver) Overlapping(ctx context.Context) (*OverlappingFields, error) {
 	panic("not implemented")
 }
 func (r *queryResolver) MapStringInterface(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error) {

--- a/codegen/testserver/schema.graphql
+++ b/codegen/testserver/schema.graphql
@@ -9,12 +9,6 @@ type Query {
     modelMethods: ModelMethods
     user(id: Int!): User!
     nullableArg(arg: Int = 123): String
-    directiveArg(arg: String! @length(min:1, max: 255, message: "invalid length")): String
-    directiveNullableArg(arg: Int @range(min:0), arg2: Int @range): String
-    directiveInputNullable(arg: InputDirectives): String
-    directiveInput(arg: InputDirectives!): String
-    directiveInputType(arg: InnerInput! @custom): String
-    directiveField: String
     inputSlice(arg: [String!]!): Boolean!
     shapeUnion: ShapeUnion!
     autobind: Autobind
@@ -75,17 +69,6 @@ input OuterInput {
 
 scalar ThirdParty
 
-input InputDirectives {
-    text: String! @length(min: 0, max: 7, message: "not valid")
-    inner: InnerDirectives!
-    innerNullable: InnerDirectives
-    thirdParty: ThirdParty @length(min: 0, max: 7)
-}
-
-input InnerDirectives {
-    message: String! @length(min: 1, message: "not valid")
-}
-
 type OuterObject {
     inner: InnerObject!
 }
@@ -117,10 +100,6 @@ type EmbeddedPointer {
     Title: String
 }
 
-directive @length(min: Int!, max: Int, message: String) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
-directive @range(min: Int = 0, max: Int) on ARGUMENT_DEFINITION
-directive @custom on ARGUMENT_DEFINITION
-directive @logged(id: UUID!) on FIELD
 scalar UUID
 
 enum Status {

--- a/codegen/testserver/stub.go
+++ b/codegen/testserver/stub.go
@@ -48,17 +48,18 @@ type Stub struct {
 		ModelMethods           func(ctx context.Context) (*ModelMethods, error)
 		User                   func(ctx context.Context, id int) (*User, error)
 		NullableArg            func(ctx context.Context, arg *int) (*string, error)
-		DirectiveArg           func(ctx context.Context, arg string) (*string, error)
-		DirectiveNullableArg   func(ctx context.Context, arg *int, arg2 *int) (*string, error)
-		DirectiveInputNullable func(ctx context.Context, arg *InputDirectives) (*string, error)
-		DirectiveInput         func(ctx context.Context, arg InputDirectives) (*string, error)
-		DirectiveInputType     func(ctx context.Context, arg InnerInput) (*string, error)
-		DirectiveField         func(ctx context.Context) (*string, error)
 		InputSlice             func(ctx context.Context, arg []string) (bool, error)
 		ShapeUnion             func(ctx context.Context) (ShapeUnion, error)
 		Autobind               func(ctx context.Context) (*Autobind, error)
 		DeprecatedField        func(ctx context.Context) (string, error)
 		Overlapping            func(ctx context.Context) (*OverlappingFields, error)
+		DirectiveArg           func(ctx context.Context, arg string) (*string, error)
+		DirectiveNullableArg   func(ctx context.Context, arg *int, arg2 *int) (*string, error)
+		DirectiveInputNullable func(ctx context.Context, arg *InputDirectives) (*string, error)
+		DirectiveInput         func(ctx context.Context, arg InputDirectives) (*string, error)
+		DirectiveInputType     func(ctx context.Context, arg InnerInput) (*string, error)
+		DirectiveFieldDef      func(ctx context.Context, ret string) (string, error)
+		DirectiveField         func(ctx context.Context) (*string, error)
 		MapStringInterface     func(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error)
 		ErrorBubble            func(ctx context.Context) (*Error, error)
 		Errors                 func(ctx context.Context) (*Errors, error)
@@ -207,6 +208,21 @@ func (r *stubQuery) User(ctx context.Context, id int) (*User, error) {
 func (r *stubQuery) NullableArg(ctx context.Context, arg *int) (*string, error) {
 	return r.QueryResolver.NullableArg(ctx, arg)
 }
+func (r *stubQuery) InputSlice(ctx context.Context, arg []string) (bool, error) {
+	return r.QueryResolver.InputSlice(ctx, arg)
+}
+func (r *stubQuery) ShapeUnion(ctx context.Context) (ShapeUnion, error) {
+	return r.QueryResolver.ShapeUnion(ctx)
+}
+func (r *stubQuery) Autobind(ctx context.Context) (*Autobind, error) {
+	return r.QueryResolver.Autobind(ctx)
+}
+func (r *stubQuery) DeprecatedField(ctx context.Context) (string, error) {
+	return r.QueryResolver.DeprecatedField(ctx)
+}
+func (r *stubQuery) Overlapping(ctx context.Context) (*OverlappingFields, error) {
+	return r.QueryResolver.Overlapping(ctx)
+}
 func (r *stubQuery) DirectiveArg(ctx context.Context, arg string) (*string, error) {
 	return r.QueryResolver.DirectiveArg(ctx, arg)
 }
@@ -222,23 +238,11 @@ func (r *stubQuery) DirectiveInput(ctx context.Context, arg InputDirectives) (*s
 func (r *stubQuery) DirectiveInputType(ctx context.Context, arg InnerInput) (*string, error) {
 	return r.QueryResolver.DirectiveInputType(ctx, arg)
 }
+func (r *stubQuery) DirectiveFieldDef(ctx context.Context, ret string) (string, error) {
+	return r.QueryResolver.DirectiveFieldDef(ctx, ret)
+}
 func (r *stubQuery) DirectiveField(ctx context.Context) (*string, error) {
 	return r.QueryResolver.DirectiveField(ctx)
-}
-func (r *stubQuery) InputSlice(ctx context.Context, arg []string) (bool, error) {
-	return r.QueryResolver.InputSlice(ctx, arg)
-}
-func (r *stubQuery) ShapeUnion(ctx context.Context) (ShapeUnion, error) {
-	return r.QueryResolver.ShapeUnion(ctx)
-}
-func (r *stubQuery) Autobind(ctx context.Context) (*Autobind, error) {
-	return r.QueryResolver.Autobind(ctx)
-}
-func (r *stubQuery) DeprecatedField(ctx context.Context) (string, error) {
-	return r.QueryResolver.DeprecatedField(ctx)
-}
-func (r *stubQuery) Overlapping(ctx context.Context) (*OverlappingFields, error) {
-	return r.QueryResolver.Overlapping(ctx)
 }
 func (r *stubQuery) MapStringInterface(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error) {
 	return r.QueryResolver.MapStringInterface(ctx, in)


### PR DESCRIPTION
Fix broken codegen when using field directives on root level objects (Query, Mutation, Subscription).

Introduced by a refactor in #756