### PR TITLE
Correctly generate a federated schema when no entity has a `@key`.

### DIFF
--- a/plugin/federation/federation.gotpl
+++ b/plugin/federation/federation.gotpl
@@ -12,6 +12,7 @@ func (ec *executionContext) __resolve__service(ctx context.Context) (federation.
 	}, nil
 }
 
+{{if .Entities}}
 func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) ([]_Entity, error) {
 	list := []_Entity{}
 	for _, rep := range representations {
@@ -46,3 +47,4 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 	}
 	return list, nil
 }
+{{end}}

--- a/plugin/federation/federation_test.go
+++ b/plugin/federation/federation_test.go
@@ -10,11 +10,12 @@ import (
 )
 
 func TestInjectSources(t *testing.T) {
-	var cfg config.Config
+	cfg, err := config.LoadConfig("test_data/gqlgen.yml")
+	require.NoError(t, err)
 	f := &federation{}
-	f.InjectSources(&cfg)
+	f.InjectSources(cfg)
 	if len(cfg.AdditionalSources) != 2 {
-		t.Fatalf("expected an additional source but got %v", len(cfg.AdditionalSources))
+		t.Fatalf("expected 2 additional sources but got %v", len(cfg.AdditionalSources))
 	}
 }
 
@@ -30,10 +31,9 @@ func TestMutateSchema(t *testing.T) {
 	if gqlErr != nil {
 		t.Fatal(gqlErr)
 	}
+
 	err := f.MutateSchema(schema)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestGetSDL(t *testing.T) {
@@ -46,6 +46,34 @@ func TestGetSDL(t *testing.T) {
 
 func TestMutateConfig(t *testing.T) {
 	cfg, err := config.LoadConfig("test_data/gqlgen.yml")
+	require.NoError(t, err)
+	require.NoError(t, cfg.Check())
+
+	f := &federation{}
+	err = f.MutateConfig(cfg)
+	require.NoError(t, err)
+}
+
+func TestInjectSourcesNoKey(t *testing.T) {
+	cfg, err := config.LoadConfig("test_data/nokey.yml")
+	require.NoError(t, err)
+	f := &federation{}
+	f.InjectSources(cfg)
+	if len(cfg.AdditionalSources) != 1 {
+		t.Fatalf("expected an additional source but got %v", len(cfg.AdditionalSources))
+	}
+}
+
+func TestGetSDLNoKey(t *testing.T) {
+	cfg, err := config.LoadConfig("test_data/nokey.yml")
+	require.NoError(t, err)
+	f := &federation{}
+	_, err = f.getSDL(cfg)
+	require.NoError(t, err)
+}
+
+func TestMutateConfigNoKey(t *testing.T) {
+	cfg, err := config.LoadConfig("test_data/nokey.yml")
 	require.NoError(t, err)
 	require.NoError(t, cfg.Check())
 

--- a/plugin/federation/test_data/nokey.graphql
+++ b/plugin/federation/test_data/nokey.graphql
@@ -1,7 +1,8 @@
-type Hello @key(fields: "name") {
+type Hello {
   name: String!
 }
 
 type Query {
   hello: Hello!
 }
+

--- a/plugin/federation/test_data/nokey.yml
+++ b/plugin/federation/test_data/nokey.yml
@@ -1,0 +1,3 @@
+schema:
+  - "test_data/nokey.graphql"
+federated: true


### PR DESCRIPTION
Normally, when a service is taking part in graphql federation, it will
have at least one type defined with a `@key` field, so that other
services can link to (that is, have an edge pointing to) the type that
this service provides.  The previous federation code assumed that was
the case.

But it's not required: a service could not define `@key` on any of its
types.  It might seem that would mean the service is unreachable,
since there is no possibility of edges into the service, but there are
two edges that can exist even without a `@key`: top level Query edges
and top level Mutation edges.  That is, if a service only provides a
top-level query or top-level mutation, it might not need to define a
`@key`.

This commit updates the federation code to support that use case.

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
