### PR TITLE
deduplicate package load between AutoBind and Binder

### DIFF
--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -23,21 +23,7 @@ type Binder struct {
 	SawInvalid bool
 }
 
-func (c *Config) NewBinder(s *ast.Schema) (*Binder, error) {
-	pkgs, err := packages.Load(&packages.Config{
-		Mode: packages.NeedName |
-			packages.NeedFiles |
-			packages.NeedCompiledGoFiles |
-			packages.NeedImports |
-			packages.NeedTypes |
-			packages.NeedTypesSizes |
-			packages.NeedSyntax |
-			packages.NeedTypesInfo,
-	}, c.Models.ReferencedPackages()...)
-	if err != nil {
-		return nil, err
-	}
-
+func (c *Config) NewBinder(s *ast.Schema, pkgs []*packages.Package) (*Binder, error) {
 	mp := map[string]*packages.Package{}
 	var pkgErrs PkgErrors
 	for _, p := range pkgs {

--- a/codegen/config/binder_test.go
+++ b/codegen/config/binder_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser"
 	"github.com/vektah/gqlparser/ast"
+	"golang.org/x/tools/go/packages"
 )
 
 func TestBindingToInvalid(t *testing.T) {
@@ -58,7 +59,21 @@ func createBinder(cfg Config) (*Binder, *ast.Schema) {
 		}
 	`})
 
-	b, err := cfg.NewBinder(s)
+	ps, err := packages.Load(&packages.Config{
+		Mode: packages.NeedName |
+			packages.NeedFiles |
+			packages.NeedCompiledGoFiles |
+			packages.NeedImports |
+			packages.NeedTypes |
+			packages.NeedTypesSizes |
+			packages.NeedSyntax |
+			packages.NeedTypesInfo,
+	}, cfg.Models.ReferencedPackages()...)
+	if err != nil {
+		panic(err)
+	}
+
+	b, err := cfg.NewBinder(s, ps)
 	if err != nil {
 		panic(err)
 	}

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -310,6 +310,9 @@ func (tm TypeMap) ReferencedPackages() []string {
 			if pkg == "" || inStrSlice(pkgs, pkg) {
 				continue
 			}
+			if !strings.Contains(pkg, ".") {
+				continue
+			}
 			pkgs = append(pkgs, code.QualifyPackagePath(pkg))
 		}
 	}

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -395,22 +395,23 @@ func (c *Config) normalize() error {
 
 	return nil
 }
-
-func (c *Config) Autobind(s *ast.Schema) error {
+func (c *Config) isAutobind(pkg *packages.Package) bool {
+	for _, ab := range c.AutoBind {
+		if strings.HasSuffix(ab, "/...") {
+			abPrefix := strings.TrimSuffix(ab, "/...")
+			if strings.HasPrefix(pkg.PkgPath, abPrefix) {
+				return true
+			}
+		}
+		if pkg.PkgPath == ab {
+			return true
+		}
+	}
+	return false
+}
+func (c *Config) Autobind(s *ast.Schema, ps []*packages.Package) error {
 	if len(c.AutoBind) == 0 {
 		return nil
-	}
-
-	ps, err := packages.Load(&packages.Config{
-		Mode: packages.NeedName |
-			packages.NeedFiles |
-			packages.NeedCompiledGoFiles |
-			packages.NeedImports |
-			packages.NeedTypes |
-			packages.NeedTypesSizes,
-	}, c.AutoBind...)
-	if err != nil {
-		return err
 	}
 
 	for _, t := range s.Types {
@@ -419,6 +420,9 @@ func (c *Config) Autobind(s *ast.Schema) error {
 		}
 
 		for _, p := range ps {
+			if !c.isAutobind(p) {
+				continue
+			}
 			if t := p.Types.Scope().Lookup(t.Name); t != nil {
 				c.Models.Add(t.Name(), t.Pkg().Path()+"."+t.Name())
 				break
@@ -436,6 +440,9 @@ func (c *Config) Autobind(s *ast.Schema) error {
 			}
 
 			for _, p := range ps {
+				if !c.isAutobind(p) {
+					continue
+				}
 				if p.Name != pkg {
 					continue
 				}

--- a/codegen/config/config_test.go
+++ b/codegen/config/config_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/vektah/gqlparser"
 	"github.com/vektah/gqlparser/ast"
+	"golang.org/x/tools/go/packages"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -132,7 +133,19 @@ func TestAutobinding(t *testing.T) {
 		type Message { id: ID }
 	`})
 
-	require.NoError(t, cfg.Autobind(s))
+	ps, err := packages.Load(&packages.Config{
+		Mode: packages.NeedName |
+			packages.NeedFiles |
+			packages.NeedCompiledGoFiles |
+			packages.NeedImports |
+			packages.NeedTypes |
+			packages.NeedTypesSizes |
+			packages.NeedSyntax |
+			packages.NeedTypesInfo,
+	}, cfg.AutoBind...)
+	require.NoError(t, err)
+
+	require.NoError(t, cfg.Autobind(s, ps))
 
 	require.Equal(t, "github.com/99designs/gqlgen/example/scalars/model.Banned", cfg.Models["Banned"].Model[0])
 	require.Equal(t, "github.com/99designs/gqlgen/example/chat.Message", cfg.Models["Message"].Model[0])

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -80,14 +80,28 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 		return err
 	}
 
-	err = cfg.Autobind(schema)
+	cfg.InjectBuiltins(schema)
+
+	ps, err := packages.Load(&packages.Config{
+		Mode: packages.NeedName |
+			packages.NeedFiles |
+			packages.NeedCompiledGoFiles |
+			packages.NeedImports |
+			packages.NeedTypes |
+			packages.NeedTypesSizes |
+			packages.NeedSyntax |
+			packages.NeedTypesInfo,
+	}, append(cfg.Models.ReferencedPackages(), cfg.AutoBind...)...)
 	if err != nil {
 		return err
 	}
 
-	cfg.InjectBuiltins(schema)
+	err = cfg.Autobind(schema, ps)
+	if err != nil {
+		return err
+	}
 
-	binder, err := cfg.NewBinder(schema)
+	binder, err := cfg.NewBinder(schema, ps)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is one of the optimizations suggested in #918.

Improvements against master:

Before:
```
auto bind load 2.684139918s
binder load 19.267647024s
auto bind load 3.140190561s
binder load 19.725400875s
build time 23.085849454s
```
After:
```
combined load 17.965141019s
combined load 17.479315829s
build time 17.721352532s
```

"build time" is the time spent in the build phase of api/generate.go. The first set of loads is part of the models plugin and the second is part of the core functionality.

Note that this reorders InjectBuiltins and AutoBind. I'm not sure what the consequences of that are.

I'm surprised that tests didn't break without https://github.com/99designs/gqlgen/pull/945/commits/8c110b7af3e4685e7678a65884ec18598b2e6c42 but generation in our private repo did. I don't fully understand this code yet. I'd appreciate tips for adding a test for it.

I have:
 - [ ]  Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - n/a Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
