### PR TITLE
Allow rewriter to work on empty but potentially importable packages

### DIFF
--- a/internal/code/imports_test.go
+++ b/internal/code/imports_test.go
@@ -24,6 +24,9 @@ func TestImportPathForDir(t *testing.T) {
 	// directory does not exist
 	assert.Equal(t, "github.com/99designs/gqlgen/dos", ImportPathForDir(filepath.Join(wd, "..", "..", "dos")))
 
+	// out of module
+	assert.Equal(t, "", ImportPathForDir(filepath.Join(wd, "..", "..", "..")))
+
 	if runtime.GOOS == "windows" {
 		assert.Equal(t, "", ImportPathForDir("C:/doesnotexist"))
 	} else {

--- a/internal/rewrite/rewriter.go
+++ b/internal/rewrite/rewriter.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/99designs/gqlgen/internal/code"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -19,7 +20,11 @@ type Rewriter struct {
 	copied map[ast.Decl]bool
 }
 
-func New(importPath string) (*Rewriter, error) {
+func New(dir string) (*Rewriter, error) {
+	importPath := code.ImportPathForDir(dir)
+	if importPath == "" {
+		return nil, fmt.Errorf("import path not found for directory: %q", dir)
+	}
 	pkgs, err := packages.Load(&packages.Config{
 		Mode: packages.NeedSyntax | packages.NeedTypes,
 	}, importPath)
@@ -28,13 +33,6 @@ func New(importPath string) (*Rewriter, error) {
 	}
 	if len(pkgs) == 0 {
 		return nil, fmt.Errorf("package not found for importPath: %s", importPath)
-	}
-	if len(pkgs[0].Errors) != 0 {
-		for _, e := range pkgs[0].Errors {
-			if e.Kind == packages.ListError {
-				return nil, e
-			}
-		}
 	}
 
 	return &Rewriter{

--- a/internal/rewrite/rewriter_test.go
+++ b/internal/rewrite/rewriter_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestRewriter(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
-		r, err := New("github.com/99designs/gqlgen/internal/rewrite/testdata")
+		r, err := New("testdata")
 		require.NoError(t, err)
 
 		body := r.GetMethodBody("Foo", "Method")

--- a/plugin/resolvergen/resolver.go
+++ b/plugin/resolvergen/resolver.go
@@ -79,7 +79,7 @@ func (m *Plugin) generateSingleFile(data *codegen.Data) error {
 }
 
 func (m *Plugin) generatePerSchema(data *codegen.Data) error {
-	rewriter, err := rewrite.New(data.Config.Resolver.ImportPath())
+	rewriter, err := rewrite.New(data.Config.Resolver.Dir())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
https://github.com/99designs/gqlgen/pull/1264 introduced some changes to accomodate the change in `x/tools/go/packages` between go versions that broke the new project `gqlgen init` use case.

This PR favours our internal `code.ImportPathForDir` over the errors from packages, which keeps the tests green and allows for `gqlgen init` to work on empty packages.

Fixes: #1283

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
