### PR TITLE
Make sure there's a Query node before trying to add a field to it.

### DIFF
--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -97,6 +97,17 @@ func (f *federation) InjectSources(cfg *config.Config) {
 	cfg.AdditionalSources = append(cfg.AdditionalSources, &ast.Source{Name: "entity.graphql", Input: s, BuiltIn: true})
 }
 
+// ensureQuery ensures that a "Query" node exists on the schema.
+func ensureQuery(s *ast.Schema) {
+	if s.Query == nil {
+		s.Query = &ast.Definition{
+			Kind: ast.Object,
+			Name: "Query",
+		}
+		s.Types["Query"] = s.Query
+	}
+}
+
 // addEntityToSchema adds the _Entity Union and _entities query to schema.
 // This is part of MutateSchema.
 func (f *federation) addEntityToSchema(s *ast.Schema) {
@@ -125,13 +136,7 @@ func (f *federation) addEntityToSchema(s *ast.Schema) {
 			},
 		},
 	}
-	if s.Query == nil {
-		s.Query = &ast.Definition{
-			Kind: ast.Object,
-			Name: "Query",
-		}
-		s.Types["Query"] = s.Query
-	}
+	ensureQuery(s)
 	s.Query.Fields = append(s.Query.Fields, fieldDef)
 }
 
@@ -155,6 +160,7 @@ func (f *federation) addServiceToSchema(s *ast.Schema) {
 		Name: "_service",
 		Type: ast.NonNullNamedType("_Service", nil),
 	}
+	ensureQuery(s)
 	s.Query.Fields = append(s.Query.Fields, _serviceDef)
 }
 


### PR DESCRIPTION
Federation adds some queries to the schema.  There already existed
code to insert a Query node if none existed previously.  But that code
was only put on addEntityToSchema(), and not the other place we update
the query, addServiceToSchema().

Almost always the old code was good enough, since we call
addEntityToSchema() before addServiceToSchema().  But there's on
exception: when the schema has no `@key`.  In that case we only call
addServiceToSchema(), so we need to do the query-existence check there
too.

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
