### PR TITLE
codegen/config: Add a new API to finish an already-validated config

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -103,6 +103,16 @@ func LoadConfig(filename string) (*Config, error) {
 		return nil, errors.Wrap(err, "unable to parse config")
 	}
 
+	if err := CompleteConfig(config); err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+// CompleteConfig fills in the schema and other values to a config loaded from
+// YAML.
+func CompleteConfig(config *Config) error {
 	defaultDirectives := map[string]DirectiveConfig{
 		"skip":       {SkipRuntime: true},
 		"include":    {SkipRuntime: true},
@@ -140,12 +150,13 @@ func LoadConfig(filename string) (*Config, error) {
 
 				return nil
 			}); err != nil {
-				return nil, errors.Wrapf(err, "failed to walk schema at root %s", pathParts[0])
+				return errors.Wrapf(err, "failed to walk schema at root %s", pathParts[0])
 			}
 		} else {
+			var err error
 			matches, err = filepath.Glob(f)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to glob schema filename %s", f)
+				return errors.Wrapf(err, "failed to glob schema filename %s", f)
 			}
 		}
 
@@ -163,13 +174,12 @@ func LoadConfig(filename string) (*Config, error) {
 		var schemaRaw []byte
 		schemaRaw, err = ioutil.ReadFile(filename)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to open schema")
+			return errors.Wrap(err, "unable to open schema")
 		}
 
 		config.Sources = append(config.Sources, &ast.Source{Name: filename, Input: string(schemaRaw)})
 	}
-
-	return config, nil
+	return nil
 }
 
 func (c *Config) Init() error {


### PR DESCRIPTION
LoadConfig parses the config from yaml, but it does a bunch of other
things too.  We want to parse the config ourselves, so that we can have
extra fields which will be passed to our plugins.  Right now, that means
we either have to duplicate all of LoadConfig, or write the config back
to disk only to ask gqlgen re-parse it.

In this commit, I expose a new function that does all the parts of
LoadConfig other than the actual YAML-reading: that way, a caller who
wants to parse the YAML themselves (or otherwise programmatically
compute the config) can do so without having to write it back to disk.

An alternative would be to move all this logic to Config.Init(), but
that could break existing clients.  Either way would work for us.

I have:
 - [x] Added tests covering the bug / feature (none needed, existing tests cover everything)
 - [x] Updated any relevant documentation (godoc should be sufficient for anyone who wants an advanced feature like this)