### PR TITLE
Add package config for federation file

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	Exec                     PackageConfig              `yaml:"exec"`
 	Model                    PackageConfig              `yaml:"model,omitempty"`
 	Resolver                 PackageConfig              `yaml:"resolver,omitempty"`
+	Federation               PackageConfig              `yaml:"federation,omitempty"`
 	AutoBind                 []string                   `yaml:"autobind"`
 	Models                   TypeMap                    `yaml:"models,omitempty"`
 	StructTag                string                     `yaml:"struct_tag,omitempty"`
@@ -42,6 +43,7 @@ func DefaultConfig() *Config {
 		SchemaFilename: StringList{"schema.graphql"},
 		Model:          PackageConfig{Filename: "models_gen.go"},
 		Exec:           PackageConfig{Filename: "generated.go"},
+		Federation:     PackageConfig{Filename: "service.go"},
 		Directives:     map[string]DirectiveConfig{},
 	}
 }
@@ -240,6 +242,11 @@ func (c *Config) Check() error {
 	if c.Resolver.IsDefined() {
 		if err := c.Resolver.Check(); err != nil {
 			return errors.Wrap(err, "config.resolver")
+		}
+	}
+	if c.Federation.IsDefined() {
+		if err := c.Federation.Check(); err != nil {
+			return errors.Wrap(err, "config.federation")
 		}
 	}
 

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -173,7 +173,7 @@ func (f *federation) MutateSchema(s *ast.Schema) error {
 func (f *federation) getSource(builtin bool) *ast.Source {
 	return &ast.Source{
 		Name: "federation.graphql",
-		Input: `# Declarations as required by the federation spec 
+		Input: `# Declarations as required by the federation spec
 # See: https://www.apollographql.com/docs/apollo-server/federation/federation-spec/
 
 scalar _Any
@@ -240,8 +240,8 @@ func (f *federation) GenerateCode(data *codegen.Data) error {
 	}
 
 	return templates.Render(templates.Options{
-		PackageName:     data.Config.Exec.Package,
-		Filename:        "service.go",
+		PackageName:     data.Config.Federation.Package,
+		Filename:        data.Config.Federation.Filename,
 		Data:            f,
 		GeneratedHeader: true,
 	})

--- a/plugin/federation/test_data/gqlgen.yml
+++ b/plugin/federation/test_data/gqlgen.yml
@@ -1,3 +1,5 @@
 schema:
   - "test_data/schema.graphql"
 federated: true
+federation:
+  filename: federation_gen.go


### PR DESCRIPTION
When generating a project with the federation, the federation service file is always on the root of the project. To allow using federation in another project layout, we must have a way to customize where the federation file should be located. 

This PR adds the option to configure the federation package, ideally, it should be part of the Exec config, but that is no clear path on adding that there.


I have:
 - [ ] Added tests covering the bug / feature
-> I could not figure out how to test this. 
 - [ ] Updated any relevant documentation
-> There is no documentation for federation
