### PR TITLE
Fix panic in template

### DIFF
--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -188,6 +188,19 @@ func (ref *TypeReference) Elem() *TypeReference {
 		}
 	}
 
+	if p, isNamed := ref.GO.(*types.Named); isNamed {
+		return &TypeReference{
+			GO:          p.Underlying(),
+			Target:      ref.Target,
+			GQL:         ref.GQL,
+			CastType:    ref.CastType,
+			Definition:  ref.Definition,
+			Unmarshaler: ref.Unmarshaler,
+			Marshaler:   ref.Marshaler,
+			IsMarshaler: ref.IsMarshaler,
+		}
+	}
+
 	if ref.IsSlice() {
 		return &TypeReference{
 			GO:          ref.GO.(*types.Slice).Elem(),


### PR DESCRIPTION
With `v0.12.1-dev` the code generator panic in type.gotpl at Line49 `var res = new({{ $type.Elem.GO | ref }})` if Elem returns nil.

With Named types that's not Pointer it happens with the following code.

```yaml
models:
    ID:
        model:
          - github.com/a/b/model.UUID
```


```golang
package model

import (
	"fmt"
	"io"

	"github.com/pborman/uuid"
)

type (
	UUID            uuid.UUID
)

//MarshalGQL implements the graphql.Marshaler interface
func (c UUID) MarshalGQL(w io.Writer) {
	data, _ := uuid.UUID(c).MarshalText()
	if data != nil {
		_, _ = io.WriteString(w, `"`)
		_, _ = w.Write(data)
		_, _ = io.WriteString(w, `"`)
	}
}

// UnmarshalGQL implements the graphql.Marshaler interface
func (c *UUID) UnmarshalGQL(v interface{}) (err error) {
	if data, ok := v.(string); !ok {
		return fmt.Errorf("ID must be strings")
	} else {
		id := uuid.Parse(data)
		if id == nil {
			return fmt.Errorf("invalid UUID value")
		}
		*c = UUID(id)
	}
	return
}
```
