### PR TITLE
Conditionally removing fields from introspection

### DIFF
--- a/graphql/handler/extension/introspection.go
+++ b/graphql/handler/extension/introspection.go
@@ -39,11 +39,11 @@ func (c Introspection) InterceptField(ctx context.Context, next graphql.Resolver
 	res, err = next(ctx)
 
 	fc := graphql.GetFieldContext(ctx)
-	t := fc.Parent.Result.(*introspection.Type)
 	if fields, ok := res.([]introspection.Field); ok {
 		if c.AllowFieldFunc == nil {
 			return
 		}
+		t := fc.Parent.Result.(*introspection.Type)
 		var newFields []introspection.Field
 		for _, field := range fields {
 			allow, err := c.AllowFieldFunc(ctx, t, &field)
@@ -59,6 +59,7 @@ func (c Introspection) InterceptField(ctx context.Context, next graphql.Resolver
 		if c.AllowInputValueFunc == nil {
 			return
 		}
+		t := fc.Parent.Result.(*introspection.Type)
 		var newFields []introspection.InputValue
 		for _, field := range fields {
 			allow, err := c.AllowInputValueFunc(ctx, t, &field)

--- a/graphql/handler/extension/introspection.go
+++ b/graphql/handler/extension/introspection.go
@@ -3,16 +3,23 @@ package extension
 import (
 	"context"
 
+	"github.com/99designs/gqlgen/graphql/introspection"
+
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/vektah/gqlparser/gqlerror"
 )
 
 // EnableIntrospection enables clients to reflect all of the types available on the graph.
-type Introspection struct{}
+type Introspection struct {
+	AllowFieldFunc func(ctx context.Context, t *introspection.Type, field *introspection.Field) (bool, error)
+
+	AllowInputValueFunc func(ctx context.Context, t *introspection.Type, inputValue *introspection.InputValue) (bool, error)
+}
 
 var _ interface {
 	graphql.OperationContextMutator
 	graphql.HandlerExtension
+	graphql.FieldInterceptor
 } = Introspection{}
 
 func (c Introspection) ExtensionName() string {
@@ -26,4 +33,43 @@ func (c Introspection) Validate(schema graphql.ExecutableSchema) error {
 func (c Introspection) MutateOperationContext(ctx context.Context, rc *graphql.OperationContext) *gqlerror.Error {
 	rc.DisableIntrospection = false
 	return nil
+}
+
+func (c Introspection) InterceptField(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+	res, err = next(ctx)
+
+	fc := graphql.GetFieldContext(ctx)
+	t := fc.Parent.Result.(*introspection.Type)
+	if fields, ok := res.([]introspection.Field); ok {
+		if c.AllowFieldFunc == nil {
+			return
+		}
+		var newFields []introspection.Field
+		for _, field := range fields {
+			allow, err := c.AllowFieldFunc(ctx, t, &field)
+			if err != nil {
+				return nil, err
+			}
+			if allow {
+				newFields = append(newFields, field)
+			}
+		}
+		res = newFields
+	} else if fields, ok := res.([]introspection.InputValue); ok {
+		if c.AllowInputValueFunc == nil {
+			return
+		}
+		var newFields []introspection.InputValue
+		for _, field := range fields {
+			allow, err := c.AllowInputValueFunc(ctx, t, &field)
+			if err != nil {
+				return nil, err
+			}
+			if allow {
+				newFields = append(newFields, field)
+			}
+		}
+		res = newFields
+	}
+	return res, err
 }

--- a/graphql/handler/extension/introspection_test.go
+++ b/graphql/handler/extension/introspection_test.go
@@ -2,9 +2,14 @@ package extension
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/99designs/gqlgen/graphql"
+
+	"github.com/99designs/gqlgen/graphql/introspection"
+	"github.com/vektah/gqlparser/ast"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,4 +19,98 @@ func TestIntrospection(t *testing.T) {
 	}
 	require.Nil(t, Introspection{}.MutateOperationContext(context.Background(), rc))
 	require.Equal(t, false, rc.DisableIntrospection)
+}
+
+func TestIntrospection_InterceptField(t *testing.T) {
+	type fields struct {
+		AllowFieldFunc      func(ctx context.Context, t *introspection.Type, field *introspection.Field) (bool, error)
+		AllowInputValueFunc func(ctx context.Context, t *introspection.Type, inputValue *introspection.InputValue) (bool, error)
+	}
+	type args struct {
+		kind ast.DefinitionKind
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantRes []string
+	}{
+		{
+			name: "field",
+			fields: fields{
+				AllowFieldFunc: func(ctx context.Context, t *introspection.Type, field *introspection.Field) (b bool, err error) {
+					if *t.Name() == "TestType1" {
+						return !strings.HasSuffix(field.Name, "1"), nil
+					}
+					return true, nil
+				},
+			},
+			args:    args{kind: ast.Object},
+			wantRes: []string{"testField2", "testField3"},
+		},
+		{
+			name: "inputValue",
+			fields: fields{
+				AllowInputValueFunc: func(ctx context.Context, t *introspection.Type, inputValue *introspection.InputValue) (b bool, err error) {
+					if *t.Name() == "TestType1" {
+						return !strings.HasSuffix(inputValue.Name, "1"), nil
+					}
+					return true, nil
+				},
+			},
+			args:    args{kind: ast.InputObject},
+			wantRes: []string{"testField2", "testField3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Introspection{
+				AllowFieldFunc:      tt.fields.AllowFieldFunc,
+				AllowInputValueFunc: tt.fields.AllowInputValueFunc,
+			}
+			typ := introspection.WrapTypeFromDef(nil, &ast.Definition{
+				Kind: tt.args.kind,
+				Name: "TestType1",
+				Fields: []*ast.FieldDefinition{
+					{Name: "testField1"},
+					{Name: "testField2"},
+					{Name: "testField3"},
+				},
+			})
+			ctx := graphql.WithFieldContext(context.Background(), &graphql.FieldContext{Result: typ})
+			ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+				Field: graphql.CollectedField{
+					Field: &ast.Field{
+						Name: tt.name,
+					},
+				},
+			})
+			gotRes, err := c.InterceptField(ctx, func(ctx context.Context) (res interface{}, err error) {
+				switch tt.args.kind {
+				case ast.Object:
+					return typ.Fields(false), nil
+				case ast.InputObject:
+					return typ.InputFields(), nil
+				}
+				require.Fail(t, "unexpected ast.DefinitionKind: %v", tt.args.kind)
+				return nil, nil
+			})
+			require.NoError(t, err)
+
+			var actualFields []string
+			switch tt.args.kind {
+			case ast.Object:
+				for _, field := range gotRes.([]introspection.Field) {
+					actualFields = append(actualFields, field.Name)
+				}
+			case ast.InputObject:
+				for _, field := range gotRes.([]introspection.InputValue) {
+					actualFields = append(actualFields, field.Name)
+				}
+			default:
+				require.FailNow(t, "", "unexpected ast.DefinitionKind: %v", tt.args.kind)
+			}
+			require.Equal(t, tt.wantRes, actualFields)
+		})
+	}
 }

--- a/graphql/handler/extension/introspection_test.go
+++ b/graphql/handler/extension/introspection_test.go
@@ -61,6 +61,16 @@ func TestIntrospection_InterceptField(t *testing.T) {
 			args:    args{kind: ast.InputObject},
 			wantRes: []string{"testField2", "testField3"},
 		},
+		{
+			name:    "nil AllowFieldFunc",
+			args:    args{kind: ast.Object},
+			wantRes: []string{"testField1", "testField2", "testField3"},
+		},
+		{
+			name:    "nil AllowInputValueFunc",
+			args:    args{kind: ast.Object},
+			wantRes: []string{"testField1", "testField2", "testField3"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #380 
## How to use
Use introspection plugin with `AllowFieldFunc` and `AllowInputValueFunc`.
## How it works
`Introspection` extension now implements `FieldInterceptor`.
When `InterceptField` is called checks if the result returned by `next()` is 
`[]introspection.Field` or `[]introspection.InputValue`.
If any of the two conditions is true proceeds to filter field using the correct `AllowFunc` specified when creating the extension.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
