### PR TITLE
make model generation optional

### DIFF
--- a/api/generate.go
+++ b/api/generate.go
@@ -15,13 +15,15 @@ import (
 
 func Generate(cfg *config.Config, option ...Option) error {
 	_ = syscall.Unlink(cfg.Exec.Filename)
-	_ = syscall.Unlink(cfg.Model.Filename)
-
-	plugins := []plugin.Plugin{
-		schemaconfig.New(),
-		modelgen.New(),
-		resolvergen.New(),
+	if cfg.Model.IsDefined() {
+		_ = syscall.Unlink(cfg.Model.Filename)
 	}
+
+	plugins := []plugin.Plugin{schemaconfig.New()}
+	if cfg.Model.IsDefined() {
+		plugins = append(plugins, modelgen.New())
+	}
+	plugins = append(plugins, resolvergen.New())
 
 	for _, o := range option {
 		o(cfg, &plugins)

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -22,7 +22,7 @@ import (
 type Config struct {
 	SchemaFilename           StringList                 `yaml:"schema,omitempty"`
 	Exec                     PackageConfig              `yaml:"exec"`
-	Model                    PackageConfig              `yaml:"model"`
+	Model                    PackageConfig              `yaml:"model,omitempty"`
 	Resolver                 PackageConfig              `yaml:"resolver,omitempty"`
 	AutoBind                 []string                   `yaml:"autobind"`
 	Models                   TypeMap                    `yaml:"models,omitempty"`
@@ -228,8 +228,10 @@ func (c *Config) Check() error {
 	if err := c.Exec.Check(); err != nil {
 		return errors.Wrap(err, "config.exec")
 	}
-	if err := c.Model.Check(); err != nil {
-		return errors.Wrap(err, "config.model")
+	if c.Model.IsDefined() {
+		if err := c.Model.Check(); err != nil {
+			return errors.Wrap(err, "config.model")
+		}
 	}
 	if c.Resolver.IsDefined() {
 		if err := c.Resolver.Check(); err != nil {
@@ -239,11 +241,14 @@ func (c *Config) Check() error {
 
 	// check packages names against conflict, if present in the same dir
 	// and check filenames for uniqueness
-	packageConfigList := []PackageConfig{
-		c.Model,
+	packageConfigList := []PackageConfig{}
+	if c.Model.IsDefined() {
+		packageConfigList = append(packageConfigList, c.Model)
+	}
+	packageConfigList = append(packageConfigList, []PackageConfig{
 		c.Exec,
 		c.Resolver,
-	}
+	}...)
 	filesMap := make(map[string]bool)
 	pkgConfigsByDir := make(map[string]PackageConfig)
 	for _, current := range packageConfigList {
@@ -364,8 +369,10 @@ func findCfgInDir(dir string) string {
 }
 
 func (c *Config) normalize() error {
-	if err := c.Model.normalize(); err != nil {
-		return errors.Wrap(err, "model")
+	if c.Model.IsDefined() {
+		if err := c.Model.normalize(); err != nil {
+			return errors.Wrap(err, "model")
+		}
 	}
 
 	if err := c.Exec.normalize(); err != nil {

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -33,6 +33,7 @@ exec:
   package: generated
 
 # Let gqlgen know where to put the generated models (if any)
+# Set to null to disable
 model:
   filename: models/generated.go
   package: models


### PR DESCRIPTION
Addresses part of #918
This change makes it possible to set model to null and prevent gqlgen from generating models. This can significantly speed up generation time for those that don't need to generate models. For me it took generation time down from 1:15 to 1:00 min.

I'm looking for advice on how to test this in an efficient way.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
