### PR TITLE
add StatusCodeFunc for HTTP Transport implementations

### DIFF
--- a/graphql/handler/apollotracing/tracer_test.go
+++ b/graphql/handler/apollotracing/tracer_test.go
@@ -60,7 +60,7 @@ func TestApolloTracing_withFail(t *testing.T) {
 	h.Use(apollotracing.Tracer{})
 
 	resp := doRequest(h, "POST", "/graphql", `{"operationName":"A","extensions":{"persistedQuery":{"version":1,"sha256Hash":"338bbc16ac780daf81845339fbf0342061c1e9d2b702c96d3958a13a557083a6"}}}`)
-	assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
+	assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
 	b := resp.Body.Bytes()
 	t.Log(string(b))
 	var respData struct {

--- a/graphql/handler/transport/http_post_test.go
+++ b/graphql/handler/transport/http_post_test.go
@@ -52,7 +52,7 @@ func TestPOST(t *testing.T) {
 
 	t.Run("execution failure", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query": "mutation { name }"}`)
-		assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
 		assert.Equal(t, resp.Header().Get("Content-Type"), "application/json")
 		assert.Equal(t, `{"errors":[{"message":"mutations are not supported"}],"data":null}`, resp.Body.String())
 	})

--- a/graphql/handler/transport/util.go
+++ b/graphql/handler/transport/util.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/vektah/gqlparser/gqlerror"
@@ -27,4 +28,19 @@ func writeJsonErrorf(w io.Writer, format string, args ...interface{}) {
 
 func writeJsonGraphqlError(w io.Writer, err ...*gqlerror.Error) {
 	writeJson(w, &graphql.Response{Errors: err})
+}
+
+func httpStatusCode(resp *graphql.Response) int {
+	if len(resp.Errors) == 0 {
+		return http.StatusOK
+	}
+
+	if len(resp.Data) != 0 {
+		return http.StatusOK
+	} else if len(resp.Errors) == 1 && resp.Errors[0].Message == "PersistedQueryNotFound" {
+		// for APQ
+		return http.StatusOK
+	}
+
+	return http.StatusUnprocessableEntity
 }


### PR DESCRIPTION
revise #948
add method that modify HTTP status code

This PR is works, but maybe not the best.

I want to add `StatusCode(ctx context.Context, resp *graphql.Response) int` but graphql.Transport doesn't limited to HTTP handling.

so, how about below API design?

```
type TransportConfigurator interface {
  AttachTransports (ctx context, transports []graphql.Transport)
}
```
and
```
func (a AutomaticPersistedQuery) AttachTransports (ctx context, transports []graphql.Transport) {
  for _, transport := range transports {
    httpTransport, ok := transport.(interface { HookStatusCode(f func(ctx context.Context, resp *graphql.Response) int) })
    if !ok { continue }
    httpTransport.HookStatusCode(func(ctx context.Context, resp *graphql.Response) int {
      if len(resp.Errors) == 1 && resp.Errors[0].Message == "PersistedQueryNotFound" {
        return http.StatusOK
      }
      return 0
    })
  }
}
```

I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [X] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
