### PR TITLE
Add support for int64 IDs

### DIFF
--- a/graphql/id.go
+++ b/graphql/id.go
@@ -20,6 +20,8 @@ func UnmarshalID(v interface{}) (string, error) {
 		return string(v), nil
 	case int:
 		return strconv.Itoa(v), nil
+	case int64:
+		return strconv.Itoa((int(v))), nil
 	case float64:
 		return fmt.Sprintf("%f", v), nil
 	case bool:

--- a/graphql/id.go
+++ b/graphql/id.go
@@ -21,7 +21,7 @@ func UnmarshalID(v interface{}) (string, error) {
 	case int:
 		return strconv.Itoa(v), nil
 	case int64:
-		return strconv.Itoa(int(v)), nil
+		return strconv.FormatInt(v, 10), nil
 	case float64:
 		return fmt.Sprintf("%f", v), nil
 	case bool:

--- a/graphql/id.go
+++ b/graphql/id.go
@@ -21,7 +21,7 @@ func UnmarshalID(v interface{}) (string, error) {
 	case int:
 		return strconv.Itoa(v), nil
 	case int64:
-		return strconv.Itoa((int(v))), nil
+		return strconv.Itoa(int(v)), nil
 	case float64:
 		return fmt.Sprintf("%f", v), nil
 	case bool:

--- a/graphql/id_test.go
+++ b/graphql/id_test.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,6 +19,16 @@ func TestMarshalID(t *testing.T) {
 			Input:       int64(12),
 			Expected:    "12",
 			ShouldError: false,
+		},
+		{
+			Name:     "int64 max",
+			Input:    math.MaxInt64,
+			Expected: "9223372036854775807",
+		},
+		{
+			Name:     "int64 min",
+			Input:    math.MinInt64,
+			Expected: "-9223372036854775808",
 		},
 	}
 

--- a/graphql/id_test.go
+++ b/graphql/id_test.go
@@ -1,0 +1,35 @@
+package graphql
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMarshalID(t *testing.T) {
+	tests := []struct {
+		Name string
+		Input interface{}
+		Expected string
+		ShouldError bool
+	}{
+		{
+			Name: "int64",
+			Input: int64(12),
+			Expected: "12",
+			ShouldError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			id, err := UnmarshalID(tt.Input)
+
+			assert.Equal(t, tt.Expected, id)
+			if tt.ShouldError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/graphql/id_test.go
+++ b/graphql/id_test.go
@@ -1,21 +1,22 @@
 package graphql
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMarshalID(t *testing.T) {
 	tests := []struct {
-		Name string
-		Input interface{}
-		Expected string
+		Name        string
+		Input       interface{}
+		Expected    string
 		ShouldError bool
 	}{
 		{
-			Name: "int64",
-			Input: int64(12),
-			Expected: "12",
+			Name:        "int64",
+			Input:       int64(12),
+			Expected:    "12",
 			ShouldError: false,
 		},
 	}


### PR DESCRIPTION
Based on the [GraphQL Spec](https://graphql.github.io/graphql-spec/June2018/#sec-ID), Input ID types should be coerced into strings if provided as an integer during input. In a local GraphQL API we started getting "int64 is not a string" errors when trying to pass an integer in as a resolver ID parameter while using the default graphql.ID type. We were able to recreate this behavior using the gqlgen starwars example project as well. This error does _not_ happen while using graphql.IntID type for marshalling.

This PR adds an int64 case to the MarshalID method, which appears to resolve the issue in my quick smoke test.

Let me know if you want me to update the formatting for the test, since it looks like it diverges from the repo style.

Related Issues:
* #798

I have:
 - [*] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [*] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
