### PR TITLE
Do not require a resolver for "empty" extended types.

### DIFF
--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -181,7 +181,9 @@ func (e *Entity) allFieldsAreExternal() bool {
 
 func (f *federation) GenerateCode(data *codegen.Data) error {
 	if len(f.Entities) > 0 {
-		data.Objects.ByName("Entity").Root = true
+		if data.Objects.ByName("Entity") != nil {
+			data.Objects.ByName("Entity").Root = true
+		}
 		for _, e := range f.Entities {
 			obj := data.Objects.ByName(e.Def.Name)
 			for _, field := range obj.Fields {

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -111,18 +111,24 @@ func (f *federation) InjectSourceLate(schema *ast.Schema) *ast.Source {
 		return nil
 	}
 
+	// resolvers can be empty if a service defines only "empty
+	// extend" types.  This should be rare.
+	if resolvers != "" {
+		resolvers = `
+# fake type to build resolver interfaces for users to implement
+type Entity {
+	` + resolvers + `
+}
+`
+	}
+
 	return &ast.Source{
 		Name:    "federation/entity.graphql",
 		BuiltIn: true,
 		Input: `
 # a union of all types that use the @key directive
 union _Entity = ` + entities + `
-
-# fake type to build resolver interfaces for users to implement
-type Entity {
-	` + resolvers + `
-}
-
+` + resolvers + `
 type _Service {
   sdl: String
 }

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -164,8 +164,13 @@ type RequireField struct {
 	TypeReference *config.TypeReference // The Go representation of that field type
 }
 
-func (e *Entity) allFieldsAreKeyFields() bool {
-	return len(e.Def.Fields) == len(e.KeyFields)
+func (e *Entity) allFieldsAreExternal() bool {
+	for _, field := range e.Def.Fields {
+		if field.Directives.ForName("external") == nil {
+			return false
+		}
+	}
+	return true
 }
 
 func (f *federation) GenerateCode(data *codegen.Data) error {
@@ -280,9 +285,9 @@ func (f *federation) setEntities(schema *ast.Schema) {
 				//    // Federation needs this type, but
 				//    // it doesn't need a resolver for it!
 				//    extend TypeDefinedInOtherService @key(fields: "id") {
-				//       id: ID @extends
+				//       id: ID @external
 				//    }
-				if (e.allFieldsAreKeyFields()) {
+				if (e.allFieldsAreExternal()) {
 					e.ResolverName = ""
 				}
 

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -287,7 +287,7 @@ func (f *federation) setEntities(schema *ast.Schema) {
 				//    extend TypeDefinedInOtherService @key(fields: "id") {
 				//       id: ID @external
 				//    }
-				if (e.allFieldsAreExternal()) {
+				if e.allFieldsAreExternal() {
 					e.ResolverName = ""
 				}
 

--- a/plugin/federation/federation.gotpl
+++ b/plugin/federation/federation.gotpl
@@ -34,29 +34,31 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 		}
 		switch typeName {
 		{{ range .Entities }}
-		case "{{.Def.Name}}":
-			{{ range $i, $keyField := .KeyFields -}}
-				id{{$i}}, err := ec.{{.TypeReference.UnmarshalFunc}}(ctx, rep["{{$keyField.Field.Name}}"])
-				if err != nil {
-					return nil, errors.New(fmt.Sprintf("Field %s undefined in schema.", "{{$keyField.Field.Name}}"))
-				}
-			{{end}}
-
-			entity, err := ec.resolvers.Entity().{{.ResolverName | go}}(ctx,
-				{{ range $i, $_ := .KeyFields -}} id{{$i}}, {{end}})
-			if err != nil {
-				return nil, err
-			}
-
-			{{ range .Requires }}
-				{{ range .Fields}}
-					entity.{{.NameGo}}, err = ec.{{.TypeReference.UnmarshalFunc}}(ctx, rep["{{.Name}}"])
+			{{ if .ResolverName }}
+			case "{{.Def.Name}}":
+				{{ range $i, $keyField := .KeyFields -}}
+					id{{$i}}, err := ec.{{.TypeReference.UnmarshalFunc}}(ctx, rep["{{$keyField.Field.Name}}"])
 					if err != nil {
-						return nil, err
+						return nil, errors.New(fmt.Sprintf("Field %s undefined in schema.", "{{$keyField.Field.Name}}"))
 					}
+				{{end}}
+	
+				entity, err := ec.resolvers.Entity().{{.ResolverName | go}}(ctx,
+					{{ range $i, $_ := .KeyFields -}} id{{$i}}, {{end}})
+				if err != nil {
+					return nil, err
+				}
+	
+				{{ range .Requires }}
+					{{ range .Fields}}
+						entity.{{.NameGo}}, err = ec.{{.TypeReference.UnmarshalFunc}}(ctx, rep["{{.Name}}"])
+						if err != nil {
+							return nil, err
+						}
+					{{ end }}
 				{{ end }}
+				list = append(list, entity)
 			{{ end }}
-			list = append(list, entity)
 		{{ end }}
 		default:
 			return nil, errors.New("unknown type: "+typeName)

--- a/plugin/resolvergen/testdata/followschema/out/resolver.go
+++ b/plugin/resolvergen/testdata/followschema/out/resolver.go
@@ -1,6 +1,7 @@
+package customresolver
+
 // This file will not be regenerated automatically.
 //
 // It serves as dependency injection for your app, add any dependencies you require here.
-package customresolver
 
 type CustomResolverType struct{}

--- a/plugin/resolvergen/testdata/singlefile/out/resolver.go
+++ b/plugin/resolvergen/testdata/singlefile/out/resolver.go
@@ -1,5 +1,6 @@
-// THIS CODE IS A STARTING POINT ONLY. IT WILL NOT BE UPDATED WITH SCHEMA CHANGES.
 package customresolver
+
+// THIS CODE IS A STARTING POINT ONLY. IT WILL NOT BE UPDATED WITH SCHEMA CHANGES.
 
 import (
 	"context"
@@ -10,11 +11,15 @@ type CustomResolverType struct{}
 func (r *queryCustomResolverType) Resolver(ctx context.Context) (*Resolver, error) {
 	panic("not implemented")
 }
+
 func (r *resolverCustomResolverType) Name(ctx context.Context, obj *Resolver) (string, error) {
 	panic("not implemented")
 }
 
-func (r *CustomResolverType) Query() QueryResolver       { return &queryCustomResolverType{r} }
+// Query returns QueryResolver implementation.
+func (r *CustomResolverType) Query() QueryResolver { return &queryCustomResolverType{r} }
+
+// Resolver returns ResolverResolver implementation.
 func (r *CustomResolverType) Resolver() ResolverResolver { return &resolverCustomResolverType{r} }
 
 type queryCustomResolverType struct{ *CustomResolverType }


### PR DESCRIPTION
Summary:
If our schema has a field with a type defined in another service, then
we need to define an "empty extend" of that type in this service, so
this service knows what the type is like.  But the graphql-server will
never ask us to actually resolve this "empty extend", so we don't
require a resolver function for it.  Example:
```
   type MyType {
      myvar: TypeDefinedInOtherService
   }

   // Federation needs this type, but it doesn't need a resolver for
   // it!  graphql-server will never ask *us* to resolve a
   // TypeDefinedInOtherService; it will ask the other service.
   extend TypeDefinedInOtherService @key(fields: "id") {
      id: ID @extends
   }
```

Test Plan:
I manually tested this on a service (`assignments`) that we have that
fell afoul of this problem.  But I had a hard time adding tests inside
gqlgen because the error happens at validation-time, and the
federation tests are not set up to go that far down the processing
path.