### PR TITLE
(docs) graph-gophers now supports Struct Field resolving

### DIFF
--- a/docs/content/feature-comparison.md
+++ b/docs/content/feature-comparison.md
@@ -15,7 +15,7 @@ weight: -1
 | Mutation | 👍 | 🚧 [pr](https://github.com/graph-gophers/graphql-go/pull/182) | 👍 | 👍 |
 | Subscription | 👍 | 🚧 [pr](https://github.com/graph-gophers/graphql-go/pull/182) | 👍 | 👍 |
 | Type Safety | 👍 | 👍 | ⛔️ | 👍 | 
-| Type Binding | 👍 | 🚧 [pr](https://github.com/graph-gophers/graphql-go/pull/194) | ⛔️ | 👍 |
+| Type Binding | 👍 | 👍 | ⛔️ | 👍 |
 | Embedding | 👍 | ⛔️ | 🚧 [pr](https://github.com/graphql-go/graphql/pull/371) | ⛔️ |
 | Interfaces | 👍 | 👍 | 👍 | ⛔️ [is](https://github.com/samsarahq/thunder/issues/78) |
 | Generated Enums | 👍 | ⛔️ | ⛔️ | ⛔️ |


### PR DESCRIPTION
https://github.com/graph-gophers/graphql-go/pull/282 is merged in and thus struct field resolving should now be possible.  
Also https://github.com/graph-gophers/graphql-go/pull/194 was already closed for some time now.  

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
