### PR TITLE
Remove empty lines on DirectiveRoot generation

### DIFF
--- a/codegen/generated!.gotpl
+++ b/codegen/generated!.gotpl
@@ -39,7 +39,7 @@ type ResolverRoot interface {
 
 type DirectiveRoot struct {
 {{ range $directive := .Directives }}
-	{{ $directive.Declaration }}
+	{{- $directive.Declaration }}
 {{ end }}
 }
 

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -52,24 +52,15 @@ type ResolverRoot interface {
 }
 
 type DirectiveRoot struct {
-	Custom func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
-
-	Directive1 func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
-
-	Directive2 func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
-
-	Length func(ctx context.Context, obj interface{}, next graphql.Resolver, min int, max *int, message *string) (res interface{}, err error)
-
-	Logged func(ctx context.Context, obj interface{}, next graphql.Resolver, id string) (res interface{}, err error)
-
-	MakeNil func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
-
-	MakeTypedNil func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
-
-	Range func(ctx context.Context, obj interface{}, next graphql.Resolver, min *int, max *int) (res interface{}, err error)
-
-	ToNull func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
-
+	Custom        func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
+	Directive1    func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
+	Directive2    func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
+	Length        func(ctx context.Context, obj interface{}, next graphql.Resolver, min int, max *int, message *string) (res interface{}, err error)
+	Logged        func(ctx context.Context, obj interface{}, next graphql.Resolver, id string) (res interface{}, err error)
+	MakeNil       func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
+	MakeTypedNil  func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
+	Range         func(ctx context.Context, obj interface{}, next graphql.Resolver, min *int, max *int) (res interface{}, err error)
+	ToNull        func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
 	Unimplemented func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
 }
 

--- a/example/todo/generated.go
+++ b/example/todo/generated.go
@@ -41,8 +41,7 @@ type ResolverRoot interface {
 
 type DirectiveRoot struct {
 	HasRole func(ctx context.Context, obj interface{}, next graphql.Resolver, role Role) (res interface{}, err error)
-
-	User func(ctx context.Context, obj interface{}, next graphql.Resolver, id int) (res interface{}, err error)
+	User    func(ctx context.Context, obj interface{}, next graphql.Resolver, id int) (res interface{}, err error)
 }
 
 type ComplexityRoot struct {

--- a/example/type-system-extension/generated.go
+++ b/example/type-system-extension/generated.go
@@ -40,19 +40,13 @@ type ResolverRoot interface {
 }
 
 type DirectiveRoot struct {
-	EnumLogging func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
-
-	FieldLogging func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
-
-	InputLogging func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
-
+	EnumLogging      func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
+	FieldLogging     func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
+	InputLogging     func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
 	InterfaceLogging func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
-
-	ObjectLogging func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
-
-	ScalarLogging func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
-
-	UnionLogging func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
+	ObjectLogging    func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
+	ScalarLogging    func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
+	UnionLogging     func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
 }
 
 type ComplexityRoot struct {


### PR DESCRIPTION
Signed-off-by: Alex Snast <alexsn@fb.com>

DirectiveRoot methods are spaced with an empty line which is unnecessary.