### PR TITLE
Fix link to examples directory in Federation docs

### DIFF
--- a/docs/content/recipes/federation.md
+++ b/docs/content/recipes/federation.md
@@ -6,7 +6,7 @@ menu: { main: { parent: 'recipes' } }
 ---
 
 In this quick guide we are going to implement the example [Apollo Federation](https://www.apollographql.com/docs/apollo-server/federation/introduction/)
-server in gqlgen. You can find the finished result in the [examples directory](/example/federation).
+server in gqlgen. You can find the finished result in the [examples directory](https://github.com/99designs/gqlgen/tree/master/example/federation).
 
 
 ## Create the federated servers


### PR DESCRIPTION
Fix link to examples directory in doc https://gqlgen.com/recipes/federation/