### PR TITLE
Dont hold error lock when calling into error presenters

### DIFF
--- a/graphql/context_response.go
+++ b/graphql/context_response.go
@@ -45,10 +45,11 @@ func AddErrorf(ctx context.Context, format string, args ...interface{}) {
 func AddError(ctx context.Context, err error) {
 	c := getResponseContext(ctx)
 
+	presentedError := c.errorPresenter(ctx, ErrorOnPath(ctx, err))
+
 	c.errorsMu.Lock()
 	defer c.errorsMu.Unlock()
-
-	c.errors = append(c.errors, c.errorPresenter(ctx, ErrorOnPath(ctx, err)))
+	c.errors = append(c.errors, presentedError)
 }
 
 func Recover(ctx context.Context, err interface{}) (userMessage error) {

--- a/graphql/context_response_test.go
+++ b/graphql/context_response_test.go
@@ -79,3 +79,16 @@ func TestAddError(t *testing.T) {
 		})
 	}
 }
+
+func TestGetErrorFromPresenter(t *testing.T) {
+	ctx := WithResponseContext(context.Background(), func(ctx context.Context, err error) *gqlerror.Error {
+		errs := GetErrors(ctx)
+
+		// because we are still presenting the error it is not expected to be returned, but this should not deadlock.
+		require.Len(t, errs, 0)
+		return DefaultErrorPresenter(ctx, err)
+	}, nil)
+
+	ctx = WithFieldContext(ctx, &FieldContext{})
+	AddError(ctx, errors.New("foo1"))
+}


### PR DESCRIPTION
This can result in a deadlock if the error handling code calls back to GetErrors.

Instead, only hold the lock while mutating the slice.