### PR TITLE
Fix duplicate fields in preloads

### DIFF
--- a/docs/content/reference/field-collection.md
+++ b/docs/content/reference/field-collection.md
@@ -94,8 +94,6 @@ func GetNestedPreloads(ctx *graphql.RequestContext, fields []graphql.CollectedFi
 		prefixColumn := GetPreloadString(prefix, column.Name)
 		preloads = append(preloads, prefixColumn)
 		preloads = append(preloads, GetNestedPreloads(ctx, graphql.CollectFields(ctx, column.SelectionSet, nil), prefixColumn)...)
-		preloads = append(preloads, GetNestedPreloads(ctx, graphql.CollectFields(ctx, column.Selections, nil), prefixColumn)...)
-
 	}
 	return
 }


### PR DESCRIPTION
This is a documentation change, where we are looping over Selections Twice, which is causing duplicates. I've removed one nested preload to removed these duplicates.