### PR TITLE
Interface regression

### DIFF
--- a/codegen/object.go
+++ b/codegen/object.go
@@ -82,7 +82,12 @@ func (b *builder) buildObject(typ *ast.Definition) (*Object, error) {
 }
 
 func (o *Object) Reference() types.Type {
-	switch o.Type.(type) {
+	switch v := o.Type.(type) {
+	case *types.Named:
+		_, isInterface := v.Underlying().(*types.Interface)
+		if isInterface {
+			return o.Type
+		}
 	case *types.Pointer, *types.Slice, *types.Map:
 		return o.Type
 	}

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -103,6 +103,12 @@ type ComplexityRoot struct {
 		Radius func(childComplexity int) int
 	}
 
+	ConcreteNodeA struct {
+		Child func(childComplexity int) int
+		ID    func(childComplexity int) int
+		Name  func(childComplexity int) int
+	}
+
 	ContentPost struct {
 		Foo func(childComplexity int) int
 	}
@@ -262,6 +268,7 @@ type ComplexityRoot struct {
 		NestedOutputs                    func(childComplexity int) int
 		NoShape                          func(childComplexity int) int
 		NoShapeTypedNil                  func(childComplexity int) int
+		Node                             func(childComplexity int) int
 		NullableArg                      func(childComplexity int, arg *int) int
 		OptionalUnion                    func(childComplexity int) int
 		Overlapping                      func(childComplexity int) int
@@ -399,6 +406,7 @@ type QueryResolver interface {
 	EnumInInput(ctx context.Context, input *InputWithEnumValue) (EnumTest, error)
 	Shapes(ctx context.Context) ([]Shape, error)
 	NoShape(ctx context.Context) (Shape, error)
+	Node(ctx context.Context) (Node, error)
 	NoShapeTypedNil(ctx context.Context) (Shape, error)
 	Animal(ctx context.Context) (Animal, error)
 	Issue896a(ctx context.Context) ([]*CheckIssue896, error)
@@ -544,6 +552,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Circle.Radius(childComplexity), true
+
+	case "ConcreteNodeA.child":
+		if e.complexity.ConcreteNodeA.Child == nil {
+			break
+		}
+
+		return e.complexity.ConcreteNodeA.Child(childComplexity), true
+
+	case "ConcreteNodeA.id":
+		if e.complexity.ConcreteNodeA.ID == nil {
+			break
+		}
+
+		return e.complexity.ConcreteNodeA.ID(childComplexity), true
+
+	case "ConcreteNodeA.name":
+		if e.complexity.ConcreteNodeA.Name == nil {
+			break
+		}
+
+		return e.complexity.ConcreteNodeA.Name(childComplexity), true
 
 	case "Content_Post.foo":
 		if e.complexity.ContentPost.Foo == nil {
@@ -1185,6 +1214,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.NoShapeTypedNil(childComplexity), true
 
+	case "Query.node":
+		if e.complexity.Query.Node == nil {
+			break
+		}
+
+		return e.complexity.Query.Node(childComplexity), true
+
 	case "Query.nullableArg":
 		if e.complexity.Query.NullableArg == nil {
 			break
@@ -1638,6 +1674,11 @@ type Circle implements Shape {
 	radius: Float
 	area: Float
 }
+type ConcreteNodeA implements Node {
+	id: ID!
+	child: Node!
+	name: String!
+}
 union Content_Child = Content_User | Content_Post
 type Content_Post {
 	foo: String
@@ -1749,6 +1790,10 @@ type ModelMethods {
 input NestedMapInput {
 	map: MapStringInterfaceInput
 }
+interface Node {
+	id: ID!
+	child: Node!
+}
 type ObjectDirectives {
 	text: String! @length(min: 0, max: 7, message: "not valid")
 	nullableText: String @toNull
@@ -1815,6 +1860,7 @@ type Query {
 	enumInInput(input: InputWithEnumValue): EnumTest!
 	shapes: [Shape]
 	noShape: Shape @makeNil
+	node: Node!
 	noShapeTypedNil: Shape @makeTypedNil
 	animal: Animal @makeTypedNil
 	issue896a: [CheckIssue896!]
@@ -3228,6 +3274,99 @@ func (ec *executionContext) _Circle_area(ctx context.Context, field graphql.Coll
 	res := resTmp.(float64)
 	fc.Result = res
 	return ec.marshalOFloat2float64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ConcreteNodeA_id(ctx context.Context, field graphql.CollectedField, obj *ConcreteNodeA) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "ConcreteNodeA",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ConcreteNodeA_child(ctx context.Context, field graphql.CollectedField, obj *ConcreteNodeA) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "ConcreteNodeA",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Child()
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(Node)
+	fc.Result = res
+	return ec.marshalNNode2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐNode(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ConcreteNodeA_name(ctx context.Context, field graphql.CollectedField, obj *ConcreteNodeA) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "ConcreteNodeA",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Content_Post_foo(ctx context.Context, field graphql.CollectedField, obj *ContentPost) (ret graphql.Marshaler) {
@@ -5858,6 +5997,37 @@ func (ec *executionContext) _Query_noShape(ctx context.Context, field graphql.Co
 	res := resTmp.(Shape)
 	fc.Result = res
 	return ec.marshalOShape2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐShape(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_node(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "Query",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Node(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(Node)
+	fc.Result = res
+	return ec.marshalNNode2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐNode(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_noShapeTypedNil(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -8908,6 +9078,20 @@ func (ec *executionContext) _Content_Child(ctx context.Context, sel ast.Selectio
 	}
 }
 
+func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj Node) graphql.Marshaler {
+	switch obj := (obj).(type) {
+	case nil:
+		return graphql.Null
+	case *ConcreteNodeA:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._ConcreteNodeA(ctx, sel, obj)
+	default:
+		panic(fmt.Errorf("unexpected type %T", obj))
+	}
+}
+
 func (ec *executionContext) _Shape(ctx context.Context, sel ast.SelectionSet, obj Shape) graphql.Marshaler {
 	switch obj := (obj).(type) {
 	case nil:
@@ -9199,6 +9383,43 @@ func (ec *executionContext) _Circle(ctx context.Context, sel ast.SelectionSet, o
 			out.Values[i] = ec._Circle_radius(ctx, field, obj)
 		case "area":
 			out.Values[i] = ec._Circle_area(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var concreteNodeAImplementors = []string{"ConcreteNodeA", "Node"}
+
+func (ec *executionContext) _ConcreteNodeA(ctx context.Context, sel ast.SelectionSet, obj *ConcreteNodeA) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, concreteNodeAImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ConcreteNodeA")
+		case "id":
+			out.Values[i] = ec._ConcreteNodeA_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "child":
+			out.Values[i] = ec._ConcreteNodeA_child(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "name":
+			out.Values[i] = ec._ConcreteNodeA_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -10498,6 +10719,20 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 				res = ec._Query_noShape(ctx, field)
 				return res
 			})
+		case "node":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_node(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "noShapeTypedNil":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {
@@ -11582,6 +11817,16 @@ func (ec *executionContext) marshalNMarshalPanic2ᚕgithubᚗcomᚋ99designsᚋg
 	}
 
 	return ret
+}
+
+func (ec *executionContext) marshalNNode2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐNode(ctx context.Context, sel ast.SelectionSet, v Node) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._Node(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNPrimitive2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐPrimitive(ctx context.Context, sel ast.SelectionSet, v Primitive) graphql.Marshaler {

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -39,6 +39,7 @@ type Config struct {
 }
 
 type ResolverRoot interface {
+	BackedByInterface() BackedByInterfaceResolver
 	Errors() ErrorsResolver
 	ForcedResolver() ForcedResolverResolver
 	ModelMethods() ModelMethodsResolver
@@ -87,6 +88,12 @@ type ComplexityRoot struct {
 
 	B struct {
 		ID func(childComplexity int) int
+	}
+
+	BackedByInterface struct {
+		ID                      func(childComplexity int) int
+		ThisShouldBind          func(childComplexity int) int
+		ThisShouldBindWithError func(childComplexity int) int
 	}
 
 	Cat struct {
@@ -269,6 +276,7 @@ type ComplexityRoot struct {
 		NoShape                          func(childComplexity int) int
 		NoShapeTypedNil                  func(childComplexity int) int
 		Node                             func(childComplexity int) int
+		NotAnInterface                   func(childComplexity int) int
 		NullableArg                      func(childComplexity int, arg *int) int
 		OptionalUnion                    func(childComplexity int) int
 		Overlapping                      func(childComplexity int) int
@@ -345,6 +353,9 @@ type ComplexityRoot struct {
 	}
 }
 
+type BackedByInterfaceResolver interface {
+	ID(ctx context.Context, obj BackedByInterface) (string, error)
+}
 type ErrorsResolver interface {
 	A(ctx context.Context, obj *Errors) (*Error, error)
 	B(ctx context.Context, obj *Errors) (*Error, error)
@@ -409,6 +420,7 @@ type QueryResolver interface {
 	Node(ctx context.Context) (Node, error)
 	NoShapeTypedNil(ctx context.Context) (Shape, error)
 	Animal(ctx context.Context) (Animal, error)
+	NotAnInterface(ctx context.Context) (BackedByInterface, error)
 	Issue896a(ctx context.Context) ([]*CheckIssue896, error)
 	MapStringInterface(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error)
 	MapNestedStringInterface(ctx context.Context, in *NestedMapInput) (map[string]interface{}, error)
@@ -517,6 +529,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.B.ID(childComplexity), true
+
+	case "BackedByInterface.id":
+		if e.complexity.BackedByInterface.ID == nil {
+			break
+		}
+
+		return e.complexity.BackedByInterface.ID(childComplexity), true
+
+	case "BackedByInterface.thisShouldBind":
+		if e.complexity.BackedByInterface.ThisShouldBind == nil {
+			break
+		}
+
+		return e.complexity.BackedByInterface.ThisShouldBind(childComplexity), true
+
+	case "BackedByInterface.thisShouldBindWithError":
+		if e.complexity.BackedByInterface.ThisShouldBindWithError == nil {
+			break
+		}
+
+		return e.complexity.BackedByInterface.ThisShouldBindWithError(childComplexity), true
 
 	case "Cat.catBreed":
 		if e.complexity.Cat.CatBreed == nil {
@@ -1221,6 +1254,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Node(childComplexity), true
 
+	case "Query.notAnInterface":
+		if e.complexity.Query.NotAnInterface == nil {
+			break
+		}
+
+		return e.complexity.Query.NotAnInterface(childComplexity), true
+
 	case "Query.nullableArg":
 		if e.complexity.Query.NullableArg == nil {
 			break
@@ -1658,6 +1698,11 @@ type Autobind {
 type B {
 	id: ID!
 }
+type BackedByInterface {
+	id: String!
+	thisShouldBind: String!
+	thisShouldBindWithError: String!
+}
 scalar Bytes
 type Cat implements Animal {
 	species: String!
@@ -1863,6 +1908,7 @@ type Query {
 	node: Node!
 	noShapeTypedNil: Shape @makeTypedNil
 	animal: Animal @makeTypedNil
+	notAnInterface: BackedByInterface
 	issue896a: [CheckIssue896!]
 	mapStringInterface(in: MapStringInterfaceInput): MapStringInterfaceType
 	mapNestedStringInterface(in: NestedMapInput): MapStringInterfaceType
@@ -3128,6 +3174,99 @@ func (ec *executionContext) _B_id(ctx context.Context, field graphql.CollectedFi
 	res := resTmp.(string)
 	fc.Result = res
 	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _BackedByInterface_id(ctx context.Context, field graphql.CollectedField, obj BackedByInterface) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "BackedByInterface",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.BackedByInterface().ID(rctx, obj)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _BackedByInterface_thisShouldBind(ctx context.Context, field graphql.CollectedField, obj BackedByInterface) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "BackedByInterface",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ThisShouldBind(), nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _BackedByInterface_thisShouldBindWithError(ctx context.Context, field graphql.CollectedField, obj BackedByInterface) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "BackedByInterface",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ThisShouldBindWithError()
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Cat_species(ctx context.Context, field graphql.CollectedField, obj *Cat) (ret graphql.Marshaler) {
@@ -6124,6 +6263,34 @@ func (ec *executionContext) _Query_animal(ctx context.Context, field graphql.Col
 	res := resTmp.(Animal)
 	fc.Result = res
 	return ec.marshalOAnimal2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐAnimal(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_notAnInterface(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "Query",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().NotAnInterface(rctx)
+	})
+
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(BackedByInterface)
+	fc.Result = res
+	return ec.marshalOBackedByInterface2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐBackedByInterface(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_issue896a(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -9312,6 +9479,52 @@ func (ec *executionContext) _B(ctx context.Context, sel ast.SelectionSet, obj *B
 	return out
 }
 
+var backedByInterfaceImplementors = []string{"BackedByInterface"}
+
+func (ec *executionContext) _BackedByInterface(ctx context.Context, sel ast.SelectionSet, obj BackedByInterface) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, backedByInterfaceImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("BackedByInterface")
+		case "id":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._BackedByInterface_id(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
+		case "thisShouldBind":
+			out.Values[i] = ec._BackedByInterface_thisShouldBind(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "thisShouldBindWithError":
+			out.Values[i] = ec._BackedByInterface_thisShouldBindWithError(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var catImplementors = []string{"Cat", "Animal"}
 
 func (ec *executionContext) _Cat(ctx context.Context, sel ast.SelectionSet, obj *Cat) graphql.Marshaler {
@@ -10753,6 +10966,17 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_animal(ctx, field)
+				return res
+			})
+		case "notAnInterface":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_notAnInterface(ctx, field)
 				return res
 			})
 		case "issue896a":
@@ -12365,6 +12589,13 @@ func (ec *executionContext) marshalOAutobind2ᚖgithubᚗcomᚋ99designsᚋgqlge
 		return graphql.Null
 	}
 	return ec._Autobind(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOBackedByInterface2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐBackedByInterface(ctx context.Context, sel ast.SelectionSet, v BackedByInterface) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._BackedByInterface(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interface{}) (bool, error) {

--- a/codegen/testserver/interfaces.go
+++ b/codegen/testserver/interfaces.go
@@ -46,3 +46,20 @@ type ConcreteNodeA struct {
 func (n *ConcreteNodeA) Child() (Node, error) {
 	return n.child, nil
 }
+
+type BackedByInterface interface {
+	ThisShouldBind() string
+	ThisShouldBindWithError() (string, error)
+}
+
+type BackedByInterfaceImpl struct {
+	Value string
+	Error error
+}
+
+func (b *BackedByInterfaceImpl) ThisShouldBind() string {
+	return b.Value
+}
+func (b *BackedByInterfaceImpl) ThisShouldBindWithError() (string, error) {
+	return b.Value, b.Error
+}

--- a/codegen/testserver/interfaces.go
+++ b/codegen/testserver/interfaces.go
@@ -32,3 +32,17 @@ func (r *Rectangle) Area() float64 {
 }
 func (r *Rectangle) isShapeUnion() {}
 func (r *Rectangle) isShape()      {}
+
+type Node interface {
+	Child() (Node, error)
+}
+
+type ConcreteNodeA struct {
+	ID    string
+	Name  string
+	child Node
+}
+
+func (n *ConcreteNodeA) Child() (Node, error) {
+	return n.child, nil
+}

--- a/codegen/testserver/interfaces.graphql
+++ b/codegen/testserver/interfaces.graphql
@@ -4,10 +4,17 @@ extend type Query {
     node: Node!
     noShapeTypedNil: Shape @makeTypedNil
     animal: Animal @makeTypedNil
+    notAnInterface: BackedByInterface
 }
 
 interface Animal {
     species: String!
+}
+
+type BackedByInterface {
+    id: String!
+    thisShouldBind: String!
+    thisShouldBindWithError: String!
 }
 
 type Dog implements Animal {

--- a/codegen/testserver/interfaces.graphql
+++ b/codegen/testserver/interfaces.graphql
@@ -1,6 +1,7 @@
 extend type Query {
     shapes: [Shape]
     noShape: Shape @makeNil
+    node: Node!
     noShapeTypedNil: Shape @makeTypedNil
     animal: Animal @makeTypedNil
 }
@@ -35,3 +36,14 @@ union ShapeUnion @goModel(model:"testserver.ShapeUnion") = Circle | Rectangle
 
 directive @makeNil on FIELD_DEFINITION
 directive @makeTypedNil on FIELD_DEFINITION
+
+interface Node {
+    id: ID!
+    child: Node!
+}
+
+type ConcreteNodeA implements Node {
+    id: ID!
+    child: Node!
+    name: String!
+}

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -186,6 +186,10 @@ func (r *queryResolver) NoShape(ctx context.Context) (Shape, error) {
 	panic("not implemented")
 }
 
+func (r *queryResolver) Node(ctx context.Context) (Node, error) {
+	panic("not implemented")
+}
+
 func (r *queryResolver) NoShapeTypedNil(ctx context.Context) (Shape, error) {
 	panic("not implemented")
 }

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -10,6 +10,10 @@ import (
 
 type Resolver struct{}
 
+func (r *backedByInterfaceResolver) ID(ctx context.Context, obj BackedByInterface) (string, error) {
+	panic("not implemented")
+}
+
 func (r *errorsResolver) A(ctx context.Context, obj *Errors) (*Error, error) {
 	panic("not implemented")
 }
@@ -198,6 +202,10 @@ func (r *queryResolver) Animal(ctx context.Context) (Animal, error) {
 	panic("not implemented")
 }
 
+func (r *queryResolver) NotAnInterface(ctx context.Context) (BackedByInterface, error) {
+	panic("not implemented")
+}
+
 func (r *queryResolver) Issue896a(ctx context.Context) ([]*CheckIssue896, error) {
 	panic("not implemented")
 }
@@ -298,6 +306,7 @@ func (r *userResolver) Friends(ctx context.Context, obj *User) ([]*User, error) 
 	panic("not implemented")
 }
 
+func (r *Resolver) BackedByInterface() BackedByInterfaceResolver { return &backedByInterfaceResolver{r} }
 func (r *Resolver) Errors() ErrorsResolver                       { return &errorsResolver{r} }
 func (r *Resolver) ForcedResolver() ForcedResolverResolver       { return &forcedResolverResolver{r} }
 func (r *Resolver) ModelMethods() ModelMethodsResolver           { return &modelMethodsResolver{r} }
@@ -309,6 +318,7 @@ func (r *Resolver) Query() QueryResolver                         { return &query
 func (r *Resolver) Subscription() SubscriptionResolver           { return &subscriptionResolver{r} }
 func (r *Resolver) User() UserResolver                           { return &userResolver{r} }
 
+type backedByInterfaceResolver struct{ *Resolver }
 type errorsResolver struct{ *Resolver }
 type forcedResolverResolver struct{ *Resolver }
 type modelMethodsResolver struct{ *Resolver }

--- a/codegen/testserver/stub.go
+++ b/codegen/testserver/stub.go
@@ -69,6 +69,7 @@ type Stub struct {
 		EnumInInput                      func(ctx context.Context, input *InputWithEnumValue) (EnumTest, error)
 		Shapes                           func(ctx context.Context) ([]Shape, error)
 		NoShape                          func(ctx context.Context) (Shape, error)
+		Node                             func(ctx context.Context) (Node, error)
 		NoShapeTypedNil                  func(ctx context.Context) (Shape, error)
 		Animal                           func(ctx context.Context) (Animal, error)
 		Issue896a                        func(ctx context.Context) ([]*CheckIssue896, error)
@@ -288,6 +289,9 @@ func (r *stubQuery) Shapes(ctx context.Context) ([]Shape, error) {
 }
 func (r *stubQuery) NoShape(ctx context.Context) (Shape, error) {
 	return r.QueryResolver.NoShape(ctx)
+}
+func (r *stubQuery) Node(ctx context.Context) (Node, error) {
+	return r.QueryResolver.Node(ctx)
 }
 func (r *stubQuery) NoShapeTypedNil(ctx context.Context) (Shape, error) {
 	return r.QueryResolver.NoShapeTypedNil(ctx)

--- a/codegen/testserver/stub.go
+++ b/codegen/testserver/stub.go
@@ -10,6 +10,9 @@ import (
 )
 
 type Stub struct {
+	BackedByInterfaceResolver struct {
+		ID func(ctx context.Context, obj BackedByInterface) (string, error)
+	}
 	ErrorsResolver struct {
 		A func(ctx context.Context, obj *Errors) (*Error, error)
 		B func(ctx context.Context, obj *Errors) (*Error, error)
@@ -72,6 +75,7 @@ type Stub struct {
 		Node                             func(ctx context.Context) (Node, error)
 		NoShapeTypedNil                  func(ctx context.Context) (Shape, error)
 		Animal                           func(ctx context.Context) (Animal, error)
+		NotAnInterface                   func(ctx context.Context) (BackedByInterface, error)
 		Issue896a                        func(ctx context.Context) ([]*CheckIssue896, error)
 		MapStringInterface               func(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error)
 		MapNestedStringInterface         func(ctx context.Context, in *NestedMapInput) (map[string]interface{}, error)
@@ -104,6 +108,9 @@ type Stub struct {
 	}
 }
 
+func (r *Stub) BackedByInterface() BackedByInterfaceResolver {
+	return &stubBackedByInterface{r}
+}
 func (r *Stub) Errors() ErrorsResolver {
 	return &stubErrors{r}
 }
@@ -133,6 +140,12 @@ func (r *Stub) Subscription() SubscriptionResolver {
 }
 func (r *Stub) User() UserResolver {
 	return &stubUser{r}
+}
+
+type stubBackedByInterface struct{ *Stub }
+
+func (r *stubBackedByInterface) ID(ctx context.Context, obj BackedByInterface) (string, error) {
+	return r.BackedByInterfaceResolver.ID(ctx, obj)
 }
 
 type stubErrors struct{ *Stub }
@@ -298,6 +311,9 @@ func (r *stubQuery) NoShapeTypedNil(ctx context.Context) (Shape, error) {
 }
 func (r *stubQuery) Animal(ctx context.Context) (Animal, error) {
 	return r.QueryResolver.Animal(ctx)
+}
+func (r *stubQuery) NotAnInterface(ctx context.Context) (BackedByInterface, error) {
+	return r.QueryResolver.NotAnInterface(ctx)
 }
 func (r *stubQuery) Issue896a(ctx context.Context) ([]*CheckIssue896, error) {
 	return r.QueryResolver.Issue896a(ctx)


### PR DESCRIPTION
Support using interfaces to back standard graphql `type`s (not interfaces). This also fixes a guard that was preventing binding to interface methods, which I assume was put in place to avoid this bad pointer codepath.

Fixes #920 #955

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
