### PR TITLE
close the connection when run returns

### DIFF
--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -136,7 +136,10 @@ func (c *wsConnection) run() {
 	// We create a cancellation that will shutdown the keep-alive when we leave
 	// this function.
 	ctx, cancel := context.WithCancel(c.ctx)
-	defer cancel()
+	defer func() {
+		cancel()
+		c.close(websocket.CloseAbnormalClosure, "unexpected closure")
+	}()
 
 	// Create a timer that will fire every interval to keep the connection alive.
 	if c.KeepAlivePingInterval != 0 {


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 
Closes #1245 

The case of client disconnecting without sending a termination message (ie Browser refresh) wasn't be handled.  This would lead to sockets just hanging open in a CLOSE_WAIT state.  This fix handles this case by always closing the connection when run returns.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
