### PR TITLE
Refactor test client

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -12,7 +11,7 @@ import (
 )
 
 func TestClient(t *testing.T) {
-	h := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			panic(err)
@@ -27,9 +26,9 @@ func TestClient(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-	}))
+	})
 
-	c := client.New(h.URL)
+	c := client.New(h)
 
 	var resp struct {
 		Name string
@@ -38,4 +37,54 @@ func TestClient(t *testing.T) {
 	c.MustPost("user(id:$id){name}", &resp, client.Var("id", 1))
 
 	require.Equal(t, "bob", resp.Name)
+}
+
+func TestAddHeader(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "ASDF", r.Header.Get("Test-Key"))
+
+		w.Write([]byte(`{}`))
+	})
+
+	c := client.New(h)
+
+	var resp struct{}
+	c.MustPost("{ id }", &resp,
+		client.AddHeader("Test-Key", "ASDF"),
+	)
+}
+
+func TestBasicAuth(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		require.True(t, ok)
+		require.Equal(t, "user", user)
+		require.Equal(t, "pass", pass)
+
+		w.Write([]byte(`{}`))
+	})
+
+	c := client.New(h)
+
+	var resp struct{}
+	c.MustPost("{ id }", &resp,
+		client.BasicAuth("user", "pass"),
+	)
+}
+
+func TestAddCookie(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := r.Cookie("foo")
+		require.NoError(t, err)
+		require.Equal(t, "value", c.Value)
+
+		w.Write([]byte(`{}`))
+	})
+
+	c := client.New(h)
+
+	var resp struct{}
+	c.MustPost("{ id }", &resp,
+		client.AddCookie(&http.Cookie{Name: "foo", Value: "value"}),
+	)
 }

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,0 +1,12 @@
+package client
+
+import "encoding/json"
+
+// RawJsonError is a json formatted error from a GraphQL server.
+type RawJsonError struct {
+	json.RawMessage
+}
+
+func (r RawJsonError) Error() string {
+	return string(r.RawMessage)
+}

--- a/client/options.go
+++ b/client/options.go
@@ -1,0 +1,50 @@
+package client
+
+import "net/http"
+
+// Var adds a variable into the outgoing request
+func Var(name string, value interface{}) Option {
+	return func(bd *Request) {
+		if bd.Variables == nil {
+			bd.Variables = map[string]interface{}{}
+		}
+
+		bd.Variables[name] = value
+	}
+}
+
+// Operation sets the operation name for the outgoing request
+func Operation(name string) Option {
+	return func(bd *Request) {
+		bd.OperationName = name
+	}
+}
+
+// Path sets the url that this request will be made against, useful if you are mounting your entire router
+// and need to specify the url to the graphql endpoint.
+func Path(url string) Option {
+	return func(bd *Request) {
+		bd.HTTP.URL.Path = url
+	}
+}
+
+// AddHeader adds a header to the outgoing request. This is useful for setting expected Authentication headers for example.
+func AddHeader(key string, value string) Option {
+	return func(bd *Request) {
+		bd.HTTP.Header.Add(key, value)
+	}
+}
+
+// BasicAuth authenticates the request using http basic auth.
+func BasicAuth(username, password string) Option {
+	return func(bd *Request) {
+		bd.HTTP.SetBasicAuth(username, password)
+	}
+}
+
+// AddCookie adds a cookie to the outgoing request
+func AddCookie(cookie *http.Cookie) Option {
+	return func(bd *Request) {
+		bd.HTTP.AddCookie(cookie)
+	}
+}

--- a/codegen/testserver/complexity_test.go
+++ b/codegen/testserver/complexity_test.go
@@ -2,7 +2,6 @@ package testserver
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -13,8 +12,7 @@ import (
 func TestComplexityCollisions(t *testing.T) {
 	resolvers := &Stub{}
 
-	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
 
 	resolvers.QueryResolver.Overlapping = func(ctx context.Context) (fields *OverlappingFields, e error) {
 		return &OverlappingFields{
@@ -50,8 +48,7 @@ func TestComplexityFuncs(t *testing.T) {
 	cfg.Complexity.OverlappingFields.Foo = func(childComplexity int) int { return 1000 }
 	cfg.Complexity.OverlappingFields.NewFoo = func(childComplexity int) int { return 5 }
 
-	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(cfg), handler.ComplexityLimit(10)))
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(NewExecutableSchema(cfg), handler.ComplexityLimit(10)))
 
 	resolvers.QueryResolver.Overlapping = func(ctx context.Context) (fields *OverlappingFields, e error) {
 		return &OverlappingFields{

--- a/codegen/testserver/directive_test.go
+++ b/codegen/testserver/directive_test.go
@@ -3,7 +3,6 @@ package testserver
 import (
 	"context"
 	"fmt"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -72,7 +71,7 @@ func TestDirectives(t *testing.T) {
 		return &s, nil
 	}
 
-	srv := httptest.NewServer(
+	srv :=
 		handler.GraphQL(
 			NewExecutableSchema(Config{
 				Resolvers: resolvers,
@@ -160,8 +159,8 @@ func TestDirectives(t *testing.T) {
 				path, _ := ctx.Value("path").([]int)
 				return next(context.WithValue(ctx, "path", append(path, 2)))
 			}),
-		))
-	c := client.New(srv.URL)
+		)
+	c := client.New(srv)
 
 	t.Run("arg directives", func(t *testing.T) {
 		t.Run("when function errors on directives", func(t *testing.T) {

--- a/codegen/testserver/generated_test.go
+++ b/codegen/testserver/generated_test.go
@@ -6,7 +6,6 @@ package testserver
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"reflect"
 	"testing"
 
@@ -40,8 +39,7 @@ func TestUnionFragments(t *testing.T) {
 		return &Circle{Radius: 32}, nil
 	}
 
-	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
 
 	t.Run("inline fragment on union", func(t *testing.T) {
 		var resp struct {

--- a/codegen/testserver/input_test.go
+++ b/codegen/testserver/input_test.go
@@ -2,7 +2,6 @@ package testserver
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -13,9 +12,7 @@ import (
 func TestInput(t *testing.T) {
 	resolvers := &Stub{}
 
-	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
-
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
 
 	t.Run("when function errors on directives", func(t *testing.T) {
 		resolvers.QueryResolver.InputSlice = func(ctx context.Context, arg []string) (b bool, e error) {

--- a/codegen/testserver/maps_test.go
+++ b/codegen/testserver/maps_test.go
@@ -2,7 +2,6 @@ package testserver
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -16,12 +15,9 @@ func TestMaps(t *testing.T) {
 		return in, nil
 	}
 
-	srv := httptest.NewServer(
-		handler.GraphQL(
-			NewExecutableSchema(Config{Resolvers: resolver}),
-		))
-	defer srv.Close()
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(
+		NewExecutableSchema(Config{Resolvers: resolver}),
+	))
 	t.Run("unset", func(t *testing.T) {
 		var resp struct {
 			MapStringInterface map[string]interface{}

--- a/codegen/testserver/middleware_test.go
+++ b/codegen/testserver/middleware_test.go
@@ -2,7 +2,6 @@ package testserver
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -28,24 +27,23 @@ func TestMiddleware(t *testing.T) {
 	}
 
 	areMethods := []bool{}
-	srv := httptest.NewServer(
-		handler.GraphQL(
-			NewExecutableSchema(Config{Resolvers: resolvers}),
-			handler.ResolverMiddleware(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
-				path, _ := ctx.Value("path").([]int)
-				return next(context.WithValue(ctx, "path", append(path, 1)))
-			}),
-			handler.ResolverMiddleware(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
-				path, _ := ctx.Value("path").([]int)
-				return next(context.WithValue(ctx, "path", append(path, 2)))
-			}),
-			handler.ResolverMiddleware(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
-				areMethods = append(areMethods, graphql.GetResolverContext(ctx).IsMethod)
-				return next(ctx)
-			}),
-		))
+	srv := handler.GraphQL(
+		NewExecutableSchema(Config{Resolvers: resolvers}),
+		handler.ResolverMiddleware(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+			path, _ := ctx.Value("path").([]int)
+			return next(context.WithValue(ctx, "path", append(path, 1)))
+		}),
+		handler.ResolverMiddleware(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+			path, _ := ctx.Value("path").([]int)
+			return next(context.WithValue(ctx, "path", append(path, 2)))
+		}),
+		handler.ResolverMiddleware(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+			areMethods = append(areMethods, graphql.GetResolverContext(ctx).IsMethod)
+			return next(ctx)
+		}),
+	)
 
-	c := client.New(srv.URL)
+	c := client.New(srv)
 
 	var resp struct {
 		User struct {

--- a/codegen/testserver/modelmethod_test.go
+++ b/codegen/testserver/modelmethod_test.go
@@ -2,7 +2,6 @@ package testserver
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -19,12 +18,9 @@ func TestModelMethods(t *testing.T) {
 		return true, nil
 	}
 
-	srv := httptest.NewServer(
-		handler.GraphQL(
-			NewExecutableSchema(Config{Resolvers: resolver}),
-		))
-	defer srv.Close()
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(
+		NewExecutableSchema(Config{Resolvers: resolver}),
+	))
 	t.Run("without context", func(t *testing.T) {
 		var resp struct {
 			ModelMethods struct {

--- a/codegen/testserver/nulls_test.go
+++ b/codegen/testserver/nulls_test.go
@@ -2,7 +2,6 @@ package testserver
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -23,8 +22,7 @@ func TestNullBubbling(t *testing.T) {
 		return &Error{ID: "E1234"}, nil
 	}
 
-	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
 
 	t.Run("when function errors on non required field", func(t *testing.T) {
 		var resp struct {

--- a/codegen/testserver/panics_test.go
+++ b/codegen/testserver/panics_test.go
@@ -2,7 +2,6 @@ package testserver
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,8 +22,7 @@ func TestPanics(t *testing.T) {
 		return []MarshalPanic{MarshalPanic("aa"), MarshalPanic("bb")}, nil
 	}
 
-	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
 
 	t.Run("panics in marshallers will not kill server", func(t *testing.T) {
 		var resp interface{}

--- a/codegen/testserver/primitive_objects_test.go
+++ b/codegen/testserver/primitive_objects_test.go
@@ -2,7 +2,6 @@ package testserver
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -20,8 +19,7 @@ func TestPrimitiveObjects(t *testing.T) {
 		return int(*obj), nil
 	}
 
-	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
 
 	t.Run("can fetch value", func(t *testing.T) {
 		var resp struct {
@@ -53,8 +51,7 @@ func TestPrimitiveStringObjects(t *testing.T) {
 		return len(string(*obj)), nil
 	}
 
-	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
 
 	t.Run("can fetch value", func(t *testing.T) {
 		var resp struct {

--- a/codegen/testserver/response_extension_test.go
+++ b/codegen/testserver/response_extension_test.go
@@ -2,7 +2,6 @@ package testserver
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -17,7 +16,7 @@ func TestResponseExtension(t *testing.T) {
 		return "Ok", nil
 	}
 
-	srv := httptest.NewServer(handler.GraphQL(
+	srv := handler.GraphQL(
 		NewExecutableSchema(Config{Resolvers: resolvers}),
 		handler.RequestMiddleware(func(ctx context.Context, next func(ctx context.Context) []byte) []byte {
 			rctx := graphql.GetRequestContext(ctx)
@@ -26,8 +25,8 @@ func TestResponseExtension(t *testing.T) {
 			}
 			return next(ctx)
 		}),
-	))
-	c := client.New(srv.URL)
+	)
+	c := client.New(srv)
 
 	raw, _ := c.RawPost(`query { valid }`)
 	require.Equal(t, raw.Extensions["example"], "value")

--- a/codegen/testserver/scalar_default_test.go
+++ b/codegen/testserver/scalar_default_test.go
@@ -2,7 +2,6 @@ package testserver
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -13,8 +12,7 @@ import (
 func TestDefaultScalarImplementation(t *testing.T) {
 	resolvers := &Stub{}
 
-	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
 
 	resolvers.QueryResolver.DefaultScalar = func(ctx context.Context, arg string) (i string, e error) {
 		return arg, nil

--- a/codegen/testserver/slices_test.go
+++ b/codegen/testserver/slices_test.go
@@ -2,7 +2,6 @@ package testserver
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -13,8 +12,7 @@ import (
 func TestSlices(t *testing.T) {
 	resolvers := &Stub{}
 
-	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
 
 	t.Run("nulls vs empty slices", func(t *testing.T) {
 		resolvers.QueryResolver.Slices = func(ctx context.Context) (slices *Slices, e error) {

--- a/codegen/testserver/time_test.go
+++ b/codegen/testserver/time_test.go
@@ -2,7 +2,6 @@ package testserver
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -14,8 +13,7 @@ import (
 func TestTime(t *testing.T) {
 	resolvers := &Stub{}
 
-	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
 
 	resolvers.QueryResolver.User = func(ctx context.Context, id int) (user *User, e error) {
 		return &User{}, nil

--- a/codegen/testserver/typefallback_test.go
+++ b/codegen/testserver/typefallback_test.go
@@ -2,7 +2,6 @@ package testserver
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -13,8 +12,7 @@ import (
 func TestTypeFallback(t *testing.T) {
 	resolvers := &Stub{}
 
-	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
 
 	resolvers.QueryResolver.Fallback = func(ctx context.Context, arg FallbackToStringEncoding) (FallbackToStringEncoding, error) {
 		return arg, nil

--- a/codegen/testserver/validtypes_test.go
+++ b/codegen/testserver/validtypes_test.go
@@ -2,7 +2,6 @@ package testserver
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -19,8 +18,7 @@ func TestValidType(t *testing.T) {
 		}, nil
 	}
 
-	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
 
 	t.Run("fields with differing cases can be distinguished", func(t *testing.T) {
 		var resp struct {

--- a/codegen/testserver/wrapped_type_test.go
+++ b/codegen/testserver/wrapped_type_test.go
@@ -2,7 +2,6 @@ package testserver
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -14,11 +13,10 @@ import (
 func TestWrappedTypes(t *testing.T) {
 	resolvers := &Stub{}
 
-	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(NewExecutableSchema(Config{Resolvers: resolvers})))
 
 	resolvers.QueryResolver.WrappedScalar = func(ctx context.Context) (scalar WrappedScalar, e error) {
-		return WrappedScalar("hello"), nil
+		return "hello", nil
 	}
 
 	resolvers.QueryResolver.WrappedStruct = func(ctx context.Context) (wrappedStruct *WrappedStruct, e error) {

--- a/example/chat/chat_test.go
+++ b/example/chat/chat_test.go
@@ -1,7 +1,6 @@
 package chat
 
 import (
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -12,8 +11,7 @@ import (
 )
 
 func TestChatSubscriptions(t *testing.T) {
-	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(New())))
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(NewExecutableSchema(New())))
 
 	sub := c.Websocket(`subscription @user(username:"vektah") { messageAdded(roomName:"#gophers") { text createdBy } }`)
 	defer sub.Close()

--- a/example/dataloader/dataloader_test.go
+++ b/example/dataloader/dataloader_test.go
@@ -1,7 +1,6 @@
 package dataloader
 
 import (
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -11,8 +10,7 @@ import (
 )
 
 func TestTodo(t *testing.T) {
-	srv := httptest.NewServer(LoaderMiddleware(handler.GraphQL(NewExecutableSchema(Config{Resolvers: &Resolver{}}))))
-	c := client.New(srv.URL)
+	c := client.New(LoaderMiddleware(handler.GraphQL(NewExecutableSchema(Config{Resolvers: &Resolver{}}))))
 
 	t.Run("create a new todo", func(t *testing.T) {
 		var resp interface{}

--- a/example/scalars/scalar_test.go
+++ b/example/scalars/scalar_test.go
@@ -1,7 +1,6 @@
 package scalars
 
 import (
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -22,8 +21,7 @@ type RawUser struct {
 }
 
 func TestScalars(t *testing.T) {
-	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: &Resolver{}})))
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(NewExecutableSchema(Config{Resolvers: &Resolver{}})))
 
 	t.Run("marshaling", func(t *testing.T) {
 		var resp struct {

--- a/example/selection/selection_test.go
+++ b/example/selection/selection_test.go
@@ -1,7 +1,6 @@
 package selection
 
 import (
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -10,8 +9,7 @@ import (
 )
 
 func TestSelection(t *testing.T) {
-	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(Config{Resolvers: &Resolver{}})))
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(NewExecutableSchema(Config{Resolvers: &Resolver{}})))
 
 	query := `{
 			events {

--- a/example/starwars/starwars_test.go
+++ b/example/starwars/starwars_test.go
@@ -1,7 +1,6 @@
 package starwars
 
 import (
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -12,8 +11,7 @@ import (
 )
 
 func TestStarwars(t *testing.T) {
-	srv := httptest.NewServer(handler.GraphQL(generated.NewExecutableSchema(NewResolver())))
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(generated.NewExecutableSchema(NewResolver())))
 
 	t.Run("Lukes starships", func(t *testing.T) {
 		var resp struct {

--- a/example/todo/todo_test.go
+++ b/example/todo/todo_test.go
@@ -1,7 +1,6 @@
 package todo
 
 import (
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -11,8 +10,7 @@ import (
 )
 
 func TestTodo(t *testing.T) {
-	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(New())))
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(NewExecutableSchema(New())))
 
 	var resp struct {
 		CreateTodo struct{ ID string }
@@ -182,8 +180,7 @@ func TestTodo(t *testing.T) {
 }
 
 func TestSkipAndIncludeDirectives(t *testing.T) {
-	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(New())))
-	c := client.New(srv.URL)
+	c := client.New(handler.GraphQL(NewExecutableSchema(New())))
 
 	t.Run("skip on field", func(t *testing.T) {
 		var resp map[string]interface{}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/99designs/gqlgen
 
+go 1.12
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-chi/chi v3.3.2+incompatible


### PR DESCRIPTION
There have been a few PRs adding various features to the http client:
 - https://github.com/99designs/gqlgen/pull/720 - add a generic Do method
 - https://github.com/99designs/gqlgen/pull/859 - add headers across whole client
 - https://github.com/99designs/gqlgen/pull/832 - add headers per request

After #720 we took this client and kept iterating internally - this pr is that code cleaned up and reintegrated with gqlgen.

Notable changes:
 - takes a http.Handler instead of a url. This produces better stacktraces on panics and hides the cleanup logic from the user.
 - makes http.Request available to Options, this means headers can now easily be added both inside this lib and outside.
 - add Options to the client.New method, so options can be applied from across multiple tests easily (eg csrf headers)

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content)) - NA
