### PR TITLE
add uint, uint64, uint32 types in graphql pkg

### DIFF
--- a/graphql/uint.go
+++ b/graphql/uint.go
@@ -1,0 +1,81 @@
+package graphql
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+)
+
+func MarshalUint(i uint) Marshaler {
+	return WriterFunc(func(w io.Writer) {
+		_, _ = io.WriteString(w, strconv.FormatUint(uint64(i), 10))
+	})
+}
+
+func UnmarshalUint(v interface{}) (uint, error) {
+	switch v := v.(type) {
+	case string:
+		u64, err := strconv.ParseUint(v, 10, 64)
+		return uint(u64), err
+	case int:
+		return uint(v), nil
+	case int64:
+		return uint(v), nil
+	case json.Number:
+		u64, err := strconv.ParseUint(string(v), 10, 64)
+		return uint(u64), err
+	default:
+		return 0, fmt.Errorf("%T is not an uint", v)
+	}
+}
+
+func MarshalUint64(i uint64) Marshaler {
+	return WriterFunc(func(w io.Writer) {
+		_, _ = io.WriteString(w, strconv.FormatUint(i, 10))
+	})
+}
+
+func UnmarshalUint64(v interface{}) (uint64, error) {
+	switch v := v.(type) {
+	case string:
+		return strconv.ParseUint(v, 10, 64)
+	case int:
+		return uint64(v), nil
+	case int64:
+		return uint64(v), nil
+	case json.Number:
+		return strconv.ParseUint(string(v), 10, 64)
+	default:
+		return 0, fmt.Errorf("%T is not an uint", v)
+	}
+}
+
+func MarshalUint32(i uint32) Marshaler {
+	return WriterFunc(func(w io.Writer) {
+		_, _ = io.WriteString(w, strconv.FormatUint(uint64(i), 10))
+	})
+}
+
+func UnmarshalUint32(v interface{}) (uint32, error) {
+	switch v := v.(type) {
+	case string:
+		iv, err := strconv.ParseInt(v, 10, 32)
+		if err != nil {
+			return 0, err
+		}
+		return uint32(iv), nil
+	case int:
+		return uint32(v), nil
+	case int64:
+		return uint32(v), nil
+	case json.Number:
+		iv, err := strconv.ParseUint(string(v), 10, 32)
+		if err != nil {
+			return 0, err
+		}
+		return uint32(iv), nil
+	default:
+		return 0, fmt.Errorf("%T is not an uint", v)
+	}
+}

--- a/graphql/uint_test.go
+++ b/graphql/uint_test.go
@@ -1,0 +1,71 @@
+package graphql
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUint(t *testing.T) {
+	t.Run("marshal", func(t *testing.T) {
+		assert.Equal(t, "123", m2s(MarshalUint(123)))
+	})
+
+	t.Run("unmarshal", func(t *testing.T) {
+		assert.Equal(t, uint(123), mustUnmarshalUint(123))
+		assert.Equal(t, uint(123), mustUnmarshalUint(int64(123)))
+		assert.Equal(t, uint(123), mustUnmarshalUint(json.Number("123")))
+		assert.Equal(t, uint(123), mustUnmarshalUint("123"))
+	})
+}
+
+func mustUnmarshalUint(v interface{}) uint {
+	res, err := UnmarshalUint(v)
+	if err != nil {
+		panic(err)
+	}
+	return res
+}
+
+func TestUint32(t *testing.T) {
+	t.Run("marshal", func(t *testing.T) {
+		assert.Equal(t, "123", m2s(MarshalUint32(123)))
+	})
+
+	t.Run("unmarshal", func(t *testing.T) {
+		assert.Equal(t, uint32(123), mustUnmarshalUint32(123))
+		assert.Equal(t, uint32(123), mustUnmarshalUint32(int64(123)))
+		assert.Equal(t, uint32(123), mustUnmarshalUint32(json.Number("123")))
+		assert.Equal(t, uint32(123), mustUnmarshalUint32("123"))
+	})
+}
+
+func mustUnmarshalUint32(v interface{}) uint32 {
+	res, err := UnmarshalUint32(v)
+	if err != nil {
+		panic(err)
+	}
+	return res
+}
+
+func TestUint64(t *testing.T) {
+	t.Run("marshal", func(t *testing.T) {
+		assert.Equal(t, "123", m2s(MarshalUint64(123)))
+	})
+
+	t.Run("unmarshal", func(t *testing.T) {
+		assert.Equal(t, uint64(123), mustUnmarshalUint64(123))
+		assert.Equal(t, uint64(123), mustUnmarshalUint64(int64(123)))
+		assert.Equal(t, uint64(123), mustUnmarshalUint64(json.Number("123")))
+		assert.Equal(t, uint64(123), mustUnmarshalUint64("123"))
+	})
+}
+
+func mustUnmarshalUint64(v interface{}) uint64 {
+	res, err := UnmarshalUint64(v)
+	if err != nil {
+		panic(err)
+	}
+	return res
+}


### PR DESCRIPTION
I added `uint`, `uint32` and `uint64` in `graphql` package.

I hope you'll merge because I love Open Source Software and I think it is better to have this code here so it is checked daily by multiple eyes.

This is **especially useful** now that with Gorm 2 we have the [default model](https://github.com/go-gorm/gorm/blob/master/model.go) which is:

```go
type Model struct {
	ID        uint `gorm:"primarykey"`
	CreatedAt time.Time
	UpdatedAt time.Time
	DeletedAt DeletedAt `gorm:"index"`
}
```

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
