### PR TITLE
Nullable fields generated with json omit empty tag

### DIFF
--- a/codegen/testserver/models-gen.go
+++ b/codegen/testserver/models-gen.go
@@ -49,17 +49,17 @@ type Cat struct {
 func (Cat) IsAnimal() {}
 
 type CheckIssue896 struct {
-	ID *int `json:"id"`
+	ID *int `json:"id,omitempty"`
 }
 
 type ContentPost struct {
-	Foo *string `json:"foo"`
+	Foo *string `json:"foo,omitempty"`
 }
 
 func (ContentPost) IsContentChild() {}
 
 type ContentUser struct {
-	Foo *string `json:"foo"`
+	Foo *string `json:"foo,omitempty"`
 }
 
 func (ContentUser) IsContentChild() {}
@@ -72,7 +72,7 @@ type Dog struct {
 func (Dog) IsAnimal() {}
 
 type EmbeddedDefaultScalar struct {
-	Value *string `json:"value"`
+	Value *string `json:"value,omitempty"`
 }
 
 type InnerDirectives struct {
@@ -89,10 +89,10 @@ type InnerObject struct {
 
 type InputDirectives struct {
 	Text          string           `json:"text"`
-	NullableText  *string          `json:"nullableText"`
+	NullableText  *string          `json:"nullableText,omitempty"`
 	Inner         *InnerDirectives `json:"inner"`
-	InnerNullable *InnerDirectives `json:"innerNullable"`
-	ThirdParty    *ThirdParty      `json:"thirdParty"`
+	InnerNullable *InnerDirectives `json:"innerNullable,omitempty"`
+	ThirdParty    *ThirdParty      `json:"thirdParty,omitempty"`
 }
 
 type InputWithEnumValue struct {
@@ -118,12 +118,12 @@ type NestedInput struct {
 }
 
 type NestedMapInput struct {
-	Map map[string]interface{} `json:"map"`
+	Map map[string]interface{} `json:"map,omitempty"`
 }
 
 type ObjectDirectives struct {
 	Text         string   `json:"text"`
-	NullableText *string  `json:"nullableText"`
+	NullableText *string  `json:"nullableText,omitempty"`
 	Order        []string `json:"order"`
 }
 
@@ -136,8 +136,8 @@ type OuterObject struct {
 }
 
 type Slices struct {
-	Test1 []*string `json:"test1"`
-	Test2 []string  `json:"test2"`
+	Test1 []*string `json:"test1,omitempty"`
+	Test2 []string  `json:"test2,omitempty"`
 	Test3 []*string `json:"test3"`
 	Test4 []string  `json:"test4"`
 }
@@ -150,7 +150,7 @@ type User struct {
 	ID      int        `json:"id"`
 	Friends []*User    `json:"friends"`
 	Created time.Time  `json:"created"`
-	Updated *time.Time `json:"updated"`
+	Updated *time.Time `json:"updated,omitempty"`
 }
 
 type ValidInput struct {

--- a/example/scalars/model/generated.go
+++ b/example/scalars/model/generated.go
@@ -8,5 +8,5 @@ import (
 
 type Address struct {
 	ID       external.ObjectID `json:"id"`
-	Location *Point            `json:"location"`
+	Location *Point            `json:"location,omitempty"`
 }

--- a/example/selection/models_gen.go
+++ b/example/selection/models_gen.go
@@ -13,8 +13,8 @@ type Event interface {
 type Like struct {
 	Reaction  string    `json:"reaction"`
 	Sent      time.Time `json:"sent"`
-	Selection []string  `json:"selection"`
-	Collected []string  `json:"collected"`
+	Selection []string  `json:"selection,omitempty"`
+	Collected []string  `json:"collected,omitempty"`
 }
 
 func (Like) IsEvent() {}
@@ -22,8 +22,8 @@ func (Like) IsEvent() {}
 type Post struct {
 	Message   string    `json:"message"`
 	Sent      time.Time `json:"sent"`
-	Selection []string  `json:"selection"`
-	Collected []string  `json:"collected"`
+	Selection []string  `json:"selection,omitempty"`
+	Collected []string  `json:"collected,omitempty"`
 }
 
 func (Post) IsEvent() {}

--- a/example/starwars/models/generated.go
+++ b/example/starwars/models/generated.go
@@ -18,7 +18,7 @@ type SearchResult interface {
 
 type FriendsEdge struct {
 	Cursor string    `json:"cursor"`
-	Node   Character `json:"node"`
+	Node   Character `json:"node,omitempty"`
 }
 
 type PageInfo struct {

--- a/example/todo/models_gen.go
+++ b/example/todo/models_gen.go
@@ -13,7 +13,7 @@ type TodoInput struct {
 	// The body text
 	Text string `json:"text"`
 	// Is it done already?
-	Done *bool `json:"done"`
+	Done *bool `json:"done,omitempty"`
 }
 
 type Role string

--- a/integration/models-go/generated.go
+++ b/integration/models-go/generated.go
@@ -10,8 +10,8 @@ import (
 
 type DateFilter struct {
 	Value    string        `json:"value"`
-	Timezone *string       `json:"timezone"`
-	Op       *DateFilterOp `json:"op"`
+	Timezone *string       `json:"timezone,omitempty"`
+	Op       *DateFilterOp `json:"op,omitempty"`
 }
 
 type DateFilterOp string

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -44,6 +44,10 @@ type Field struct {
 	Tag         string
 }
 
+func (f *Field) Nullable(name string) {
+	f.Tag = `json:"` + name + `,omitempty"`
+}
+
 type Enum struct {
 	Description string
 	Name        string
@@ -162,12 +166,18 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 					typ = types.NewPointer(typ)
 				}
 
-				it.Fields = append(it.Fields, &Field{
+				f := &Field{
 					Name:        name,
 					Type:        typ,
 					Description: field.Description,
 					Tag:         `json:"` + field.Name + `"`,
-				})
+				}
+				// if field is nullable, omit in json marshall to save bandwidth and avoid unexpected behaviour sending null
+				if !field.Type.NonNull {
+					f.Nullable(field.Name)
+				}
+
+				it.Fields = append(it.Fields, f)
 			}
 
 			b.Models = append(b.Models, it)

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -55,9 +55,9 @@ func TestModelGeneration(t *testing.T) {
 
 		expectedTags := []string{
 			`json:"missing2" database:"MissingTypeNotNullmissing2"`,
-			`json:"name" database:"MissingInputname"`,
-			`json:"missing2" database:"MissingTypeNullablemissing2"`,
-			`json:"name" database:"TypeWithDescriptionname"`,
+			`json:"name,omitempty" database:"MissingInputname"`,
+			`json:"missing2,omitempty" database:"MissingTypeNullablemissing2"`,
+			`json:"name,omitempty" database:"TypeWithDescriptionname"`,
 		}
 
 		for _, tag := range expectedTags {

--- a/plugin/modelgen/out/existing.go
+++ b/plugin/modelgen/out/existing.go
@@ -1,10 +1,10 @@
 package out
 
 type ExistingType struct {
-	Name     *string              `json:"name"`
-	Enum     *ExistingEnum        `json:"enum"`
-	Int      ExistingInterface    `json:"int"`
-	Existing *MissingTypeNullable `json:"existing"`
+	Name     *string              `json:"name,omitempty"`
+	Enum     *ExistingEnum        `json:"enum,omitempty"`
+	Int      ExistingInterface    `json:"int,omitempty"`
+	Existing *MissingTypeNullable `json:"existing,omitempty"`
 }
 
 type ExistingModel struct {

--- a/plugin/modelgen/out/generated.go
+++ b/plugin/modelgen/out/generated.go
@@ -31,8 +31,8 @@ type UnionWithDescription interface {
 }
 
 type MissingInput struct {
-	Name *string      `json:"name" database:"MissingInputname"`
-	Enum *MissingEnum `json:"enum" database:"MissingInputenum"`
+	Name *string      `json:"name,omitempty" database:"MissingInputname"`
+	Enum *MissingEnum `json:"enum,omitempty" database:"MissingInputenum"`
 }
 
 type MissingTypeNotNull struct {
@@ -49,11 +49,11 @@ func (MissingTypeNotNull) IsMissingUnion()      {}
 func (MissingTypeNotNull) IsExistingUnion()     {}
 
 type MissingTypeNullable struct {
-	Name     *string             `json:"name" database:"MissingTypeNullablename"`
-	Enum     *MissingEnum        `json:"enum" database:"MissingTypeNullableenum"`
-	Int      MissingInterface    `json:"int" database:"MissingTypeNullableint"`
-	Existing *ExistingType       `json:"existing" database:"MissingTypeNullableexisting"`
-	Missing2 *MissingTypeNotNull `json:"missing2" database:"MissingTypeNullablemissing2"`
+	Name     *string             `json:"name,omitempty" database:"MissingTypeNullablename"`
+	Enum     *MissingEnum        `json:"enum,omitempty" database:"MissingTypeNullableenum"`
+	Int      MissingInterface    `json:"int,omitempty" database:"MissingTypeNullableint"`
+	Existing *ExistingType       `json:"existing,omitempty" database:"MissingTypeNullableexisting"`
+	Missing2 *MissingTypeNotNull `json:"missing2,omitempty" database:"MissingTypeNullablemissing2"`
 }
 
 func (MissingTypeNullable) IsMissingInterface()  {}
@@ -63,7 +63,7 @@ func (MissingTypeNullable) IsExistingUnion()     {}
 
 // TypeWithDescription is a type with a description
 type TypeWithDescription struct {
-	Name *string `json:"name" database:"TypeWithDescriptionname"`
+	Name *string `json:"name,omitempty" database:"TypeWithDescriptionname"`
 }
 
 func (TypeWithDescription) IsUnionWithDescription() {}


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

Nullable fields should be generated with json omit empty tag.
There are cases where the graphql server accepts only one of the field to perform a mutation (an example could be performing a mutation on an union field which expects only one of the type reference set).

This is the case working in particular with Dgraph, which expects a strict format for inputs.

I have:
 - [X ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
