### PR TITLE
Adding Missing Header to response

### DIFF
--- a/graphql/handler/transport/http_get.go
+++ b/graphql/handler/transport/http_get.go
@@ -27,6 +27,8 @@ func (h GET) Supports(r *http.Request) bool {
 }
 
 func (h GET) Do(w http.ResponseWriter, r *http.Request, exec graphql.GraphExecutor) {
+	w.Header().Set("Content-Type", "application/json")
+
 	raw := &graphql.RawParams{
 		Query:         r.URL.Query().Get("query"),
 		OperationName: r.URL.Query().Get("operationName"),

--- a/graphql/handler/transport/http_get_test.go
+++ b/graphql/handler/transport/http_get_test.go
@@ -19,6 +19,11 @@ func TestGET(t *testing.T) {
 		assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
 	})
 
+	t.Run("has json content-type header", func(t *testing.T) {
+		resp := doRequest(h, "GET", "/graphql?query={name}", ``)
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
+	})
+
 	t.Run("decode failure", func(t *testing.T) {
 		resp := doRequest(h, "GET", "/graphql?query={name}&variables=notjson", "")
 		assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
@@ -42,4 +47,5 @@ func TestGET(t *testing.T) {
 		assert.Equal(t, http.StatusNotAcceptable, resp.Code, resp.Body.String())
 		assert.Equal(t, `{"errors":[{"message":"GET requests only allow query operations"}],"data":null}`, resp.Body.String())
 	})
+
 }


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

Adding `Content-Type: application/json` header to `HTTP GET` responses

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
