### PR TITLE
feat(codegen): handle (v, ok) methods

### DIFF
--- a/codegen/field.go
+++ b/codegen/field.go
@@ -25,6 +25,7 @@ type Field struct {
 	Args             []*FieldArgument // A list of arguments to be passed to this field
 	MethodHasContext bool             // If this is bound to a go method, does the method also take a context
 	NoErr            bool             // If this is bound to a go method, does that method have an error as the second argument
+	VOkFunc          bool             // If this is bound to a go method, is it of shape (interface{}, bool)
 	Object           *Object          // A link back to the parent object
 	Default          interface{}      // The default value
 	Stream           bool             // does this field return a channel?
@@ -152,6 +153,8 @@ func (b *builder) bindField(obj *Object, f *Field) (errret error) {
 		sig := target.Type().(*types.Signature)
 		if sig.Results().Len() == 1 {
 			f.NoErr = true
+		} else if s := sig.Results(); s.Len() == 2 && s.At(1).Type().String() == "bool" {
+			f.VOkFunc = true
 		} else if sig.Results().Len() != 2 {
 			return fmt.Errorf("method has wrong number of args")
 		}

--- a/codegen/field.gotpl
+++ b/codegen/field.gotpl
@@ -112,7 +112,13 @@ func (ec *executionContext) _{{$object.Name}}_{{$field.Name}}(ctx context.Contex
 			return nil, fmt.Errorf("unexpected type %T for field %s", v, {{ .Name | quote}})
 		}
 	{{- else if .IsMethod -}}
-		{{- if .NoErr -}}
+		{{- if .VOkFunc -}}
+			v, ok := {{.GoReceiverName}}.{{.GoFieldName}}({{ .CallArgs }})
+			if !ok {
+				return nil, nil
+			}
+			return v, nil
+		{{- else if .NoErr -}}
 			return {{.GoReceiverName}}.{{.GoFieldName}}({{ .CallArgs }}), nil
 		{{- else -}}
 			return {{.GoReceiverName}}.{{.GoFieldName}}({{ .CallArgs }})

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -306,6 +306,8 @@ type ComplexityRoot struct {
 		Shapes                           func(childComplexity int) int
 		Slices                           func(childComplexity int) int
 		User                             func(childComplexity int, id int) int
+		VOkCaseNil                       func(childComplexity int) int
+		VOkCaseValue                     func(childComplexity int) int
 		Valid                            func(childComplexity int) int
 		ValidType                        func(childComplexity int) int
 		WrappedMap                       func(childComplexity int) int
@@ -342,6 +344,14 @@ type ComplexityRoot struct {
 		Friends func(childComplexity int) int
 		ID      func(childComplexity int) int
 		Updated func(childComplexity int) int
+	}
+
+	VOkCaseNil struct {
+		Value func(childComplexity int) int
+	}
+
+	VOkCaseValue struct {
+		Value func(childComplexity int) int
 	}
 
 	ValidType struct {
@@ -467,6 +477,8 @@ type QueryResolver interface {
 	ScalarSlice(ctx context.Context) ([]byte, error)
 	Fallback(ctx context.Context, arg FallbackToStringEncoding) (FallbackToStringEncoding, error)
 	OptionalUnion(ctx context.Context) (TestUnion, error)
+	VOkCaseValue(ctx context.Context) (*VOkCaseValue, error)
+	VOkCaseNil(ctx context.Context) (*VOkCaseNil, error)
 	ValidType(ctx context.Context) (*ValidType, error)
 	WrappedStruct(ctx context.Context) (*WrappedStruct, error)
 	WrappedScalar(ctx context.Context) (otherpkg.Scalar, error)
@@ -1445,6 +1457,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.User(childComplexity, args["id"].(int)), true
 
+	case "Query.vOkCaseNil":
+		if e.complexity.Query.VOkCaseNil == nil {
+			break
+		}
+
+		return e.complexity.Query.VOkCaseNil(childComplexity), true
+
+	case "Query.vOkCaseValue":
+		if e.complexity.Query.VOkCaseValue == nil {
+			break
+		}
+
+		return e.complexity.Query.VOkCaseValue(childComplexity), true
+
 	case "Query.valid":
 		if e.complexity.Query.Valid == nil {
 			break
@@ -1622,6 +1648,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.User.Updated(childComplexity), true
+
+	case "VOkCaseNil.value":
+		if e.complexity.VOkCaseNil.Value == nil {
+			break
+		}
+
+		return e.complexity.VOkCaseNil.Value(childComplexity), true
+
+	case "VOkCaseValue.value":
+		if e.complexity.VOkCaseValue.Value == nil {
+			break
+		}
+
+		return e.complexity.VOkCaseValue.Value(childComplexity), true
 
 	case "ValidType.differentCase":
 		if e.complexity.ValidType.DifferentCase == nil {
@@ -2234,6 +2274,19 @@ union TestUnion = A | B
 
 extend type Query {
     optionalUnion: TestUnion
+}
+`, BuiltIn: false},
+	{Name: "v-ok.graphql", Input: `extend type Query {
+    vOkCaseValue: VOkCaseValue
+    vOkCaseNil: VOkCaseNil
+}
+
+type VOkCaseValue @goModel(model:"testserver.VOkCaseValue") {
+  value: String
+}
+
+type VOkCaseNil @goModel(model:"testserver.VOkCaseNil") {
+  value: String
 }
 `, BuiltIn: false},
 	{Name: "validtypes.graphql", Input: `extend type Query {
@@ -7534,6 +7587,64 @@ func (ec *executionContext) _Query_optionalUnion(ctx context.Context, field grap
 	return ec.marshalOTestUnion2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐTestUnion(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Query_vOkCaseValue(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().VOkCaseValue(rctx)
+	})
+
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*VOkCaseValue)
+	fc.Result = res
+	return ec.marshalOVOkCaseValue2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐVOkCaseValue(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_vOkCaseNil(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().VOkCaseNil(rctx)
+	})
+
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*VOkCaseNil)
+	fc.Result = res
+	return ec.marshalOVOkCaseNil2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐVOkCaseNil(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Query_validType(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -8427,6 +8538,72 @@ func (ec *executionContext) _User_updated(ctx context.Context, field graphql.Col
 	res := resTmp.(*time.Time)
 	fc.Result = res
 	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _VOkCaseNil_value(ctx context.Context, field graphql.CollectedField, obj *VOkCaseNil) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "VOkCaseNil",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		v, ok := obj.Value()
+		if !ok {
+			return nil, nil
+		}
+		return v, nil
+	})
+
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _VOkCaseValue_value(ctx context.Context, field graphql.CollectedField, obj *VOkCaseValue) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "VOkCaseValue",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		v, ok := obj.Value()
+		if !ok {
+			return nil, nil
+		}
+		return v, nil
+	})
+
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _ValidType_differentCase(ctx context.Context, field graphql.CollectedField, obj *ValidType) (ret graphql.Marshaler) {
@@ -12394,6 +12571,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 				res = ec._Query_optionalUnion(ctx, field)
 				return res
 			})
+		case "vOkCaseValue":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_vOkCaseValue(ctx, field)
+				return res
+			})
+		case "vOkCaseNil":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_vOkCaseNil(ctx, field)
+				return res
+			})
 		case "validType":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {
@@ -12609,6 +12808,54 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			}
 		case "updated":
 			out.Values[i] = ec._User_updated(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var vOkCaseNilImplementors = []string{"VOkCaseNil"}
+
+func (ec *executionContext) _VOkCaseNil(ctx context.Context, sel ast.SelectionSet, obj *VOkCaseNil) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, vOkCaseNilImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("VOkCaseNil")
+		case "value":
+			out.Values[i] = ec._VOkCaseNil_value(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var vOkCaseValueImplementors = []string{"VOkCaseValue"}
+
+func (ec *executionContext) _VOkCaseValue(ctx context.Context, sel ast.SelectionSet, obj *VOkCaseValue) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, vOkCaseValueImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("VOkCaseValue")
+		case "value":
+			out.Values[i] = ec._VOkCaseValue_value(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -14640,6 +14887,20 @@ func (ec *executionContext) marshalOTime2ᚖtimeᚐTime(ctx context.Context, sel
 		return graphql.Null
 	}
 	return graphql.MarshalTime(*v)
+}
+
+func (ec *executionContext) marshalOVOkCaseNil2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐVOkCaseNil(ctx context.Context, sel ast.SelectionSet, v *VOkCaseNil) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._VOkCaseNil(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOVOkCaseValue2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐVOkCaseValue(ctx context.Context, sel ast.SelectionSet, v *VOkCaseValue) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._VOkCaseValue(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOValidInput2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚐValidInput(ctx context.Context, v interface{}) (*ValidInput, error) {

--- a/codegen/testserver/resolver.go
+++ b/codegen/testserver/resolver.go
@@ -272,6 +272,14 @@ func (r *queryResolver) OptionalUnion(ctx context.Context) (TestUnion, error) {
 	panic("not implemented")
 }
 
+func (r *queryResolver) VOkCaseValue(ctx context.Context) (*VOkCaseValue, error) {
+	panic("not implemented")
+}
+
+func (r *queryResolver) VOkCaseNil(ctx context.Context) (*VOkCaseNil, error) {
+	panic("not implemented")
+}
+
 func (r *queryResolver) ValidType(ctx context.Context) (*ValidType, error) {
 	panic("not implemented")
 }

--- a/codegen/testserver/stub.go
+++ b/codegen/testserver/stub.go
@@ -95,6 +95,8 @@ type Stub struct {
 		ScalarSlice                      func(ctx context.Context) ([]byte, error)
 		Fallback                         func(ctx context.Context, arg FallbackToStringEncoding) (FallbackToStringEncoding, error)
 		OptionalUnion                    func(ctx context.Context) (TestUnion, error)
+		VOkCaseValue                     func(ctx context.Context) (*VOkCaseValue, error)
+		VOkCaseNil                       func(ctx context.Context) (*VOkCaseNil, error)
 		ValidType                        func(ctx context.Context) (*ValidType, error)
 		WrappedStruct                    func(ctx context.Context) (*WrappedStruct, error)
 		WrappedScalar                    func(ctx context.Context) (otherpkg.Scalar, error)
@@ -387,6 +389,12 @@ func (r *stubQuery) Fallback(ctx context.Context, arg FallbackToStringEncoding) 
 }
 func (r *stubQuery) OptionalUnion(ctx context.Context) (TestUnion, error) {
 	return r.QueryResolver.OptionalUnion(ctx)
+}
+func (r *stubQuery) VOkCaseValue(ctx context.Context) (*VOkCaseValue, error) {
+	return r.QueryResolver.VOkCaseValue(ctx)
+}
+func (r *stubQuery) VOkCaseNil(ctx context.Context) (*VOkCaseNil, error) {
+	return r.QueryResolver.VOkCaseNil(ctx)
 }
 func (r *stubQuery) ValidType(ctx context.Context) (*ValidType, error) {
 	return r.QueryResolver.ValidType(ctx)

--- a/codegen/testserver/v-ok.go
+++ b/codegen/testserver/v-ok.go
@@ -1,0 +1,17 @@
+package testserver
+
+// VOkCaseValue model
+type VOkCaseValue struct {
+}
+
+func (v VOkCaseValue) Value() (string, bool) {
+	return "hi", true
+}
+
+// VOkCaseNil model
+type VOkCaseNil struct {
+}
+
+func (v VOkCaseNil) Value() (string, bool) {
+	return "", false
+}

--- a/codegen/testserver/v-ok.graphql
+++ b/codegen/testserver/v-ok.graphql
@@ -1,0 +1,12 @@
+extend type Query {
+    vOkCaseValue: VOkCaseValue
+    vOkCaseNil: VOkCaseNil
+}
+
+type VOkCaseValue @goModel(model:"testserver.VOkCaseValue") {
+  value: String
+}
+
+type VOkCaseNil @goModel(model:"testserver.VOkCaseNil") {
+  value: String
+}

--- a/codegen/testserver/v-ok_test.go
+++ b/codegen/testserver/v-ok_test.go
@@ -1,0 +1,47 @@
+package testserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/99designs/gqlgen/client"
+	"github.com/99designs/gqlgen/graphql/handler"
+)
+
+func TestOk(t *testing.T) {
+	resolver := &Stub{}
+	resolver.QueryResolver.VOkCaseValue = func(ctx context.Context) (*VOkCaseValue, error) {
+		return &VOkCaseValue{}, nil
+	}
+	resolver.QueryResolver.VOkCaseNil = func(ctx context.Context) (*VOkCaseNil, error) {
+		return &VOkCaseNil{}, nil
+	}
+
+	c := client.New(handler.NewDefaultServer(
+		NewExecutableSchema(Config{Resolvers: resolver}),
+	))
+
+	t.Run("v ok case value", func(t *testing.T) {
+		var resp struct {
+			VOkCaseValue struct {
+				Value string
+			}
+		}
+		err := c.Post(`query { vOkCaseValue { value } }`, &resp)
+		require.NoError(t, err)
+		require.Equal(t, resp.VOkCaseValue.Value, "hi")
+	})
+
+	t.Run("v ok case nil", func(t *testing.T) {
+		var resp struct {
+			VOkCaseNil struct {
+				Value *string
+			}
+		}
+		err := c.Post(`query { vOkCaseNil { value } }`, &resp)
+		require.NoError(t, err)
+		require.Equal(t, true, resp.VOkCaseNil.Value == nil)
+	})
+}


### PR DESCRIPTION
This adds support for resolver fields which are in shape of (v interface{}, ok bool).

When:

- ok is false, nil is returned
- ok is true, v is returned

fix #1445 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
