### PR TITLE
Allow changing context in websocket init func

### DIFF
--- a/handler/graphql.go
+++ b/handler/graphql.go
@@ -52,7 +52,7 @@ type PersistedQueryCache interface {
 	Get(ctx context.Context, hash string) (string, bool)
 }
 
-type websocketInitFunc func(ctx context.Context, initPayload InitPayload) error
+type websocketInitFunc func(ctx context.Context, initPayload InitPayload) (context.Context, error)
 
 type Config struct {
 	cacheSize                       int
@@ -278,7 +278,7 @@ func (tw *tracerWrapper) EndOperationExecution(ctx context.Context) {
 
 // WebsocketInitFunc is called when the server receives connection init message from the client.
 // This can be used to check initial payload to see whether to accept the websocket connection.
-func WebsocketInitFunc(websocketInitFunc func(ctx context.Context, initPayload InitPayload) error) Option {
+func WebsocketInitFunc(websocketInitFunc websocketInitFunc) Option {
 	return func(cfg *Config) {
 		cfg.websocketInitFunc = websocketInitFunc
 	}

--- a/handler/mock.go
+++ b/handler/mock.go
@@ -9,6 +9,7 @@ import (
 )
 
 type executableSchemaMock struct {
+	QueryFunc    func(ctx context.Context, op *ast.OperationDefinition) *graphql.Response
 	MutationFunc func(ctx context.Context, op *ast.OperationDefinition) *graphql.Response
 }
 
@@ -42,7 +43,10 @@ func (e *executableSchemaMock) Complexity(typeName, field string, childComplexit
 }
 
 func (e *executableSchemaMock) Query(ctx context.Context, op *ast.OperationDefinition) *graphql.Response {
-	return graphql.ErrorResponse(ctx, "queries are not supported")
+	if e.QueryFunc == nil {
+		return graphql.ErrorResponse(ctx, "queries are not supported")
+	}
+	return e.QueryFunc(ctx, op)
 }
 
 func (e *executableSchemaMock) Mutation(ctx context.Context, op *ast.OperationDefinition) *graphql.Response {

--- a/handler/websocket.go
+++ b/handler/websocket.go
@@ -95,11 +95,13 @@ func (c *wsConnection) init() bool {
 		}
 
 		if c.cfg.websocketInitFunc != nil {
-			if err := c.cfg.websocketInitFunc(c.ctx, c.initPayload); err != nil {
+			ctx, err := c.cfg.websocketInitFunc(c.ctx, c.initPayload)
+			if err != nil {
 				c.sendConnectionError(err.Error())
 				c.close(websocket.CloseNormalClosure, "terminated")
 				return false
 			}
+			c.ctx = ctx
 		}
 
 		c.write(&operationMessage{Type: connectionAckMsg})


### PR DESCRIPTION
Adds context to the return for the WebsocketInitFunc so that it can add new context keys (eg the authenticated user)

fixes https://github.com/99designs/gqlgen/issues/777

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
