### PR TITLE
Call middleware and directives for subscriptions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,7 +31,6 @@ linters:
     - stylecheck
     - typecheck
     - unconvert
-    - unparam
     - unused
     - varcheck
 

--- a/codegen/field.go
+++ b/codegen/field.go
@@ -27,6 +27,7 @@ type Field struct {
 	NoErr            bool             // If this is bound to a go method, does that method have an error as the second argument
 	Object           *Object          // A link back to the parent object
 	Default          interface{}      // The default value
+	Stream           bool             // does this field return a channel?
 	Directives       []*Directive
 }
 
@@ -83,6 +84,8 @@ func (b *builder) bindField(obj *Object, f *Field) error {
 			f.TypeReference = tr
 		}
 	}()
+
+	f.Stream = obj.Stream
 
 	switch {
 	case f.Name == "__schema":

--- a/codegen/field.gotpl
+++ b/codegen/field.gotpl
@@ -1,29 +1,59 @@
 {{- range $object := .Objects }}{{- range $field := $object.Fields }}
 
-{{- if $object.Stream }}
-	func (ec *executionContext) _{{$object.Name}}_{{$field.Name}}(ctx context.Context, field graphql.CollectedField) func() graphql.Marshaler {
-		ctx = graphql.WithResolverContext(ctx, &graphql.ResolverContext{
-			Field: field,
-			Args:  nil,
-		})
-		{{- if $field.Args }}
-			rawArgs := field.ArgumentMap(ec.Variables)
-			args, err := ec.{{ $field.ArgsFunc }}(ctx,rawArgs)
-			if err != nil {
-				ec.Error(ctx, err)
-				return nil
-			}
-		{{- end }}
-		// FIXME: subscriptions are missing request middleware stack https://github.com/99designs/gqlgen/issues/259
-		//          and Tracer stack
-		rctx := ctx
-		results, err := ec.resolvers.{{ $field.ShortInvocation }}
+func (ec *executionContext) _{{$object.Name}}_{{$field.Name}}(ctx context.Context, field graphql.CollectedField{{ if not $object.Root }}, obj {{$object.Reference | ref}}{{end}}) (ret {{ if $object.Stream }}func(){{ end }}graphql.Marshaler) {
+	{{- $null := "graphql.Null" }}
+	{{- if $object.Stream }}
+		{{- $null = "nil" }}
+	{{- end }}
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func () {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = {{ $null }}
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object: {{$object.Name|quote}},
+		Field: field,
+		Args:  nil,
+		IsMethod: {{or $field.IsMethod $field.IsResolver}},
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	{{- if $field.Args }}
+		rawArgs := field.ArgumentMap(ec.Variables)
+		args, err := ec.{{ $field.ArgsFunc }}(ctx,rawArgs)
 		if err != nil {
 			ec.Error(ctx, err)
-			return nil
+			return {{ $null }}
 		}
+		rctx.Args = args
+	{{- end }}
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	{{- if  $.Directives.LocationDirectives "FIELD" }}
+		resTmp := ec._fieldMiddleware(ctx, {{if $object.Root}}nil{{else}}obj{{end}}, func(rctx context.Context) (interface{}, error) {
+			{{ template "field" $field }}
+		})
+	{{ else }}
+		resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+			{{ template "field" $field }}
+		})
+		if err != nil {
+			ec.Error(ctx, err)
+			return {{ $null }}
+		}
+	{{- end }}
+	if resTmp == nil {
+		{{- if $field.TypeReference.GQL.NonNull }}
+			if !ec.HasError(rctx) {
+				ec.Errorf(ctx, "must not be null")
+			}
+		{{- end }}
+		return {{ $null }}
+	}
+	{{- if $object.Stream }}
 		return func() graphql.Marshaler {
-			res, ok := <-results
+			res, ok := <-resTmp.(<-chan {{$field.TypeReference.GO | ref}})
 			if !ok {
 				return nil
 			}
@@ -35,61 +65,13 @@
 				w.Write([]byte{'}'})
 			})
 		}
-	}
-{{ else }}
-	func (ec *executionContext) _{{$object.Name}}_{{$field.Name}}(ctx context.Context, field graphql.CollectedField{{ if not $object.Root }}, obj {{$object.Reference | ref}}{{end}}) (ret graphql.Marshaler) {
-		ctx = ec.Tracer.StartFieldExecution(ctx, field)
-		defer func () {
-			if r := recover(); r != nil {
-				ec.Error(ctx, ec.Recover(ctx, r))
-				ret = graphql.Null
-			}
-			ec.Tracer.EndFieldExecution(ctx)
-		}()
-		rctx := &graphql.ResolverContext{
-			Object: {{$object.Name|quote}},
-			Field: field,
-			Args:  nil,
-			IsMethod: {{or $field.IsMethod $field.IsResolver}},
-		}
-		ctx = graphql.WithResolverContext(ctx, rctx)
-		{{- if $field.Args }}
-			rawArgs := field.ArgumentMap(ec.Variables)
-			args, err := ec.{{ $field.ArgsFunc }}(ctx,rawArgs)
-			if err != nil {
-				ec.Error(ctx, err)
-				return graphql.Null
-			}
-			rctx.Args = args
-		{{- end }}
-		ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-		{{- if  $.Directives.LocationDirectives "FIELD" }}
-			resTmp := ec._fieldMiddleware(ctx, {{if $object.Root}}nil{{else}}obj{{end}}, func(rctx context.Context) (interface{}, error) {
-				{{ template "field" $field }}
-			})
-		{{ else }}
-			resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-				{{ template "field" $field }}
-			})
-			if err != nil {
-				ec.Error(ctx, err)
-				return graphql.Null
-			}
-		{{- end }}
-		if resTmp == nil {
-			{{- if $field.TypeReference.GQL.NonNull }}
-				if !ec.HasError(rctx) {
-					ec.Errorf(ctx, "must not be null")
-				}
-			{{- end }}
-			return graphql.Null
-		}
+	{{- else }}
 		res := resTmp.({{$field.TypeReference.GO | ref}})
 		rctx.Result = res
 		ctx = ec.Tracer.StartFieldChildExecution(ctx)
 		return ec.{{ $field.TypeReference.MarshalFunc }}(ctx, field.Selections, res)
-	}
-{{ end }}
+	{{- end }}
+}
 
 {{- end }}{{- end}}
 
@@ -107,10 +89,10 @@
 		if tmp == nil {
 		    return nil, nil
 		}
-		if data, ok := tmp.({{ .TypeReference.GO | ref }}) ; ok {
+		if data, ok := tmp.({{if .Stream}}<-chan {{end}}{{ .TypeReference.GO | ref }}) ; ok {
 			return data, nil
 		}
-		return nil, fmt.Errorf(`unexpected type %T from directive, should be {{ .TypeReference.GO }}`, tmp)
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be {{if .Stream}}<-chan {{end}}{{ .TypeReference.GO }}`, tmp)
 	{{- else -}}
 		ctx = rctx  // use context from middleware stack in children
 		{{ template "fieldDefinition" . }}
@@ -122,9 +104,9 @@
 		return ec.resolvers.{{ .ShortInvocation }}
 	{{- else if .IsMap -}}
 		switch v := {{.GoReceiverName}}[{{.Name|quote}}].(type) {
-		case {{.TypeReference.GO | ref}}:
+		case {{if .Stream}}<-chan {{end}}{{.TypeReference.GO | ref}}:
 			return v, nil
-		case {{.TypeReference.Elem.GO | ref}}:
+		case {{if .Stream}}<-chan {{end}}{{.TypeReference.Elem.GO | ref}}:
 			return &v, nil
 		case nil:
 			return ({{.TypeReference.GO | ref}})(nil), nil

--- a/codegen/testserver/directive.graphql
+++ b/codegen/testserver/directive.graphql
@@ -21,6 +21,13 @@ extend type Query {
     directiveUnimplemented: String @unimplemented
 }
 
+extend type Subscription {
+    directiveArg(arg: String! @length(min:1, max: 255, message: "invalid length")): String
+    directiveNullableArg(arg: Int @range(min:0), arg2: Int @range, arg3: String @toNull): String
+    directiveDouble: String @directive1 @directive2
+    directiveUnimplemented: String @unimplemented
+}
+
 input InputDirectives {
     text: String! @length(min: 0, max: 7, message: "not valid")
     nullableText: String @toNull

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -236,6 +236,18 @@ func (r *subscriptionResolver) Updated(ctx context.Context) (<-chan string, erro
 func (r *subscriptionResolver) InitPayload(ctx context.Context) (<-chan string, error) {
 	panic("not implemented")
 }
+func (r *subscriptionResolver) DirectiveArg(ctx context.Context, arg string) (<-chan *string, error) {
+	panic("not implemented")
+}
+func (r *subscriptionResolver) DirectiveNullableArg(ctx context.Context, arg *int, arg2 *int, arg3 *string) (<-chan *string, error) {
+	panic("not implemented")
+}
+func (r *subscriptionResolver) DirectiveDouble(ctx context.Context) (<-chan *string, error) {
+	panic("not implemented")
+}
+func (r *subscriptionResolver) DirectiveUnimplemented(ctx context.Context) (<-chan *string, error) {
+	panic("not implemented")
+}
 
 type userResolver struct{ *Resolver }
 

--- a/codegen/testserver/stub.go
+++ b/codegen/testserver/stub.go
@@ -81,8 +81,12 @@ type Stub struct {
 		WrappedScalar                    func(ctx context.Context) (WrappedScalar, error)
 	}
 	SubscriptionResolver struct {
-		Updated     func(ctx context.Context) (<-chan string, error)
-		InitPayload func(ctx context.Context) (<-chan string, error)
+		Updated                func(ctx context.Context) (<-chan string, error)
+		InitPayload            func(ctx context.Context) (<-chan string, error)
+		DirectiveArg           func(ctx context.Context, arg string) (<-chan *string, error)
+		DirectiveNullableArg   func(ctx context.Context, arg *int, arg2 *int, arg3 *string) (<-chan *string, error)
+		DirectiveDouble        func(ctx context.Context) (<-chan *string, error)
+		DirectiveUnimplemented func(ctx context.Context) (<-chan *string, error)
 	}
 	UserResolver struct {
 		Friends func(ctx context.Context, obj *User) ([]*User, error)
@@ -313,6 +317,18 @@ func (r *stubSubscription) Updated(ctx context.Context) (<-chan string, error) {
 }
 func (r *stubSubscription) InitPayload(ctx context.Context) (<-chan string, error) {
 	return r.SubscriptionResolver.InitPayload(ctx)
+}
+func (r *stubSubscription) DirectiveArg(ctx context.Context, arg string) (<-chan *string, error) {
+	return r.SubscriptionResolver.DirectiveArg(ctx, arg)
+}
+func (r *stubSubscription) DirectiveNullableArg(ctx context.Context, arg *int, arg2 *int, arg3 *string) (<-chan *string, error) {
+	return r.SubscriptionResolver.DirectiveNullableArg(ctx, arg, arg2, arg3)
+}
+func (r *stubSubscription) DirectiveDouble(ctx context.Context) (<-chan *string, error) {
+	return r.SubscriptionResolver.DirectiveDouble(ctx)
+}
+func (r *stubSubscription) DirectiveUnimplemented(ctx context.Context) (<-chan *string, error) {
+	return r.SubscriptionResolver.DirectiveUnimplemented(ctx)
 }
 
 type stubUser struct{ *Stub }

--- a/example/chat/generated.go
+++ b/example/chat/generated.go
@@ -841,27 +841,46 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 	return ec.marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Subscription_messageAdded(ctx context.Context, field graphql.CollectedField) func() graphql.Marshaler {
-	ctx = graphql.WithResolverContext(ctx, &graphql.ResolverContext{
-		Field: field,
-		Args:  nil,
-	})
+func (ec *executionContext) _Subscription_messageAdded(ctx context.Context, field graphql.CollectedField) (ret func() graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = nil
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Subscription",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
 	rawArgs := field.ArgumentMap(ec.Variables)
 	args, err := ec.field_Subscription_messageAdded_args(ctx, rawArgs)
 	if err != nil {
 		ec.Error(ctx, err)
 		return nil
 	}
-	// FIXME: subscriptions are missing request middleware stack https://github.com/99designs/gqlgen/issues/259
-	//          and Tracer stack
-	rctx := ctx
-	results, err := ec.resolvers.Subscription().MessageAdded(rctx, args["roomName"].(string))
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Subscription().MessageAdded(rctx, args["roomName"].(string))
+	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return nil
 	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return nil
+	}
 	return func() graphql.Marshaler {
-		res, ok := <-results
+		res, ok := <-resTmp.(<-chan *Message)
 		if !ok {
 			return nil
 		}


### PR DESCRIPTION
obj will always be nil as these are always children of subscription, and calling next will return a `<-chan Thing`

fixes https://github.com/99designs/gqlgen/issues/259

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
