### PR TITLE
Add possibility to hook into modelgen plugin

### DIFF
--- a/docs/content/recipes/modelgen-hook.md
+++ b/docs/content/recipes/modelgen-hook.md
@@ -1,0 +1,79 @@
+---
+title: "Allowing mutation of generated models before rendering"
+description: How to use a model mutation function to insert a ORM-specific tags onto struct fields.
+linkTitle: "Modelgen hook"
+menu: { main: { parent: 'recipes' } }
+---
+
+The following recipe shows how to use a `modelgen` plugin hook to mutate generated
+models before they are rendered into a resulting file. This feature has many uses but
+the example focuses only on inserting ORM-specific tags into generated struct fields. This
+is a common use case since it allows for better field matching of DB queries and
+the generated data structure.
+
+First of all, we need to create a function that will mutate the generated model.
+Then we can attach the function to the plugin and use it like any other plugin.
+
+``` go
+import (
+	"fmt"
+	"os"
+
+	"github.com/99designs/gqlgen/api"
+	"github.com/99designs/gqlgen/codegen/config"
+	"github.com/99designs/gqlgen/plugin/modelgen"
+)
+
+// Defining mutation function
+func mutateHook(b *ModelBuild) *ModelBuild {
+	for _, model := range b.Models {
+		for _, field := range model.Fields {
+			field.Tag += ` orm_binding:"` + model.Name + `.` +  field.Name + `"`
+		}
+	}
+
+	return b
+}
+
+func main() {
+	cfg, err := config.LoadConfigFromDefaultLocations()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to load config", err.Error())
+		os.Exit(2)
+	}
+
+	// Attaching the mutation function onto modelgen plugin
+	p := modelgen.Plugin{
+		MutateHook: mutateHook,
+	}
+
+	err = api.Generate(cfg,
+		api.NoPlugins(),
+		api.AddPlugin(p),
+	)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(3)
+	}
+}
+```
+
+Now fields from generated models will contain a additional tag `orm_binding`.
+
+This schema:
+
+```graphql
+type Object {
+    field1: String
+    field2: Int
+}
+```
+
+Will gen generated into:
+
+```go
+type Object struct {
+	field1 *string  `json:"field1" orm_binding:"Object.field1"`
+	field2 *int     `json:"field2" orm_binding:"Object.field2"`
+}
+```

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -1,7 +1,6 @@
 package modelgen
 
 import (
-	"go/ast"
 	"go/parser"
 	"go/token"
 	"io/ioutil"
@@ -47,18 +46,20 @@ func TestModelGeneration(t *testing.T) {
 	})
 
 	t.Run("tags are applied", func(t *testing.T) {
-		node, err := parser.ParseFile(token.NewFileSet(), "./out/generated.go", nil, 0)
+		file, err := ioutil.ReadFile("./out/generated.go")
 		require.NoError(t, err)
-		for _, obj := range node.Scope.Objects {
-			if spec, ok := (obj.Decl).(*ast.TypeSpec); ok {
-				if st, ok := (spec.Type).(*ast.StructType); ok {
-					for _, field := range st.Fields.List {
-						fieldName := strings.ToLower(field.Names[0].String())
-						expectedTag := "`json:\"" + fieldName + "\" database:\"" + spec.Name.String() + fieldName + "\"`"
-						require.True(t, field.Tag.Value == expectedTag)
-					}
-				}
-			}
+
+		fileText := string(file)
+
+		expectedTags := []string{
+			`json:"missing2" database:"MissingTypeNotNullmissing2"`,
+			`json:"name" database:"MissingInputname"`,
+			`json:"missing2" database:"MissingTypeNullablemissing2"`,
+			`json:"name" database:"TypeWithDescriptionname"`,
+		}
+
+		for _, tag := range expectedTags {
+			require.True(t, strings.Contains(fileText, tag))
 		}
 	})
 }

--- a/plugin/modelgen/out/generated.go
+++ b/plugin/modelgen/out/generated.go
@@ -27,16 +27,16 @@ type UnionWithDescription interface {
 }
 
 type MissingInput struct {
-	Name *string      `json:"name"`
-	Enum *MissingEnum `json:"enum"`
+	Name *string      `json:"name" database:"MissingInputname"`
+	Enum *MissingEnum `json:"enum" database:"MissingInputenum"`
 }
 
 type MissingTypeNotNull struct {
-	Name     string               `json:"name"`
-	Enum     MissingEnum          `json:"enum"`
-	Int      MissingInterface     `json:"int"`
-	Existing *ExistingType        `json:"existing"`
-	Missing2 *MissingTypeNullable `json:"missing2"`
+	Name     string               `json:"name" database:"MissingTypeNotNullname"`
+	Enum     MissingEnum          `json:"enum" database:"MissingTypeNotNullenum"`
+	Int      MissingInterface     `json:"int" database:"MissingTypeNotNullint"`
+	Existing *ExistingType        `json:"existing" database:"MissingTypeNotNullexisting"`
+	Missing2 *MissingTypeNullable `json:"missing2" database:"MissingTypeNotNullmissing2"`
 }
 
 func (MissingTypeNotNull) IsMissingInterface()  {}
@@ -45,11 +45,11 @@ func (MissingTypeNotNull) IsMissingUnion()      {}
 func (MissingTypeNotNull) IsExistingUnion()     {}
 
 type MissingTypeNullable struct {
-	Name     *string             `json:"name"`
-	Enum     *MissingEnum        `json:"enum"`
-	Int      MissingInterface    `json:"int"`
-	Existing *ExistingType       `json:"existing"`
-	Missing2 *MissingTypeNotNull `json:"missing2"`
+	Name     *string             `json:"name" database:"MissingTypeNullablename"`
+	Enum     *MissingEnum        `json:"enum" database:"MissingTypeNullableenum"`
+	Int      MissingInterface    `json:"int" database:"MissingTypeNullableint"`
+	Existing *ExistingType       `json:"existing" database:"MissingTypeNullableexisting"`
+	Missing2 *MissingTypeNotNull `json:"missing2" database:"MissingTypeNullablemissing2"`
 }
 
 func (MissingTypeNullable) IsMissingInterface()  {}
@@ -59,7 +59,7 @@ func (MissingTypeNullable) IsExistingUnion()     {}
 
 // TypeWithDescription is a type with a description
 type TypeWithDescription struct {
-	Name *string `json:"name"`
+	Name *string `json:"name" database:"TypeWithDescriptionname"`
 }
 
 func (TypeWithDescription) IsUnionWithDescription() {}


### PR DESCRIPTION
I realize there already is a branch [modelgen-structtags](https://github.com/99designs/gqlgen/tree/modelgen-structtags) for the mentioned issue and for what this change tries to accomplish. I'm opening a PR nonetheless at least as a suggestion since the feature has more general implications (possibility to mutate the whole generated models before rendering). Feel free to close this if the mentioned branch is close to solving the issue.

---

This change introduces option to implement custom hook for model
generation plugin without the need to completly copy the whole `modelgen` plugin.

One very possible case is as described in #876 and with this change the solution for
that can be:

```golang
func mutateHook(b *ModelBuild) *ModelBuild {
	for _, model := range b.Models {
		for _, field := range model.Fields {
			field.Tag += ` orm_binding:"` + model.Name + `.`  +  field.Name + `"`
		}
	}

	return b
}

...

func main() {
    p := modelgen.Plugin {
        MutateHook: mutateHook,
    }

    ...
}

```

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
