### PR TITLE
Gracefully handle invalid types from invalid go packages

### DIFF
--- a/api/generate.go
+++ b/api/generate.go
@@ -38,11 +38,11 @@ func Generate(cfg *config.Config, option ...Option) error {
 	// Merge again now that the generated models have been injected into the typemap
 	data, err := codegen.BuildData(cfg)
 	if err != nil {
-		return errors.Wrap(err, "merging failed")
+		return errors.Wrap(err, "merging type systems failed")
 	}
 
 	if err = codegen.GenerateCode(data); err != nil {
-		return errors.Wrap(err, "generating core failed")
+		return errors.Wrap(err, "generating code failed")
 	}
 
 	for _, p := range plugins {

--- a/codegen/config/binder_test.go
+++ b/codegen/config/binder_test.go
@@ -1,13 +1,19 @@
 package config
 
 import (
+	"go/types"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"github.com/vektah/gqlparser"
 	"github.com/vektah/gqlparser/ast"
 )
+
+func TestBindingToInvalid(t *testing.T) {
+	binder, schema := createBinder(Config{})
+	_, err := binder.TypeReference(schema.Query.Fields.ForName("messages").Type, &types.Basic{})
+	require.EqualError(t, err, "Message has an invalid type")
+}
 
 func TestSlicePointerBinding(t *testing.T) {
 	t.Run("without OmitSliceElementPointers", func(t *testing.T) {

--- a/codegen/data.go
+++ b/codegen/data.go
@@ -133,6 +133,16 @@ func BuildData(cfg *config.Config) (*Data, error) {
 		return s.Inputs[i].Definition.Name < s.Inputs[j].Definition.Name
 	})
 
+	if b.Binder.SawInvalid {
+		// if we have a syntax error, show it
+		if len(b.Binder.PkgErrors) > 0 {
+			return nil, b.Binder.PkgErrors
+		}
+
+		// otherwise show a generic error message
+		return nil, fmt.Errorf("invalid types were encountered while traversing the go source code, this probably means the invalid code generated isnt correct. add try adding -v to debug")
+	}
+
 	return &s, nil
 }
 

--- a/codegen/field.go
+++ b/codegen/field.go
@@ -74,12 +74,12 @@ func (b *builder) buildField(obj *Object, field *ast.FieldDefinition) (*Field, e
 	return &f, nil
 }
 
-func (b *builder) bindField(obj *Object, f *Field) error {
+func (b *builder) bindField(obj *Object, f *Field) (errret error) {
 	defer func() {
 		if f.TypeReference == nil {
 			tr, err := b.Binder.TypeReference(f.Type, nil)
 			if err != nil {
-				panic(err)
+				errret = err
 			}
 			f.TypeReference = tr
 		}


### PR DESCRIPTION
gqlgen has to be able to deal with importing partially broken packages as this often caused during model regeneration (they get deleted, things depending on them become invalid). This works fine 99% of the time, as long as everything we need to build the graph is still valid.

#880 hits an exception where the generated models are in a directory that contains an empty go file (one without a matching package stanza) and causes all imports in the package to become invalid.

I've hooked the binder to remember if it saw any invalid tokens and fail at the end with any package load errors to make debugging these issues easier in the future.

eg:
```
$ go run github.com/99designs/gqlgen
merging type systems failed: packages.Load: -: 
foo.go:1:1: expected 'package', found 'EOF'
/home/vektah/projects/99designs/foobar/models_gen.go:6:2: could not import time (no metadata for time)
/home/vektah/projects/99designs/foobar/resolver.go:4:2: could not import context (no metadata for context)
/home/vektah/projects/99designs/foobar/resolver.go:9:31: undeclared name: MutationResolver
/home/vektah/projects/99designs/foobar/resolver.go:12:28: undeclared name: QueryResolver
```

fixes https://github.com/99designs/gqlgen/issues/880

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
