### PR TITLE
feat: generate resolvers for inputs if fields are missing

### DIFF
--- a/codegen/field.go
+++ b/codegen/field.go
@@ -452,6 +452,9 @@ func (f *Field) GoNameUnexported() string {
 }
 
 func (f *Field) ShortInvocation() string {
+	if f.Object.Kind == ast.InputObject {
+		return fmt.Sprintf("%s().%s(ctx, &it, data)", f.Object.Definition.Name, f.GoFieldName)
+	}
 	return fmt.Sprintf("%s().%s(%s)", f.Object.Definition.Name, f.GoFieldName, f.CallArgs())
 }
 
@@ -472,6 +475,13 @@ func (f *Field) ResolverType() string {
 }
 
 func (f *Field) ShortResolverDeclaration() string {
+	if f.Object.Kind == ast.InputObject {
+		return fmt.Sprintf("(ctx context.Context, obj %s, data %s) error",
+			templates.CurrentImports.LookupType(f.Object.Reference()),
+			templates.CurrentImports.LookupType(f.TypeReference.GO),
+		)
+	}
+
 	res := "(ctx context.Context"
 
 	if !f.Object.Root {

--- a/codegen/generated!.gotpl
+++ b/codegen/generated!.gotpl
@@ -35,6 +35,11 @@ type ResolverRoot interface {
 		{{$object.Name}}() {{$object.Name}}Resolver
 	{{ end }}
 {{- end }}
+{{- range $object := .Inputs -}}
+	{{ if $object.HasResolvers -}}
+		{{$object.Name}}() {{$object.Name}}Resolver
+	{{ end }}
+{{- end }}
 }
 
 type DirectiveRoot struct {
@@ -59,6 +64,18 @@ type ComplexityRoot struct {
 }
 
 {{ range $object := .Objects -}}
+	{{ if $object.HasResolvers }}
+		type {{$object.Name}}Resolver interface {
+		{{ range $field := $object.Fields -}}
+			{{- if $field.IsResolver }}
+				{{- $field.GoFieldName}}{{ $field.ShortResolverDeclaration }}
+			{{- end }}
+		{{ end }}
+		}
+	{{- end }}
+{{- end }}
+
+{{ range $object := .Inputs -}}
 	{{ if $object.HasResolvers }}
 		type {{$object.Name}}Resolver interface {
 		{{ range $field := $object.Fields -}}

--- a/codegen/input.gotpl
+++ b/codegen/input.gotpl
@@ -26,20 +26,38 @@
 						return it, graphql.ErrorOnPath(ctx, err)
 					}
 					if data, ok := tmp.({{ $field.TypeReference.GO | ref }}) ; ok {
-						it.{{$field.GoFieldName}} = data
+						{{- if $field.IsResolver }}
+							if err = ec.resolvers.{{ $field.ShortInvocation }}; err != nil {
+								return it, err
+							}
+						{{- else }}
+							it.{{$field.GoFieldName}} = data
+						{{- end }}
 					{{- if $field.TypeReference.IsNilable }}
+						{{- if not $field.IsResolver }}
 						} else if tmp == nil {
 							it.{{$field.GoFieldName}} = nil
+						{{- end }}
 					{{- end }}
 					} else {
 						err := fmt.Errorf(`unexpected type %T from directive, should be {{ $field.TypeReference.GO }}`, tmp)
 						return it, graphql.ErrorOnPath(ctx, err)
 					}
 				{{- else }}
-					it.{{$field.GoFieldName}}, err = ec.{{ $field.TypeReference.UnmarshalFunc }}(ctx, v)
-					if err != nil {
-						return it, err
-					}
+					{{- if $field.IsResolver }}
+						data, err := ec.{{ $field.TypeReference.UnmarshalFunc }}(ctx, v)
+						if err != nil {
+							return it, err
+						}
+						if err = ec.resolvers.{{ $field.ShortInvocation }}; err != nil {
+							return it, err
+						}
+					{{- else }}
+						it.{{$field.GoFieldName}}, err = ec.{{ $field.TypeReference.UnmarshalFunc }}(ctx, v)
+						if err != nil {
+							return it, err
+						}
+					{{- end }}
 				{{- end }}
 			{{- end }}
 			}


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

Generate resolvers for input type fields in case the user defined type is missing those fields.

fixes #1403

I have:
 - [  ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [  ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
