### PR TITLE
Add function to check presense of operation context

### DIFF
--- a/graphql/context_operation.go
+++ b/graphql/context_operation.go
@@ -62,6 +62,14 @@ func WithOperationContext(ctx context.Context, rc *OperationContext) context.Con
 	return context.WithValue(ctx, operationCtx, rc)
 }
 
+// HasOperationContext checks if the given context is part of an ongoing operation
+//
+// Some errors can happen outside of an operation, eg json unmarshal errors.
+func HasOperationContext(ctx context.Context) bool {
+	_, ok := ctx.Value(operationCtx).(*OperationContext)
+	return ok
+}
+
 // This is just a convenient wrapper method for CollectFields
 func CollectFieldsCtx(ctx context.Context, satisfies []string) []CollectedField {
 	resctx := GetFieldContext(ctx)

--- a/graphql/context_operation_test.go
+++ b/graphql/context_operation_test.go
@@ -10,7 +10,22 @@ import (
 
 func TestGetOperationContext(t *testing.T) {
 	rc := &OperationContext{}
-	require.Equal(t, rc, GetOperationContext(WithOperationContext(context.Background(), rc)))
+
+	t.Run("with operation context", func(t *testing.T) {
+		ctx := WithOperationContext(context.Background(), rc)
+
+		require.True(t, HasOperationContext(ctx))
+		require.Equal(t, rc, GetOperationContext(ctx))
+	})
+
+	t.Run("without operation context", func(t *testing.T) {
+		ctx := context.Background()
+
+		require.False(t, HasOperationContext(ctx))
+		require.Panics(t, func() {
+			GetOperationContext(ctx)
+		})
+	})
 }
 
 func TestCollectAllFields(t *testing.T) {


### PR DESCRIPTION
The new `GetOperationContext` panics if the context is not available, which makes logic errors more visible but there is no way to check for its presence before hand in places where you're not certain if it is excuting within an operation, like an error handler.

This PR adds a HasOperationContext function to make that check.

Alternativley, we could wind back the panic change, in favor of `GetOperationContext() (ctx, ok)`. Thoughts?