### PR TITLE
Optimizes CollectAllFields function 

### DIFF
--- a/docs/content/reference/field-collection.md
+++ b/docs/content/reference/field-collection.md
@@ -54,4 +54,4 @@ The type `Circle` would satisfy `Circle`, `Shape`, and `Shapes` — these values
 
 > Note
 >
-> `CollectFieldsCtx` is just a convenience wrapper around `CollectFields` that calls the later with the selection set automatically passed through from the resolver context.
+> `CollectFieldsCtx` is just a convenience wrapper around `CollectFields` that calls the latter with the selection set automatically passed through from the resolver context.

--- a/graphql/context_operation.go
+++ b/graphql/context_operation.go
@@ -80,7 +80,6 @@ func CollectAllFields(ctx context.Context) []string {
 			uniq[f.Name] = struct{}{}
 			res = append(res, f.Name)
 		}
-
 	}
 	return res
 }

--- a/graphql/context_operation.go
+++ b/graphql/context_operation.go
@@ -73,17 +73,16 @@ func CollectFieldsCtx(ctx context.Context, satisfies []string) []CollectedField 
 func CollectAllFields(ctx context.Context) []string {
 	resctx := GetFieldContext(ctx)
 	collected := CollectFields(GetOperationContext(ctx), resctx.Field.Selections, nil)
-	uniq := make([]string, 0, len(collected))
-Next:
+	uniq := make(map[string]struct{})
+	res := make([]string, 0, len(collected))
 	for _, f := range collected {
-		for _, name := range uniq {
-			if name == f.Name {
-				continue Next
-			}
+		if _, ok := uniq[f.Name]; !ok {
+			uniq[f.Name] = struct{}{}
+			res = append(res, f.Name)
 		}
-		uniq = append(uniq, f.Name)
+
 	}
-	return uniq
+	return res
 }
 
 // Errorf sends an error string to the client, passing it through the formatter.


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

I have:
 - [x] Added tests covering the bug / feature (see [testing] (https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

I was working on optimizing my gqlgen implementation, and when looking into using the CollectAllFields method. I noticed there was an unnecessary embedded loop. This PR simply uses a map for constant time lookup of unique entries instead of relooping through the results list for every index.