### PR TITLE
[issue #1258] explicitly add gqlparser alias to vektah/gqlparser/v2 import

### DIFF
--- a/codegen/generated!.gotpl
+++ b/codegen/generated!.gotpl
@@ -8,7 +8,7 @@
 {{ reserveImport "errors"  }}
 {{ reserveImport "bytes"  }}
 
-{{ reserveImport "github.com/vektah/gqlparser/v2" }}
+{{ reserveImport "github.com/vektah/gqlparser/v2" "gqlparser" }}
 {{ reserveImport "github.com/vektah/gqlparser/v2/ast" }}
 {{ reserveImport "github.com/99designs/gqlgen/graphql" }}
 {{ reserveImport "github.com/99designs/gqlgen/graphql/introspection" }}


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

As described in https://github.com/99designs/gqlgen/issues/1258, generated.go doesn't compile with v0.11.3 (it used to work with v0.10.2). Compilation fails with:
```
/private/var/tmp/_bazel_sateesh/.../sandbox/darwin-sandbox/1531/execroot/__main__/bazel-out/darwin-fastbuild/bin/src/.../generated.go:4521:20: undefined: gqlparser
```

Special aspects of our environment:
1. It is a bazel based project
2. generation is invoked using api package

After debugging, realized that alias for github.com/vektah/gqlparser/v2 is computed as v2 while the generated!.gotpl uses `gqlparser` alias. Since v2 alias is not used, it does get imported the generated.go file. Couldn't really find why alias is computed wrongly in our setup. However, updating generated!.gotpl template to explicitly use gqlparser alias got us a working generated.go. Hence this PR.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
