### PR TITLE
Provide option to customize request parameter parsing

### DIFF
--- a/graphql/params.go
+++ b/graphql/params.go
@@ -1,0 +1,22 @@
+package graphql
+
+import "net/http"
+
+type ParsedParams struct {
+	Query         string                 `json:"query"`
+	OperationName string                 `json:"operationName"`
+	Variables     map[string]interface{} `json:"variables"`
+	Extensions    *Extensions            `json:"extensions"`
+}
+
+type Extensions struct {
+	PersistedQuery *PersistedQuery `json:"persistedQuery"`
+}
+
+type PersistedQuery struct {
+	Sha256  string `json:"sha256Hash"`
+	Version int64  `json:"version"`
+}
+
+type ParserFunc func(http.ResponseWriter, *http.Request, ParsedParams)
+type ParserHandlerFunc func(ParserFunc) http.HandlerFunc

--- a/handler/websocket.go
+++ b/handler/websocket.go
@@ -182,7 +182,7 @@ func (c *wsConnection) keepAlive(ctx context.Context) {
 }
 
 func (c *wsConnection) subscribe(message *operationMessage) bool {
-	var reqParams params
+	var reqParams graphql.ParsedParams
 	if err := jsonDecode(bytes.NewReader(message.Payload), &reqParams); err != nil {
 		c.sendConnectionError("invalid json")
 		return false


### PR DESCRIPTION
**TL;DR** Allow users to override the default query parsing with their own logic

**Problem:**
The current `ServeHTTP` assumes many details when populating and parsing  the struct holding`query`, `operationName`, etc. This "out of the box" functionality  is great for getting up and running quickly  but it is limiting for many use cases:

* Want to use `PUT` or `Content-Type: multipart/alternative` for your requests? Unfortunately we currently can't customize the http method and content-types used during requests for they are hard coded in switch statements. 
* Do you want to handle large file uploads by streaming files in with`MultipartReader`? Again, unfortunately the current implementation simply reads all data into temp files via `ParseMultipartForm`. 


**Solution:**
To enable the use cases I listed above, this pull request does the following:

* creates a new option, `ParserMiddleware`  allowing users to define custom ways of parsing out the query from a request. This option takes in a new type `ParserHandlerFunc` which is somewhat obtuse, but exact in what is required to enable this kind of option.
* In order to enable said option, I had to make public the type holding onto the query params which were ultimately parsed, see `ParsedParams`.  

I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
- [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))  _If this has a chance to be merged I'll fill out the documentation on the types and provide some simple examples for the usage of the option_

**Origin**

This all started when I was running into an error when making `POST` requests with `"multipart/form-data"`. I have a custom http middleware which does some internal file streaming house keeping and starts a `MultipartReader`. 

When the request made its way into graphql related code to be parsed out, the `processMultipart` call  would always cause and error due to the earlier handling of files.  I couldn't avoid this error which originates from the `http.request` package
```
       // this prevents double parsing of form data after request body has been
       // handed off to a MultipartReader instead of ParseMultipartFrom.
	if r.MultipartForm == multipartByReader {
		return errors.New("http: multipart handled by MultipartReader")
	}
```
Initially to fix and avoid this condition, I just completely gutted the internals of `ServeHTTP` to use `MultipartReader` within my fork, but I figured making this configurable might help others to avoid similar situations. 

With that being said I admit this is a rather intrusive option to provide, in how it's exposing what was once internal. Therefore I'm totally open to change the naming, options, etc. if that helps gets this merged.