### PR TITLE
Fix pointer returns from directive

### DIFF
--- a/codegen/args.gotpl
+++ b/codegen/args.gotpl
@@ -14,6 +14,10 @@ func (ec *executionContext) {{ $name }}(ctx context.Context, rawArgs map[string]
 				}
 				if data, ok := tmp.({{ $arg.TypeReference.GO | ref }}) ; ok {
 					arg{{$i}} = data
+				{{- if $arg.TypeReference.IsNilable }}
+					} else if tmp == nil {
+						arg{{$i}} = nil
+				{{- end }}
 				} else {
 					return nil, fmt.Errorf(`unexpected type %T from directive, should be {{ $arg.TypeReference.GO }}`, tmp)
 				}

--- a/codegen/field.gotpl
+++ b/codegen/field.gotpl
@@ -107,6 +107,11 @@
 		if data, ok := tmp.({{ .TypeReference.GO | ref }}) ; ok {
 			return data, nil
 		}
+		{{- if .TypeReference.IsNilable -}}
+			else if tmp == nil {
+				return nil, nil
+			}
+		{{- end }}
 		return nil, fmt.Errorf(`unexpected type %T from directive, should be {{ .TypeReference.GO }}`, tmp)
 	{{- else -}}
 		ctx = rctx  // use context from middleware stack in children

--- a/codegen/input.gotpl
+++ b/codegen/input.gotpl
@@ -25,6 +25,10 @@
 					}
 					if data, ok := tmp.({{ $field.TypeReference.GO | ref }}) ; ok {
 						it.{{$field.GoFieldName}} = data
+					{{- if $field.TypeReference.IsNilable }}
+						} else if tmp == nil {
+							it.{{$field.GoFieldName}} = nil
+					{{- end }}
 					} else {
 						return it, fmt.Errorf(`unexpected type %T from directive, should be {{ $field.TypeReference.GO }}`, tmp)
 					}

--- a/codegen/testserver/directive.graphql
+++ b/codegen/testserver/directive.graphql
@@ -2,19 +2,22 @@ directive @length(min: Int!, max: Int, message: String) on ARGUMENT_DEFINITION |
 directive @range(min: Int = 0, max: Int) on ARGUMENT_DEFINITION
 directive @custom on ARGUMENT_DEFINITION
 directive @logged(id: UUID!) on FIELD
+directive @toNull on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 extend type Query {
     directiveArg(arg: String! @length(min:1, max: 255, message: "invalid length")): String
-    directiveNullableArg(arg: Int @range(min:0), arg2: Int @range): String
+    directiveNullableArg(arg: Int @range(min:0), arg2: Int @range, arg3: String @toNull): String
     directiveInputNullable(arg: InputDirectives): String
     directiveInput(arg: InputDirectives!): String
     directiveInputType(arg: InnerInput! @custom): String
+    directiveObject: ObjectDirectives
     directiveFieldDef(ret: String!): String! @length(min: 1, message: "not valid")
     directiveField: String
 }
 
 input InputDirectives {
     text: String! @length(min: 0, max: 7, message: "not valid")
+    nullableText: String @toNull
     inner: InnerDirectives!
     innerNullable: InnerDirectives
     thirdParty: ThirdParty @length(min: 0, max: 7)
@@ -22,4 +25,9 @@ input InputDirectives {
 
 input InnerDirectives {
     message: String! @length(min: 1, message: "not valid")
+}
+
+type ObjectDirectives {
+    text: String! @length(min: 0, max: 7, message: "not valid")
+    nullableText: String @toNull
 }

--- a/codegen/testserver/models-gen.go
+++ b/codegen/testserver/models-gen.go
@@ -67,6 +67,7 @@ type InnerObject struct {
 
 type InputDirectives struct {
 	Text          string           `json:"text"`
+	NullableText  *string          `json:"nullableText"`
 	Inner         *InnerDirectives `json:"inner"`
 	InnerNullable *InnerDirectives `json:"innerNullable"`
 	ThirdParty    *ThirdParty      `json:"thirdParty"`
@@ -84,6 +85,11 @@ type LoopB struct {
 // added to the TypeMap
 type Map struct {
 	ID string `json:"id"`
+}
+
+type ObjectDirectives struct {
+	Text         string  `json:"text"`
+	NullableText *string `json:"nullableText"`
 }
 
 type OuterInput struct {

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -152,7 +152,7 @@ func (r *queryResolver) Overlapping(ctx context.Context) (*OverlappingFields, er
 func (r *queryResolver) DirectiveArg(ctx context.Context, arg string) (*string, error) {
 	panic("not implemented")
 }
-func (r *queryResolver) DirectiveNullableArg(ctx context.Context, arg *int, arg2 *int) (*string, error) {
+func (r *queryResolver) DirectiveNullableArg(ctx context.Context, arg *int, arg2 *int, arg3 *string) (*string, error) {
 	panic("not implemented")
 }
 func (r *queryResolver) DirectiveInputNullable(ctx context.Context, arg *InputDirectives) (*string, error) {
@@ -162,6 +162,9 @@ func (r *queryResolver) DirectiveInput(ctx context.Context, arg InputDirectives)
 	panic("not implemented")
 }
 func (r *queryResolver) DirectiveInputType(ctx context.Context, arg InnerInput) (*string, error) {
+	panic("not implemented")
+}
+func (r *queryResolver) DirectiveObject(ctx context.Context) (*ObjectDirectives, error) {
 	panic("not implemented")
 }
 func (r *queryResolver) DirectiveFieldDef(ctx context.Context, ret string) (string, error) {

--- a/codegen/testserver/stub.go
+++ b/codegen/testserver/stub.go
@@ -54,10 +54,11 @@ type Stub struct {
 		DeprecatedField        func(ctx context.Context) (string, error)
 		Overlapping            func(ctx context.Context) (*OverlappingFields, error)
 		DirectiveArg           func(ctx context.Context, arg string) (*string, error)
-		DirectiveNullableArg   func(ctx context.Context, arg *int, arg2 *int) (*string, error)
+		DirectiveNullableArg   func(ctx context.Context, arg *int, arg2 *int, arg3 *string) (*string, error)
 		DirectiveInputNullable func(ctx context.Context, arg *InputDirectives) (*string, error)
 		DirectiveInput         func(ctx context.Context, arg InputDirectives) (*string, error)
 		DirectiveInputType     func(ctx context.Context, arg InnerInput) (*string, error)
+		DirectiveObject        func(ctx context.Context) (*ObjectDirectives, error)
 		DirectiveFieldDef      func(ctx context.Context, ret string) (string, error)
 		DirectiveField         func(ctx context.Context) (*string, error)
 		MapStringInterface     func(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error)
@@ -226,8 +227,8 @@ func (r *stubQuery) Overlapping(ctx context.Context) (*OverlappingFields, error)
 func (r *stubQuery) DirectiveArg(ctx context.Context, arg string) (*string, error) {
 	return r.QueryResolver.DirectiveArg(ctx, arg)
 }
-func (r *stubQuery) DirectiveNullableArg(ctx context.Context, arg *int, arg2 *int) (*string, error) {
-	return r.QueryResolver.DirectiveNullableArg(ctx, arg, arg2)
+func (r *stubQuery) DirectiveNullableArg(ctx context.Context, arg *int, arg2 *int, arg3 *string) (*string, error) {
+	return r.QueryResolver.DirectiveNullableArg(ctx, arg, arg2, arg3)
 }
 func (r *stubQuery) DirectiveInputNullable(ctx context.Context, arg *InputDirectives) (*string, error) {
 	return r.QueryResolver.DirectiveInputNullable(ctx, arg)
@@ -237,6 +238,9 @@ func (r *stubQuery) DirectiveInput(ctx context.Context, arg InputDirectives) (*s
 }
 func (r *stubQuery) DirectiveInputType(ctx context.Context, arg InnerInput) (*string, error) {
 	return r.QueryResolver.DirectiveInputType(ctx, arg)
+}
+func (r *stubQuery) DirectiveObject(ctx context.Context) (*ObjectDirectives, error) {
+	return r.QueryResolver.DirectiveObject(ctx)
 }
 func (r *stubQuery) DirectiveFieldDef(ctx context.Context, ret string) (string, error) {
 	return r.QueryResolver.DirectiveFieldDef(ctx, ret)


### PR DESCRIPTION
add handling `<nil>` value returns from directives.
after update v0.9.1, I got `unexpected type <nil> from directive, should be *string"` error message.
This PR fixes it.

I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [X] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
