### PR TITLE
Use autobinding in testserver

### DIFF
--- a/codegen/testserver/complexity.graphql
+++ b/codegen/testserver/complexity.graphql
@@ -3,9 +3,9 @@ extend type Query {
 }
 
 type OverlappingFields {
-  oneFoo: Int!
-  twoFoo: Int!
-  oldFoo: Int!
+  oneFoo: Int! @goField(name: "foo")
+  twoFoo: Int! @goField(name: "foo")
+  oldFoo: Int! @goField(name: "foo", forceResolver: true)
   newFoo: Int!
   new_foo: Int!
 }

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -1461,9 +1461,9 @@ type Map {
 }
 
 type OverlappingFields {
-  oneFoo: Int!
-  twoFoo: Int!
-  oldFoo: Int!
+  oneFoo: Int! @goField(name: "foo")
+  twoFoo: Int! @goField(name: "foo")
+  oldFoo: Int! @goField(name: "foo", forceResolver: true)
   newFoo: Int!
   new_foo: Int!
 }
@@ -1536,7 +1536,7 @@ type Rectangle implements Shape {
     width: Float
     area: Float
 }
-union ShapeUnion = Circle | Rectangle
+union ShapeUnion @goModel(model:"testserver.ShapeUnion") = Circle | Rectangle
 
 directive @makeNil on FIELD_DEFINITION
 `},
@@ -1553,12 +1553,12 @@ type LoopB {
     mapNestedStringInterface(in: NestedMapInput): MapStringInterfaceType
 }
 
-type MapStringInterfaceType {
+type MapStringInterfaceType @goModel(model: "map[string]interface{}") {
     a: String
     b: Int
 }
 
-input MapStringInterfaceInput {
+input MapStringInterfaceInput @goModel(model: "map[string]interface{}") {
     a: String
     b: Int
 }
@@ -1628,7 +1628,10 @@ type EmbeddedDefaultScalar {
     value: DefaultScalarImplementation
 }
 `},
-	&ast.Source{Name: "schema.graphql", Input: `type Query {
+	&ast.Source{Name: "schema.graphql", Input: `directive @goModel(model: String, models: [String!]) on OBJECT | INPUT_OBJECT | SCALAR | ENUM | INTERFACE | UNION
+directive @goField(forceResolver: Boolean, name: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+
+type Query {
     invalidIdentifier: InvalidIdentifier
     collision: It
     mapInput(input: Changes): Boolean
@@ -1651,7 +1654,7 @@ type Subscription {
 
 type User {
     id: Int!
-    friends: [User!]!
+    friends: [User!]! @goField(forceResolver: true)
     created: Time!
     updated: Time
 }
@@ -1679,7 +1682,7 @@ type It {
     id: ID!
 }
 
-input Changes {
+input Changes @goModel(model:"map[string]interface{}") {
     a: Int
     b: Int
 }
@@ -1696,7 +1699,7 @@ input OuterInput {
     inner: InnerInput!
 }
 
-scalar ThirdParty
+scalar ThirdParty @goModel(model:"testserver.ThirdParty")
 
 type OuterObject {
     inner: InnerObject!
@@ -1707,10 +1710,10 @@ type InnerObject {
 }
 
 type ForcedResolver {
-    field: Circle
+    field: Circle @goField(forceResolver: true)
 }
 
-type EmbeddedPointer {
+type EmbeddedPointer @goModel(model:"testserver.EmbeddedPointerModel") {
     ID: String
     Title: String
 }
@@ -1769,7 +1772,7 @@ extend type Query {
 """ These things are all valid, but without care generate invalid go code """
 type ValidType {
     differentCase: String!
-    different_case: String!
+    different_case: String! @goField(name:"DifferentCaseOld")
     validInputKeywords(input: ValidInput): Boolean!
     validArgs(
         break:       String!,
@@ -1827,7 +1830,7 @@ input ValidInput {
     import:      String!
     return:      String!
     var:         String!
-    _:           String!
+    _:           String! @goField(name: "Underscore")
 }
 
 # see https://github.com/99designs/gqlgen/issues/694

--- a/codegen/testserver/gqlgen.yml
+++ b/codegen/testserver/gqlgen.yml
@@ -9,76 +9,8 @@ resolver:
   filename: resolver.go
   type: Resolver
 
-models:
-  It:
-    model: "github.com/99designs/gqlgen/codegen/testserver/introspection.It"
-  ModelMethods:
-    model: "github.com/99designs/gqlgen/codegen/testserver.ModelMethods"
-  InvalidIdentifier:
-    model: "github.com/99designs/gqlgen/codegen/testserver/invalid-packagename.InvalidIdentifier"
-  Changes:
-    model: "map[string]interface{}"
-  RecursiveInputSlice:
-    model: "github.com/99designs/gqlgen/codegen/testserver.RecursiveInputSlice"
-  Shape:
-    model: "github.com/99designs/gqlgen/codegen/testserver.Shape"
-  ShapeUnion:
-    model: "github.com/99designs/gqlgen/codegen/testserver.ShapeUnion"
-  Circle:
-    model: "github.com/99designs/gqlgen/codegen/testserver.Circle"
-  Rectangle:
-    model: "github.com/99designs/gqlgen/codegen/testserver.Rectangle"
-  ForcedResolver:
-    model: "github.com/99designs/gqlgen/codegen/testserver.ForcedResolver"
-    fields:
-      field: { resolver: true }
-  User:
-    fields:
-      friends: { resolver: true }
-  Error:
-    model: "github.com/99designs/gqlgen/codegen/testserver.Error"
-  Errors:
-    model: "github.com/99designs/gqlgen/codegen/testserver.Errors"
-  EmbeddedPointer:
-    model: "github.com/99designs/gqlgen/codegen/testserver.EmbeddedPointerModel"
-  ThirdParty:
-    model: "github.com/99designs/gqlgen/codegen/testserver.ThirdParty"
-  Keywords:
-    fields:
-      _: { fieldName: Underscore }
-  ValidInput:
-    fields:
-      _: { fieldName: Underscore }
-  ValidType:
-    fields:
-      different_case: { fieldName: DifferentCaseOld }
-  Panics:
-    model: "github.com/99designs/gqlgen/codegen/testserver.Panics"
-  MarshalPanic:
-    model: "github.com/99designs/gqlgen/codegen/testserver.MarshalPanic"
-  Autobind:
-    model: "github.com/99designs/gqlgen/codegen/testserver.Autobind"
-  Primitive:
-    model: "github.com/99designs/gqlgen/codegen/testserver.Primitive"
-  PrimitiveString:
-    model: "github.com/99designs/gqlgen/codegen/testserver.PrimitiveString"
-  MapStringInterfaceInput:
-    model: "map[string]interface{}"
-  MapStringInterfaceType:
-    model: "map[string]interface{}"
-  OverlappingFields:
-    model: "github.com/99designs/gqlgen/codegen/testserver.OverlappingFields"
-    fields:
-      oneFoo: { fieldName: foo }
-      twoFoo: { fieldName: foo }
-      oldFoo: { fieldName: foo, resolver: true }
-  ObjectDirectivesWithCustomGoModel:
-    model: "github.com/99designs/gqlgen/codegen/testserver.ObjectDirectivesWithCustomGoModel"
-  FallbackToStringEncoding:
-    model: "github.com/99designs/gqlgen/codegen/testserver.FallbackToStringEncoding"
-  Bytes:
-    model: "github.com/99designs/gqlgen/codegen/testserver.Bytes"
-  WrappedStruct:
-    model: "github.com/99designs/gqlgen/codegen/testserver.WrappedStruct"
-  WrappedScalar:
-    model: "github.com/99designs/gqlgen/codegen/testserver.WrappedScalar"
+autobind:
+  - "github.com/99designs/gqlgen/codegen/testserver"
+  - "github.com/99designs/gqlgen/codegen/testserver/introspection"
+  - "github.com/99designs/gqlgen/codegen/testserver/invalid-packagename"
+

--- a/codegen/testserver/interfaces.graphql
+++ b/codegen/testserver/interfaces.graphql
@@ -15,6 +15,6 @@ type Rectangle implements Shape {
     width: Float
     area: Float
 }
-union ShapeUnion = Circle | Rectangle
+union ShapeUnion @goModel(model:"testserver.ShapeUnion") = Circle | Rectangle
 
 directive @makeNil on FIELD_DEFINITION

--- a/codegen/testserver/maps.graphql
+++ b/codegen/testserver/maps.graphql
@@ -3,12 +3,12 @@ extend type Query {
     mapNestedStringInterface(in: NestedMapInput): MapStringInterfaceType
 }
 
-type MapStringInterfaceType {
+type MapStringInterfaceType @goModel(model: "map[string]interface{}") {
     a: String
     b: Int
 }
 
-input MapStringInterfaceInput {
+input MapStringInterfaceInput @goModel(model: "map[string]interface{}") {
     a: String
     b: Int
 }

--- a/codegen/testserver/models.go
+++ b/codegen/testserver/models.go
@@ -102,3 +102,5 @@ type PrimitiveString string
 func (s PrimitiveString) Doubled() string {
 	return string(s) + string(s)
 }
+
+type Bytes []byte

--- a/codegen/testserver/schema.graphql
+++ b/codegen/testserver/schema.graphql
@@ -1,3 +1,6 @@
+directive @goModel(model: String, models: [String!]) on OBJECT | INPUT_OBJECT | SCALAR | ENUM | INTERFACE | UNION
+directive @goField(forceResolver: Boolean, name: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+
 type Query {
     invalidIdentifier: InvalidIdentifier
     collision: It
@@ -21,7 +24,7 @@ type Subscription {
 
 type User {
     id: Int!
-    friends: [User!]!
+    friends: [User!]! @goField(forceResolver: true)
     created: Time!
     updated: Time
 }
@@ -49,7 +52,7 @@ type It {
     id: ID!
 }
 
-input Changes {
+input Changes @goModel(model:"map[string]interface{}") {
     a: Int
     b: Int
 }
@@ -66,7 +69,7 @@ input OuterInput {
     inner: InnerInput!
 }
 
-scalar ThirdParty
+scalar ThirdParty @goModel(model:"testserver.ThirdParty")
 
 type OuterObject {
     inner: InnerObject!
@@ -77,10 +80,10 @@ type InnerObject {
 }
 
 type ForcedResolver {
-    field: Circle
+    field: Circle @goField(forceResolver: true)
 }
 
-type EmbeddedPointer {
+type EmbeddedPointer @goModel(model:"testserver.EmbeddedPointerModel") {
     ID: String
     Title: String
 }

--- a/codegen/testserver/validtypes.graphql
+++ b/codegen/testserver/validtypes.graphql
@@ -5,7 +5,7 @@ extend type Query {
 """ These things are all valid, but without care generate invalid go code """
 type ValidType {
     differentCase: String!
-    different_case: String!
+    different_case: String! @goField(name:"DifferentCaseOld")
     validInputKeywords(input: ValidInput): Boolean!
     validArgs(
         break:       String!,
@@ -63,7 +63,7 @@ input ValidInput {
     import:      String!
     return:      String!
     var:         String!
-    _:           String!
+    _:           String! @goField(name: "Underscore")
 }
 
 # see https://github.com/99designs/gqlgen/issues/694


### PR DESCRIPTION
Removes the central testserver config as much as possible in favour of directives. The only changes to generated.go are in the schema so this should be a 1:1 replacement.

This hopefully makes it easier to see what's being tested in each of these files.