### PR TITLE
propagate resolver errors to response error in ResponseMiddleware

### DIFF
--- a/graphql/handler/executor.go
+++ b/graphql/handler/executor.go
@@ -101,6 +101,7 @@ func (e executor) DispatchOperation(ctx context.Context, rc *graphql.OperationCo
 				if resp == nil {
 					return nil
 				}
+				resp.Errors = append(resp.Errors, graphql.GetErrors(ctx)...)
 				resp.Extensions = graphql.GetExtensions(ctx)
 				return resp
 			})
@@ -108,7 +109,6 @@ func (e executor) DispatchOperation(ctx context.Context, rc *graphql.OperationCo
 				return nil
 			}
 
-			resp.Errors = append(resp.Errors, graphql.GetErrors(ctx)...)
 			return resp
 		}
 	})

--- a/graphql/handler/server_test.go
+++ b/graphql/handler/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vektah/gqlparser/gqlerror"
 	"github.com/vektah/gqlparser/parser"
 )
+
 func TestServer(t *testing.T) {
 	srv := testserver.New()
 	srv.AddTransport(&transport.GET{})
@@ -138,7 +139,6 @@ func TestServer(t *testing.T) {
 			require.Equal(t, "Bar", cacheDoc.(*ast.QueryDocument).Operations[0].Name)
 		})
 	})
-
 }
 
 func TestErrorServer(t *testing.T) {
@@ -160,9 +160,7 @@ func TestErrorServer(t *testing.T) {
 		assert.Equal(t, 1, len(errors1))
 		assert.Equal(t, 1, len(errors2))
 	})
-
 }
-
 
 func get(handler http.Handler, target string) *httptest.ResponseRecorder {
 	r := httptest.NewRequest("GET", target, nil)

--- a/graphql/handler/testserver/testserver.go
+++ b/graphql/handler/testserver/testserver.go
@@ -90,6 +90,58 @@ func New() *TestServer {
 	return srv
 }
 
+// NewError provides a server for use in resolver error tests that isn't relying on generated code. It isnt a perfect reproduction of
+// a generated server, but it aims to be good enough to test the handler package without relying on codegen.
+func NewError() *TestServer {
+	next := make(chan struct{})
+
+	schema := gqlparser.MustLoadSchema(&ast.Source{Input: `
+		type Query {
+			name: String!
+		}
+	`})
+
+	srv := &TestServer{
+		next: next,
+	}
+
+	srv.Server = handler.New(&graphql.ExecutableSchemaMock{
+		ExecFunc: func(ctx context.Context) graphql.ResponseHandler {
+			rc := graphql.GetOperationContext(ctx)
+			switch rc.Operation.Operation {
+			case ast.Query:
+				ran := false
+				return func(ctx context.Context) *graphql.Response {
+					if ran {
+						return nil
+					}
+					ran = true
+
+					graphql.AddError(ctx,fmt.Errorf("resolver error"))
+
+					return &graphql.Response{
+						Data: []byte(`null`),
+					}
+				}
+			case ast.Mutation:
+				return graphql.OneShot(graphql.ErrorResponse(ctx, "mutations are not supported"))
+			case ast.Subscription:
+				return graphql.OneShot(graphql.ErrorResponse(ctx, "subscription are not supported"))
+			default:
+				return graphql.OneShot(graphql.ErrorResponse(ctx, "unsupported GraphQL operation"))
+			}
+		},
+		SchemaFunc: func() *ast.Schema {
+			return schema
+		},
+		ComplexityFunc: func(typeName string, fieldName string, childComplexity int, args map[string]interface{}) (i int, b bool) {
+			return srv.complexity, true
+		},
+	})
+	return srv
+}
+
+
 type TestServer struct {
 	*handler.Server
 	next       chan struct{}

--- a/graphql/handler/testserver/testserver.go
+++ b/graphql/handler/testserver/testserver.go
@@ -117,7 +117,7 @@ func NewError() *TestServer {
 					}
 					ran = true
 
-					graphql.AddError(ctx,fmt.Errorf("resolver error"))
+					graphql.AddError(ctx, fmt.Errorf("resolver error"))
 
 					return &graphql.Response{
 						Data: []byte(`null`),
@@ -140,7 +140,6 @@ func NewError() *TestServer {
 	})
 	return srv
 }
-
 
 type TestServer struct {
 	*handler.Server

--- a/graphql/handler/testserver/testserver.go
+++ b/graphql/handler/testserver/testserver.go
@@ -153,7 +153,6 @@ func (s *TestServer) SendNextSubscriptionMessage() {
 	case <-time.After(1 * time.Second):
 		fmt.Println("WARNING: no active subscription")
 	}
-
 }
 
 func (s *TestServer) SetCalculatedComplexity(complexity int) {


### PR DESCRIPTION
We want to get errors in ResponseMiddleware with Response.Errors

- issue

```go
func MyResponseMiddleware(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
	resp := next(ctx) // resp.Errors is empty when resolver return err
	
	return resp
}
```

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))