### PR TITLE
Don't crash when interface resolver returns a typed nil

### DIFF
--- a/codegen/interface.gotpl
+++ b/codegen/interface.gotpl
@@ -10,6 +10,9 @@ func (ec *executionContext) _{{$interface.Name}}(ctx context.Context, sel ast.Se
 				return ec._{{$implementor.Name}}(ctx, sel, &obj)
 		{{- end}}
 		case *{{$implementor.Type | ref}}:
+			if obj == nil {
+				return graphql.Null
+			}
 			return ec._{{$implementor.Name}}(ctx, sel, obj)
 	{{- end }}
 	default:

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -98,6 +98,11 @@ type ComplexityRoot struct {
 		ID func(childComplexity int) int
 	}
 
+	Cat struct {
+		CatBreed func(childComplexity int) int
+		Species  func(childComplexity int) int
+	}
+
 	CheckIssue896 struct {
 		ID func(childComplexity int) int
 	}
@@ -113,6 +118,11 @@ type ComplexityRoot struct {
 
 	ContentUser struct {
 		Foo func(childComplexity int) int
+	}
+
+	Dog struct {
+		DogBreed func(childComplexity int) int
+		Species  func(childComplexity int) int
 	}
 
 	EmbeddedCase1 struct {
@@ -227,6 +237,7 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
+		Animal                           func(childComplexity int) int
 		Autobind                         func(childComplexity int) int
 		Collision                        func(childComplexity int) int
 		DefaultScalar                    func(childComplexity int, arg string) int
@@ -398,6 +409,7 @@ type QueryResolver interface {
 	Shapes(ctx context.Context) ([]Shape, error)
 	NoShape(ctx context.Context) (Shape, error)
 	NoShapeTypedNil(ctx context.Context) (Shape, error)
+	Animal(ctx context.Context) (Animal, error)
 	Issue896a(ctx context.Context) ([]*CheckIssue896, error)
 	MapStringInterface(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error)
 	MapNestedStringInterface(ctx context.Context, in *NestedMapInput) (map[string]interface{}, error)
@@ -507,6 +519,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.B.ID(childComplexity), true
 
+	case "Cat.catBreed":
+		if e.complexity.Cat.CatBreed == nil {
+			break
+		}
+
+		return e.complexity.Cat.CatBreed(childComplexity), true
+
+	case "Cat.species":
+		if e.complexity.Cat.Species == nil {
+			break
+		}
+
+		return e.complexity.Cat.Species(childComplexity), true
+
 	case "CheckIssue896.id":
 		if e.complexity.CheckIssue896.ID == nil {
 			break
@@ -541,6 +567,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ContentUser.Foo(childComplexity), true
+
+	case "Dog.dogBreed":
+		if e.complexity.Dog.DogBreed == nil {
+			break
+		}
+
+		return e.complexity.Dog.DogBreed(childComplexity), true
+
+	case "Dog.species":
+		if e.complexity.Dog.Species == nil {
+			break
+		}
+
+		return e.complexity.Dog.Species(childComplexity), true
 
 	case "EmbeddedCase1.exportedEmbeddedPointerExportedMethod":
 		if e.complexity.EmbeddedCase1.ExportedEmbeddedPointerExportedMethod == nil {
@@ -845,6 +885,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PrimitiveString.Value(childComplexity), true
+
+	case "Query.animal":
+		if e.complexity.Query.Animal == nil {
+			break
+		}
+
+		return e.complexity.Query.Animal(childComplexity), true
 
 	case "Query.autobind":
 		if e.complexity.Query.Autobind == nil {
@@ -1668,6 +1715,21 @@ extend type Query {
     shapes: [Shape]
     noShape: Shape @makeNil
     noShapeTypedNil: Shape @makeTypedNil
+    animal: Animal @makeTypedNil
+}
+
+interface Animal {
+    species: String!
+}
+
+type Dog implements Animal {
+    species: String!
+    dogBreed: String!
+}
+
+type Cat implements Animal {
+    species: String!
+    catBreed: String!
 }
 
 interface Shape {
@@ -3210,6 +3272,74 @@ func (ec *executionContext) _B_id(ctx context.Context, field graphql.CollectedFi
 	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Cat_species(ctx context.Context, field graphql.CollectedField, obj *Cat) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Cat",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Species, nil
+	})
+
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Cat_catBreed(ctx context.Context, field graphql.CollectedField, obj *Cat) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Cat",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CatBreed, nil
+	})
+
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _CheckIssue896_id(ctx context.Context, field graphql.CollectedField, obj *CheckIssue896) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
@@ -3363,6 +3493,74 @@ func (ec *executionContext) _Content_User_foo(ctx context.Context, field graphql
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
 	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Dog_species(ctx context.Context, field graphql.CollectedField, obj *Dog) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Dog",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Species, nil
+	})
+
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Dog_dogBreed(ctx context.Context, field graphql.CollectedField, obj *Dog) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Dog",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DogBreed, nil
+	})
+
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _EmbeddedCase1_exportedEmbeddedPointerExportedMethod(ctx context.Context, field graphql.CollectedField, obj *EmbeddedCase1) (ret graphql.Marshaler) {
@@ -6151,6 +6349,57 @@ func (ec *executionContext) _Query_noShapeTypedNil(ctx context.Context, field gr
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
 	return ec.marshalOShape2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐShape(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_animal(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Query",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Query().Animal(rctx)
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			if ec.directives.MakeTypedNil == nil {
+				return nil, errors.New("directive makeTypedNil is not implemented")
+			}
+			return ec.directives.MakeTypedNil(ctx, nil, directive0)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, err
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(Animal); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be github.com/99designs/gqlgen/codegen/testserver.Animal`, tmp)
+	})
+
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(Animal)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOAnimal2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐAnimal(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_issue896a(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -9286,6 +9535,29 @@ func (ec *executionContext) unmarshalInputValidInput(ctx context.Context, obj in
 
 // region    ************************** interface.gotpl ***************************
 
+func (ec *executionContext) _Animal(ctx context.Context, sel ast.SelectionSet, obj Animal) graphql.Marshaler {
+	switch obj := (obj).(type) {
+	case nil:
+		return graphql.Null
+	case Dog:
+		return ec._Dog(ctx, sel, &obj)
+	case *Dog:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Dog(ctx, sel, obj)
+	case Cat:
+		return ec._Cat(ctx, sel, &obj)
+	case *Cat:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Cat(ctx, sel, obj)
+	default:
+		panic(fmt.Errorf("unexpected type %T", obj))
+	}
+}
+
 func (ec *executionContext) _Content_Child(ctx context.Context, sel ast.SelectionSet, obj ContentChild) graphql.Marshaler {
 	switch obj := (obj).(type) {
 	case nil:
@@ -9529,6 +9801,38 @@ func (ec *executionContext) _B(ctx context.Context, sel ast.SelectionSet, obj *B
 	return out
 }
 
+var catImplementors = []string{"Cat", "Animal"}
+
+func (ec *executionContext) _Cat(ctx context.Context, sel ast.SelectionSet, obj *Cat) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.RequestContext, sel, catImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Cat")
+		case "species":
+			out.Values[i] = ec._Cat_species(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "catBreed":
+			out.Values[i] = ec._Cat_catBreed(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var checkIssue896Implementors = []string{"CheckIssue896"}
 
 func (ec *executionContext) _CheckIssue896(ctx context.Context, sel ast.SelectionSet, obj *CheckIssue896) graphql.Marshaler {
@@ -9616,6 +9920,38 @@ func (ec *executionContext) _Content_User(ctx context.Context, sel ast.Selection
 			out.Values[i] = graphql.MarshalString("Content_User")
 		case "foo":
 			out.Values[i] = ec._Content_User_foo(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var dogImplementors = []string{"Dog", "Animal"}
+
+func (ec *executionContext) _Dog(ctx context.Context, sel ast.SelectionSet, obj *Dog) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.RequestContext, sel, dogImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Dog")
+		case "species":
+			out.Values[i] = ec._Dog_species(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "dogBreed":
+			out.Values[i] = ec._Dog_dogBreed(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -10844,6 +11180,17 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_noShapeTypedNil(ctx, field)
+				return res
+			})
+		case "animal":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_animal(ctx, field)
 				return res
 			})
 		case "issue896a":
@@ -12428,6 +12775,13 @@ func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel a
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) marshalOAnimal2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐAnimal(ctx context.Context, sel ast.SelectionSet, v Animal) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Animal(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOAutobind2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐAutobind(ctx context.Context, sel ast.SelectionSet, v Autobind) graphql.Marshaler {

--- a/codegen/testserver/interfaces.graphql
+++ b/codegen/testserver/interfaces.graphql
@@ -2,6 +2,21 @@ extend type Query {
     shapes: [Shape]
     noShape: Shape @makeNil
     noShapeTypedNil: Shape @makeTypedNil
+    animal: Animal @makeTypedNil
+}
+
+interface Animal {
+    species: String!
+}
+
+type Dog implements Animal {
+    species: String!
+    dogBreed: String!
+}
+
+type Cat implements Animal {
+    species: String!
+    catBreed: String!
 }
 
 interface Shape {

--- a/codegen/testserver/interfaces.graphql
+++ b/codegen/testserver/interfaces.graphql
@@ -1,6 +1,7 @@
 extend type Query {
     shapes: [Shape]
     noShape: Shape @makeNil
+    noShapeTypedNil: Shape @makeTypedNil
 }
 
 interface Shape {
@@ -18,3 +19,4 @@ type Rectangle implements Shape {
 union ShapeUnion @goModel(model:"testserver.ShapeUnion") = Circle | Rectangle
 
 directive @makeNil on FIELD_DEFINITION
+directive @makeTypedNil on FIELD_DEFINITION

--- a/codegen/testserver/interfaces_test.go
+++ b/codegen/testserver/interfaces_test.go
@@ -76,7 +76,7 @@ func TestInterfaces(t *testing.T) {
 				Resolvers: resolvers,
 				Directives: DirectiveRoot{
 					MakeTypedNil: func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
-						var dog *Dog
+						var dog *Dog // return a typed nil, not just nil
 						return dog, nil
 					},
 				},

--- a/codegen/testserver/interfaces_test.go
+++ b/codegen/testserver/interfaces_test.go
@@ -40,4 +40,28 @@ func TestInterfaces(t *testing.T) {
 		var resp interface{}
 		c.MustPost(`{ noShape { area } }`, &resp)
 	})
+
+	t.Run("interfaces can be typed nil", func(t *testing.T) {
+		resolvers := &Stub{}
+		resolvers.QueryResolver.NoShapeTypedNil = func(ctx context.Context) (shapes Shape, e error) {
+			panic("should not be called")
+		}
+
+		srv := handler.GraphQL(
+			NewExecutableSchema(Config{
+				Resolvers: resolvers,
+				Directives: DirectiveRoot{
+					MakeTypedNil: func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+						var circle *Circle
+						return circle, nil
+					},
+				},
+			}),
+		)
+
+		c := client.New(srv)
+
+		var resp interface{}
+		c.MustPost(`{ noShapeTypedNil { area } }`, &resp)
+	})
 }

--- a/codegen/testserver/models-gen.go
+++ b/codegen/testserver/models-gen.go
@@ -9,6 +9,10 @@ import (
 	"time"
 )
 
+type Animal interface {
+	IsAnimal()
+}
+
 type ContentChild interface {
 	IsContentChild()
 }
@@ -37,6 +41,13 @@ type B struct {
 
 func (B) IsTestUnion() {}
 
+type Cat struct {
+	Species  string `json:"species"`
+	CatBreed string `json:"catBreed"`
+}
+
+func (Cat) IsAnimal() {}
+
 type CheckIssue896 struct {
 	ID *int `json:"id"`
 }
@@ -52,6 +63,13 @@ type ContentUser struct {
 }
 
 func (ContentUser) IsContentChild() {}
+
+type Dog struct {
+	Species  string `json:"species"`
+	DogBreed string `json:"dogBreed"`
+}
+
+func (Dog) IsAnimal() {}
 
 type EmbeddedDefaultScalar struct {
 	Value *string `json:"value"`

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -200,6 +200,9 @@ func (r *queryResolver) NoShape(ctx context.Context) (Shape, error) {
 func (r *queryResolver) NoShapeTypedNil(ctx context.Context) (Shape, error) {
 	panic("not implemented")
 }
+func (r *queryResolver) Animal(ctx context.Context) (Animal, error) {
+	panic("not implemented")
+}
 func (r *queryResolver) Issue896a(ctx context.Context) ([]*CheckIssue896, error) {
 	panic("not implemented")
 }

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -197,6 +197,9 @@ func (r *queryResolver) Shapes(ctx context.Context) ([]Shape, error) {
 func (r *queryResolver) NoShape(ctx context.Context) (Shape, error) {
 	panic("not implemented")
 }
+func (r *queryResolver) NoShapeTypedNil(ctx context.Context) (Shape, error) {
+	panic("not implemented")
+}
 func (r *queryResolver) Issue896a(ctx context.Context) ([]*CheckIssue896, error) {
 	panic("not implemented")
 }

--- a/codegen/testserver/stub.go
+++ b/codegen/testserver/stub.go
@@ -69,6 +69,7 @@ type Stub struct {
 		EnumInInput                      func(ctx context.Context, input *InputWithEnumValue) (EnumTest, error)
 		Shapes                           func(ctx context.Context) ([]Shape, error)
 		NoShape                          func(ctx context.Context) (Shape, error)
+		NoShapeTypedNil                  func(ctx context.Context) (Shape, error)
 		Issue896a                        func(ctx context.Context) ([]*CheckIssue896, error)
 		MapStringInterface               func(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error)
 		MapNestedStringInterface         func(ctx context.Context, in *NestedMapInput) (map[string]interface{}, error)
@@ -286,6 +287,9 @@ func (r *stubQuery) Shapes(ctx context.Context) ([]Shape, error) {
 }
 func (r *stubQuery) NoShape(ctx context.Context) (Shape, error) {
 	return r.QueryResolver.NoShape(ctx)
+}
+func (r *stubQuery) NoShapeTypedNil(ctx context.Context) (Shape, error) {
+	return r.QueryResolver.NoShapeTypedNil(ctx)
 }
 func (r *stubQuery) Issue896a(ctx context.Context) ([]*CheckIssue896, error) {
 	return r.QueryResolver.Issue896a(ctx)

--- a/codegen/testserver/stub.go
+++ b/codegen/testserver/stub.go
@@ -70,6 +70,7 @@ type Stub struct {
 		Shapes                           func(ctx context.Context) ([]Shape, error)
 		NoShape                          func(ctx context.Context) (Shape, error)
 		NoShapeTypedNil                  func(ctx context.Context) (Shape, error)
+		Animal                           func(ctx context.Context) (Animal, error)
 		Issue896a                        func(ctx context.Context) ([]*CheckIssue896, error)
 		MapStringInterface               func(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error)
 		MapNestedStringInterface         func(ctx context.Context, in *NestedMapInput) (map[string]interface{}, error)
@@ -290,6 +291,9 @@ func (r *stubQuery) NoShape(ctx context.Context) (Shape, error) {
 }
 func (r *stubQuery) NoShapeTypedNil(ctx context.Context) (Shape, error) {
 	return r.QueryResolver.NoShapeTypedNil(ctx)
+}
+func (r *stubQuery) Animal(ctx context.Context) (Animal, error) {
+	return r.QueryResolver.Animal(ctx)
 }
 func (r *stubQuery) Issue896a(ctx context.Context) ([]*CheckIssue896, error) {
 	return r.QueryResolver.Issue896a(ctx)

--- a/example/selection/generated.go
+++ b/example/selection/generated.go
@@ -1828,10 +1828,16 @@ func (ec *executionContext) _Event(ctx context.Context, sel ast.SelectionSet, ob
 	case Post:
 		return ec._Post(ctx, sel, &obj)
 	case *Post:
+		if obj == nil {
+			return graphql.Null
+		}
 		return ec._Post(ctx, sel, obj)
 	case Like:
 		return ec._Like(ctx, sel, &obj)
 	case *Like:
+		if obj == nil {
+			return graphql.Null
+		}
 		return ec._Like(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))

--- a/example/starwars/generated/exec.go
+++ b/example/starwars/generated/exec.go
@@ -3645,10 +3645,16 @@ func (ec *executionContext) _Character(ctx context.Context, sel ast.SelectionSet
 	case models.Human:
 		return ec._Human(ctx, sel, &obj)
 	case *models.Human:
+		if obj == nil {
+			return graphql.Null
+		}
 		return ec._Human(ctx, sel, obj)
 	case models.Droid:
 		return ec._Droid(ctx, sel, &obj)
 	case *models.Droid:
+		if obj == nil {
+			return graphql.Null
+		}
 		return ec._Droid(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
@@ -3662,14 +3668,23 @@ func (ec *executionContext) _SearchResult(ctx context.Context, sel ast.Selection
 	case models.Human:
 		return ec._Human(ctx, sel, &obj)
 	case *models.Human:
+		if obj == nil {
+			return graphql.Null
+		}
 		return ec._Human(ctx, sel, obj)
 	case models.Droid:
 		return ec._Droid(ctx, sel, &obj)
 	case *models.Droid:
+		if obj == nil {
+			return graphql.Null
+		}
 		return ec._Droid(ctx, sel, obj)
 	case models.Starship:
 		return ec._Starship(ctx, sel, &obj)
 	case *models.Starship:
+		if obj == nil {
+			return graphql.Null
+		}
 		return ec._Starship(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))

--- a/example/type-system-extension/generated.go
+++ b/example/type-system-extension/generated.go
@@ -1921,6 +1921,9 @@ func (ec *executionContext) _Data(ctx context.Context, sel ast.SelectionSet, obj
 	case Todo:
 		return ec._Todo(ctx, sel, &obj)
 	case *Todo:
+		if obj == nil {
+			return graphql.Null
+		}
 		return ec._Todo(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
@@ -1934,6 +1937,9 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 	case Todo:
 		return ec._Todo(ctx, sel, &obj)
 	case *Todo:
+		if obj == nil {
+			return graphql.Null
+		}
 		return ec._Todo(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))


### PR DESCRIPTION
When implementing a resolver that returns an interface, it is convenient to be able to return a nil pointer of the underlying struct. This currently causes gqlgen's generated code to panic (nil pointer dereference). 

Consider the schema:
```graphql
interface Animal { name: String! }
type Dog implements Animal { name: String! age: Float }
type Query {
    animal: Animal
}
```

The following implementation leads to a crash:
```golang
func (r *queryResolver) Animal(ctx context.Context) (Animal, error) {
    var ptr *Dog
    return ptr, nil 
}
```

The fix is very simple, we have added an extra check in `interface.gotpl`, like so:
```golang
case *{{$implementor.Type | ref}}:
    if obj == nil {
        return graphql.Null
    }
    return ec._{{$implementor.Name}}(ctx, sel, obj)
```

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
