### PR TITLE
Update file upload docs with Apollo client usage

### DIFF
--- a/docs/content/reference/file-upload.md
+++ b/docs/content/reference/file-upload.md
@@ -142,3 +142,34 @@ That invokes the following operation:
 ```
 
 See the [example/fileupload](https://github.com/99designs/gqlgen/tree/master/example/fileupload) package for more examples.
+
+# Usage with Apollo
+
+[apollo-upload-client](https://github.com/jaydenseric/apollo-upload-client) needs to be installed in order for file uploading to work with Apollo:
+
+```javascript
+import ApolloClient from "apollo-client";
+import { createUploadLink } from "apollo-upload-client";
+
+const client = new ApolloClient({
+	cache: new InMemoryCache(),
+	link: createUploadLink({ uri: "/graphql" })
+});
+```
+
+A `File` object can then be passed into your mutation as a variable:
+
+```javascript
+{
+  query: `
+    mutation($file: Upload!) {
+      singleUpload(file: $file) {
+        id
+      }
+    }
+  `,
+  variables: {
+    file: new File(...)
+  }
+}
+```


### PR DESCRIPTION
This updates the File Upload docs with some more information on usage with Apollo client.

I have:
 - [ ] ~~Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))~~
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
