### PR TITLE
fix same field name in two different fragments

### DIFF
--- a/graphql/context_operation_test.go
+++ b/graphql/context_operation_test.go
@@ -78,4 +78,35 @@ func TestCollectAllFields(t *testing.T) {
 		s := CollectAllFields(ctx)
 		require.Equal(t, []string{"fieldA", "fieldB"}, s)
 	})
+
+	t.Run("collect fragments with same field name", func(t *testing.T) {
+		ctx := testContext(ast.SelectionSet{
+			&ast.InlineFragment{
+				TypeCondition: "ExampleTypeA",
+				SelectionSet: ast.SelectionSet{
+					&ast.Field{
+						Name: "fieldA",
+						ObjectDefinition:  &ast.Definition{Name:"ExampleTypeA"},
+					},
+				},
+			},
+			&ast.InlineFragment{
+				TypeCondition: "ExampleTypeB",
+				SelectionSet: ast.SelectionSet{
+					&ast.Field{
+						Name: "fieldA",
+						ObjectDefinition:  &ast.Definition{Name:"ExampleTypeB"},
+					},
+				},
+			},
+		})
+
+		resctx := GetFieldContext(ctx)
+		collected := CollectFields(GetOperationContext(ctx), resctx.Field.Selections, nil)
+		s := make([]string, 0, len(collected))
+		for _, f := range collected {
+			s = append(s, f.Name)
+		}
+		require.Equal(t, []string{"fieldA", "fieldA"}, s)
+	})
 }

--- a/graphql/context_operation_test.go
+++ b/graphql/context_operation_test.go
@@ -79,7 +79,7 @@ func TestCollectAllFields(t *testing.T) {
 		require.Equal(t, []string{"fieldA", "fieldB"}, s)
 	})
 
-	t.Run("collect fragments with same field name", func(t *testing.T) {
+	t.Run("collect fragments with same field name on different types", func(t *testing.T) {
 		ctx := testContext(ast.SelectionSet{
 			&ast.InlineFragment{
 				TypeCondition: "ExampleTypeA",
@@ -100,13 +100,10 @@ func TestCollectAllFields(t *testing.T) {
 				},
 			},
 		})
-
-		resctx := GetFieldContext(ctx)
-		collected := CollectFields(GetOperationContext(ctx), resctx.Field.Selections, nil)
-		s := make([]string, 0, len(collected))
-		for _, f := range collected {
-			s = append(s, f.Name)
-		}
-		require.Equal(t, []string{"fieldA", "fieldA"}, s)
+		resCtx := GetFieldContext(ctx)
+		collected := CollectFields(GetOperationContext(ctx), resCtx.Field.Selections, nil)
+		require.Len(t, collected, 2)
+		require.NotEqual(t, collected[0], collected[1])
+		require.Equal(t, collected[0].Name, collected[1].Name)
 	})
 }

--- a/graphql/context_operation_test.go
+++ b/graphql/context_operation_test.go
@@ -85,8 +85,8 @@ func TestCollectAllFields(t *testing.T) {
 				TypeCondition: "ExampleTypeA",
 				SelectionSet: ast.SelectionSet{
 					&ast.Field{
-						Name: "fieldA",
-						ObjectDefinition:  &ast.Definition{Name:"ExampleTypeA"},
+						Name:             "fieldA",
+						ObjectDefinition: &ast.Definition{Name: "ExampleTypeA"},
 					},
 				},
 			},
@@ -94,8 +94,8 @@ func TestCollectAllFields(t *testing.T) {
 				TypeCondition: "ExampleTypeB",
 				SelectionSet: ast.SelectionSet{
 					&ast.Field{
-						Name: "fieldA",
-						ObjectDefinition:  &ast.Definition{Name:"ExampleTypeB"},
+						Name:             "fieldA",
+						ObjectDefinition: &ast.Definition{Name: "ExampleTypeB"},
 					},
 				},
 			},

--- a/graphql/executable_schema.go
+++ b/graphql/executable_schema.go
@@ -32,11 +32,7 @@ func collectFields(reqCtx *OperationContext, selSet ast.SelectionSet, satisfies 
 			if !shouldIncludeNode(sel.Directives, reqCtx.Variables) {
 				continue
 			}
-
-			if sel.ObjectDefinition == nil {
-				sel.ObjectDefinition = &ast.Definition{Name: ""}
-			}
-			f := getOrCreateAndAppendField(&groupedFields, sel.Alias, sel.ObjectDefinition.Name, func() CollectedField {
+			f := getOrCreateAndAppendField(&groupedFields, sel.Alias, sel.ObjectDefinition, func() CollectedField {
 				return CollectedField{Field: sel}
 			})
 
@@ -49,10 +45,7 @@ func collectFields(reqCtx *OperationContext, selSet ast.SelectionSet, satisfies 
 				continue
 			}
 			for _, childField := range collectFields(reqCtx, sel.SelectionSet, satisfies, visited) {
-				if childField.ObjectDefinition == nil {
-					childField.ObjectDefinition = &ast.Definition{Name: ""}
-				}
-				f := getOrCreateAndAppendField(&groupedFields, childField.Name, childField.ObjectDefinition.Name, func() CollectedField { return childField })
+				f := getOrCreateAndAppendField(&groupedFields, childField.Name, childField.ObjectDefinition, func() CollectedField { return childField })
 				f.Selections = append(f.Selections, childField.Selections...)
 			}
 
@@ -77,10 +70,7 @@ func collectFields(reqCtx *OperationContext, selSet ast.SelectionSet, satisfies 
 			}
 
 			for _, childField := range collectFields(reqCtx, fragment.SelectionSet, satisfies, visited) {
-				if childField.ObjectDefinition == nil {
-					childField.ObjectDefinition = &ast.Definition{Name: ""}
-				}
-				f := getOrCreateAndAppendField(&groupedFields, childField.Name, childField.ObjectDefinition.Name, func() CollectedField { return childField })
+				f := getOrCreateAndAppendField(&groupedFields, childField.Name, childField.ObjectDefinition, func() CollectedField { return childField })
 				f.Selections = append(f.Selections, childField.Selections...)
 			}
 		default:
@@ -106,9 +96,9 @@ func instanceOf(val string, satisfies []string) bool {
 	return false
 }
 
-func getOrCreateAndAppendField(c *[]CollectedField, name string, objectDefinitionName string, creator func() CollectedField) *CollectedField {
+func getOrCreateAndAppendField(c *[]CollectedField, name string, objectDefinition *ast.Definition, creator func() CollectedField) *CollectedField {
 	for i, cf := range *c {
-		if cf.Alias == name && cf.ObjectDefinition.Name == objectDefinitionName {
+		if cf.Alias == name && (cf.ObjectDefinition == objectDefinition || (cf.ObjectDefinition != nil && objectDefinition != nil && cf.ObjectDefinition.Name == objectDefinition.Name)) {
 			return &(*c)[i]
 		}
 	}

--- a/graphql/executable_schema.go
+++ b/graphql/executable_schema.go
@@ -32,6 +32,10 @@ func collectFields(reqCtx *OperationContext, selSet ast.SelectionSet, satisfies 
 			if !shouldIncludeNode(sel.Directives, reqCtx.Variables) {
 				continue
 			}
+
+			if sel.ObjectDefinition==nil{
+			    sel.ObjectDefinition	=&ast.Definition{Name: ""}
+			}
 			f := getOrCreateAndAppendField(&groupedFields, sel.Alias,sel.ObjectDefinition.Name , func() CollectedField {
 				return CollectedField{Field: sel}
 			})
@@ -45,6 +49,9 @@ func collectFields(reqCtx *OperationContext, selSet ast.SelectionSet, satisfies 
 				continue
 			}
 			for _, childField := range collectFields(reqCtx, sel.SelectionSet, satisfies, visited) {
+				if childField.ObjectDefinition==nil{
+					childField.ObjectDefinition	=&ast.Definition{Name: ""}
+				}
 				f := getOrCreateAndAppendField(&groupedFields, childField.Name,childField.ObjectDefinition.Name, func() CollectedField { return childField })
 				f.Selections = append(f.Selections, childField.Selections...)
 			}
@@ -70,6 +77,9 @@ func collectFields(reqCtx *OperationContext, selSet ast.SelectionSet, satisfies 
 			}
 
 			for _, childField := range collectFields(reqCtx, fragment.SelectionSet, satisfies, visited) {
+				if childField.ObjectDefinition==nil{
+					childField.ObjectDefinition	=&ast.Definition{Name: ""}
+				}
 				f := getOrCreateAndAppendField(&groupedFields, childField.Name,childField.ObjectDefinition.Name, func() CollectedField { return childField })
 				f.Selections = append(f.Selections, childField.Selections...)
 			}

--- a/graphql/executable_schema.go
+++ b/graphql/executable_schema.go
@@ -32,7 +32,7 @@ func collectFields(reqCtx *OperationContext, selSet ast.SelectionSet, satisfies 
 			if !shouldIncludeNode(sel.Directives, reqCtx.Variables) {
 				continue
 			}
-			f := getOrCreateAndAppendField(&groupedFields, sel.Alias, func() CollectedField {
+			f := getOrCreateAndAppendField(&groupedFields, sel, func() CollectedField {
 				return CollectedField{Field: sel}
 			})
 
@@ -45,7 +45,7 @@ func collectFields(reqCtx *OperationContext, selSet ast.SelectionSet, satisfies 
 				continue
 			}
 			for _, childField := range collectFields(reqCtx, sel.SelectionSet, satisfies, visited) {
-				f := getOrCreateAndAppendField(&groupedFields, childField.Name, func() CollectedField { return childField })
+				f := getOrCreateAndAppendField(&groupedFields, childField.Field, func() CollectedField { return childField })
 				f.Selections = append(f.Selections, childField.Selections...)
 			}
 
@@ -70,7 +70,7 @@ func collectFields(reqCtx *OperationContext, selSet ast.SelectionSet, satisfies 
 			}
 
 			for _, childField := range collectFields(reqCtx, fragment.SelectionSet, satisfies, visited) {
-				f := getOrCreateAndAppendField(&groupedFields, childField.Name, func() CollectedField { return childField })
+				f := getOrCreateAndAppendField(&groupedFields, childField.Field, func() CollectedField { return childField })
 				f.Selections = append(f.Selections, childField.Selections...)
 			}
 		default:
@@ -96,9 +96,9 @@ func instanceOf(val string, satisfies []string) bool {
 	return false
 }
 
-func getOrCreateAndAppendField(c *[]CollectedField, name string, creator func() CollectedField) *CollectedField {
+func getOrCreateAndAppendField(c *[]CollectedField, childField *ast.Field, creator func() CollectedField) *CollectedField {
 	for i, cf := range *c {
-		if cf.Alias == name {
+		if cf.Alias == childField.Name && childField.ObjectDefinition.Name==cf.ObjectDefinition.Name {
 			return &(*c)[i]
 		}
 	}
@@ -108,6 +108,7 @@ func getOrCreateAndAppendField(c *[]CollectedField, name string, creator func() 
 	*c = append(*c, f)
 	return &(*c)[len(*c)-1]
 }
+
 
 func shouldIncludeNode(directives ast.DirectiveList, variables map[string]interface{}) bool {
 	if len(directives) == 0 {

--- a/graphql/executable_schema.go
+++ b/graphql/executable_schema.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/vektah/gqlparser/v2/ast"
+	 "github.com/vektah/gqlparser/v2/ast"
 )
 
 type ExecutableSchema interface {
@@ -32,7 +32,7 @@ func collectFields(reqCtx *OperationContext, selSet ast.SelectionSet, satisfies 
 			if !shouldIncludeNode(sel.Directives, reqCtx.Variables) {
 				continue
 			}
-			f := getOrCreateAndAppendField(&groupedFields, sel, func() CollectedField {
+			f := getOrCreateAndAppendField(&groupedFields, sel.Alias,sel.ObjectDefinition.Name , func() CollectedField {
 				return CollectedField{Field: sel}
 			})
 
@@ -45,7 +45,7 @@ func collectFields(reqCtx *OperationContext, selSet ast.SelectionSet, satisfies 
 				continue
 			}
 			for _, childField := range collectFields(reqCtx, sel.SelectionSet, satisfies, visited) {
-				f := getOrCreateAndAppendField(&groupedFields, childField.Field, func() CollectedField { return childField })
+				f := getOrCreateAndAppendField(&groupedFields, childField.Name,childField.ObjectDefinition.Name, func() CollectedField { return childField })
 				f.Selections = append(f.Selections, childField.Selections...)
 			}
 
@@ -70,7 +70,7 @@ func collectFields(reqCtx *OperationContext, selSet ast.SelectionSet, satisfies 
 			}
 
 			for _, childField := range collectFields(reqCtx, fragment.SelectionSet, satisfies, visited) {
-				f := getOrCreateAndAppendField(&groupedFields, childField.Field, func() CollectedField { return childField })
+				f := getOrCreateAndAppendField(&groupedFields, childField.Name,childField.ObjectDefinition.Name, func() CollectedField { return childField })
 				f.Selections = append(f.Selections, childField.Selections...)
 			}
 		default:
@@ -96,9 +96,9 @@ func instanceOf(val string, satisfies []string) bool {
 	return false
 }
 
-func getOrCreateAndAppendField(c *[]CollectedField, childField *ast.Field, creator func() CollectedField) *CollectedField {
+func getOrCreateAndAppendField(c *[]CollectedField, name string,objectDefinitionName string, creator func() CollectedField) *CollectedField {
 	for i, cf := range *c {
-		if cf.Alias == childField.Name && childField.ObjectDefinition.Name==cf.ObjectDefinition.Name {
+		if cf.Alias == name && cf.ObjectDefinition.Name==objectDefinitionName {
 			return &(*c)[i]
 		}
 	}
@@ -108,7 +108,6 @@ func getOrCreateAndAppendField(c *[]CollectedField, childField *ast.Field, creat
 	*c = append(*c, f)
 	return &(*c)[len(*c)-1]
 }
-
 
 func shouldIncludeNode(directives ast.DirectiveList, variables map[string]interface{}) bool {
 	if len(directives) == 0 {

--- a/graphql/executable_schema.go
+++ b/graphql/executable_schema.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 
-	 "github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/ast"
 )
 
 type ExecutableSchema interface {
@@ -33,10 +33,10 @@ func collectFields(reqCtx *OperationContext, selSet ast.SelectionSet, satisfies 
 				continue
 			}
 
-			if sel.ObjectDefinition==nil{
-			    sel.ObjectDefinition	=&ast.Definition{Name: ""}
+			if sel.ObjectDefinition == nil {
+				sel.ObjectDefinition = &ast.Definition{Name: ""}
 			}
-			f := getOrCreateAndAppendField(&groupedFields, sel.Alias,sel.ObjectDefinition.Name , func() CollectedField {
+			f := getOrCreateAndAppendField(&groupedFields, sel.Alias, sel.ObjectDefinition.Name, func() CollectedField {
 				return CollectedField{Field: sel}
 			})
 
@@ -49,10 +49,10 @@ func collectFields(reqCtx *OperationContext, selSet ast.SelectionSet, satisfies 
 				continue
 			}
 			for _, childField := range collectFields(reqCtx, sel.SelectionSet, satisfies, visited) {
-				if childField.ObjectDefinition==nil{
-					childField.ObjectDefinition	=&ast.Definition{Name: ""}
+				if childField.ObjectDefinition == nil {
+					childField.ObjectDefinition = &ast.Definition{Name: ""}
 				}
-				f := getOrCreateAndAppendField(&groupedFields, childField.Name,childField.ObjectDefinition.Name, func() CollectedField { return childField })
+				f := getOrCreateAndAppendField(&groupedFields, childField.Name, childField.ObjectDefinition.Name, func() CollectedField { return childField })
 				f.Selections = append(f.Selections, childField.Selections...)
 			}
 
@@ -77,10 +77,10 @@ func collectFields(reqCtx *OperationContext, selSet ast.SelectionSet, satisfies 
 			}
 
 			for _, childField := range collectFields(reqCtx, fragment.SelectionSet, satisfies, visited) {
-				if childField.ObjectDefinition==nil{
-					childField.ObjectDefinition	=&ast.Definition{Name: ""}
+				if childField.ObjectDefinition == nil {
+					childField.ObjectDefinition = &ast.Definition{Name: ""}
 				}
-				f := getOrCreateAndAppendField(&groupedFields, childField.Name,childField.ObjectDefinition.Name, func() CollectedField { return childField })
+				f := getOrCreateAndAppendField(&groupedFields, childField.Name, childField.ObjectDefinition.Name, func() CollectedField { return childField })
 				f.Selections = append(f.Selections, childField.Selections...)
 			}
 		default:
@@ -106,9 +106,9 @@ func instanceOf(val string, satisfies []string) bool {
 	return false
 }
 
-func getOrCreateAndAppendField(c *[]CollectedField, name string,objectDefinitionName string, creator func() CollectedField) *CollectedField {
+func getOrCreateAndAppendField(c *[]CollectedField, name string, objectDefinitionName string, creator func() CollectedField) *CollectedField {
 	for i, cf := range *c {
-		if cf.Alias == name && cf.ObjectDefinition.Name==objectDefinitionName {
+		if cf.Alias == name && cf.ObjectDefinition.Name == objectDefinitionName {
 			return &(*c)[i]
 		}
 	}


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 
This PR solves issue (https://github.com/99designs/gqlgen/issues/1280 issue) by adding check for object defination name with name of the field.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
