### PR TITLE
federation: generate _entities / _service root queries regardless of …

### DIFF
--- a/example/federation/accounts/graph/generated/federation.go
+++ b/example/federation/accounts/graph/generated/federation.go
@@ -17,7 +17,6 @@ func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.
 	}
 
 	var sdl []string
-
 	for _, src := range sources {
 		if src.BuiltIn {
 			continue

--- a/example/federation/accounts/graph/generated/generated.go
+++ b/example/federation/accounts/graph/generated/generated.go
@@ -216,13 +216,10 @@ directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
 directive @extends on OBJECT
 `, BuiltIn: true},
 	{Name: "federation/entity.graphql", Input: `
-# a union of all types that use the @key directive
 union _Entity = User
 
-# fake type to build resolver interfaces for users to implement
 type Entity {
-		findUserByID(id: ID!,): User!
-
+  findUserByID(id: ID!): User!
 }
 
 type _Service {

--- a/example/federation/products/graph/generated/federation.go
+++ b/example/federation/products/graph/generated/federation.go
@@ -17,7 +17,6 @@ func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.
 	}
 
 	var sdl []string
-
 	for _, src := range sources {
 		if src.BuiltIn {
 			continue

--- a/example/federation/products/graph/generated/generated.go
+++ b/example/federation/products/graph/generated/generated.go
@@ -230,13 +230,10 @@ directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
 directive @extends on OBJECT
 `, BuiltIn: true},
 	{Name: "federation/entity.graphql", Input: `
-# a union of all types that use the @key directive
 union _Entity = Product
 
-# fake type to build resolver interfaces for users to implement
 type Entity {
-		findProductByUpc(upc: String!,): Product!
-
+  findProductByUpc(upc: String!): Product!
 }
 
 type _Service {

--- a/example/federation/reviews/graph/generated/federation.go
+++ b/example/federation/reviews/graph/generated/federation.go
@@ -17,7 +17,6 @@ func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.
 	}
 
 	var sdl []string
-
 	for _, src := range sources {
 		if src.BuiltIn {
 			continue

--- a/example/federation/reviews/graph/generated/generated.go
+++ b/example/federation/reviews/graph/generated/generated.go
@@ -279,14 +279,11 @@ directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
 directive @extends on OBJECT
 `, BuiltIn: true},
 	{Name: "federation/entity.graphql", Input: `
-# a union of all types that use the @key directive
 union _Entity = Product | User
 
-# fake type to build resolver interfaces for users to implement
 type Entity {
-		findProductByUpc(upc: String!,): Product!
-	findUserByID(id: ID!,): User!
-
+  findProductByUpc(upc: String!): Product!
+  findUserByID(id: ID!): User!
 }
 
 type _Service {

--- a/plugin/federation/federation.gotpl
+++ b/plugin/federation/federation.gotpl
@@ -11,7 +11,6 @@ func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.
 	}
 
 	var sdl []string
-
 	for _, src := range sources {
 		if src.BuiltIn {
 			continue
@@ -24,9 +23,9 @@ func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.
 	}, nil
 }
 
-{{if .Entities}}
 func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) ([]fedruntime.Entity, error) {
 	list := []fedruntime.Entity{}
+{{- if .Entities }}
 	for _, rep := range representations {
 		typeName, ok := rep["__typename"].(string)
 		if !ok {
@@ -62,6 +61,6 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 			return nil, errors.New("unknown type: "+typeName)
 		}
 	}
+{{- end }}
 	return list, nil
 }
-{{end}}

--- a/plugin/federation/federation_test.go
+++ b/plugin/federation/federation_test.go
@@ -15,6 +15,7 @@ func TestWithEntities(t *testing.T) {
 	require.Equal(t, "findExternalExtensionByUpc", cfg.Schema.Types["Entity"].Fields[0].Name)
 	require.Equal(t, "findHelloByName", cfg.Schema.Types["Entity"].Fields[1].Name)
 	require.Equal(t, "findWorldByFooAndBar", cfg.Schema.Types["Entity"].Fields[2].Name)
+	require.Equal(t, "sdl", cfg.Schema.Types["_Service"].Fields[0].Name)
 
 	require.NoError(t, f.MutateConfig(cfg))
 }
@@ -22,8 +23,11 @@ func TestWithEntities(t *testing.T) {
 func TestNoEntities(t *testing.T) {
 	f, cfg := load(t, "test_data/nokey.yml")
 
-	err := f.MutateConfig(cfg)
-	require.NoError(t, err)
+	require.NotContains(t, cfg.Schema.Types, "Entity")
+	require.Empty(t, cfg.Schema.Types["_Entity"].Types)
+	require.Equal(t, "sdl", cfg.Schema.Types["_Service"].Fields[0].Name)
+
+	require.NoError(t, f.MutateConfig(cfg))
 }
 
 func load(t *testing.T, name string) (*federation, *config.Config) {


### PR DESCRIPTION
…entity count

Generate a valid federation schema extention if no object uses @key
directive.

On this case the extension will be defined as follows:
```graphql
union _Entity

type _Service {
  sdl: String
}

extend type Query {
  _entities(representations: [_Any!]!): [_Entity]!
  _service: _Service!
}
```

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
