### PR TITLE
Allow prefixes when using autobind

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -406,6 +406,27 @@ func (c *Config) Autobind(s *ast.Schema) error {
 		}
 	}
 
+	for i, t := range c.Models {
+		for j, m := range t.Model {
+			pkg, typename := code.PkgAndType(m)
+
+			// skip anything that looks like an import path
+			if strings.Contains(pkg, "/") {
+				continue
+			}
+
+			for _, p := range ps {
+				if p.Name != pkg {
+					continue
+				}
+				if t := p.Types.Scope().Lookup(typename); t != nil {
+					c.Models[i].Model[j] = t.Pkg().Path() + "." + t.Name()
+					break
+				}
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -45,7 +45,7 @@ resolver:
 struct_tag: json
 
 # Instead of listing out every model like below, you can automatically bind to any matching types
-# within the given path. EXPERIMENTAL in v0.9.1
+# within the given path by using `model: User` or `model: models.User`. EXPERIMENTAL in v0.9.1
 autobind:
  - github.com/my/app/models
 
@@ -53,9 +53,9 @@ autobind:
 # graphql. These normally come from the db or a remote api.
 models:
   User:
-    model: github.com/my/app/models.User
+    model: models.User # can use short paths when the package is listed in autobind
   Todo:
-    model: github.com/my/app/models.Todo
+    model: github.com/my/app/models.Todo # or full paths if you need to go elsewhere
     fields:
       id:
         resolver: true # force a resolver to be generated

--- a/example/starwars/.gqlgen.yml
+++ b/example/starwars/.gqlgen.yml
@@ -8,7 +8,7 @@ autobind:
 
 models:
   ReviewInput:
-    model: github.com/99designs/gqlgen/example/starwars/models.Review
+    model: models.Review
   Starship:
     fields:
       length:


### PR DESCRIPTION
Lookup full import paths by matching package names in the autobind list as a way to discriminate when multiple models match.

Fixes https://github.com/99designs/gqlgen/issues/778

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
