### PR TITLE
fix(codegen): adress case of nullable types which have no known elements (e.g. external scalar type)

### DIFF
--- a/codegen/type.gotpl
+++ b/codegen/type.gotpl
@@ -46,8 +46,12 @@
 					return v.(map[string]interface{}), nil
 				{{- else if $type.IsMarshaler }}
 					{{- if $type.IsNilable }}
-						var res = new({{ $type.Elem.GO | ref }})
-					{{- else}}
+                      {{- if $type.Elem }}
+						  var res = new({{ $type.Elem.GO | ref }})
+                      {{- else }}
+						  var res {{ $type.GO | ref }}
+                      {{- end }}
+                    {{- else}}
 						var res {{ $type.GO | ref }}
 					{{- end }}
 					err := res.UnmarshalGQL(v)


### PR DESCRIPTION
This PR covers the case when the type is nullable, but element is not defined.

* fixes #1391

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
