### PR TITLE
Format import order using goimports

### DIFF
--- a/codegen/testserver/thirdparty.go
+++ b/codegen/testserver/thirdparty.go
@@ -2,9 +2,10 @@ package testserver
 
 import (
 	"fmt"
-	"github.com/99designs/gqlgen/graphql"
 	"io"
 	"strconv"
+
+	"github.com/99designs/gqlgen/graphql"
 )
 
 type ThirdParty struct {


### PR DESCRIPTION
This is really just to prevent CI tools from constantly trying to rewrite this piece of code.