### PR TITLE
Fix typo in authentication docs

### DIFF
--- a/docs/content/recipes/authentication.md
+++ b/docs/content/recipes/authentication.md
@@ -5,7 +5,7 @@ linkTitle: Authentication
 menu: { main: { parent: 'recipes' } }
 ---
 
-We have an app where users are authenticated using a cookie in the HTTP request, and we want to check this authentication status somewhere in our graph. Because GraphQL is transport agnostic we can't assume there will even be an HTTP request, so we need to expose these authention details to our graph using a middleware.
+We have an app where users are authenticated using a cookie in the HTTP request, and we want to check this authentication status somewhere in our graph. Because GraphQL is transport agnostic we can't assume there will even be an HTTP request, so we need to expose these authentication details to our graph using a middleware.
 
 
 ```go


### PR DESCRIPTION
Fix typo in authentication docs.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
