### PR TITLE
Fixed broken GitHub link within the APQ page

### DIFF
--- a/docs/content/reference/apq.md
+++ b/docs/content/reference/apq.md
@@ -19,7 +19,7 @@ In order to enable Automatic Persisted Queries you need to change your client. F
 For the server you need to implement `PersistedQueryCache` interface and pass instance to 
 `handler.EnablePersistedQueryCache` option.
 
-See example using [go-redis](github.com/go-redis/redis) package below:
+See example using [go-redis](https://github.com/go-redis/redis) package below:
 ```go
 import (
 	"context"


### PR DESCRIPTION
The link to the [go-redis](https://github.com/go-redis/redis) is currently broken and redirect to https://gqlgen.com/reference/apq/github.com/go-redis/redis which is an invalid page.

I assumed you meant for it to redirect to the GitHub page so I added the https part of the URL :) 

Describe your PR and link to any relevant issues. 

I have:
 - [ ] **N/A** Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content)) 
