### PR TITLE
errors: Add support for wrapped gqlerror.Error in DefaultErrorPresenter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,20 +33,20 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    container: alpine:3.10
+    container: golang:1.13-alpine
     steps:
       - uses: actions/checkout@v1
-      - run: apk add --no-cache --no-progress nodejs npm go musl-dev git bash
+      - run: apk add --no-cache --no-progress nodejs npm git bash
       - run: go mod download
       - run: cd integration ; npm install
       - run: .github/workflows/check-integration
 
   federation:
     runs-on: ubuntu-latest
-    container: alpine:3.10
+    container: golang:1.13-alpine
     steps:
       - uses: actions/checkout@v1
-      - run: apk add --no-cache --no-progress nodejs npm go musl-dev git bash
+      - run: apk add --no-cache --no-progress nodejs npm git bash
       - run: go mod download
       - run: cd example/federation ; npm install
       - run: .github/workflows/check-federation


### PR DESCRIPTION
This adds the support for wrapped `*gqlerror.Error` being presented to `DefaultErrorPresenter`. Note that this required go 1.13+.