### PR TITLE
Fix mismatching documentation of Todo struct

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -167,10 +167,10 @@ Create a new file called `graph/model/todo.go`
 package model
 
 type Todo struct {
-	ID   string `json:"id"`
-	Text string `json:"text"`
-	Done bool   `json:"done"`
-	UserId int  `json:"user"`
+	ID     string `json:"id"`
+	Text   string `json:"text"`
+	Done   bool   `json:"done"`
+	UserID string `json:"user"`
 }
 ```
 


### PR DESCRIPTION
Mismatch between the code and the getting started documentation.

Just tried the tutorial at https://gqlgen.com/getting-started/ and stumbled across a minor error between the documentation and the code.