### PR TITLE
fix typo

### DIFF
--- a/docs/content/recipes/gin.md
+++ b/docs/content/recipes/gin.md
@@ -16,7 +16,7 @@ Install Gin:
 $ go get github.com/gin-gonic/gin
 ```
 
-In your router file, define the handlers for the GraphQL and Playground endpoints in two different methods and tie then together in the Gin router:
+In your router file, define the handlers for the GraphQL and Playground endpoints in two different methods and tie them together in the Gin router:
 
 ```go
 import (


### PR DESCRIPTION
Changed this:
`In your router file, define the handlers for the GraphQL and Playground endpoints in two different methods and tie then together in the Gin router:
`
to: 
`In your router file, define the handlers for the GraphQL and Playground endpoints in two different methods and tie them together in the Gin router:
`

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
