### PR TITLE
Use mutation instead of query in 'Changesets' doc example

### DIFF
--- a/docs/content/reference/changesets.md
+++ b/docs/content/reference/changesets.md
@@ -9,7 +9,7 @@ Occasionally you need to distinguish presence from nil (undefined vs null). In g
 
 
 ```graphql
-type Query {
+type Mutation {
 	updateUser(id: ID!, changes: UserChanges!): User
 }
 
@@ -28,7 +28,7 @@ models:
 
 After running go generate you should end up with a resolver that looks like this:
 ```go
-func (r *queryResolver) UpdateUser(ctx context.Context, id int, changes map[string]interface{}) (*User, error) {
+func (r *mutationResolver) UpdateUser(ctx context.Context, id int, changes map[string]interface{}) (*User, error) {
 	u := fetchFromDb(id)
 	/// apply the changes
 	saveToDb(u)


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

The Changesets doc has an example query `updateUser` that would modify data in the db, so it should be a mutation. The technical implementation of the example doesn't change, but a beginner might get the wrong idea/get confused about the separation between queries and mutations.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
