### PR TITLE
fix init not use custom schema filename

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -113,6 +113,7 @@ func initConfig(ctx *cli.Context) {
 		Filename: "resolver.go",
 		Type:     "Resolver",
 	}
+	cfg.SchemaFilename = config.StringList{ctx.String("schema")}
 
 	var buf bytes.Buffer
 	buf.WriteString(strings.TrimSpace(configComment))


### PR DESCRIPTION
init command ignores custom schema filename from `--schema` option and uses default schema filename.