### PR TITLE
getting started: making the resolver fn section clearer

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -103,14 +103,15 @@ func (r *queryResolver) Todos(ctx context.Context) ([]*model.Todo, error) {
 
 We just need to implement these two methods to get our server working:
 
-First we need somewhere to track our state, lets put it in `graph/resolver.go`:
+First we need somewhere to track our state, lets put it in `graph/resolver.go`. `graph/resolver.go` is where we declare any dependencies for our app, like our database. It gets initialized once in `server.go` when we create the graph.
+
 ```go
 type Resolver struct{
 	todos []*model.Todo
 }
 ```
-This is where we declare any dependencies for our app like our database, it gets initialized once in `server.go` when
-we create the graph.
+
+Returning to `graph/schema.resolvers.go`, let's implement our unimplemented function bodies:
 
 ```go
 func (r *mutationResolver) CreateTodo(ctx context.Context, input model.NewTodo) (*model.Todo, error) {

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -103,7 +103,7 @@ func (r *queryResolver) Todos(ctx context.Context) ([]*model.Todo, error) {
 
 We just need to implement these two methods to get our server working:
 
-First we need somewhere to track our state, lets put it in `graph/resolver.go`. `graph/resolver.go` is where we declare any dependencies for our app, like our database. It gets initialized once in `server.go` when we create the graph.
+First we need somewhere to track our state, lets put it in `graph/resolver.go`. The `graph/resolver.go` file is where we declare our app's dependencies, like our database. It gets initialized once in `server.go` when we create the graph.
 
 ```go
 type Resolver struct{
@@ -111,7 +111,7 @@ type Resolver struct{
 }
 ```
 
-Returning to `graph/schema.resolvers.go`, let's implement our unimplemented function bodies:
+Returning to `graph/schema.resolvers.go`, let's implement the bodies of our automatically generated resolver functions:
 
 ```go
 func (r *mutationResolver) CreateTodo(ctx context.Context, input model.NewTodo) (*model.Todo, error) {

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -111,7 +111,7 @@ type Resolver struct{
 }
 ```
 
-Returning to `graph/schema.resolvers.go`, let's implement the bodies of our automatically generated resolver functions:
+Returning to `graph/schema.resolvers.go`, let's implement the bodies of those automatically generated resolver functions:
 
 ```go
 func (r *mutationResolver) CreateTodo(ctx context.Context, input model.NewTodo) (*model.Todo, error) {


### PR DESCRIPTION
I tripped over these lines while going through the getting started example. What confused me was not having a clear indicator that we were switching back to the original file; so, I made it clearer (to me at least) what we're doing in the example, but also the purpose of the `resolvers.go` file