### PR TITLE
Update cors.md to allow CORS for websockets

### DIFF
--- a/docs/content/recipes/cors.md
+++ b/docs/content/recipes/cors.md
@@ -2,7 +2,7 @@
 title: "Setting CORS headers using rs/cors for gqlgen"
 description: Use the best of breed rs/cors library to set CORS headers when working with gqlgen
 linkTitle: CORS
-menu: { main: { parent: 'recipes' } }
+menu: { main: { parent: "recipes" } }
 ---
 
 Cross-Origin Resource Sharing (CORS) headers are required when your graphql server lives on a different domain to the one your client code is served. You can read more about CORS in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS).
@@ -37,7 +37,7 @@ func main() {
 	upgrader := websocket.Upgrader{
 		CheckOrigin: func(r *http.Request) bool {
 			// Check against your desired domains here
-			return true
+			 return r.Host == "example.org"
 		},
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,

--- a/docs/content/recipes/cors.md
+++ b/docs/content/recipes/cors.md
@@ -34,9 +34,18 @@ func main() {
 		Debug:            true,
 	}).Handler)
 
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool {
+			// Check against your desired domains here
+			return true
+		},
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+	}
+
 	router.Handle("/", handler.Playground("Starwars", "/query"))
 	router.Handle("/query",
-		handler.GraphQL(starwars.NewExecutableSchema(starwars.NewResolver())),
+		handler.GraphQL(starwars.NewExecutableSchema(starwars.NewResolver()), handler.WebsocketUpgrader(upgrader)),
 	)
 
 	err := http.ListenAndServe(":8080", router)


### PR DESCRIPTION
The cors.md file did not cover websockets in particular. I have updated the example in the cors.md file to show how this is done.
