### PR TITLE
bugfix: Default Recover func should return gqlerror.Error

### DIFF
--- a/graphql/recovery.go
+++ b/graphql/recovery.go
@@ -2,10 +2,11 @@ package graphql
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"runtime/debug"
+
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 type RecoverFunc func(ctx context.Context, err interface{}) (userMessage error)
@@ -15,5 +16,5 @@ func DefaultRecover(ctx context.Context, err interface{}) error {
 	fmt.Fprintln(os.Stderr)
 	debug.PrintStack()
 
-	return errors.New("internal system error")
+	return gqlerror.Errorf("internal system error")
 }


### PR DESCRIPTION
`DefaultRecover` should return gqlerror.Error, since `DefaultErrorPresenter` expected that.