### PR TITLE
Trim underscores from around go identifiers

### DIFF
--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -276,6 +276,9 @@ func Call(p *types.Func) string {
 }
 
 func ToGo(name string) string {
+	if name == "_" {
+		return "_"
+	}
 	runes := make([]rune, 0, len(name))
 
 	wordWalker(name, func(info *wordInfo) {
@@ -296,6 +299,9 @@ func ToGo(name string) string {
 }
 
 func ToGoPrivate(name string) string {
+	if name == "_" {
+		return "_"
+	}
 	runes := make([]rune, 0, len(name))
 
 	first := true
@@ -331,7 +337,7 @@ type wordInfo struct {
 // This function is based on the following code.
 // https://github.com/golang/lint/blob/06c8688daad7faa9da5a0c2f163a3d14aac986ca/lint.go#L679
 func wordWalker(str string, f func(*wordInfo)) {
-	runes := []rune(str)
+	runes := []rune(strings.TrimFunc(str, isDelimiter))
 	w, i := 0, 0 // index of start of word, scan
 	hasCommonInitial := false
 	for i+1 <= len(runes) {

--- a/codegen/templates/templates_test.go
+++ b/codegen/templates/templates_test.go
@@ -16,6 +16,9 @@ func TestToGo(t *testing.T) {
 	require.Equal(t, "ToCamel", ToGo("toCamel"))
 	require.Equal(t, "ToCamel", ToGo("ToCamel"))
 	require.Equal(t, "ToCamel", ToGo("to-camel"))
+	require.Equal(t, "ToCamel", ToGo("-to-camel"))
+	require.Equal(t, "ToCamel", ToGo("_to-camel"))
+	require.Equal(t, "_", ToGo("_"))
 
 	require.Equal(t, "RelatedURLs", ToGo("RelatedURLs"))
 	require.Equal(t, "ImageIDs", ToGo("ImageIDs"))
@@ -63,6 +66,7 @@ func TestToGoPrivate(t *testing.T) {
 	require.Equal(t, "id", ToGoPrivate("ID"))
 	require.Equal(t, "id", ToGoPrivate("id"))
 	require.Equal(t, "", ToGoPrivate(""))
+	require.Equal(t, "_", ToGoPrivate("_"))
 }
 
 func Test_wordWalker(t *testing.T) {

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -333,7 +333,7 @@ type ComplexityRoot struct {
 	ValidType struct {
 		DifferentCase      func(childComplexity int) int
 		DifferentCaseOld   func(childComplexity int) int
-		ValidArgs          func(childComplexity int, breakArg string, defaultArg string, funcArg string, interfaceArg string, selectArg string, caseArg string, deferArg string, goArg string, mapArg string, structArg string, chanArg string, elseArg string, gotoArg string, packageArg string, switchArg string, constArg string, fallthroughArg string, ifArg string, rangeArg string, typeArg string, continueArg string, forArg string, importArg string, returnArg string, varArg string, _Arg string) int
+		ValidArgs          func(childComplexity int, breakArg string, defaultArg string, funcArg string, interfaceArg string, selectArg string, caseArg string, deferArg string, goArg string, mapArg string, structArg string, chanArg string, elseArg string, gotoArg string, packageArg string, switchArg string, constArg string, fallthroughArg string, ifArg string, rangeArg string, typeArg string, continueArg string, forArg string, importArg string, returnArg string, varArg string, _ string) int
 		ValidInputKeywords func(childComplexity int, input *ValidInput) int
 	}
 

--- a/example/federation/accounts/graph/generated/generated.go
+++ b/example/federation/accounts/graph/generated/generated.go
@@ -60,7 +60,7 @@ type ComplexityRoot struct {
 		Username func(childComplexity int) int
 	}
 
-	_Service struct {
+	Service struct {
 		SDL func(childComplexity int) int
 	}
 }
@@ -140,11 +140,11 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		return e.complexity.User.Username(childComplexity), true
 
 	case "_Service.sdl":
-		if e.complexity._Service.SDL == nil {
+		if e.complexity.Service.SDL == nil {
 			break
 		}
 
-		return e.complexity._Service.SDL(childComplexity), true
+		return e.complexity.Service.SDL(childComplexity), true
 
 	}
 	return 0, false

--- a/example/federation/accounts/graph/model/models_gen.go
+++ b/example/federation/accounts/graph/model/models_gen.go
@@ -7,4 +7,4 @@ type User struct {
 	Username string `json:"username"`
 }
 
-func (User) Is_Entity() {}
+func (User) IsEntity() {}

--- a/example/federation/products/graph/generated/generated.go
+++ b/example/federation/products/graph/generated/generated.go
@@ -61,7 +61,7 @@ type ComplexityRoot struct {
 		__resolve_entities func(childComplexity int, representations []map[string]interface{}) int
 	}
 
-	_Service struct {
+	Service struct {
 		SDL func(childComplexity int) int
 	}
 }
@@ -153,11 +153,11 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		return e.complexity.Query.__resolve_entities(childComplexity, args["representations"].([]map[string]interface{})), true
 
 	case "_Service.sdl":
-		if e.complexity._Service.SDL == nil {
+		if e.complexity.Service.SDL == nil {
 			break
 		}
 
-		return e.complexity._Service.SDL(childComplexity), true
+		return e.complexity.Service.SDL(childComplexity), true
 
 	}
 	return 0, false

--- a/example/federation/products/graph/model/models_gen.go
+++ b/example/federation/products/graph/model/models_gen.go
@@ -8,4 +8,4 @@ type Product struct {
 	Price int    `json:"price"`
 }
 
-func (Product) Is_Entity() {}
+func (Product) IsEntity() {}

--- a/example/federation/reviews/graph/generated/generated.go
+++ b/example/federation/reviews/graph/generated/generated.go
@@ -72,7 +72,7 @@ type ComplexityRoot struct {
 		Reviews func(childComplexity int) int
 	}
 
-	_Service struct {
+	Service struct {
 		SDL func(childComplexity int) int
 	}
 }
@@ -196,11 +196,11 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		return e.complexity.User.Reviews(childComplexity), true
 
 	case "_Service.sdl":
-		if e.complexity._Service.SDL == nil {
+		if e.complexity.Service.SDL == nil {
 			break
 		}
 
-		return e.complexity._Service.SDL(childComplexity), true
+		return e.complexity.Service.SDL(childComplexity), true
 
 	}
 	return 0, false

--- a/example/federation/reviews/graph/model/models.go
+++ b/example/federation/reviews/graph/model/models.go
@@ -4,7 +4,7 @@ type Product struct {
 	Upc string `json:"upc"`
 }
 
-func (Product) Is_Entity() {}
+func (Product) IsEntity() {}
 
 type Review struct {
 	Body    string
@@ -16,4 +16,4 @@ type User struct {
 	ID string `json:"id"`
 }
 
-func (User) Is_Entity() {}
+func (User) IsEntity() {}

--- a/plugin/federation/fedruntime/runtime.go
+++ b/plugin/federation/fedruntime/runtime.go
@@ -9,5 +9,5 @@ type Service struct {
 
 // Everything with a @key implements this
 type Entity interface {
-	Is_Entity()
+	IsEntity()
 }

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/99designs/gqlgen/codegen/config"
+	"github.com/99designs/gqlgen/plugin/modelgen/out"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,6 +63,10 @@ func TestModelGeneration(t *testing.T) {
 		for _, tag := range expectedTags {
 			require.True(t, strings.Contains(fileText, tag))
 		}
+	})
+
+	t.Run("concrete types implement interface", func(t *testing.T) {
+		var _ out.FooBarer = out.FooBarr{}
 	})
 }
 

--- a/plugin/modelgen/out/generated.go
+++ b/plugin/modelgen/out/generated.go
@@ -8,6 +8,10 @@ import (
 	"strconv"
 )
 
+type FooBarer interface {
+	IsFooBarer()
+}
+
 // InterfaceWithDescription is an interface with a description
 type InterfaceWithDescription interface {
 	IsInterfaceWithDescription()
@@ -63,6 +67,12 @@ type TypeWithDescription struct {
 }
 
 func (TypeWithDescription) IsUnionWithDescription() {}
+
+type FooBarr struct {
+	Name string `json:"name" database:"_Foo_Barrname"`
+}
+
+func (FooBarr) IsFooBarer() {}
 
 // EnumWithDescription is an enum with a description
 type EnumWithDescription string

--- a/plugin/modelgen/testdata/schema.graphql
+++ b/plugin/modelgen/testdata/schema.graphql
@@ -83,3 +83,12 @@ interface InterfaceWithDescription {
 
 "UnionWithDescription is an union with a description"
 union UnionWithDescription = TypeWithDescription | ExistingType
+
+
+interface Foo_Barer {
+    name: String!
+}
+
+type _Foo_Barr implements  Foo_Barer {
+    name: String!
+}


### PR DESCRIPTION
Removes leading and trailing underscores when camelCasing identifiers to prevent `Is_Entitiy`

fixes https://github.com/99designs/gqlgen/issues/1032