### PR TITLE
Add support for OBJECT directive

### DIFF
--- a/codegen/field.go
+++ b/codegen/field.go
@@ -83,6 +83,13 @@ func (b *builder) bindField(obj *Object, f *Field) (errret error) {
 			}
 			f.TypeReference = tr
 		}
+		if f.TypeReference != nil {
+			dirs, err := b.getDirectives(f.TypeReference.Definition.Directives)
+			if err != nil {
+				errret = err
+			}
+			f.Directives = append(dirs, f.Directives...)
+		}
 	}()
 
 	f.Stream = obj.Stream

--- a/codegen/testserver/directive.graphql
+++ b/codegen/testserver/directive.graphql
@@ -6,6 +6,7 @@ directive @toNull on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINI
 directive @directive1 on FIELD_DEFINITION
 directive @directive2 on FIELD_DEFINITION
 directive @unimplemented on FIELD_DEFINITION
+directive @order(location: String!) on FIELD_DEFINITION | OBJECT
 
 extend type Query {
     directiveArg(arg: String! @length(min:1, max: 255, message: "invalid length")): String
@@ -13,7 +14,7 @@ extend type Query {
     directiveInputNullable(arg: InputDirectives): String
     directiveInput(arg: InputDirectives!): String
     directiveInputType(arg: InnerInput! @custom): String
-    directiveObject: ObjectDirectives
+    directiveObject: ObjectDirectives @order(location: "Query_field")
     directiveObjectWithCustomGoModel: ObjectDirectivesWithCustomGoModel
     directiveFieldDef(ret: String!): String! @length(min: 1, message: "not valid")
     directiveField: String
@@ -40,9 +41,10 @@ input InnerDirectives {
     message: String! @length(min: 1, message: "not valid")
 }
 
-type ObjectDirectives {
+type ObjectDirectives @order(location: "ObjectDirectives_object") {
     text: String! @length(min: 0, max: 7, message: "not valid")
     nullableText: String @toNull
+    order: [String!]!
 }
 
 type ObjectDirectivesWithCustomGoModel {

--- a/codegen/testserver/models-gen.go
+++ b/codegen/testserver/models-gen.go
@@ -118,8 +118,9 @@ type NestedMapInput struct {
 }
 
 type ObjectDirectives struct {
-	Text         string  `json:"text"`
-	NullableText *string `json:"nullableText"`
+	Text         string   `json:"text"`
+	NullableText *string  `json:"nullableText"`
+	Order        []string `json:"order"`
 }
 
 type OuterInput struct {


### PR DESCRIPTION
I propose the implementation of the execution of directives for OBJECT.
When resolving an object that has a directive, the directive function can insert some process before and after executing resolver.

In the case of setting the same directive at field and object, it executes field directive before object directive.

If directive for OBJECT should do other behaviors or in other execute timing, I will close this PR and rewrite.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
