### PR TITLE
Fix small typo in complexity docs

### DIFF
--- a/docs/content/reference/complexity.md
+++ b/docs/content/reference/complexity.md
@@ -74,7 +74,7 @@ func main() {
     c.Complexity.Post.Related = countComplexity
 
     srv := handler.NewDefaultServer(blog.NewExecutableSchema(c))
-		srv.Use(extension.FixedComplexityLimit(5))
+	srv.Use(extension.FixedComplexityLimit(5))
     http.Handle("/query", gqlHandler)
 }
 ```

--- a/docs/content/reference/complexity.md
+++ b/docs/content/reference/complexity.md
@@ -47,12 +47,11 @@ Limiting query complexity is as simple as specifying it with the provided extens
 
 ```go
 func main() {
-    c := Config{ Resolvers: &resolvers{} }
+	c := Config{ Resolvers: &resolvers{} }
 
-
-		srv := handler.NewDefaultServer(blog.NewExecutableSchema(c))
-		srv.Use(extension.FixedComplexityLimit(5)) // This line is key
-    r.Handle("/query", srv)
+	srv := handler.NewDefaultServer(blog.NewExecutableSchema(c))
+	srv.Use(extension.FixedComplexityLimit(5)) // This line is key
+	r.Handle("/query", srv)
 }
 ```
 


### PR DESCRIPTION
Made the indents consistent in a code example in complexity docs.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
