### PR TITLE
shortcut QualifyPackagePath in go module mode

### DIFF
--- a/internal/code/imports.go
+++ b/internal/code/imports.go
@@ -51,21 +51,21 @@ func NameForDir(dir string) string {
 	return SanitizePackageName(filepath.Base(dir))
 }
 
-// ImportPathForDir takes a path and returns a golang import path for the package
-func ImportPathForDir(dir string) (res string) {
+// GoModuleRoot returns the root of the current go module if there is a go.mod file in the directory tree
+// If not, it returns false
+func GoModuleRoot(dir string) (string, bool) {
 	dir, err := filepath.Abs(dir)
 	if err != nil {
 		panic(err)
 	}
 	dir = filepath.ToSlash(dir)
-
 	modDir := dir
 	assumedPart := ""
 	for {
 		f, err := ioutil.ReadFile(filepath.Join(modDir, "go.mod"))
 		if err == nil {
 			// found it, stop searching
-			return string(modregex.FindSubmatch(f)[1]) + assumedPart
+			return string(modregex.FindSubmatch(f)[1]) + assumedPart, true
 		}
 
 		assumedPart = "/" + filepath.Base(modDir) + assumedPart
@@ -79,6 +79,21 @@ func ImportPathForDir(dir string) (res string) {
 			break
 		}
 		modDir = parentDir
+	}
+	return "", false
+}
+
+// ImportPathForDir takes a path and returns a golang import path for the package
+func ImportPathForDir(dir string) (res string) {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		panic(err)
+	}
+	dir = filepath.ToSlash(dir)
+
+	modDir, ok := GoModuleRoot(dir)
+	if ok {
+		return modDir
 	}
 
 	for _, gopath := range gopaths {

--- a/internal/code/imports.go
+++ b/internal/code/imports.go
@@ -51,9 +51,9 @@ func NameForDir(dir string) string {
 	return SanitizePackageName(filepath.Base(dir))
 }
 
-// GoModuleRoot returns the root of the current go module if there is a go.mod file in the directory tree
+// goModuleRoot returns the root of the current go module if there is a go.mod file in the directory tree
 // If not, it returns false
-func GoModuleRoot(dir string) (string, bool) {
+func goModuleRoot(dir string) (string, bool) {
 	dir, err := filepath.Abs(dir)
 	if err != nil {
 		panic(err)
@@ -91,7 +91,7 @@ func ImportPathForDir(dir string) (res string) {
 	}
 	dir = filepath.ToSlash(dir)
 
-	modDir, ok := GoModuleRoot(dir)
+	modDir, ok := goModuleRoot(dir)
 	if ok {
 		return modDir
 	}

--- a/internal/code/util.go
+++ b/internal/code/util.go
@@ -42,7 +42,7 @@ func QualifyPackagePath(importPath string) string {
 	wd, _ := os.Getwd()
 
 	// in go module mode, the import path doesn't need fixing
-	if _, ok := GoModuleRoot(wd); ok {
+	if _, ok := goModuleRoot(wd); ok {
 		return importPath
 	}
 

--- a/internal/code/util.go
+++ b/internal/code/util.go
@@ -41,6 +41,11 @@ func NormalizeVendor(pkg string) string {
 func QualifyPackagePath(importPath string) string {
 	wd, _ := os.Getwd()
 
+	// in go module mode, the import path doesn't need fixing
+	if _, ok := GoModuleRoot(wd); ok {
+		return importPath
+	}
+
 	pkg, err := build.Import(importPath, wd, 0)
 	if err != nil {
 		return importPath


### PR DESCRIPTION
Addresses part of #918

This is a code generation performance optimization that applies only in go module mode. It speeds up generation time for me from 1:15 to 0:40.

I have:
 - n/a Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - n/a Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
