### PR TITLE
urfave/cli upgrade

### DIFF
--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -10,14 +10,14 @@ import (
 	"github.com/urfave/cli"
 )
 
-var genCmd = cli.Command{
+var genCmd = &cli.Command{
 	Name:  "generate",
 	Usage: "generate a graphql server based on schema",
 	Flags: []cli.Flag{
-		cli.BoolFlag{Name: "verbose, v", Usage: "show logs"},
-		cli.StringFlag{Name: "config, c", Usage: "the config filename"},
+		&cli.BoolFlag{Name: "verbose, v", Usage: "show logs"},
+		&cli.StringFlag{Name: "config, c", Usage: "the config filename"},
 	},
-	Action: func(ctx *cli.Context) {
+	Action: func(ctx *cli.Context) error {
 		var cfg *config.Config
 		var err error
 		if configFilename := ctx.String("config"); configFilename != "" {
@@ -25,6 +25,7 @@ var genCmd = cli.Command{
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err.Error())
 				os.Exit(1)
+				return err
 			}
 		} else {
 			cfg, err = config.LoadConfigFromDefaultLocations()
@@ -33,12 +34,15 @@ var genCmd = cli.Command{
 			} else if err != nil {
 				fmt.Fprintln(os.Stderr, err.Error())
 				os.Exit(2)
+				return err
 			}
 		}
 
 		if err = api.Generate(cfg); err != nil {
 			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(3)
+			return err
 		}
+		return nil
 	},
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -54,20 +54,21 @@ type Mutation {
 }
 `
 
-var initCmd = cli.Command{
+var initCmd = &cli.Command{
 	Name:  "init",
 	Usage: "create a new gqlgen project",
 	Flags: []cli.Flag{
-		cli.BoolFlag{Name: "verbose, v", Usage: "show logs"},
-		cli.StringFlag{Name: "config, c", Usage: "the config filename"},
-		cli.StringFlag{Name: "server", Usage: "where to write the server stub to", Value: "server/server.go"},
-		cli.StringFlag{Name: "schema", Usage: "where to write the schema stub to", Value: "schema.graphql"},
+		&cli.BoolFlag{Name: "verbose, v", Usage: "show logs"},
+		&cli.StringFlag{Name: "config, c", Usage: "the config filename"},
+		&cli.StringFlag{Name: "server", Usage: "where to write the server stub to", Value: "server/server.go"},
+		&cli.StringFlag{Name: "schema", Usage: "where to write the schema stub to", Value: "schema.graphql"},
 	},
-	Action: func(ctx *cli.Context) {
+	Action: func(ctx *cli.Context) error {
 		initSchema(ctx.String("schema"))
 		initConfig(ctx)
 
 		GenerateGraphServer(ctx.String("server"))
+		return nil
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,7 +32,7 @@ func Execute() {
 	}
 
 	app.Action = genCmd.Action
-	app.Commands = []cli.Command{
+	app.Commands = []*cli.Command{
 		genCmd,
 		initCmd,
 		versionCmd,

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,10 +7,11 @@ import (
 	"github.com/urfave/cli"
 )
 
-var versionCmd = cli.Command{
+var versionCmd = &cli.Command{
 	Name:  "version",
 	Usage: "print the version string",
-	Action: func(ctx *cli.Context) {
+	Action: func(ctx *cli.Context) error {
 		fmt.Println(graphql.Version)
+		return nil
 	},
 }


### PR DESCRIPTION
I've got erros when trying to run 
```
go run github.com/99designs/gqlgen --verbose
```

These are due the urfave/cli package has been changed on master and the default is the new v2 api.


Describe your PR and link to any relevant issues. 
https://github.com/99designs/gqlgen/pull/960#issue-354126694
I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
