### PR TITLE
Allow send first keep alive message instantly

### DIFF
--- a/handler/graphql.go
+++ b/handler/graphql.go
@@ -55,21 +55,22 @@ type PersistedQueryCache interface {
 type websocketInitFunc func(ctx context.Context, initPayload InitPayload) error
 
 type Config struct {
-	cacheSize                       int
-	upgrader                        websocket.Upgrader
-	recover                         graphql.RecoverFunc
-	errorPresenter                  graphql.ErrorPresenterFunc
-	resolverHook                    graphql.FieldMiddleware
-	requestHook                     graphql.RequestMiddleware
-	tracer                          graphql.Tracer
-	complexityLimit                 int
-	complexityLimitFunc             graphql.ComplexityLimitFunc
-	websocketInitFunc               websocketInitFunc
-	disableIntrospection            bool
-	connectionKeepAlivePingInterval time.Duration
-	uploadMaxMemory                 int64
-	uploadMaxSize                   int64
-	apqCache                        PersistedQueryCache
+	cacheSize                         int
+	upgrader                          websocket.Upgrader
+	recover                           graphql.RecoverFunc
+	errorPresenter                    graphql.ErrorPresenterFunc
+	resolverHook                      graphql.FieldMiddleware
+	requestHook                       graphql.RequestMiddleware
+	tracer                            graphql.Tracer
+	complexityLimit                   int
+	complexityLimitFunc               graphql.ComplexityLimitFunc
+	websocketInitFunc                 websocketInitFunc
+	disableIntrospection              bool
+	connectionKeepAlivePingInterval   time.Duration
+	connectionKeepAliveFirstInstantly bool
+	uploadMaxMemory                   int64
+	uploadMaxSize                     int64
+	apqCache                          PersistedQueryCache
 }
 
 func (c *Config) newRequestContext(es graphql.ExecutableSchema, doc *ast.QueryDocument, op *ast.OperationDefinition, query string, variables map[string]interface{}) *graphql.RequestContext {
@@ -316,6 +317,16 @@ func UploadMaxMemory(size int64) Option {
 func WebsocketKeepAliveDuration(duration time.Duration) Option {
 	return func(cfg *Config) {
 		cfg.connectionKeepAlivePingInterval = duration
+	}
+}
+
+// WebsocketKeepAliveFirstInstantly allows you to reconfigure the keepalive behavior.
+// By default, keepalive is sent when first keep alive ping interval is over.
+// Set handler.connectionKeepAliveFirstInstantly = true to send first keepalive
+// instantly. This behaviour is required by a few frontend libraries.
+func WebsocketKeepAliveFirstInstantly(enabled bool) Option {
+	return func(cfg *Config) {
+		cfg.connectionKeepAliveFirstInstantly = enabled
 	}
 }
 

--- a/handler/websocket.go
+++ b/handler/websocket.go
@@ -169,6 +169,10 @@ func (c *wsConnection) run() {
 }
 
 func (c *wsConnection) keepAlive(ctx context.Context) {
+	if c.cfg.connectionKeepAliveFirstInstantly {
+		c.write(&operationMessage{Type: connectionKeepAliveMsg})
+	}
+
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
#745 Allow send keep alive message instantly (after connection_ack). 

[Linked with subscription-transport-ws](https://github.com/apollographql/subscriptions-transport-ws/issues/598)