### PR TITLE
fix redundant type warning

### DIFF
--- a/codegen/generated!.gotpl
+++ b/codegen/generated!.gotpl
@@ -208,7 +208,7 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 
 var sources = []*ast.Source{
 {{- range $source := .Config.Sources }}
-	&ast.Source{Name: {{$source.Name|quote}}, Input: {{$source.Input|rawQuote}}, BuiltIn: {{$source.BuiltIn}}},
+	{Name: {{$source.Name|quote}}, Input: {{$source.Input|rawQuote}}, BuiltIn: {{$source.BuiltIn}}},
 {{- end }}
 }
 var parsedSchema = gqlparser.MustLoadSchema(sources...)

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -1683,7 +1683,7 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	&ast.Source{Name: "builtinscalar.graphql", Input: `
+	{Name: "builtinscalar.graphql", Input: `
 """
 Since gqlgen defines default implementation for a Map scalar, this tests that the builtin is _not_
 added to the TypeMap
@@ -1692,7 +1692,7 @@ type Map {
     id: ID!
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "complexity.graphql", Input: `extend type Query {
+	{Name: "complexity.graphql", Input: `extend type Query {
     overlapping: OverlappingFields
 }
 
@@ -1704,7 +1704,7 @@ type OverlappingFields {
   new_foo: Int!
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "directive.graphql", Input: `directive @length(min: Int!, max: Int, message: String) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+	{Name: "directive.graphql", Input: `directive @length(min: Int!, max: Int, message: String) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 directive @range(min: Int = 0, max: Int) on ARGUMENT_DEFINITION
 directive @custom on ARGUMENT_DEFINITION
 directive @logged(id: UUID!) on FIELD
@@ -1755,7 +1755,7 @@ type ObjectDirectivesWithCustomGoModel {
     nullableText: String @toNull
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "embedded.graphql", Input: `extend type Query {
+	{Name: "embedded.graphql", Input: `extend type Query {
     embeddedCase1: EmbeddedCase1
     embeddedCase2: EmbeddedCase2
     embeddedCase3: EmbeddedCase3
@@ -1773,7 +1773,7 @@ type EmbeddedCase3 @goModel(model:"testserver.EmbeddedCase3") {
     unexportedEmbeddedInterfaceExportedMethod: String!
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "enum.graphql", Input: `enum EnumTest {
+	{Name: "enum.graphql", Input: `enum EnumTest {
     OK
     NG
 }
@@ -1786,7 +1786,7 @@ extend type Query {
     enumInInput(input: InputWithEnumValue): EnumTest!
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "interfaces.graphql", Input: `extend type Query {
+	{Name: "interfaces.graphql", Input: `extend type Query {
     shapes: [Shape]
     noShape: Shape @makeNil
     node: Node!
@@ -1849,7 +1849,7 @@ type ConcreteNodeInterface implements Node {
     child: Node!
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "issue896.graphql", Input: `# This example should build stable output. If the file content starts
+	{Name: "issue896.graphql", Input: `# This example should build stable output. If the file content starts
 # alternating nondeterministically between two outputs, then see
 # https://github.com/99designs/gqlgen/issues/896.
 
@@ -1868,7 +1868,7 @@ extend type Subscription {
   issue896b: [CheckIssue896] # Note the "!" or lack thereof.
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "loops.graphql", Input: `type LoopA {
+	{Name: "loops.graphql", Input: `type LoopA {
     b: LoopB!
 }
 
@@ -1876,7 +1876,7 @@ type LoopB {
     a: LoopA!
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "maps.graphql", Input: `extend type Query {
+	{Name: "maps.graphql", Input: `extend type Query {
     mapStringInterface(in: MapStringInterfaceInput): MapStringInterfaceType
     mapNestedStringInterface(in: NestedMapInput): MapStringInterfaceType
 }
@@ -1895,7 +1895,7 @@ input NestedMapInput {
     map: MapStringInterfaceInput
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "nulls.graphql", Input: `extend type Query {
+	{Name: "nulls.graphql", Input: `extend type Query {
     errorBubble: Error
     errors: Errors
     valid: String!
@@ -1916,7 +1916,7 @@ type Error {
     nilOnRequiredField: String!
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "panics.graphql", Input: `extend type Query {
+	{Name: "panics.graphql", Input: `extend type Query {
     panics: Panics
 }
 
@@ -1929,7 +1929,7 @@ type Panics {
 
 scalar MarshalPanic
 `, BuiltIn: false},
-	&ast.Source{Name: "primitive_objects.graphql", Input: `extend type Query {
+	{Name: "primitive_objects.graphql", Input: `extend type Query {
     primitiveObject: [Primitive!]!
     primitiveStringObject: [PrimitiveString!]!
 }
@@ -1945,7 +1945,7 @@ type PrimitiveString {
     len: Int!
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "scalar_default.graphql", Input: `extend type Query {
+	{Name: "scalar_default.graphql", Input: `extend type Query {
     defaultScalar(arg: DefaultScalarImplementation! = "default"): DefaultScalarImplementation!
 }
 
@@ -1956,7 +1956,7 @@ type EmbeddedDefaultScalar {
     value: DefaultScalarImplementation
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "schema.graphql", Input: `directive @goModel(model: String, models: [String!]) on OBJECT | INPUT_OBJECT | SCALAR | ENUM | INTERFACE | UNION
+	{Name: "schema.graphql", Input: `directive @goModel(model: String, models: [String!]) on OBJECT | INPUT_OBJECT | SCALAR | ENUM | INTERFACE | UNION
 directive @goField(forceResolver: Boolean, name: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 type Query {
@@ -2055,7 +2055,7 @@ enum Status {
 
 scalar Time
 `, BuiltIn: false},
-	&ast.Source{Name: "slices.graphql", Input: `extend type Query {
+	{Name: "slices.graphql", Input: `extend type Query {
     slices: Slices
     scalarSlice: Bytes!
 }
@@ -2069,7 +2069,7 @@ type Slices {
 
 scalar Bytes
 `, BuiltIn: false},
-	&ast.Source{Name: "typefallback.graphql", Input: `extend type Query {
+	{Name: "typefallback.graphql", Input: `extend type Query {
     fallback(arg: FallbackToStringEncoding!): FallbackToStringEncoding!
 }
 
@@ -2079,7 +2079,7 @@ enum FallbackToStringEncoding {
     C
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "useptr.graphql", Input: `type A {
+	{Name: "useptr.graphql", Input: `type A {
     id: ID!
 }
 
@@ -2093,7 +2093,7 @@ extend type Query {
     optionalUnion: TestUnion
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "validtypes.graphql", Input: `extend type Query {
+	{Name: "validtypes.graphql", Input: `extend type Query {
     validType: ValidType
 }
 
@@ -2172,7 +2172,7 @@ type Content_Post {
 
 union Content_Child = Content_User | Content_Post
 `, BuiltIn: false},
-	&ast.Source{Name: "weird_type_cases.graphql", Input: `# regression test for https://github.com/99designs/gqlgen/issues/583
+	{Name: "weird_type_cases.graphql", Input: `# regression test for https://github.com/99designs/gqlgen/issues/583
 
 type asdfIt { id: ID! }
 type iIt { id: ID! }
@@ -2181,7 +2181,7 @@ type XXIt { id: ID! }
 type AbIt { id: ID! }
 type XxIt { id: ID! }
 `, BuiltIn: false},
-	&ast.Source{Name: "wrapped_type.graphql", Input: `# regression test for https://github.com/99designs/gqlgen/issues/721
+	{Name: "wrapped_type.graphql", Input: `# regression test for https://github.com/99designs/gqlgen/issues/721
 
 extend type Query {
     wrappedStruct: WrappedStruct!

--- a/example/chat/generated.go
+++ b/example/chat/generated.go
@@ -256,7 +256,7 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	&ast.Source{Name: "schema.graphql", Input: `type Chatroom {
+	{Name: "schema.graphql", Input: `type Chatroom {
     name: String!
     messages: [Message!]!
 }

--- a/example/config/generated.go
+++ b/example/config/generated.go
@@ -222,7 +222,7 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	&ast.Source{Name: "schema.graphql", Input: `directive @goModel(model: String, models: [String!]) on OBJECT | INPUT_OBJECT | SCALAR | ENUM | INTERFACE | UNION
+	{Name: "schema.graphql", Input: `directive @goModel(model: String, models: [String!]) on OBJECT | INPUT_OBJECT | SCALAR | ENUM | INTERFACE | UNION
 directive @goField(forceResolver: Boolean, name: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 type Query {
@@ -233,7 +233,7 @@ type Mutation {
   createTodo(input: NewTodo!): Todo!
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "todo.graphql", Input: `type Todo {
+	{Name: "todo.graphql", Input: `type Todo {
   id: ID! @goField(forceResolver: true)
   databaseId: Int!
   text: String!
@@ -246,7 +246,7 @@ input NewTodo {
   userId: String!
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "user.graphql", Input: `type User
+	{Name: "user.graphql", Input: `type User
 @goModel(model:"github.com/99designs/gqlgen/example/config.User") {
   id: ID!
   name: String! @goField(name:"FullName")

--- a/example/dataloader/generated.go
+++ b/example/dataloader/generated.go
@@ -268,7 +268,7 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	&ast.Source{Name: "schema.graphql", Input: `type Query {
+	{Name: "schema.graphql", Input: `type Query {
     customers: [Customer!]
 
     # these methods are here to test code generation of nested arrays

--- a/example/federation/accounts/graph/generated/generated.go
+++ b/example/federation/accounts/graph/generated/generated.go
@@ -196,7 +196,7 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	&ast.Source{Name: "graph/schema.graphqls", Input: `extend type Query {
+	{Name: "graph/schema.graphqls", Input: `extend type Query {
     me: User
 }
 
@@ -205,7 +205,7 @@ type User @key(fields: "id") {
     username: String!
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "federation/directives.graphql", Input: `
+	{Name: "federation/directives.graphql", Input: `
 scalar _Any
 scalar _FieldSet
 
@@ -215,7 +215,7 @@ directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
 directive @extends on OBJECT
 `, BuiltIn: true},
-	&ast.Source{Name: "federation/entity.graphql", Input: `
+	{Name: "federation/entity.graphql", Input: `
 # a union of all types that use the @key directive
 union _Entity = User
 

--- a/example/federation/products/graph/generated/generated.go
+++ b/example/federation/products/graph/generated/generated.go
@@ -209,7 +209,7 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	&ast.Source{Name: "graph/schema.graphqls", Input: `extend type Query {
+	{Name: "graph/schema.graphqls", Input: `extend type Query {
     topProducts(first: Int = 5): [Product]
 }
 
@@ -219,7 +219,7 @@ type Product @key(fields: "upc") {
     price: Int!
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "federation/directives.graphql", Input: `
+	{Name: "federation/directives.graphql", Input: `
 scalar _Any
 scalar _FieldSet
 
@@ -229,7 +229,7 @@ directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
 directive @extends on OBJECT
 `, BuiltIn: true},
-	&ast.Source{Name: "federation/entity.graphql", Input: `
+	{Name: "federation/entity.graphql", Input: `
 # a union of all types that use the @key directive
 union _Entity = Product
 

--- a/example/federation/reviews/graph/generated/generated.go
+++ b/example/federation/reviews/graph/generated/generated.go
@@ -252,7 +252,7 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	&ast.Source{Name: "graph/schema.graphqls", Input: `type Review {
+	{Name: "graph/schema.graphqls", Input: `type Review {
     body: String!
     author: User! @provides(fields: "username")
     product: Product!
@@ -268,7 +268,7 @@ extend type Product @key(fields: "upc") {
     reviews: [Review]
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "federation/directives.graphql", Input: `
+	{Name: "federation/directives.graphql", Input: `
 scalar _Any
 scalar _FieldSet
 
@@ -278,7 +278,7 @@ directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
 directive @extends on OBJECT
 `, BuiltIn: true},
-	&ast.Source{Name: "federation/entity.graphql", Input: `
+	{Name: "federation/entity.graphql", Input: `
 # a union of all types that use the @key directive
 union _Entity = Product | User
 

--- a/example/fileupload/generated.go
+++ b/example/fileupload/generated.go
@@ -234,7 +234,7 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	&ast.Source{Name: "schema.graphql", Input: `"The ` + "`" + `Upload` + "`" + ` scalar type represents a multipart file upload."
+	{Name: "schema.graphql", Input: `"The ` + "`" + `Upload` + "`" + ` scalar type represents a multipart file upload."
 scalar Upload
 
 "The ` + "`" + `File` + "`" + ` type, represents the response of uploading a file."

--- a/example/scalars/generated.go
+++ b/example/scalars/generated.go
@@ -235,7 +235,7 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	&ast.Source{Name: "schema.graphql", Input: `type Query {
+	{Name: "schema.graphql", Input: `type Query {
     user(id: ID!): User
     search(input: SearchArgs = {location: "37,144", isBanned: false}): [User!]!
 }

--- a/example/selection/generated.go
+++ b/example/selection/generated.go
@@ -193,7 +193,7 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	&ast.Source{Name: "schema.graphql", Input: `interface Event {
+	{Name: "schema.graphql", Input: `interface Event {
     selection: [String!]
     collected: [String!]
 }

--- a/example/starwars/generated/exec.go
+++ b/example/starwars/generated/exec.go
@@ -550,7 +550,7 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	&ast.Source{Name: "schema.graphql", Input: `# The query type, represents all of the entry points into our object graph
+	{Name: "schema.graphql", Input: `# The query type, represents all of the entry points into our object graph
 type Query {
     hero(episode: Episode = NEWHOPE): Character
     reviews(episode: Episode!, since: Time): [Review!]!

--- a/example/todo/generated.go
+++ b/example/todo/generated.go
@@ -227,7 +227,7 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	&ast.Source{Name: "schema.graphql", Input: `schema {
+	{Name: "schema.graphql", Input: `schema {
     query: MyQuery
     mutation: MyMutation
 }

--- a/example/type-system-extension/generated.go
+++ b/example/type-system-extension/generated.go
@@ -213,27 +213,27 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	&ast.Source{Name: "schemas/enum-extension.graphql", Input: `directive @enumLogging on ENUM
+	{Name: "schemas/enum-extension.graphql", Input: `directive @enumLogging on ENUM
 
 extend enum State @enumLogging
 `, BuiltIn: false},
-	&ast.Source{Name: "schemas/input-object-extension.graphql", Input: `directive @inputLogging on INPUT_OBJECT
+	{Name: "schemas/input-object-extension.graphql", Input: `directive @inputLogging on INPUT_OBJECT
 
 extend input TodoInput @inputLogging
 `, BuiltIn: false},
-	&ast.Source{Name: "schemas/interface-extension.graphql", Input: `directive @interfaceLogging on INTERFACE
+	{Name: "schemas/interface-extension.graphql", Input: `directive @interfaceLogging on INTERFACE
 
 extend interface Node @interfaceLogging
 `, BuiltIn: false},
-	&ast.Source{Name: "schemas/object-extension.graphql", Input: `directive @objectLogging on OBJECT
+	{Name: "schemas/object-extension.graphql", Input: `directive @objectLogging on OBJECT
 
 extend type Todo @objectLogging
 `, BuiltIn: false},
-	&ast.Source{Name: "schemas/scalar-extension.graphql", Input: `directive @scalarLogging on SCALAR
+	{Name: "schemas/scalar-extension.graphql", Input: `directive @scalarLogging on SCALAR
 
 extend scalar ID @scalarLogging
 `, BuiltIn: false},
-	&ast.Source{Name: "schemas/schema-extension.graphql", Input: `extend schema {
+	{Name: "schemas/schema-extension.graphql", Input: `extend schema {
   mutation: MyMutation
 }
 
@@ -249,7 +249,7 @@ input TodoInput {
   text: String!
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "schemas/schema.graphql", Input: `# GraphQL schema example
+	{Name: "schemas/schema.graphql", Input: `# GraphQL schema example
 #
 # https://gqlgen.com/getting-started/
 
@@ -278,13 +278,13 @@ enum State {
   DONE
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "schemas/type-extension.graphql", Input: `directive @fieldLogging on FIELD_DEFINITION
+	{Name: "schemas/type-extension.graphql", Input: `directive @fieldLogging on FIELD_DEFINITION
 
 extend type Todo {
   verified: Boolean! @fieldLogging
 }
 `, BuiltIn: false},
-	&ast.Source{Name: "schemas/union-extension.graphql", Input: `directive @unionLogging on UNION
+	{Name: "schemas/union-extension.graphql", Input: `directive @unionLogging on UNION
 
 extend union Data @unionLogging
 `, BuiltIn: false},

--- a/integration/generated.go
+++ b/integration/generated.go
@@ -252,7 +252,7 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	&ast.Source{Name: "schema.graphql", Input: `"This directive does magical things"
+	{Name: "schema.graphql", Input: `"This directive does magical things"
 directive @magic(kind: Int) on FIELD_DEFINITION
 
 type Element {
@@ -299,7 +299,7 @@ enum ErrorType {
 
 # this is a comment with a ` + "`" + `backtick` + "`" + `
 `, BuiltIn: false},
-	&ast.Source{Name: "user.graphql", Input: `type User {
+	{Name: "user.graphql", Input: `type User {
     name: String!
     likes: [String!]!
 }


### PR DESCRIPTION
The most recent versions of `gopls` report explicit type definitions on individual slice/array/map items as a warning:

`redundant type from array, slice, or map composite literal`

<img width="581" alt="Screen Shot 2020-04-22 at 12 12 56" src="https://user-images.githubusercontent.com/1042048/79970066-abc30d80-8492-11ea-9426-ba690ae27737.png">

I believe this is because of the inclusion of https://golang.org/cmd/gofmt/#hdr-The_simplify_command in the checks performed by the `lsp`.

The PR makes a small modification to `codegen/generated!.gotpl` template to prevent this warning from showing up in the code generated by `gqlgen`.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))

It's effectively a code-formatting change and it doesn't affect any functionality.

 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

It's effectively a code-formatting change and it doesn't affect any functionality.
