### PR TITLE
fix chat example

### DIFF
--- a/example/chat/server/server.go
+++ b/example/chat/server/server.go
@@ -31,6 +31,7 @@ func main() {
 
 	srv := handler.New(chat.NewExecutableSchema(chat.New()))
 
+	srv.AddTransport(transport.POST{})
 	srv.AddTransport(transport.Websocket{
 		KeepAlivePingInterval: 10 * time.Second,
 		Upgrader: websocket.Upgrader{


### PR DESCRIPTION
The example app uses a split transport with both HTTP POST and Websockets, but the server isnt configured to respond to POST.

fixes #1001

