### PR TITLE
Pool goroutines

### DIFF
--- a/codegen/object.gotpl
+++ b/codegen/object.gotpl
@@ -76,7 +76,7 @@ func (ec *executionContext) _{{$object.Name}}(ctx context.Context, sel ast.Selec
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 { return graphql.Null }
 	return out
 }

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -8198,7 +8198,7 @@ func (ec *executionContext) _A(ctx context.Context, sel ast.SelectionSet, obj *A
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8225,7 +8225,7 @@ func (ec *executionContext) _AIt(ctx context.Context, sel ast.SelectionSet, obj 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8252,7 +8252,7 @@ func (ec *executionContext) _AbIt(ctx context.Context, sel ast.SelectionSet, obj
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8299,7 +8299,7 @@ func (ec *executionContext) _Autobind(ctx context.Context, sel ast.SelectionSet,
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8326,7 +8326,7 @@ func (ec *executionContext) _B(ctx context.Context, sel ast.SelectionSet, obj *B
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8352,7 +8352,7 @@ func (ec *executionContext) _Circle(ctx context.Context, sel ast.SelectionSet, o
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8376,7 +8376,7 @@ func (ec *executionContext) _Content_Post(ctx context.Context, sel ast.Selection
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8400,7 +8400,7 @@ func (ec *executionContext) _Content_User(ctx context.Context, sel ast.Selection
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8424,7 +8424,7 @@ func (ec *executionContext) _EmbeddedDefaultScalar(ctx context.Context, sel ast.
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8450,7 +8450,7 @@ func (ec *executionContext) _EmbeddedPointer(ctx context.Context, sel ast.Select
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8489,7 +8489,7 @@ func (ec *executionContext) _Error(ctx context.Context, sel ast.SelectionSet, ob
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8581,7 +8581,7 @@ func (ec *executionContext) _Errors(ctx context.Context, sel ast.SelectionSet, o
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8614,7 +8614,7 @@ func (ec *executionContext) _ForcedResolver(ctx context.Context, sel ast.Selecti
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8641,7 +8641,7 @@ func (ec *executionContext) _InnerObject(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8668,7 +8668,7 @@ func (ec *executionContext) _InvalidIdentifier(ctx context.Context, sel ast.Sele
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8695,7 +8695,7 @@ func (ec *executionContext) _It(ctx context.Context, sel ast.SelectionSet, obj *
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8722,7 +8722,7 @@ func (ec *executionContext) _LoopA(ctx context.Context, sel ast.SelectionSet, ob
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8749,7 +8749,7 @@ func (ec *executionContext) _LoopB(ctx context.Context, sel ast.SelectionSet, ob
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8776,7 +8776,7 @@ func (ec *executionContext) _Map(ctx context.Context, sel ast.SelectionSet, obj 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8802,7 +8802,7 @@ func (ec *executionContext) _MapStringInterfaceType(ctx context.Context, sel ast
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8857,7 +8857,7 @@ func (ec *executionContext) _ModelMethods(ctx context.Context, sel ast.Selection
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8886,7 +8886,7 @@ func (ec *executionContext) _ObjectDirectives(ctx context.Context, sel ast.Selec
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8910,7 +8910,7 @@ func (ec *executionContext) _ObjectDirectivesWithCustomGoModel(ctx context.Conte
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8937,7 +8937,7 @@ func (ec *executionContext) _OuterObject(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -8993,7 +8993,7 @@ func (ec *executionContext) _OverlappingFields(ctx context.Context, sel ast.Sele
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -9057,7 +9057,7 @@ func (ec *executionContext) _Panics(ctx context.Context, sel ast.SelectionSet, o
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -9098,7 +9098,7 @@ func (ec *executionContext) _Primitive(ctx context.Context, sel ast.SelectionSet
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -9153,7 +9153,7 @@ func (ec *executionContext) _PrimitiveString(ctx context.Context, sel ast.Select
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -9673,7 +9673,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -9701,7 +9701,7 @@ func (ec *executionContext) _Rectangle(ctx context.Context, sel ast.SelectionSet
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -9737,7 +9737,7 @@ func (ec *executionContext) _Slices(ctx context.Context, sel ast.SelectionSet, o
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -9807,7 +9807,7 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -9849,7 +9849,7 @@ func (ec *executionContext) _ValidType(ctx context.Context, sel ast.SelectionSet
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -9876,7 +9876,7 @@ func (ec *executionContext) _WrappedStruct(ctx context.Context, sel ast.Selectio
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -9903,7 +9903,7 @@ func (ec *executionContext) _XXIt(ctx context.Context, sel ast.SelectionSet, obj
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -9930,7 +9930,7 @@ func (ec *executionContext) _XxIt(ctx context.Context, sel ast.SelectionSet, obj
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -9969,7 +9969,7 @@ func (ec *executionContext) ___Directive(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -10005,7 +10005,7 @@ func (ec *executionContext) ___EnumValue(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -10051,7 +10051,7 @@ func (ec *executionContext) ___Field(ctx context.Context, sel ast.SelectionSet, 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -10087,7 +10087,7 @@ func (ec *executionContext) ___InputValue(ctx context.Context, sel ast.Selection
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -10128,7 +10128,7 @@ func (ec *executionContext) ___Schema(ctx context.Context, sel ast.SelectionSet,
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -10171,7 +10171,7 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -10198,7 +10198,7 @@ func (ec *executionContext) _asdfIt(ctx context.Context, sel ast.SelectionSet, o
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -10225,7 +10225,7 @@ func (ec *executionContext) _iIt(ctx context.Context, sel ast.SelectionSet, obj 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -10503,7 +10503,7 @@ func (ec *executionContext) marshalNPrimitive2ᚕgithubᚗcomᚋ99designsᚋgqlg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -10516,9 +10516,9 @@ func (ec *executionContext) marshalNPrimitive2ᚕgithubᚗcomᚋ99designsᚋgqlg
 			ret[i] = ec.marshalNPrimitive2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐPrimitive(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -10544,7 +10544,7 @@ func (ec *executionContext) marshalNPrimitiveString2ᚕgithubᚗcomᚋ99designs�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -10557,9 +10557,9 @@ func (ec *executionContext) marshalNPrimitiveString2ᚕgithubᚗcomᚋ99designs�
 			ret[i] = ec.marshalNPrimitiveString2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐPrimitiveString(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -10711,7 +10711,7 @@ func (ec *executionContext) marshalNUser2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -10724,9 +10724,9 @@ func (ec *executionContext) marshalNUser2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalNUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐUser(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -10791,7 +10791,7 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -10804,9 +10804,9 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -10862,7 +10862,7 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -10875,9 +10875,9 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			ret[i] = ec.marshalN__DirectiveLocation2string(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -10911,7 +10911,7 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -10924,9 +10924,9 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -10952,7 +10952,7 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -10965,9 +10965,9 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -11293,7 +11293,7 @@ func (ec *executionContext) marshalOOuterObject2ᚕᚕᚖgithubᚗcomᚋ99design
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -11306,9 +11306,9 @@ func (ec *executionContext) marshalOOuterObject2ᚕᚕᚖgithubᚗcomᚋ99design
 			ret[i] = ec.marshalOOuterObject2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐOuterObject(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -11333,7 +11333,7 @@ func (ec *executionContext) marshalOOuterObject2ᚕᚖgithubᚗcomᚋ99designs�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -11346,9 +11346,9 @@ func (ec *executionContext) marshalOOuterObject2ᚕᚖgithubᚗcomᚋ99designs�
 			ret[i] = ec.marshalOOuterObject2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐOuterObject(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -11438,7 +11438,7 @@ func (ec *executionContext) marshalOShape2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -11451,9 +11451,9 @@ func (ec *executionContext) marshalOShape2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalOShape2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐShape(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -11649,7 +11649,7 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -11662,9 +11662,9 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -11689,7 +11689,7 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -11702,9 +11702,9 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -11729,7 +11729,7 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -11742,9 +11742,9 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -11784,7 +11784,7 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -11797,9 +11797,9 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}

--- a/codegen/type.gotpl
+++ b/codegen/type.gotpl
@@ -80,7 +80,7 @@
 							Result: &v[i],
 						}
 						ctx := graphql.WithResolverContext(ctx, rctx)
-						f := func(i int) {
+						f := func() {
 							defer func() {
                         		if r := recover(); r != nil {
                         			ec.Error(ctx, ec.Recover(ctx, r))
@@ -93,9 +93,9 @@
 							ret[i] = ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, v[i])
 						}
 						if isLen1 {
-							f(i)
+							f()
 						} else {
-							go f(i)
+							ec.Pool.Go(f)
 						}
 					{{ else }}
 						ret[i] = ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, v[i])

--- a/example/chat/generated.go
+++ b/example/chat/generated.go
@@ -2059,7 +2059,7 @@ func (ec *executionContext) _Chatroom(ctx context.Context, sel ast.SelectionSet,
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2101,7 +2101,7 @@ func (ec *executionContext) _Message(ctx context.Context, sel ast.SelectionSet, 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2132,7 +2132,7 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2173,7 +2173,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2232,7 +2232,7 @@ func (ec *executionContext) ___Directive(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2268,7 +2268,7 @@ func (ec *executionContext) ___EnumValue(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2314,7 +2314,7 @@ func (ec *executionContext) ___Field(ctx context.Context, sel ast.SelectionSet, 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2350,7 +2350,7 @@ func (ec *executionContext) ___InputValue(ctx context.Context, sel ast.Selection
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2391,7 +2391,7 @@ func (ec *executionContext) ___Schema(ctx context.Context, sel ast.SelectionSet,
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2434,7 +2434,7 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2491,7 +2491,7 @@ func (ec *executionContext) marshalNMessage2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2504,9 +2504,9 @@ func (ec *executionContext) marshalNMessage2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalNMessage2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋchatᚐMessage(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2570,7 +2570,7 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2583,9 +2583,9 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2641,7 +2641,7 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2654,9 +2654,9 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			ret[i] = ec.marshalN__DirectiveLocation2string(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2690,7 +2690,7 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2703,9 +2703,9 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2731,7 +2731,7 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2744,9 +2744,9 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2852,7 +2852,7 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2865,9 +2865,9 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2892,7 +2892,7 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2905,9 +2905,9 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2932,7 +2932,7 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2945,9 +2945,9 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2987,7 +2987,7 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -3000,9 +3000,9 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}

--- a/example/config/generated.go
+++ b/example/config/generated.go
@@ -1943,7 +1943,7 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -1987,7 +1987,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2043,7 +2043,7 @@ func (ec *executionContext) _Todo(ctx context.Context, sel ast.SelectionSet, obj
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2075,7 +2075,7 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2114,7 +2114,7 @@ func (ec *executionContext) ___Directive(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2150,7 +2150,7 @@ func (ec *executionContext) ___EnumValue(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2196,7 +2196,7 @@ func (ec *executionContext) ___Field(ctx context.Context, sel ast.SelectionSet, 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2232,7 +2232,7 @@ func (ec *executionContext) ___InputValue(ctx context.Context, sel ast.Selection
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2273,7 +2273,7 @@ func (ec *executionContext) ___Schema(ctx context.Context, sel ast.SelectionSet,
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2316,7 +2316,7 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2405,7 +2405,7 @@ func (ec *executionContext) marshalNTodo2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2418,9 +2418,9 @@ func (ec *executionContext) marshalNTodo2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalNTodo2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋconfigᚐTodo(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2470,7 +2470,7 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2483,9 +2483,9 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2541,7 +2541,7 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2554,9 +2554,9 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			ret[i] = ec.marshalN__DirectiveLocation2string(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2590,7 +2590,7 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2603,9 +2603,9 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2631,7 +2631,7 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2644,9 +2644,9 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2773,7 +2773,7 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2786,9 +2786,9 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2813,7 +2813,7 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2826,9 +2826,9 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2853,7 +2853,7 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2866,9 +2866,9 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2908,7 +2908,7 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2921,9 +2921,9 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}

--- a/example/dataloader/generated.go
+++ b/example/dataloader/generated.go
@@ -2199,7 +2199,7 @@ func (ec *executionContext) _Address(ctx context.Context, sel ast.SelectionSet, 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2253,7 +2253,7 @@ func (ec *executionContext) _Customer(ctx context.Context, sel ast.SelectionSet,
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2280,7 +2280,7 @@ func (ec *executionContext) _Item(ctx context.Context, sel ast.SelectionSet, obj
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2328,7 +2328,7 @@ func (ec *executionContext) _Order(ctx context.Context, sel ast.SelectionSet, ob
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2391,7 +2391,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2430,7 +2430,7 @@ func (ec *executionContext) ___Directive(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2466,7 +2466,7 @@ func (ec *executionContext) ___EnumValue(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2512,7 +2512,7 @@ func (ec *executionContext) ___Field(ctx context.Context, sel ast.SelectionSet, 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2548,7 +2548,7 @@ func (ec *executionContext) ___InputValue(ctx context.Context, sel ast.Selection
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2589,7 +2589,7 @@ func (ec *executionContext) ___Schema(ctx context.Context, sel ast.SelectionSet,
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2632,7 +2632,7 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2773,7 +2773,7 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2786,9 +2786,9 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2844,7 +2844,7 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2857,9 +2857,9 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			ret[i] = ec.marshalN__DirectiveLocation2string(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2893,7 +2893,7 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2906,9 +2906,9 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2934,7 +2934,7 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2947,9 +2947,9 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -3032,7 +3032,7 @@ func (ec *executionContext) marshalOCustomer2ᚕᚕᚖgithubᚗcomᚋ99designs�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -3045,9 +3045,9 @@ func (ec *executionContext) marshalOCustomer2ᚕᚕᚖgithubᚗcomᚋ99designs�
 			ret[i] = ec.marshalOCustomer2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋdataloaderᚐCustomer(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -3072,7 +3072,7 @@ func (ec *executionContext) marshalOCustomer2ᚕᚖgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -3085,9 +3085,9 @@ func (ec *executionContext) marshalOCustomer2ᚕᚖgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalNCustomer2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋdataloaderᚐCustomer(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -3176,7 +3176,7 @@ func (ec *executionContext) marshalOItem2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -3189,9 +3189,9 @@ func (ec *executionContext) marshalOItem2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalNItem2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋdataloaderᚐItem(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -3216,7 +3216,7 @@ func (ec *executionContext) marshalOOrder2ᚕᚖgithubᚗcomᚋ99designsᚋgqlge
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -3229,9 +3229,9 @@ func (ec *executionContext) marshalOOrder2ᚕᚖgithubᚗcomᚋ99designsᚋgqlge
 			ret[i] = ec.marshalNOrder2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋdataloaderᚐOrder(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -3279,7 +3279,7 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -3292,9 +3292,9 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -3319,7 +3319,7 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -3332,9 +3332,9 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -3359,7 +3359,7 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -3372,9 +3372,9 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -3414,7 +3414,7 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -3427,9 +3427,9 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}

--- a/example/fileupload/generated.go
+++ b/example/fileupload/generated.go
@@ -1978,7 +1978,7 @@ func (ec *executionContext) _File(ctx context.Context, sel ast.SelectionSet, obj
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2024,7 +2024,7 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2068,7 +2068,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2107,7 +2107,7 @@ func (ec *executionContext) ___Directive(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2143,7 +2143,7 @@ func (ec *executionContext) ___EnumValue(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2189,7 +2189,7 @@ func (ec *executionContext) ___Field(ctx context.Context, sel ast.SelectionSet, 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2225,7 +2225,7 @@ func (ec *executionContext) ___InputValue(ctx context.Context, sel ast.Selection
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2266,7 +2266,7 @@ func (ec *executionContext) ___Schema(ctx context.Context, sel ast.SelectionSet,
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2309,7 +2309,7 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2352,7 +2352,7 @@ func (ec *executionContext) marshalNFile2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2365,9 +2365,9 @@ func (ec *executionContext) marshalNFile2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalNFile2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋfileuploadᚋmodelᚐFile(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2524,7 +2524,7 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2537,9 +2537,9 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2595,7 +2595,7 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2608,9 +2608,9 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			ret[i] = ec.marshalN__DirectiveLocation2string(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2644,7 +2644,7 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2657,9 +2657,9 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2685,7 +2685,7 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2698,9 +2698,9 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2795,7 +2795,7 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2808,9 +2808,9 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2835,7 +2835,7 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2848,9 +2848,9 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2875,7 +2875,7 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2888,9 +2888,9 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2930,7 +2930,7 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2943,9 +2943,9 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}

--- a/example/scalars/generated.go
+++ b/example/scalars/generated.go
@@ -2084,7 +2084,7 @@ func (ec *executionContext) _Address(ctx context.Context, sel ast.SelectionSet, 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2139,7 +2139,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2210,7 +2210,7 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2249,7 +2249,7 @@ func (ec *executionContext) ___Directive(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2285,7 +2285,7 @@ func (ec *executionContext) ___EnumValue(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2331,7 +2331,7 @@ func (ec *executionContext) ___Field(ctx context.Context, sel ast.SelectionSet, 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2367,7 +2367,7 @@ func (ec *executionContext) ___InputValue(ctx context.Context, sel ast.Selection
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2408,7 +2408,7 @@ func (ec *executionContext) ___Schema(ctx context.Context, sel ast.SelectionSet,
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2451,7 +2451,7 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2558,7 +2558,7 @@ func (ec *executionContext) marshalNUser2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2571,9 +2571,9 @@ func (ec *executionContext) marshalNUser2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalNUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋscalarsᚋmodelᚐUser(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2609,7 +2609,7 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2622,9 +2622,9 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2680,7 +2680,7 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2693,9 +2693,9 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			ret[i] = ec.marshalN__DirectiveLocation2string(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2729,7 +2729,7 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2742,9 +2742,9 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2770,7 +2770,7 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2783,9 +2783,9 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2972,7 +2972,7 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2985,9 +2985,9 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -3012,7 +3012,7 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -3025,9 +3025,9 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -3052,7 +3052,7 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -3065,9 +3065,9 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -3107,7 +3107,7 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -3120,9 +3120,9 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}

--- a/example/selection/generated.go
+++ b/example/selection/generated.go
@@ -1871,7 +1871,7 @@ func (ec *executionContext) _Like(ctx context.Context, sel ast.SelectionSet, obj
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -1907,7 +1907,7 @@ func (ec *executionContext) _Post(ctx context.Context, sel ast.SelectionSet, obj
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -1948,7 +1948,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -1987,7 +1987,7 @@ func (ec *executionContext) ___Directive(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2023,7 +2023,7 @@ func (ec *executionContext) ___EnumValue(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2069,7 +2069,7 @@ func (ec *executionContext) ___Field(ctx context.Context, sel ast.SelectionSet, 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2105,7 +2105,7 @@ func (ec *executionContext) ___InputValue(ctx context.Context, sel ast.Selection
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2146,7 +2146,7 @@ func (ec *executionContext) ___Schema(ctx context.Context, sel ast.SelectionSet,
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2189,7 +2189,7 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2264,7 +2264,7 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2277,9 +2277,9 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2335,7 +2335,7 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2348,9 +2348,9 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			ret[i] = ec.marshalN__DirectiveLocation2string(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2384,7 +2384,7 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2397,9 +2397,9 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2425,7 +2425,7 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2438,9 +2438,9 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2512,7 +2512,7 @@ func (ec *executionContext) marshalOEvent2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2525,9 +2525,9 @@ func (ec *executionContext) marshalOEvent2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalNEvent2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋselectionᚐEvent(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2607,7 +2607,7 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2620,9 +2620,9 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2647,7 +2647,7 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2660,9 +2660,9 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2687,7 +2687,7 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2700,9 +2700,9 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2742,7 +2742,7 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2755,9 +2755,9 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}

--- a/example/starwars/generated/exec.go
+++ b/example/starwars/generated/exec.go
@@ -3737,7 +3737,7 @@ func (ec *executionContext) _Droid(ctx context.Context, sel ast.SelectionSet, ob
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -3791,7 +3791,7 @@ func (ec *executionContext) _FriendsConnection(ctx context.Context, sel ast.Sele
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -3820,7 +3820,7 @@ func (ec *executionContext) _FriendsEdge(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -3900,7 +3900,7 @@ func (ec *executionContext) _Human(ctx context.Context, sel ast.SelectionSet, ob
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -3928,7 +3928,7 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -3965,7 +3965,7 @@ func (ec *executionContext) _PageInfo(ctx context.Context, sel ast.SelectionSet,
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -4078,7 +4078,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -4109,7 +4109,7 @@ func (ec *executionContext) _Review(ctx context.Context, sel ast.SelectionSet, o
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -4160,7 +4160,7 @@ func (ec *executionContext) _Starship(ctx context.Context, sel ast.SelectionSet,
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -4199,7 +4199,7 @@ func (ec *executionContext) ___Directive(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -4235,7 +4235,7 @@ func (ec *executionContext) ___EnumValue(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -4281,7 +4281,7 @@ func (ec *executionContext) ___Field(ctx context.Context, sel ast.SelectionSet, 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -4317,7 +4317,7 @@ func (ec *executionContext) ___InputValue(ctx context.Context, sel ast.Selection
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -4358,7 +4358,7 @@ func (ec *executionContext) ___Schema(ctx context.Context, sel ast.SelectionSet,
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -4401,7 +4401,7 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -4473,7 +4473,7 @@ func (ec *executionContext) marshalNEpisode2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -4486,9 +4486,9 @@ func (ec *executionContext) marshalNEpisode2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalNEpisode2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋstarwarsᚋmodelsᚐEpisode(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -4646,7 +4646,7 @@ func (ec *executionContext) marshalNReview2ᚕᚖgithubᚗcomᚋ99designsᚋgqlg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -4659,9 +4659,9 @@ func (ec *executionContext) marshalNReview2ᚕᚖgithubᚗcomᚋ99designsᚋgqlg
 			ret[i] = ec.marshalNReview2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋstarwarsᚋmodelsᚐReview(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -4701,7 +4701,7 @@ func (ec *executionContext) marshalNSearchResult2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -4714,9 +4714,9 @@ func (ec *executionContext) marshalNSearchResult2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalNSearchResult2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋstarwarsᚋmodelsᚐSearchResult(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -4770,7 +4770,7 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -4783,9 +4783,9 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -4841,7 +4841,7 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -4854,9 +4854,9 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			ret[i] = ec.marshalN__DirectiveLocation2string(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -4890,7 +4890,7 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -4903,9 +4903,9 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -4931,7 +4931,7 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -4944,9 +4944,9 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -5022,7 +5022,7 @@ func (ec *executionContext) marshalOCharacter2ᚕgithubᚗcomᚋ99designsᚋgqlg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -5035,9 +5035,9 @@ func (ec *executionContext) marshalOCharacter2ᚕgithubᚗcomᚋ99designsᚋgqlg
 			ret[i] = ec.marshalNCharacter2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋstarwarsᚋmodelsᚐCharacter(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -5105,7 +5105,7 @@ func (ec *executionContext) marshalOFriendsEdge2ᚕᚖgithubᚗcomᚋ99designs�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -5118,9 +5118,9 @@ func (ec *executionContext) marshalOFriendsEdge2ᚕᚖgithubᚗcomᚋ99designs�
 			ret[i] = ec.marshalNFriendsEdge2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋstarwarsᚋmodelsᚐFriendsEdge(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -5241,7 +5241,7 @@ func (ec *executionContext) marshalOStarship2ᚕᚖgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -5254,9 +5254,9 @@ func (ec *executionContext) marshalOStarship2ᚕᚖgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalNStarship2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋstarwarsᚋmodelsᚐStarship(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -5334,7 +5334,7 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -5347,9 +5347,9 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -5374,7 +5374,7 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -5387,9 +5387,9 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -5414,7 +5414,7 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -5427,9 +5427,9 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -5469,7 +5469,7 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -5482,9 +5482,9 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}

--- a/example/todo/generated.go
+++ b/example/todo/generated.go
@@ -1985,7 +1985,7 @@ func (ec *executionContext) _MyMutation(ctx context.Context, sel ast.SelectionSe
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2051,7 +2051,7 @@ func (ec *executionContext) _MyQuery(ctx context.Context, sel ast.SelectionSet) 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2088,7 +2088,7 @@ func (ec *executionContext) _Todo(ctx context.Context, sel ast.SelectionSet, obj
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2127,7 +2127,7 @@ func (ec *executionContext) ___Directive(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2163,7 +2163,7 @@ func (ec *executionContext) ___EnumValue(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2209,7 +2209,7 @@ func (ec *executionContext) ___Field(ctx context.Context, sel ast.SelectionSet, 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2245,7 +2245,7 @@ func (ec *executionContext) ___InputValue(ctx context.Context, sel ast.Selection
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2286,7 +2286,7 @@ func (ec *executionContext) ___Schema(ctx context.Context, sel ast.SelectionSet,
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2329,7 +2329,7 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2432,7 +2432,7 @@ func (ec *executionContext) marshalNTodo2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2445,9 +2445,9 @@ func (ec *executionContext) marshalNTodo2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalNTodo2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋtodoᚐTodo(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2487,7 +2487,7 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2500,9 +2500,9 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2558,7 +2558,7 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2571,9 +2571,9 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			ret[i] = ec.marshalN__DirectiveLocation2string(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2607,7 +2607,7 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2620,9 +2620,9 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2648,7 +2648,7 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2661,9 +2661,9 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2769,7 +2769,7 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2782,9 +2782,9 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2809,7 +2809,7 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2822,9 +2822,9 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2849,7 +2849,7 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2862,9 +2862,9 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2904,7 +2904,7 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2917,9 +2917,9 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}

--- a/example/type-system-extension/generated.go
+++ b/example/type-system-extension/generated.go
@@ -1968,7 +1968,7 @@ func (ec *executionContext) _MyMutation(ctx context.Context, sel ast.SelectionSe
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2023,7 +2023,7 @@ func (ec *executionContext) _MyQuery(ctx context.Context, sel ast.SelectionSet) 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2065,7 +2065,7 @@ func (ec *executionContext) _Todo(ctx context.Context, sel ast.SelectionSet, obj
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2104,7 +2104,7 @@ func (ec *executionContext) ___Directive(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2140,7 +2140,7 @@ func (ec *executionContext) ___EnumValue(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2186,7 +2186,7 @@ func (ec *executionContext) ___Field(ctx context.Context, sel ast.SelectionSet, 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2222,7 +2222,7 @@ func (ec *executionContext) ___InputValue(ctx context.Context, sel ast.Selection
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2263,7 +2263,7 @@ func (ec *executionContext) ___Schema(ctx context.Context, sel ast.SelectionSet,
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2306,7 +2306,7 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2386,7 +2386,7 @@ func (ec *executionContext) marshalNTodo2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2399,9 +2399,9 @@ func (ec *executionContext) marshalNTodo2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalNTodo2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋtypeᚑsystemᚑextensionᚐTodo(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2441,7 +2441,7 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2454,9 +2454,9 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2512,7 +2512,7 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2525,9 +2525,9 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			ret[i] = ec.marshalN__DirectiveLocation2string(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2561,7 +2561,7 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2574,9 +2574,9 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2602,7 +2602,7 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2615,9 +2615,9 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2723,7 +2723,7 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2736,9 +2736,9 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2763,7 +2763,7 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2776,9 +2776,9 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2803,7 +2803,7 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2816,9 +2816,9 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2858,7 +2858,7 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2871,9 +2871,9 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}

--- a/graphql/context.go
+++ b/graphql/context.go
@@ -31,6 +31,7 @@ type RequestContext struct {
 	DirectiveMiddleware FieldMiddleware
 	RequestMiddleware   RequestMiddleware
 	Tracer              Tracer
+	Pool                *Pool
 
 	errorsMu     sync.Mutex
 	Errors       gqlerror.List
@@ -61,6 +62,7 @@ func NewRequestContext(doc *ast.QueryDocument, query string, variables map[strin
 		Recover:             DefaultRecover,
 		ErrorPresenter:      DefaultErrorPresenter,
 		Tracer:              &NopTracer{},
+		Pool:                NewPool(0),
 	}
 }
 

--- a/graphql/pool.go
+++ b/graphql/pool.go
@@ -1,0 +1,56 @@
+package graphql
+
+import (
+	"sync/atomic"
+)
+
+// Pool is a pool of goroutines intended to allow easy reuse of goroutines and to
+// optionally limit concurrency.
+// When finished with the Pool, its Stop method must be called to avoid leaking goroutines.
+// Pool is safe for concurrent use.
+type Pool struct {
+	curSize int64
+	maxSize int64
+	funcs   chan func()
+}
+
+// NewPool returns a new Pool that runs a maximum of maxSize goroutine at once.
+// If maxSize <= 0, then the number of goroutines is unlimited.
+func NewPool(maxSize int64) *Pool {
+	return &Pool{
+		maxSize: maxSize,
+		funcs:   make(chan func()),
+	}
+}
+
+// worker is the method that runs in all goroutines in the Pool.
+// It receives off of the funcs channel, but also accepts parameter f to guarantee
+// that that function will be executed first.
+func (p *Pool) worker(f func()) {
+	f()
+	for f := range p.funcs {
+		f()
+	}
+}
+
+// Run runs f() in a pooled goroutine.
+// If there is a goroutine limit and no goroutine is available,
+// it blocks until one becomes available.
+func (p *Pool) Go(f func()) {
+	select {
+	case p.funcs <- f:
+	default:
+		curSize := atomic.AddInt64(&p.curSize, 1)
+		if p.maxSize <= 0 || curSize <= p.maxSize {
+			go p.worker(f)
+			return
+		}
+		// There's no goroutine available and we're at the limit. We must wait.
+		p.funcs <- f
+	}
+}
+
+// Stop stops all goroutines in the Pool.
+func (p *Pool) Stop() {
+	close(p.funcs)
+}

--- a/handler/graphql.go
+++ b/handler/graphql.go
@@ -536,6 +536,7 @@ func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx = graphql.WithRequestContext(ctx, reqCtx)
 
 	defer func() {
+		reqCtx.Pool.Stop()
 		if err := recover(); err != nil {
 			userErr := reqCtx.Recover(ctx, err)
 			sendErrorf(w, http.StatusUnprocessableEntity, userErr.Error())

--- a/integration/generated.go
+++ b/integration/generated.go
@@ -2193,7 +2193,7 @@ func (ec *executionContext) _Element(ctx context.Context, sel ast.SelectionSet, 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2301,7 +2301,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2342,7 +2342,7 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2366,7 +2366,7 @@ func (ec *executionContext) _Viewer(ctx context.Context, sel ast.SelectionSet, o
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2405,7 +2405,7 @@ func (ec *executionContext) ___Directive(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2441,7 +2441,7 @@ func (ec *executionContext) ___EnumValue(ctx context.Context, sel ast.SelectionS
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2487,7 +2487,7 @@ func (ec *executionContext) ___Field(ctx context.Context, sel ast.SelectionSet, 
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2523,7 +2523,7 @@ func (ec *executionContext) ___InputValue(ctx context.Context, sel ast.Selection
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2564,7 +2564,7 @@ func (ec *executionContext) ___Schema(ctx context.Context, sel ast.SelectionSet,
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2607,7 +2607,7 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
 	}
-	out.Dispatch()
+	out.Dispatch(ec.Pool)
 	if invalids > 0 {
 		return graphql.Null
 	}
@@ -2725,7 +2725,7 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2738,9 +2738,9 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2796,7 +2796,7 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2809,9 +2809,9 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstring(ctx context.Co
 			ret[i] = ec.marshalN__DirectiveLocation2string(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2845,7 +2845,7 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2858,9 +2858,9 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -2886,7 +2886,7 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -2899,9 +2899,9 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -3033,7 +3033,7 @@ func (ec *executionContext) marshalOElement2ᚕᚖgithubᚗcomᚋ99designsᚋgql
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -3046,9 +3046,9 @@ func (ec *executionContext) marshalOElement2ᚕᚖgithubᚗcomᚋ99designsᚋgql
 			ret[i] = ec.marshalOElement2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋmodelsᚑgoᚐElement(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -3172,7 +3172,7 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -3185,9 +3185,9 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			ret[i] = ec.marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -3212,7 +3212,7 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -3225,9 +3225,9 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			ret[i] = ec.marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -3252,7 +3252,7 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -3265,9 +3265,9 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}
@@ -3307,7 +3307,7 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			Result: &v[i],
 		}
 		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
+		f := func() {
 			defer func() {
 				if r := recover(); r != nil {
 					ec.Error(ctx, ec.Recover(ctx, r))
@@ -3320,9 +3320,9 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
-			f(i)
+			f()
 		} else {
-			go f(i)
+			ec.Pool.Go(f)
 		}
 
 	}


### PR DESCRIPTION
This is a draft proposal/approach for pooling goroutines. It's not ready to merge, but available for early feedback on the general approach before I go through the effort of trying to add tests, docs, and add further configurability.

There are two problems I'd like to solve:

* Limiting concurrency available for the execution of a single operation.
* Allow a better mechanism for to trigger dataloaders that doesn't rely on timeouts (somewhat related to #518, definitely related to https://github.com/vektah/dataloaden/issues/14). Not solved by pooling goroutines, but I have thoughts around how we might build on top of the pool. If we get to the point that we're happy with this, I'll draft up a proposal issue.

There may also be performance benefits to pooling goroutines, but I haven't measured yet. Judging from #465 it looks like there's potential.

The solution is relatively simple. It adds a new `Pool` type which can be configured with a goroutine limit. The limit defaults to 0, in which case there is no limit, but goroutines are still pooled and reused. `RequestContext` now has a `Pool` field that's used for kicking off goroutines, so goroutines are pooled per-request.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
