### PR TITLE
adding requestHeaders to the websocket client

### DIFF
--- a/client/websocket.go
+++ b/client/websocket.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/gorilla/websocket"
@@ -38,11 +39,11 @@ func errorSubscription(err error) *Subscription {
 	}
 }
 
-func (p *Client) Websocket(query string, options ...Option) *Subscription {
-	return p.WebsocketWithPayload(query, nil, options...)
+func (p *Client) Websocket(query string, reqHeaders http.Header, options ...Option) *Subscription {
+	return p.WebsocketWithPayload(query, nil, reqHeaders, options...)
 }
 
-func (p *Client) WebsocketWithPayload(query string, initPayload map[string]interface{}, options ...Option) *Subscription {
+func (p *Client) WebsocketWithPayload(query string, initPayload map[string]interface{}, reqHeaders http.Header, options ...Option) *Subscription {
 	r := p.mkRequest(query, options...)
 	requestBody, err := json.Marshal(r)
 	if err != nil {
@@ -52,7 +53,7 @@ func (p *Client) WebsocketWithPayload(query string, initPayload map[string]inter
 	url := strings.Replace(p.url, "http://", "ws://", -1)
 	url = strings.Replace(url, "https://", "wss://", -1)
 
-	c, resp, err := websocket.DefaultDialer.Dial(url, nil)
+	c, resp, err := websocket.DefaultDialer.Dial(url, reqHeaders)
 	if err != nil {
 		return errorSubscription(fmt.Errorf("dial: %s", err.Error()))
 	}

--- a/client/websocket.go
+++ b/client/websocket.go
@@ -53,7 +53,7 @@ func (p *Client) WebsocketWithPayload(query string, initPayload map[string]inter
 	url := strings.Replace(p.url, "http://", "ws://", -1)
 	url = strings.Replace(url, "https://", "wss://", -1)
 
-	c, resp, err := websocket.DefaultDialer.Dial(url, reqHeaders)
+	c, resp, err := websocket.DefaultDialer.Dial(url, reqHeaders) //nolint:bodyclose
 	if err != nil {
 		return errorSubscription(fmt.Errorf("dial: %s", err.Error()))
 	}

--- a/codegen/testserver/subscription_test.go
+++ b/codegen/testserver/subscription_test.go
@@ -85,7 +85,7 @@ func TestSubscriptions(t *testing.T) {
 		runtime.GC() // ensure no go-routines left from preceding tests
 		initialGoroutineCount := runtime.NumGoroutine()
 
-		sub := c.Websocket(`subscription { updated }`)
+		sub := c.Websocket(`subscription { updated }`, nil)
 
 		tick <- "message"
 
@@ -114,7 +114,7 @@ func TestSubscriptions(t *testing.T) {
 			"Authorization": "Bearer of the curse",
 			"number":        32,
 			"strings":       []string{"hello", "world"},
-		})
+		}, nil)
 
 		var msg struct {
 			resp struct {

--- a/example/chat/chat_test.go
+++ b/example/chat/chat_test.go
@@ -15,16 +15,16 @@ func TestChatSubscriptions(t *testing.T) {
 	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(New())))
 	c := client.New(srv.URL)
 
-	sub := c.Websocket(`subscription @user(username:"vektah") { messageAdded(roomName:"#gophers") { text createdBy } }`)
+	sub := c.Websocket(`subscription @user(username:"vektah") { messageAdded(roomName:"#gophers") { text createdBy } }`, nil)
 	defer sub.Close()
 
 	go func() {
 		var resp interface{}
 		time.Sleep(10 * time.Millisecond)
-		err := c.Post(`mutation { 
-				a:post(text:"Hello!", roomName:"#gophers", username:"vektah") { id } 
-				b:post(text:"Hello Vektah!", roomName:"#gophers", username:"andrey") { id } 
-				c:post(text:"Whats up?", roomName:"#gophers", username:"vektah") { id } 
+		err := c.Post(`mutation {
+				a:post(text:"Hello!", roomName:"#gophers", username:"vektah") { id }
+				b:post(text:"Hello Vektah!", roomName:"#gophers", username:"andrey") { id }
+				c:post(text:"Whats up?", roomName:"#gophers", username:"vektah") { id }
 			}`, &resp)
 		assert.NoError(t, err)
 	}()


### PR DESCRIPTION

Adding `requestHeaders` argument to the websocket client funcs to have the possibilty of passing request Headers .

For example, if you need to pass other authorization header like `X-Auth-Token` or/and  other headers like `Sec-WebSocket-Key` , `Sec-WebSocket-Version`this PR opens that possibility.

Example: 
```golang
client.Websocket(query, http.Header{
     "X-Auth-Token": {"validToken"},
     "Sec-WebSocket-Key": {"SGVsbG8sIHdvcmxkIQ=="},
     "Sec-WebSocket-Version": {13},
}
```
