### PR TITLE
fix apq status

### DIFF
--- a/graphql/handler/transport/http_post.go
+++ b/graphql/handler/transport/http_post.go
@@ -38,7 +38,7 @@ func (h POST) Do(w http.ResponseWriter, r *http.Request, exec graphql.GraphExecu
 
 	rc, err := exec.CreateOperationContext(r.Context(), params)
 	if err != nil {
-		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.WriteHeader(http.StatusOK)
 		resp := exec.DispatchError(graphql.WithOperationContext(r.Context(), rc), err)
 		writeJson(w, resp)
 		return


### PR DESCRIPTION
I don't have good solutions... 🤔 

so, APQ works in CreateOperationContext method.
and handler exec `w.WriteHeader(http.StatusUnprocessableEntity)` when its returns error.
but It's unexpected behavior in client.

I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [X] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
