### PR TITLE
Add context.Context to graphql.Cache interface's methods

### DIFF
--- a/graphql/cache.go
+++ b/graphql/cache.go
@@ -1,27 +1,29 @@
 package graphql
 
+import "context"
+
 // Cache is a shared store for APQ and query AST caching
 type Cache interface {
 	// Get looks up a key's value from the cache.
-	Get(key string) (value interface{}, ok bool)
+	Get(ctx context.Context, key string) (value interface{}, ok bool)
 
 	// Add adds a value to the cache.
-	Add(key string, value interface{})
+	Add(ctx context.Context, key string, value interface{})
 }
 
 // MapCache is the simplest implementation of a cache, because it can not evict it should only be used in tests
 type MapCache map[string]interface{}
 
 // Get looks up a key's value from the cache.
-func (m MapCache) Get(key string) (value interface{}, ok bool) {
+func (m MapCache) Get(ctx context.Context, key string) (value interface{}, ok bool) {
 	v, ok := m[key]
 	return v, ok
 }
 
 // Add adds a value to the cache.
-func (m MapCache) Add(key string, value interface{}) { m[key] = value }
+func (m MapCache) Add(ctx context.Context, key string, value interface{}) { m[key] = value }
 
 type NoCache struct{}
 
-func (n NoCache) Get(key string) (value interface{}, ok bool) { return nil, false }
-func (n NoCache) Add(key string, value interface{})           {}
+func (n NoCache) Get(ctx context.Context, key string) (value interface{}, ok bool) { return nil, false }
+func (n NoCache) Add(ctx context.Context, key string, value interface{})           {}

--- a/graphql/handler/executor.go
+++ b/graphql/handler/executor.go
@@ -185,7 +185,7 @@ func (e executor) DispatchError(ctx context.Context, list gqlerror.List) *graphq
 func (e executor) parseQuery(ctx context.Context, stats *graphql.Stats, query string) (*ast.QueryDocument, gqlerror.List) {
 	stats.Parsing.Start = graphql.Now()
 
-	if doc, ok := e.server.queryCache.Get(query); ok {
+	if doc, ok := e.server.queryCache.Get(ctx, query); ok {
 		now := graphql.Now()
 
 		stats.Parsing.End = now
@@ -209,7 +209,7 @@ func (e executor) parseQuery(ctx context.Context, stats *graphql.Stats, query st
 		return nil, listErr
 	}
 
-	e.server.queryCache.Add(query, doc)
+	e.server.queryCache.Add(ctx, query, doc)
 
 	return doc, nil
 }

--- a/graphql/handler/extension/apq.go
+++ b/graphql/handler/extension/apq.go
@@ -72,7 +72,7 @@ func (a AutomaticPersistedQuery) MutateOperationParameters(ctx context.Context, 
 	fullQuery := false
 	if rawParams.Query == "" {
 		// client sent optimistic query hash without query string, get it from the cache
-		query, ok := a.Cache.Get(extension.Sha256)
+		query, ok := a.Cache.Get(ctx, extension.Sha256)
 		if !ok {
 			err := gqlerror.Errorf(errPersistedQueryNotFound)
 			errcode.Set(err, errPersistedQueryNotFoundCode)
@@ -84,7 +84,7 @@ func (a AutomaticPersistedQuery) MutateOperationParameters(ctx context.Context, 
 		if computeQueryHash(rawParams.Query) != extension.Sha256 {
 			return gqlerror.Errorf("provided APQ hash does not match query")
 		}
-		a.Cache.Add(extension.Sha256, rawParams.Query)
+		a.Cache.Add(ctx, extension.Sha256, rawParams.Query)
 		fullQuery = true
 	}
 

--- a/graphql/handler/lru/lru.go
+++ b/graphql/handler/lru/lru.go
@@ -1,6 +1,8 @@
 package lru
 
 import (
+	"context"
+
 	"github.com/99designs/gqlgen/graphql"
 	lru "github.com/hashicorp/golang-lru"
 )
@@ -21,10 +23,10 @@ func New(size int) *LRU {
 	return &LRU{cache}
 }
 
-func (l LRU) Get(key string) (value interface{}, ok bool) {
+func (l LRU) Get(ctx context.Context, key string) (value interface{}, ok bool) {
 	return l.lru.Get(key)
 }
 
-func (l LRU) Add(key string, value interface{}) {
+func (l LRU) Add(ctx context.Context, key string, value interface{}) {
 	l.lru.Add(key, value)
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -226,11 +226,11 @@ type apqAdapter struct {
 	PersistedQueryCache
 }
 
-func (a apqAdapter) Get(key string) (value interface{}, ok bool) {
-	return a.PersistedQueryCache.Get(context.Background(), key)
+func (a apqAdapter) Get(ctx context.Context, key string) (value interface{}, ok bool) {
+	return a.PersistedQueryCache.Get(ctx, key)
 }
-func (a apqAdapter) Add(key string, value interface{}) {
-	a.PersistedQueryCache.Add(context.Background(), key, value.(string))
+func (a apqAdapter) Add(ctx context.Context, key string, value interface{}) {
+	a.PersistedQueryCache.Add(ctx, key, value.(string))
 }
 
 type PersistedQueryCache interface {


### PR DESCRIPTION
closes #991
add `context.Context` to graphql.Cache interface.

before
```
type Cache interface {
	Get(key string) (value interface{}, ok bool)
	Add(key string, value interface{})
}
```

after
```
type Cache interface {
	Get(ctx context.Context, key string) (value interface{}, ok bool)
	Add(ctx context.Context, key string, value interface{})
}
```

I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [X] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
