### PR TITLE
Fix intermittent websocket ka test failure

### DIFF
--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -141,7 +141,7 @@ func TestWebsocketWithKeepAlive(t *testing.T) {
 
 	h := testserver.New()
 	h.AddTransport(transport.Websocket{
-		KeepAlivePingInterval: 10 * time.Millisecond,
+		KeepAlivePingInterval: 100 * time.Millisecond,
 	})
 
 	srv := httptest.NewServer(h)


### PR DESCRIPTION
This test occasionally fails in CI, I cant reproduce locally but it looks like a timing issue. Lets widen the window.
