### PR TITLE
fix go syntax issue when field has 2 directives

### DIFF
--- a/codegen/directives.gotpl
+++ b/codegen/directives.gotpl
@@ -16,7 +16,7 @@
 			{{- end }}
 			return ec.directives.{{$directive.Name|ucFirst}}({{$directive.ResolveArgs $in $i }})
 		}
-	{{- end -}}
+	{{ end -}}
 {{ end }}
 
 {{define "queryDirectives"}}

--- a/codegen/testserver/directive.graphql
+++ b/codegen/testserver/directive.graphql
@@ -3,6 +3,8 @@ directive @range(min: Int = 0, max: Int) on ARGUMENT_DEFINITION
 directive @custom on ARGUMENT_DEFINITION
 directive @logged(id: UUID!) on FIELD
 directive @toNull on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+directive @directive1 on FIELD_DEFINITION
+directive @directive2 on FIELD_DEFINITION
 
 extend type Query {
     directiveArg(arg: String! @length(min:1, max: 255, message: "invalid length")): String
@@ -13,6 +15,7 @@ extend type Query {
     directiveObject: ObjectDirectives
     directiveFieldDef(ret: String!): String! @length(min: 1, message: "not valid")
     directiveField: String
+    directiveDouble: String @directive1 @directive2
 }
 
 input InputDirectives {

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -173,6 +173,9 @@ func (r *queryResolver) DirectiveFieldDef(ctx context.Context, ret string) (stri
 func (r *queryResolver) DirectiveField(ctx context.Context) (*string, error) {
 	panic("not implemented")
 }
+func (r *queryResolver) DirectiveDouble(ctx context.Context) (*string, error) {
+	panic("not implemented")
+}
 func (r *queryResolver) MapStringInterface(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error) {
 	panic("not implemented")
 }

--- a/codegen/testserver/stub.go
+++ b/codegen/testserver/stub.go
@@ -61,6 +61,7 @@ type Stub struct {
 		DirectiveObject        func(ctx context.Context) (*ObjectDirectives, error)
 		DirectiveFieldDef      func(ctx context.Context, ret string) (string, error)
 		DirectiveField         func(ctx context.Context) (*string, error)
+		DirectiveDouble        func(ctx context.Context) (*string, error)
 		MapStringInterface     func(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error)
 		ErrorBubble            func(ctx context.Context) (*Error, error)
 		Errors                 func(ctx context.Context) (*Errors, error)
@@ -247,6 +248,9 @@ func (r *stubQuery) DirectiveFieldDef(ctx context.Context, ret string) (string, 
 }
 func (r *stubQuery) DirectiveField(ctx context.Context) (*string, error) {
 	return r.QueryResolver.DirectiveField(ctx)
+}
+func (r *stubQuery) DirectiveDouble(ctx context.Context) (*string, error) {
+	return r.QueryResolver.DirectiveDouble(ctx)
 }
 func (r *stubQuery) MapStringInterface(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error) {
 	return r.QueryResolver.MapStringInterface(ctx, in)

--- a/example/todo/generated.go
+++ b/example/todo/generated.go
@@ -834,6 +834,7 @@ func (ec *executionContext) _Todo_done(ctx context.Context, field graphql.Collec
 			}
 			return ec.directives.HasRole(ctx, obj, directive0, role)
 		}
+
 		tmp, err := directive1(rctx)
 		if err != nil {
 			return nil, err

--- a/example/type-system-extension/generated.go
+++ b/example/type-system-extension/generated.go
@@ -709,6 +709,7 @@ func (ec *executionContext) _Todo_verified(ctx context.Context, field graphql.Co
 		directive1 := func(ctx context.Context) (interface{}, error) {
 			return ec.directives.FieldLogging(ctx, obj, directive0)
 		}
+
 		tmp, err := directive1(rctx)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

current code template will make invalid go code.

```
		directive1 := func(ctx context.Context) (interface{}, error) {
			return ec.directives.Directive1(ctx, nil, directive0)
		}directive2 := func(ctx context.Context) (interface{}, error) {
			return ec.directives.Directive2(ctx, nil, directive1)
		}
```

I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [X] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
