### PR TITLE
Fix for nested fields backed by map or interface

### DIFF
--- a/codegen/testserver/maps.graphql
+++ b/codegen/testserver/maps.graphql
@@ -1,5 +1,6 @@
 extend type Query {
     mapStringInterface(in: MapStringInterfaceInput): MapStringInterfaceType
+    mapNestedStringInterface(in: NestedMapInput): MapStringInterfaceType
 }
 
 type MapStringInterfaceType {
@@ -10,4 +11,8 @@ type MapStringInterfaceType {
 input MapStringInterfaceInput {
     a: String
     b: Int
+}
+
+input NestedMapInput {
+    map: MapStringInterfaceInput
 }

--- a/codegen/testserver/maps_test.go
+++ b/codegen/testserver/maps_test.go
@@ -15,6 +15,12 @@ func TestMaps(t *testing.T) {
 	resolver.QueryResolver.MapStringInterface = func(ctx context.Context, in map[string]interface{}) (i map[string]interface{}, e error) {
 		return in, nil
 	}
+	resolver.QueryResolver.MapNestedStringInterface = func(ctx context.Context, in *NestedMapInput) (i map[string]interface{}, e error) {
+		if in == nil {
+			return nil, nil
+		}
+		return in.Map, nil
+	}
 
 	srv := httptest.NewServer(
 		handler.GraphQL(
@@ -48,5 +54,24 @@ func TestMaps(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "a", resp.MapStringInterface["a"])
 		require.Nil(t, resp.MapStringInterface["b"])
+	})
+
+	t.Run("nested", func(t *testing.T) {
+		var resp struct {
+			MapNestedStringInterface map[string]interface{}
+		}
+		err := c.Post(`query { mapNestedStringInterface(in: { map: { a: "a", b: null } }) { a, b } }`, &resp)
+		require.NoError(t, err)
+		require.Equal(t, "a", resp.MapNestedStringInterface["a"])
+		require.Nil(t, resp.MapNestedStringInterface["b"])
+	})
+
+	t.Run("nested nil", func(t *testing.T) {
+		var resp struct {
+			MapNestedStringInterface map[string]interface{}
+		}
+		err := c.Post(`query { mapNestedStringInterface(in: { map: null }) { a, b } }`, &resp)
+		require.NoError(t, err)
+		require.Nil(t, resp.MapNestedStringInterface)
 	})
 }

--- a/codegen/testserver/models-gen.go
+++ b/codegen/testserver/models-gen.go
@@ -87,6 +87,10 @@ type Map struct {
 	ID string `json:"id"`
 }
 
+type NestedMapInput struct {
+	Map map[string]interface{} `json:"map"`
+}
+
 type ObjectDirectives struct {
 	Text         string  `json:"text"`
 	NullableText *string `json:"nullableText"`

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -185,6 +185,9 @@ func (r *queryResolver) DirectiveUnimplemented(ctx context.Context) (*string, er
 func (r *queryResolver) MapStringInterface(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error) {
 	panic("not implemented")
 }
+func (r *queryResolver) MapNestedStringInterface(ctx context.Context, in *NestedMapInput) (map[string]interface{}, error) {
+	panic("not implemented")
+}
 func (r *queryResolver) ErrorBubble(ctx context.Context) (*Error, error) {
 	panic("not implemented")
 }

--- a/codegen/testserver/stub.go
+++ b/codegen/testserver/stub.go
@@ -65,6 +65,7 @@ type Stub struct {
 		DirectiveDouble                  func(ctx context.Context) (*string, error)
 		DirectiveUnimplemented           func(ctx context.Context) (*string, error)
 		MapStringInterface               func(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error)
+		MapNestedStringInterface         func(ctx context.Context, in *NestedMapInput) (map[string]interface{}, error)
 		ErrorBubble                      func(ctx context.Context) (*Error, error)
 		Errors                           func(ctx context.Context) (*Errors, error)
 		Valid                            func(ctx context.Context) (string, error)
@@ -262,6 +263,9 @@ func (r *stubQuery) DirectiveUnimplemented(ctx context.Context) (*string, error)
 }
 func (r *stubQuery) MapStringInterface(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error) {
 	return r.QueryResolver.MapStringInterface(ctx, in)
+}
+func (r *stubQuery) MapNestedStringInterface(ctx context.Context, in *NestedMapInput) (map[string]interface{}, error) {
+	return r.QueryResolver.MapNestedStringInterface(ctx, in)
 }
 func (r *stubQuery) ErrorBubble(ctx context.Context) (*Error, error) {
 	return r.QueryResolver.ErrorBubble(ctx)

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/99designs/gqlgen/codegen/templates"
-	"github.com/99designs/gqlgen/internal/code"
 	"github.com/99designs/gqlgen/plugin"
 	"github.com/vektah/gqlparser/ast"
 )
@@ -119,8 +118,7 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 				fieldDef := schema.Types[field.Type.Name()]
 
 				if cfg.Models.UserDefined(field.Type.Name()) {
-					pkg, typeName := code.PkgAndType(cfg.Models[field.Type.Name()].Model[0])
-					typ, err = binder.FindType(pkg, typeName)
+					typ, err = binder.FindTypeFromName(cfg.Models[field.Type.Name()].Model[0])
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
In order to support distinguishing between null and missing values in GraphQL, gqlgen allows [binding GraphQL types](https://github.com/99designs/gqlgen/blob/55b2144289debeb5ca104a4d01d36f96be5ed84c/docs/content/reference/changesets.md) to `map[string]interface{}`. However, currently those types can't be embedded in generated models because model generation doesn't know about the special cases in type binding that make it work. Trying with master or v0.9.3 gives the error `modelgen: package cannot be nil`.

In order to fix this, this PR makes two changes:

* Check for a type name of `interface{}` and `map[string]interface{}` in `Binder.FindType`. I added a variant function that takes responsibility for splitting the package and type names, but the old function is still there for backwards compatibility.

* Extend the nilable type logic used in codegen for the executor to model field generation, so that an optional GraphQL value is bound to a field of type `map[string]interface{}` instead of `*map[string]interface{}`. In order to maintain backwards compatibility, this change only applies to the special cases where the map or interface type is specified directly in the gqlgen config, not to other Go types that have an underlying nilable type.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] **N/A** Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
