### PR TITLE
Fix tab spacing in cors.md

### DIFF
--- a/docs/content/recipes/cors.md
+++ b/docs/content/recipes/cors.md
@@ -15,10 +15,10 @@ gqlgen doesn't include a CORS implementation, but it is built to work with all s
 package main
 
 import (
-    "net/http"
+	"net/http"
 
 	"github.com/99designs/gqlgen/graphql/handler/transport"
-    "github.com/99designs/gqlgen/example/starwars"
+	"github.com/99designs/gqlgen/example/starwars"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/go-chi/chi"
 	"github.com/rs/cors"


### PR DESCRIPTION
The tab spacing of the current documentation looks a little off because most of the imports use tabs as spaces. This PR corrects it so that the documentation looks more consistent.
<img width="521" alt="cors screen" src="https://user-images.githubusercontent.com/15604207/94760553-6d346600-03d5-11eb-9539-00735e811da1.png">