### PR TITLE
Add LoadDefaultConfig to load the schema by default

### DIFF
--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -27,8 +27,10 @@ var genCmd = &cli.Command{
 		} else {
 			cfg, err = config.LoadConfigFromDefaultLocations()
 			if os.IsNotExist(errors.Cause(err)) {
-				cfg = config.DefaultConfig()
-			} else if err != nil {
+				cfg, err = config.LoadDefaultConfig()
+			}
+
+			if err != nil {
 				return err
 			}
 		}

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -49,6 +49,25 @@ func DefaultConfig() *Config {
 	}
 }
 
+// LoadDefaultConfig loads the default config so that it is ready to be used
+func LoadDefaultConfig() (*Config, error) {
+	config := DefaultConfig()
+
+	for _, filename := range config.SchemaFilename {
+		filename = filepath.ToSlash(filename)
+		var err error
+		var schemaRaw []byte
+		schemaRaw, err = ioutil.ReadFile(filename)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to open schema")
+		}
+
+		config.Sources = append(config.Sources, &ast.Source{Name: filename, Input: string(schemaRaw)})
+	}
+
+	return config, nil
+}
+
 // LoadConfigFromDefaultLocations looks for a config file in the current directory, and all parent directories
 // walking up the tree. The closest config file will be returned.
 func LoadConfigFromDefaultLocations() (*Config, error) {

--- a/codegen/config/config_test.go
+++ b/codegen/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/v2"
@@ -53,7 +54,7 @@ func TestLoadConfig(t *testing.T) {
 	})
 }
 
-func TestLoadDefaultConfig(t *testing.T) {
+func TestLoadConfigFromDefaultLocation(t *testing.T) {
 	testDir, err := os.Getwd()
 	require.NoError(t, err)
 	var cfg *Config
@@ -82,6 +83,29 @@ func TestLoadDefaultConfig(t *testing.T) {
 
 		cfg, err = LoadConfigFromDefaultLocations()
 		require.True(t, os.IsNotExist(err))
+	})
+}
+
+func TestLoadDefaultConfig(t *testing.T) {
+	testDir, err := os.Getwd()
+	require.NoError(t, err)
+	var cfg *Config
+
+	t.Run("will find the schema", func(t *testing.T) {
+		err = os.Chdir(filepath.Join(testDir, "testdata", "defaultconfig"))
+		require.NoError(t, err)
+
+		cfg, err = LoadDefaultConfig()
+		require.NoError(t, err)
+		require.NotEmpty(t, cfg.Sources)
+	})
+
+	t.Run("will return error if schema doesn't exist", func(t *testing.T) {
+		err = os.Chdir(testDir)
+		require.NoError(t, err)
+
+		cfg, err = LoadDefaultConfig()
+		require.True(t, os.IsNotExist(errors.Cause(err)))
 	})
 }
 


### PR DESCRIPTION
When `gqlgen gen` falls back to the `DefaultConfig`, the generated code does not have any models, queries or mutations.

The reason is that the default `schema.graphql` is never loaded. `api.Generate` is called with an empty list of `ast.Source`.

This PR changes the `gen` command to properly generate code based on the default config.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
    - There was no documentation to update that I could see.
