### PR TITLE
doc: fix typo in embedded struct example

### DIFF
--- a/docs/content/reference/resolvers.md
+++ b/docs/content/reference/resolvers.md
@@ -171,7 +171,7 @@ models:
 All of the rules from above apply to a struct that has an embedded struct.
 Here is an example
 ```go
-type Truck {
+type Truck struct {
     Car
 
     Is4x4 bool


### PR DESCRIPTION
Just noticed a quick typo in the docs while reading.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

None of the above seem relevant.