### PR TITLE
serialize ID just like String

### DIFF
--- a/graphql/id.go
+++ b/graphql/id.go
@@ -8,9 +8,7 @@ import (
 )
 
 func MarshalID(s string) Marshaler {
-	return WriterFunc(func(w io.Writer) {
-		io.WriteString(w, strconv.Quote(s))
-	})
+	return MarshalString(s)
 }
 func UnmarshalID(v interface{}) (string, error) {
 	switch v := v.(type) {

--- a/graphql/id_test.go
+++ b/graphql/id_test.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"bytes"
 	"math"
 	"testing"
 
@@ -8,6 +9,25 @@ import (
 )
 
 func TestMarshalID(t *testing.T) {
+	marshalID := func(s string) string {
+		var buf bytes.Buffer
+		MarshalID(s).MarshalGQL(&buf)
+		return buf.String()
+	}
+
+	assert.Equal(t, `"hello"`, marshalID("hello"))
+	assert.Equal(t, `"he\tllo"`, marshalID("he\tllo"))
+	assert.Equal(t, `"he\tllo"`, marshalID("he	llo"))
+	assert.Equal(t, `"he\nllo"`, marshalID("he\nllo"))
+	assert.Equal(t, `"he\r\nllo"`, marshalID("he\r\nllo"))
+	assert.Equal(t, `"he\\llo"`, marshalID(`he\llo`))
+	assert.Equal(t, `"quotes\"nested\"in\"quotes\""`, marshalID(`quotes"nested"in"quotes"`))
+	assert.Equal(t, `"\u0000"`, marshalID("\u0000"))
+	assert.Equal(t, "\"\U000fe4ed\"", marshalID("\U000fe4ed"))
+	assert.Equal(t, "\"\\u001B\"", marshalID("\u001B"))
+}
+
+func TestUnmarshalID(t *testing.T) {
 	tests := []struct {
 		Name        string
 		Input       interface{}


### PR DESCRIPTION
Fix https://github.com/99designs/gqlgen/issues/1338

This PR serialize ID as same as how String is serialized, this is in line with [GraphQL documentation](https://graphql.org/learn/schema/#scalar-types) and will fix https://github.com/99designs/gqlgen/issues/1338, I also add case which cause https://github.com/99designs/gqlgen/issues/1338 into unittest.