### PR TITLE
Gnerate to fast by exec codegen.GenerateCode before plugin GenerateCode

### DIFF
--- a/api/generate.go
+++ b/api/generate.go
@@ -74,6 +74,10 @@ func Generate(cfg *config.Config, option ...Option) error {
 		return errors.Wrap(err, "merging type systems failed")
 	}
 
+	if err = codegen.GenerateCode(data); err != nil {
+		return errors.Wrap(err, "generating core failed")
+	}
+
 	for _, p := range plugins {
 		if mut, ok := p.(plugin.CodeGenerator); ok {
 			err := mut.GenerateCode(data)
@@ -81,10 +85,6 @@ func Generate(cfg *config.Config, option ...Option) error {
 				return errors.Wrap(err, p.Name())
 			}
 		}
-	}
-
-	if err = codegen.GenerateCode(data); err != nil {
-		return errors.Wrap(err, "generating core failed")
 	}
 
 	if !cfg.SkipValidation {


### PR DESCRIPTION
I fixed to only called once during generation in #1079 but it slowed down generation.
I found to fast by exec codegen.GenerateCode before plugin GenerateCode.

Benchmark in my code.

```shell
// v0.11.2
$ time gqlgen generate
gqlgen generate  20.41s user 15.53s system 30% cpu 1:59.05 total

// this PR
$ time gqlgen generate
gqlgen generate  6.15s user 4.54s system 383% cpu 2.791 total
```

I don't know why...