### PR TITLE
add skip_validation flag

### DIFF
--- a/api/generate.go
+++ b/api/generate.go
@@ -54,8 +54,10 @@ func Generate(cfg *config.Config, option ...Option) error {
 		}
 	}
 
-	if err := validate(cfg); err != nil {
-		return errors.Wrap(err, "validation failed")
+	if !cfg.SkipValidation {
+		if err := validate(cfg); err != nil {
+			return errors.Wrap(err, "validation failed")
+		}
 	}
 
 	return nil

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	StructTag                string                     `yaml:"struct_tag,omitempty"`
 	Directives               map[string]DirectiveConfig `yaml:"directives,omitempty"`
 	OmitSliceElementPointers bool                       `yaml:"omit_slice_element_pointers,omitempty"`
+	SkipValidation           bool                       `yaml:"skip_validation,omitempty"`
 }
 
 var cfgFilenames = []string{".gqlgen.yml", "gqlgen.yml", "gqlgen.yaml"}

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -48,6 +48,9 @@ struct_tag: json
 # Optional, set to true if you prefer []Thing over []*Thing
 omit_slice_element_pointers: false
 
+# Optional, set to speed up generation time by not performing a final validation pass
+skip_validation: true
+
 # Instead of listing out every model like below, you can automatically bind to any matching types
 # within the given path by using `model: User` or `model: models.User`. EXPERIMENTAL in v0.9.1
 autobind:


### PR DESCRIPTION
Addresses part of #918

This adds a flag called skip_validation. When enabled, the final validation pass after generation is not performed. This saves me 10 seconds from a 1:15 initial generation time.

Let me know if this is worth testing and the preferred way to test it.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
