### PR TITLE
fixed generating a description to golang comments for enum type

### DIFF
--- a/plugin/modelgen/models.gotpl
+++ b/plugin/modelgen/models.gotpl
@@ -36,7 +36,7 @@
 {{- end}}
 
 {{ range $enum := .Enums }}
-	{{ with .Description|go }} {{.|prefixLines "// "}} {{end}}
+	{{ with .Description }} {{.|prefixLines "// "}} {{end}}
 	type {{.Name|go }} string
 	const (
 	{{- range $value := .Values}}

--- a/plugin/modelgen/out/generated.go
+++ b/plugin/modelgen/out/generated.go
@@ -8,12 +8,22 @@ import (
 	"strconv"
 )
 
+// InterfaceWithDescription is an interface with a description
+type InterfaceWithDescription interface {
+	IsInterfaceWithDescription()
+}
+
 type MissingInterface interface {
 	IsMissingInterface()
 }
 
 type MissingUnion interface {
 	IsMissingUnion()
+}
+
+// UnionWithDescription is an union with a description
+type UnionWithDescription interface {
+	IsUnionWithDescription()
 }
 
 type MissingInput struct {
@@ -46,6 +56,55 @@ func (MissingTypeNullable) IsMissingInterface()  {}
 func (MissingTypeNullable) IsExistingInterface() {}
 func (MissingTypeNullable) IsMissingUnion()      {}
 func (MissingTypeNullable) IsExistingUnion()     {}
+
+// TypeWithDescription is a type with a description
+type TypeWithDescription struct {
+	Name *string `json:"name"`
+}
+
+func (TypeWithDescription) IsUnionWithDescription() {}
+
+// EnumWithDescription is an enum with a description
+type EnumWithDescription string
+
+const (
+	EnumWithDescriptionCat EnumWithDescription = "CAT"
+	EnumWithDescriptionDog EnumWithDescription = "DOG"
+)
+
+var AllEnumWithDescription = []EnumWithDescription{
+	EnumWithDescriptionCat,
+	EnumWithDescriptionDog,
+}
+
+func (e EnumWithDescription) IsValid() bool {
+	switch e {
+	case EnumWithDescriptionCat, EnumWithDescriptionDog:
+		return true
+	}
+	return false
+}
+
+func (e EnumWithDescription) String() string {
+	return string(e)
+}
+
+func (e *EnumWithDescription) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = EnumWithDescription(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid EnumWithDescription", str)
+	}
+	return nil
+}
+
+func (e EnumWithDescription) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
 
 type MissingEnum string
 

--- a/plugin/modelgen/testdata/schema.graphql
+++ b/plugin/modelgen/testdata/schema.graphql
@@ -65,3 +65,21 @@ interface ExistingInterface {
 
 union ExistingUnion = MissingTypeNotNull | MissingTypeNullable  | ExistingType
 
+"TypeWithDescription is a type with a description"
+type TypeWithDescription {
+    name: String
+}
+
+"EnumWithDescription is an enum with a description"
+enum EnumWithDescription {
+    CAT
+    DOG
+}
+
+"InterfaceWithDescription is an interface with a description"
+interface InterfaceWithDescription {
+    name: String
+}
+
+"UnionWithDescription is an union with a description"
+union UnionWithDescription = TypeWithDescription | ExistingType


### PR DESCRIPTION
Hello, I've created a bug fix for plugin modelgen. I and my team have recently started using the tool in production and we really like it. 

I wanted to dig into the code by submitting an easy fix of something that I found out. When models are generated from GraphQL schema, a description is used as golang comments. It works fine for all GraphQL types but enum. It worked in a way that the description was formatted into a single word CamelCased. I've added test cases and fixed it by removing calling `go` in a template pipe. 

Those tests from me could be more sophisticated as I am checking only for the number of words in a comment.

Let me know if this is welcomed. I would like to contribute more.