### PR TITLE
suppress golint messages

### DIFF
--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -44,6 +44,8 @@ type Options struct {
 	GeneratedHeader bool
 	// PackageDoc is documentation written above the package line
 	PackageDoc string
+	// FileNotice is notice written below the package line
+	FileNotice string
 	// Data will be passed to the template execution.
 	Data  interface{}
 	Funcs template.FuncMap
@@ -144,6 +146,10 @@ func Render(cfg Options) error {
 	result.WriteString("package ")
 	result.WriteString(cfg.PackageName)
 	result.WriteString("\n\n")
+	if cfg.FileNotice != "" {
+		result.WriteString(cfg.FileNotice)
+		result.WriteString("\n\n")
+	}
 	result.WriteString("import (\n")
 	result.WriteString(CurrentImports.String())
 	result.WriteString(")\n")

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -1,5 +1,6 @@
-// THIS CODE IS A STARTING POINT ONLY. IT WILL NOT BE UPDATED WITH SCHEMA CHANGES.
 package testserver
+
+// THIS CODE IS A STARTING POINT ONLY. IT WILL NOT BE UPDATED WITH SCHEMA CHANGES.
 
 import (
 	"context"
@@ -306,17 +307,38 @@ func (r *userResolver) Friends(ctx context.Context, obj *User) ([]*User, error) 
 	panic("not implemented")
 }
 
+// BackedByInterface returns BackedByInterfaceResolver implementation.
 func (r *Resolver) BackedByInterface() BackedByInterfaceResolver { return &backedByInterfaceResolver{r} }
-func (r *Resolver) Errors() ErrorsResolver                       { return &errorsResolver{r} }
-func (r *Resolver) ForcedResolver() ForcedResolverResolver       { return &forcedResolverResolver{r} }
-func (r *Resolver) ModelMethods() ModelMethodsResolver           { return &modelMethodsResolver{r} }
+
+// Errors returns ErrorsResolver implementation.
+func (r *Resolver) Errors() ErrorsResolver { return &errorsResolver{r} }
+
+// ForcedResolver returns ForcedResolverResolver implementation.
+func (r *Resolver) ForcedResolver() ForcedResolverResolver { return &forcedResolverResolver{r} }
+
+// ModelMethods returns ModelMethodsResolver implementation.
+func (r *Resolver) ModelMethods() ModelMethodsResolver { return &modelMethodsResolver{r} }
+
+// OverlappingFields returns OverlappingFieldsResolver implementation.
 func (r *Resolver) OverlappingFields() OverlappingFieldsResolver { return &overlappingFieldsResolver{r} }
-func (r *Resolver) Panics() PanicsResolver                       { return &panicsResolver{r} }
-func (r *Resolver) Primitive() PrimitiveResolver                 { return &primitiveResolver{r} }
-func (r *Resolver) PrimitiveString() PrimitiveStringResolver     { return &primitiveStringResolver{r} }
-func (r *Resolver) Query() QueryResolver                         { return &queryResolver{r} }
-func (r *Resolver) Subscription() SubscriptionResolver           { return &subscriptionResolver{r} }
-func (r *Resolver) User() UserResolver                           { return &userResolver{r} }
+
+// Panics returns PanicsResolver implementation.
+func (r *Resolver) Panics() PanicsResolver { return &panicsResolver{r} }
+
+// Primitive returns PrimitiveResolver implementation.
+func (r *Resolver) Primitive() PrimitiveResolver { return &primitiveResolver{r} }
+
+// PrimitiveString returns PrimitiveStringResolver implementation.
+func (r *Resolver) PrimitiveString() PrimitiveStringResolver { return &primitiveStringResolver{r} }
+
+// Query returns QueryResolver implementation.
+func (r *Resolver) Query() QueryResolver { return &queryResolver{r} }
+
+// Subscription returns SubscriptionResolver implementation.
+func (r *Resolver) Subscription() SubscriptionResolver { return &subscriptionResolver{r} }
+
+// User returns UserResolver implementation.
+func (r *Resolver) User() UserResolver { return &userResolver{r} }
 
 type backedByInterfaceResolver struct{ *Resolver }
 type errorsResolver struct{ *Resolver }

--- a/example/config/schema.resolvers.go
+++ b/example/config/schema.resolvers.go
@@ -1,6 +1,7 @@
+package config
+
 // This file will be automatically regenerated based on the schema, any resolver implementations
 // will be copied through when generating and any unknown code will be moved to the end.
-package config
 
 import (
 	"context"
@@ -24,8 +25,11 @@ func (r *queryResolver) Todos(ctx context.Context) ([]*Todo, error) {
 	return r.todos, nil
 }
 
+// Mutation returns MutationResolver implementation.
 func (r *Resolver) Mutation() MutationResolver { return &mutationResolver{r} }
-func (r *Resolver) Query() QueryResolver       { return &queryResolver{r} }
+
+// Query returns QueryResolver implementation.
+func (r *Resolver) Query() QueryResolver { return &queryResolver{r} }
 
 type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }

--- a/example/config/todo.resolvers.go
+++ b/example/config/todo.resolvers.go
@@ -1,6 +1,7 @@
+package config
+
 // This file will be automatically regenerated based on the schema, any resolver implementations
 // will be copied through when generating and any unknown code will be moved to the end.
-package config
 
 import (
 	"context"
@@ -17,6 +18,7 @@ func (r *todoResolver) ID(ctx context.Context, obj *Todo) (string, error) {
 	return obj.ID, nil
 }
 
+// Todo returns TodoResolver implementation.
 func (r *Resolver) Todo() TodoResolver { return &todoResolver{r} }
 
 type todoResolver struct{ *Resolver }

--- a/example/federation/accounts/graph/entity.resolvers.go
+++ b/example/federation/accounts/graph/entity.resolvers.go
@@ -1,6 +1,7 @@
+package graph
+
 // This file will be automatically regenerated based on the schema, any resolver implementations
 // will be copied through when generating and any unknown code will be moved to the end.
-package graph
 
 import (
 	"context"
@@ -21,6 +22,7 @@ func (r *entityResolver) FindUserByID(ctx context.Context, id string) (*model.Us
 	}, nil
 }
 
+// Entity returns generated.EntityResolver implementation.
 func (r *Resolver) Entity() generated.EntityResolver { return &entityResolver{r} }
 
 type entityResolver struct{ *Resolver }

--- a/example/federation/accounts/graph/schema.resolvers.go
+++ b/example/federation/accounts/graph/schema.resolvers.go
@@ -1,6 +1,7 @@
+package graph
+
 // This file will be automatically regenerated based on the schema, any resolver implementations
 // will be copied through when generating and any unknown code will be moved to the end.
-package graph
 
 import (
 	"context"
@@ -16,6 +17,7 @@ func (r *queryResolver) Me(ctx context.Context) (*model.User, error) {
 	}, nil
 }
 
+// Query returns generated.QueryResolver implementation.
 func (r *Resolver) Query() generated.QueryResolver { return &queryResolver{r} }
 
 type queryResolver struct{ *Resolver }

--- a/example/federation/products/graph/entity.resolvers.go
+++ b/example/federation/products/graph/entity.resolvers.go
@@ -1,6 +1,7 @@
+package graph
+
 // This file will be automatically regenerated based on the schema, any resolver implementations
 // will be copied through when generating and any unknown code will be moved to the end.
-package graph
 
 import (
 	"context"
@@ -18,6 +19,7 @@ func (r *entityResolver) FindProductByUpc(ctx context.Context, upc string) (*mod
 	return nil, nil
 }
 
+// Entity returns generated.EntityResolver implementation.
 func (r *Resolver) Entity() generated.EntityResolver { return &entityResolver{r} }
 
 type entityResolver struct{ *Resolver }

--- a/example/federation/products/graph/schema.resolvers.go
+++ b/example/federation/products/graph/schema.resolvers.go
@@ -1,6 +1,7 @@
+package graph
+
 // This file will be automatically regenerated based on the schema, any resolver implementations
 // will be copied through when generating and any unknown code will be moved to the end.
-package graph
 
 import (
 	"context"
@@ -13,6 +14,7 @@ func (r *queryResolver) TopProducts(ctx context.Context, first *int) ([]*model.P
 	return hats, nil
 }
 
+// Query returns generated.QueryResolver implementation.
 func (r *Resolver) Query() generated.QueryResolver { return &queryResolver{r} }
 
 type queryResolver struct{ *Resolver }

--- a/example/federation/reviews/graph/entity.resolvers.go
+++ b/example/federation/reviews/graph/entity.resolvers.go
@@ -1,6 +1,7 @@
+package graph
+
 // This file will be automatically regenerated based on the schema, any resolver implementations
 // will be copied through when generating and any unknown code will be moved to the end.
-package graph
 
 import (
 	"context"
@@ -21,6 +22,7 @@ func (r *entityResolver) FindUserByID(ctx context.Context, id string) (*model.Us
 	}, nil
 }
 
+// Entity returns generated.EntityResolver implementation.
 func (r *Resolver) Entity() generated.EntityResolver { return &entityResolver{r} }
 
 type entityResolver struct{ *Resolver }

--- a/example/federation/reviews/graph/schema.resolvers.go
+++ b/example/federation/reviews/graph/schema.resolvers.go
@@ -1,6 +1,7 @@
+package graph
+
 // This file will be automatically regenerated based on the schema, any resolver implementations
 // will be copied through when generating and any unknown code will be moved to the end.
-package graph
 
 import (
 	"context"
@@ -33,8 +34,11 @@ func (r *userResolver) Reviews(ctx context.Context, obj *model.User) ([]*model.R
 	return res, nil
 }
 
+// Product returns generated.ProductResolver implementation.
 func (r *Resolver) Product() generated.ProductResolver { return &productResolver{r} }
-func (r *Resolver) User() generated.UserResolver       { return &userResolver{r} }
+
+// User returns generated.UserResolver implementation.
+func (r *Resolver) User() generated.UserResolver { return &userResolver{r} }
 
 type productResolver struct{ *Resolver }
 type userResolver struct{ *Resolver }

--- a/plugin/resolvergen/resolver.go
+++ b/plugin/resolvergen/resolver.go
@@ -71,7 +71,7 @@ func (m *Plugin) generateSingleFile(data *codegen.Data) error {
 
 	return templates.Render(templates.Options{
 		PackageName: data.Config.Resolver.Package,
-		PackageDoc:  `// THIS CODE IS A STARTING POINT ONLY. IT WILL NOT BE UPDATED WITH SCHEMA CHANGES.`,
+		FileNotice:  `// THIS CODE IS A STARTING POINT ONLY. IT WILL NOT BE UPDATED WITH SCHEMA CHANGES.`,
 		Filename:    data.Config.Resolver.Filename,
 		Data:        resolverBuild,
 		Packages:    data.Config.Packages,
@@ -132,7 +132,7 @@ func (m *Plugin) generatePerSchema(data *codegen.Data) error {
 
 		err := templates.Render(templates.Options{
 			PackageName: data.Config.Resolver.Package,
-			PackageDoc: `
+			FileNotice: `
 				// This file will be automatically regenerated based on the schema, any resolver implementations
 				// will be copied through when generating and any unknown code will be moved to the end.`,
 			Filename: filename,
@@ -147,7 +147,7 @@ func (m *Plugin) generatePerSchema(data *codegen.Data) error {
 	if _, err := os.Stat(data.Config.Resolver.Filename); os.IsNotExist(errors.Cause(err)) {
 		err := templates.Render(templates.Options{
 			PackageName: data.Config.Resolver.Package,
-			PackageDoc: `
+			FileNotice: `
 				// This file will not be regenerated automatically.
 				//
 				// It serves as dependency injection for your app, add any dependencies you require here.`,

--- a/plugin/resolvergen/resolver.gotpl
+++ b/plugin/resolvergen/resolver.gotpl
@@ -26,6 +26,7 @@
 {{ end }}
 
 {{ range $object := .Objects -}}
+	// {{$object.Name}} returns {{ $object.ResolverInterface | ref }} implementation.
 	func (r *{{$.ResolverType}}) {{$object.Name}}() {{ $object.ResolverInterface | ref }} { return &{{lcFirst $object.Name}}{{ucFirst $.ResolverType}}{r} }
 {{ end }}
 


### PR DESCRIPTION
I tried new resolver layout. It's pretty nice!
In my app, golint emit messages to resolver files.
```
package comment should be of the form "Package graphqlapi ..."
exported method Resolver.CircleExhibitInfo should have comment or be unexported
```
I wanna suppress it.
gqlgen maintenance files are manually edited & generated file both.
I can't ignore these messages...

I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [X] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
