### PR TITLE
propagate errors to response context in DispatchError

### DIFF
--- a/graphql/handler/executor.go
+++ b/graphql/handler/executor.go
@@ -167,6 +167,10 @@ func (e executor) CreateOperationContext(ctx context.Context, params *graphql.Ra
 
 func (e executor) DispatchError(ctx context.Context, list gqlerror.List) *graphql.Response {
 	ctx = graphql.WithResponseContext(ctx, e.server.errorPresenter, e.server.recoverFunc)
+	for _, gErr := range list {
+		graphql.AddError(ctx, gErr)
+	}
+
 	resp := e.responseMiddleware(ctx, func(ctx context.Context) *graphql.Response {
 		resp := &graphql.Response{
 			Errors: list,


### PR DESCRIPTION
request from @sonatard
We want to get errors in InterceptResponse with `graphql.GetErrors`.
We can use `*graphql.Response#Errors`. make consistent with it. 

I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [X] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
