### PR TITLE
single packages.Load for NameForPackage

### DIFF
--- a/codegen/data.go
+++ b/codegen/data.go
@@ -6,9 +6,11 @@ import (
 	"sort"
 
 	"github.com/99designs/gqlgen/codegen/config"
+	"github.com/99designs/gqlgen/internal/code"
 	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/ast"
 	"github.com/vektah/gqlparser/formatter"
+	"golang.org/x/tools/go/packages"
 )
 
 // Data is a unified model of the code to be generated. Plugins may modify this structure to do things like implement
@@ -87,6 +89,12 @@ func BuildData(cfg *config.Config, plugins []SchemaMutator) (*Data, error) {
 			dataDirectives[name] = d
 		}
 	}
+
+	pkgs, err := packages.Load(&packages.Config{Mode: packages.NeedName}, cfg.Models.ReferencedPackages()...)
+	if err != nil {
+		return nil, errors.Wrap(err, "loading failed")
+	}
+	code.RecordPackagesList(pkgs)
 
 	s := Data{
 		Config:     cfg,

--- a/codegen/templates/import_test.go
+++ b/codegen/templates/import_test.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/99designs/gqlgen/internal/code"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
 )
 
 func TestImports(t *testing.T) {
@@ -15,6 +17,11 @@ func TestImports(t *testing.T) {
 	aBar := "github.com/99designs/gqlgen/codegen/templates/testdata/a/bar"
 	bBar := "github.com/99designs/gqlgen/codegen/templates/testdata/b/bar"
 	mismatch := "github.com/99designs/gqlgen/codegen/templates/testdata/pkg_mismatch"
+
+	ps, err := packages.Load(nil, aBar, bBar, mismatch)
+	require.NoError(t, err)
+
+	code.RecordPackagesList(ps)
 
 	t.Run("multiple lookups is ok", func(t *testing.T) {
 		a := Imports{destDir: wd}

--- a/internal/code/imports_test.go
+++ b/internal/code/imports_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
 )
 
 func TestImportPathForDir(t *testing.T) {
@@ -31,11 +32,17 @@ func TestImportPathForDir(t *testing.T) {
 }
 
 func TestNameForPackage(t *testing.T) {
-	assert.Equal(t, "api", NameForPackage("github.com/99designs/gqlgen/api"))
+	testPkg1 := "github.com/99designs/gqlgen/api"
+	testPkg2 := "github.com/99designs/gqlgen/docs"
+	testPkg3 := "github.com"
+	ps, err := packages.Load(nil, testPkg1, testPkg2, testPkg3)
+	require.NoError(t, err)
+	RecordPackagesList(ps)
+	assert.Equal(t, "api", NameForPackage(testPkg1))
 
 	// does not contain go code, should still give a valid name
-	assert.Equal(t, "docs", NameForPackage("github.com/99designs/gqlgen/docs"))
-	assert.Equal(t, "github_com", NameForPackage("github.com"))
+	assert.Equal(t, "docs", NameForPackage(testPkg2))
+	assert.Equal(t, "github_com", NameForPackage(testPkg3))
 }
 
 func TestNameForDir(t *testing.T) {

--- a/internal/imports/prune_test.go
+++ b/internal/imports/prune_test.go
@@ -4,10 +4,15 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/99designs/gqlgen/internal/code"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
 )
 
 func TestPrune(t *testing.T) {
+	// prime the packages cache so that it's not considered uninitialized
+	code.RecordPackagesList([]*packages.Package{})
+
 	b, err := Prune("testdata/unused.go", mustReadFile("testdata/unused.go"))
 	require.NoError(t, err)
 	require.Equal(t, string(mustReadFile("testdata/unused.expected.go")), string(b))

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -7,8 +7,11 @@ import (
 
 	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/99designs/gqlgen/codegen/templates"
+	"github.com/99designs/gqlgen/internal/code"
 	"github.com/99designs/gqlgen/plugin"
+	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/ast"
+	"golang.org/x/tools/go/packages"
 )
 
 type BuildMutateHook = func(b *ModelBuild) *ModelBuild
@@ -245,6 +248,12 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 	if m.MutateHook != nil {
 		b = m.MutateHook(b)
 	}
+
+	pkgs, err := packages.Load(&packages.Config{Mode: packages.NeedName}, cfg.Models.ReferencedPackages()...)
+	if err != nil {
+		return errors.Wrap(err, "loading failed")
+	}
+	code.RecordPackagesList(pkgs)
 
 	return templates.Render(templates.Options{
 		PackageName:     cfg.Model.Package,


### PR DESCRIPTION
I simplified this PR to make the minimum necessary changes to get the job done. This PR supersedes #944 
Unfortunately, I had to use global state because the existing code was using global state. I'm willing to refactor this in a follow up, ending up with something similar to #944 if that makes more sense.

I didn't add any new tests because exists tests already cover this change.

Non-scientific test comparing master vs this PR on our proprietary codebase:

Before:
```
40.92user 23.75system 0:27.99elapsed 231%CPU (0avgtext+0avgdata 197584maxresident)k
0inputs+0outputs (1major+430432minor)pagefaults 0swaps
```
After:
```
21.46user 8.37system 0:13.77elapsed 216%CPU (0avgtext+0avgdata 201152maxresident)k
0inputs+0outputs (1major+160637minor)pagefaults 0swaps
```
This is done on a pretty weak machine with somewhat slow IO. I used the second results for each after running the tests twice.

I have:
 - n/a Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - n/a Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
