### PR TITLE
Add config option to omit pointers to slice elements

### DIFF
--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -408,7 +408,7 @@ func (b *Binder) TypeReference(schemaType *ast.Type, bindTarget types.Type) (ret
 func (b *Binder) CopyModifiersFromAst(t *ast.Type, base types.Type) types.Type {
 	if t.Elem != nil {
 		child := b.CopyModifiersFromAst(t.Elem, base)
-		if _, isStruct := child.Underlying().(*types.Struct); isStruct {
+		if _, isStruct := child.Underlying().(*types.Struct); isStruct && !b.cfg.OmitSliceElementPointers {
 			child = types.NewPointer(child)
 		}
 		return types.NewSlice(child)

--- a/codegen/config/binder_test.go
+++ b/codegen/config/binder_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vektah/gqlparser"
+	"github.com/vektah/gqlparser/ast"
+)
+
+func TestSlicePointerBinding(t *testing.T) {
+	t.Run("without OmitSliceElementPointers", func(t *testing.T) {
+		binder, schema := createBinder(Config{
+			OmitSliceElementPointers: false,
+		})
+
+		ta, err := binder.TypeReference(schema.Query.Fields.ForName("messages").Type, nil)
+		if err != nil {
+			panic(err)
+		}
+
+		require.Equal(t, ta.GO.String(), "[]*github.com/99designs/gqlgen/example/chat.Message")
+	})
+
+	t.Run("with OmitSliceElementPointers", func(t *testing.T) {
+		binder, schema := createBinder(Config{
+			OmitSliceElementPointers: true,
+		})
+
+		ta, err := binder.TypeReference(schema.Query.Fields.ForName("messages").Type, nil)
+		if err != nil {
+			panic(err)
+		}
+
+		require.Equal(t, ta.GO.String(), "[]github.com/99designs/gqlgen/example/chat.Message")
+	})
+}
+
+func createBinder(cfg Config) (*Binder, *ast.Schema) {
+	cfg.Models = TypeMap{
+		"Message": TypeMapEntry{
+			Model: []string{"github.com/99designs/gqlgen/example/chat.Message"},
+		},
+	}
+
+	s := gqlparser.MustLoadSchema(&ast.Source{Name: "TestAutobinding.schema", Input: `
+		type Message { id: ID }
+
+		type Query {
+			messages: [Message!]!
+		}
+	`})
+
+	b, err := cfg.NewBinder(s)
+	if err != nil {
+		panic(err)
+	}
+
+	return b, s
+}

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -20,14 +20,15 @@ import (
 )
 
 type Config struct {
-	SchemaFilename StringList                 `yaml:"schema,omitempty"`
-	Exec           PackageConfig              `yaml:"exec"`
-	Model          PackageConfig              `yaml:"model"`
-	Resolver       PackageConfig              `yaml:"resolver,omitempty"`
-	AutoBind       []string                   `yaml:"autobind"`
-	Models         TypeMap                    `yaml:"models,omitempty"`
-	StructTag      string                     `yaml:"struct_tag,omitempty"`
-	Directives     map[string]DirectiveConfig `yaml:"directives,omitempty"`
+	SchemaFilename           StringList                 `yaml:"schema,omitempty"`
+	Exec                     PackageConfig              `yaml:"exec"`
+	Model                    PackageConfig              `yaml:"model"`
+	Resolver                 PackageConfig              `yaml:"resolver,omitempty"`
+	AutoBind                 []string                   `yaml:"autobind"`
+	Models                   TypeMap                    `yaml:"models,omitempty"`
+	StructTag                string                     `yaml:"struct_tag,omitempty"`
+	Directives               map[string]DirectiveConfig `yaml:"directives,omitempty"`
+	OmitSliceElementPointers bool                       `yaml:"omit_slice_element_pointers,omitempty"`
 }
 
 var cfgFilenames = []string{".gqlgen.yml", "gqlgen.yml", "gqlgen.yaml"}

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -44,6 +44,9 @@ resolver:
 # Optional, turns on binding to field names by tag provided
 struct_tag: json
 
+# Optional, set to true if you prefer []*Thing over []Thing
+omit_slice_element_pointers: false
+
 # Instead of listing out every model like below, you can automatically bind to any matching types
 # within the given path by using `model: User` or `model: models.User`. EXPERIMENTAL in v0.9.1
 autobind:


### PR DESCRIPTION
To help compatibility with prisma there is now a setting in config to `omit_slice_element_pointers: true` which will generate `[]Thing` instead of `[]*Thing` everywhere. 

fixes https://github.com/99designs/gqlgen/issues/738

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
