### PR TITLE
single packages.Load for NameForPackage

### DIFF
--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -11,5 +11,6 @@ func GenerateCode(data *Data) error {
 		Data:            data,
 		RegionTags:      true,
 		GeneratedHeader: true,
+		NameForPackage:  data.NameForPackage,
 	})
 }

--- a/codegen/templates/import.go
+++ b/codegen/templates/import.go
@@ -10,14 +10,16 @@ import (
 )
 
 type Import struct {
-	Name  string
-	Path  string
-	Alias string
+	NameForPackage code.NameForPackage
+	Name           string
+	Path           string
+	Alias          string
 }
 
 type Imports struct {
-	imports []*Import
-	destDir string
+	nameForPackage code.NameForPackage
+	imports        []*Import
+	destDir        string
 }
 
 func (i *Import) String() string {
@@ -49,7 +51,7 @@ func (s *Imports) Reserve(path string, aliases ...string) (string, error) {
 		return "", nil
 	}
 
-	name := code.NameForPackage(path)
+	name := s.nameForPackage.Get(path)
 	var alias string
 	if len(aliases) != 1 {
 		alias = name
@@ -69,9 +71,10 @@ func (s *Imports) Reserve(path string, aliases ...string) (string, error) {
 	}
 
 	s.imports = append(s.imports, &Import{
-		Name:  name,
-		Path:  path,
-		Alias: alias,
+		NameForPackage: s.nameForPackage,
+		Name:           name,
+		Path:           path,
+		Alias:          alias,
 	})
 
 	return "", nil
@@ -94,8 +97,9 @@ func (s *Imports) Lookup(path string) string {
 	}
 
 	imp := &Import{
-		Name: code.NameForPackage(path),
-		Path: path,
+		NameForPackage: s.nameForPackage,
+		Name:           s.nameForPackage.Get(path),
+		Path:           path,
 	}
 	s.imports = append(s.imports, imp)
 

--- a/codegen/templates/import_test.go
+++ b/codegen/templates/import_test.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/99designs/gqlgen/internal/code"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
 )
 
 func TestImports(t *testing.T) {
@@ -16,15 +18,20 @@ func TestImports(t *testing.T) {
 	bBar := "github.com/99designs/gqlgen/codegen/templates/testdata/b/bar"
 	mismatch := "github.com/99designs/gqlgen/codegen/templates/testdata/pkg_mismatch"
 
+	ps, err := packages.Load(nil, aBar, bBar, mismatch)
+	require.NoError(t, err)
+
+	nameForPackage := code.NewNameForPackage(ps)
+
 	t.Run("multiple lookups is ok", func(t *testing.T) {
-		a := Imports{destDir: wd}
+		a := Imports{nameForPackage: nameForPackage, destDir: wd}
 
 		require.Equal(t, "bar", a.Lookup(aBar))
 		require.Equal(t, "bar", a.Lookup(aBar))
 	})
 
 	t.Run("lookup by type", func(t *testing.T) {
-		a := Imports{destDir: wd}
+		a := Imports{nameForPackage: nameForPackage, destDir: wd}
 
 		pkg := types.NewPackage("github.com/99designs/gqlgen/codegen/templates/testdata/b/bar", "bar")
 		typ := types.NewNamed(types.NewTypeName(0, pkg, "Boolean", types.Typ[types.Bool]), types.Typ[types.Bool], nil)
@@ -33,7 +40,7 @@ func TestImports(t *testing.T) {
 	})
 
 	t.Run("duplicates are decollisioned", func(t *testing.T) {
-		a := Imports{destDir: wd}
+		a := Imports{nameForPackage: nameForPackage, destDir: wd}
 
 		require.Equal(t, "bar", a.Lookup(aBar))
 		require.Equal(t, "bar1", a.Lookup(bBar))
@@ -44,13 +51,13 @@ func TestImports(t *testing.T) {
 	})
 
 	t.Run("package name defined in code will be used", func(t *testing.T) {
-		a := Imports{destDir: wd}
+		a := Imports{nameForPackage: nameForPackage, destDir: wd}
 
 		require.Equal(t, "turtles", a.Lookup(mismatch))
 	})
 
 	t.Run("string printing for import block", func(t *testing.T) {
-		a := Imports{destDir: wd}
+		a := Imports{nameForPackage: nameForPackage, destDir: wd}
 		a.Lookup(aBar)
 		a.Lookup(bBar)
 		a.Lookup(mismatch)
@@ -65,7 +72,7 @@ turtles "github.com/99designs/gqlgen/codegen/templates/testdata/pkg_mismatch"`,
 	})
 
 	t.Run("aliased imports will not collide", func(t *testing.T) {
-		a := Imports{destDir: wd}
+		a := Imports{nameForPackage: nameForPackage, destDir: wd}
 
 		_, _ = a.Reserve(aBar, "abar")
 		_, _ = a.Reserve(bBar, "bbar")

--- a/internal/code/imports_test.go
+++ b/internal/code/imports_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
 )
 
 func TestImportPathForDir(t *testing.T) {
@@ -31,11 +32,15 @@ func TestImportPathForDir(t *testing.T) {
 }
 
 func TestNameForPackage(t *testing.T) {
-	assert.Equal(t, "api", NameForPackage("github.com/99designs/gqlgen/api"))
+	ps, _ := packages.Load(&packages.Config{Mode: packages.NeedName},
+		"github.com/99designs/gqlgen/api", "github.com/99designs/gqlgen/docs", "github.com")
+	nfp := NewNameForPackage(ps)
+
+	assert.Equal(t, "api", nfp.Get("github.com/99designs/gqlgen/api"))
 
 	// does not contain go code, should still give a valid name
-	assert.Equal(t, "docs", NameForPackage("github.com/99designs/gqlgen/docs"))
-	assert.Equal(t, "github_com", NameForPackage("github.com"))
+	assert.Equal(t, "docs", nfp.Get("github.com/99designs/gqlgen/docs"))
+	assert.Equal(t, "github_com", nfp.Get("github.com"))
 }
 
 func TestNameForDir(t *testing.T) {

--- a/internal/imports/prune.go
+++ b/internal/imports/prune.go
@@ -24,7 +24,7 @@ func (fn visitFn) Visit(node ast.Node) ast.Visitor {
 }
 
 // Prune removes any unused imports
-func Prune(filename string, src []byte) ([]byte, error) {
+func Prune(filename string, src []byte, nameForPackage code.NameForPackage) ([]byte, error) {
 	fset := token.NewFileSet()
 
 	file, err := parser.ParseFile(fset, filename, src, parser.ParseComments|parser.AllErrors)
@@ -32,7 +32,7 @@ func Prune(filename string, src []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	unused := getUnusedImports(file)
+	unused := getUnusedImports(file, nameForPackage)
 	for ipath, name := range unused {
 		astutil.DeleteNamedImport(fset, file, name, ipath)
 	}
@@ -46,7 +46,7 @@ func Prune(filename string, src []byte) ([]byte, error) {
 	return imports.Process(filename, buf.Bytes(), &imports.Options{FormatOnly: true, Comments: true, TabIndent: true, TabWidth: 8})
 }
 
-func getUnusedImports(file ast.Node) map[string]string {
+func getUnusedImports(file ast.Node, nameForPackage code.NameForPackage) map[string]string {
 	imported := map[string]*ast.ImportSpec{}
 	used := map[string]bool{}
 
@@ -65,7 +65,7 @@ func getUnusedImports(file ast.Node) map[string]string {
 				break
 			}
 
-			local := code.NameForPackage(ipath)
+			local := nameForPackage.Get(ipath)
 
 			imported[local] = v
 		case *ast.SelectorExpr:

--- a/internal/imports/prune_test.go
+++ b/internal/imports/prune_test.go
@@ -4,11 +4,12 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/99designs/gqlgen/internal/code"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPrune(t *testing.T) {
-	b, err := Prune("testdata/unused.go", mustReadFile("testdata/unused.go"))
+	b, err := Prune("testdata/unused.go", mustReadFile("testdata/unused.go"), code.NewNameForPackage(nil))
 	require.NoError(t, err)
 	require.Equal(t, string(mustReadFile("testdata/unused.expected.go")), string(b))
 }

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -7,8 +7,11 @@ import (
 
 	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/99designs/gqlgen/codegen/templates"
+	"github.com/99designs/gqlgen/internal/code"
 	"github.com/99designs/gqlgen/plugin"
+	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/ast"
+	"golang.org/x/tools/go/packages"
 )
 
 type BuildMutateHook = func(b *ModelBuild) *ModelBuild
@@ -235,11 +238,17 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 		b = m.MutateHook(b)
 	}
 
+	pkgs, err := packages.Load(&packages.Config{Mode: packages.NeedName}, cfg.Models.ReferencedPackages()...)
+	if err != nil {
+		return errors.Wrap(err, "loading failed")
+	}
+
 	return templates.Render(templates.Options{
 		PackageName:     cfg.Model.Package,
 		Filename:        cfg.Model.Filename,
 		Data:            b,
 		GeneratedHeader: true,
+		NameForPackage:  code.NewNameForPackage(pkgs),
 	})
 }
 

--- a/plugin/resolvergen/resolver.go
+++ b/plugin/resolvergen/resolver.go
@@ -36,9 +36,10 @@ func (m *Plugin) GenerateCode(data *codegen.Data) error {
 
 	if _, err := os.Stat(filename); os.IsNotExist(errors.Cause(err)) {
 		return templates.Render(templates.Options{
-			PackageName: data.Config.Resolver.Package,
-			Filename:    data.Config.Resolver.Filename,
-			Data:        resolverBuild,
+			PackageName:    data.Config.Resolver.Package,
+			Filename:       data.Config.Resolver.Filename,
+			Data:           resolverBuild,
+			NameForPackage: data.NameForPackage,
 		})
 	}
 

--- a/plugin/servergen/server.go
+++ b/plugin/servergen/server.go
@@ -31,9 +31,10 @@ func (m *Plugin) GenerateCode(data *codegen.Data) error {
 
 	if _, err := os.Stat(m.filename); os.IsNotExist(errors.Cause(err)) {
 		return templates.Render(templates.Options{
-			PackageName: "main",
-			Filename:    m.filename,
-			Data:        serverBuild,
+			PackageName:    "main",
+			Filename:       m.filename,
+			Data:           serverBuild,
+			NameForPackage: data.NameForPackage,
 		})
 	}
 

--- a/plugin/stubgen/stubs.go
+++ b/plugin/stubgen/stubs.go
@@ -48,6 +48,7 @@ func (m *Plugin) GenerateCode(data *codegen.Data) error {
 			TypeName: m.typeName,
 		},
 		GeneratedHeader: true,
+		NameForPackage:  data.NameForPackage,
 	})
 }
 


### PR DESCRIPTION
This is one of the optimizations suggested in #918. The original suggestion was to load every package that needs to be loaded in a single packages.Load call. I ran into issues trying to implement that because packages.Load has flags that define how much data should be loaded. It turned out that if we load all data for all relevant packages, that actually slows things down. Instead, I batched the loads of packages for calls to NameForPackage.

I tested this change on top of all of #942 #941 #940.

This is what the timings looked like before this commit (in my private codebase):
```
load autobind 1.893891096s
binder load time 2.383718776s
build time 4.523106863s
load time 548.545523ms
load time 503.184846ms
load time 513.424915ms
load time 628.098503ms
load time 570.70579ms
load time 508.176378ms
load time 480.067102ms
load time 495.141265ms
load time 544.685734ms
load time 537.060982ms
load time 510.831309ms
load time 544.138726ms
load time 580.567556ms
load time 601.751553ms
load time 583.932285ms
load time 893.051704ms
load time 835.748479ms
load time 854.607076ms
load time 1.057673489s
load time 602.564898ms
load time 654.87885ms
load time 652.425622ms
load time 652.79054ms
generate time 16.909831482s
29.26user 24.03system 0:23.90elapsed 222%CPU (0avgtext+0avgdata 198584maxresident)k
0inputs+0outputs (1major+459356minor)pagefaults 0swaps
```

After this commit:
```
load autobind 2.05095349s
binder load time 2.620924994s
load time 719.630163ms
build time 5.659686914s
generate time 2.255979872s
12.99user 8.68system 0:10.07elapsed 215%CPU (0avgtext+0avgdata 196372maxresident)k
0inputs+0outputs (1major+182189minor)pagefaults 0swaps
```

`build` and `generate` time correspond to the two main parts of api/generate.go.
`load time` is the time spent in packages.Load for the purposes of  NameForPackage. As you can see, the combined packages.Load call is moved from the Load phase into the Build phase but even though so many more packages are being loaded, it takes about as long as a single one of the later calls.

I didn't see an improvement when this commit is applied without the others, but I didn't test it extensively by itself.

I need feeback on how NameForPackage is passed through the various structs and also on the name of the new struct.

Results when directly applied to master by itself:
before:
```
load autobind 1.957855281s
binder load time 18.537183239s
load autobind 2.677523501s
binder load time 15.554334922s
build time 18.423786225s
load time 926.142032ms
load time 1.027569047s
load time 618.982484ms
load time 581.960888ms
load time 638.869157ms
load time 563.321504ms
load time 555.43315ms
load time 536.209612ms
load time 589.453371ms
load time 563.956469ms
load time 553.15628ms
load time 566.709479ms
load time 558.047512ms
load time 660.112754ms
load time 608.56697ms
load time 794.513994ms
load time 712.262528ms
load time 775.887765ms
load time 710.474496ms
load time 726.115501ms
load time 652.594165ms
load time 668.182971ms
load time 736.236443ms
generate time 26.084938958s
87.87user 75.67system 1:10.62elapsed 231%CPU (0avgtext+0avgdata 196956maxresident)k
0inputs+0outputs (1major+785188minor)pagefaults 0swaps
```
after:
```
load autobind 1.970106545s
binder load time 13.081893745s
load autobind 2.489918625s
binder load time 18.986631712s
load time 13.878410384s
build time 35.582962805s
generate time 11.627699718s
82.33user 69.53system 1:07.58elapsed 224%CPU (0avgtext+0avgdata 186284maxresident)k
0inputs+0outputs (1major+635377minor)pagefaults 0swaps
```
I can't explain those results. There must be something weird with calling packages.Load multiple times on the same packages.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - n/a Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
