### PR TITLE
getting started: making `gqlgen generate` a runnable command

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -85,7 +85,7 @@ type Mutation {
 
 ### Implement the resolvers
 
-`gqlgen generate` compares the schema file (`graph/schema.graphqls`) with the models `graph/model/*` and wherever it
+Running `go run github.com/99designs/gqlgen generate` compares the schema file (`graph/schema.graphqls`) with the models `graph/model/*` and wherever it
 can it will bind directly to the model.
 
 If we take a look in `graph/schema.resolvers.go` we will see all the times that gqlgen couldn't match them up. For us


### PR DESCRIPTION
Making `gqlgen generate` a runnable command to help reduce friction for folks going through the example. 
