### PR TITLE
Don't impose complexity limit on introspection queries

### DIFF
--- a/graphql/handler/extension/complexity.go
+++ b/graphql/handler/extension/complexity.go
@@ -68,7 +68,7 @@ func (c ComplexityLimit) MutateOperationContext(ctx context.Context, rc *graphql
 		ComplexityLimit: limit,
 	})
 
-	if complexity > limit {
+	if complexity > limit && rc.OperationName != "IntrospectionQuery" {
 		err := gqlerror.Errorf("operation has complexity %d, which exceeds the limit of %d", complexity, limit)
 		errcode.Set(err, errComplexityLimit)
 		return err

--- a/graphql/handler/extension/complexity_test.go
+++ b/graphql/handler/extension/complexity_test.go
@@ -95,6 +95,16 @@ func TestFixedComplexity(t *testing.T) {
 		require.Equal(t, 2, stats.ComplexityLimit)
 		require.Equal(t, 4, stats.Complexity)
 	})
+
+	t.Run("IntrospectionQuery above complexity limit is allowed", func(t *testing.T) {
+		h.SetCalculatedComplexity(4)
+		resp := doRequest(h, "POST", "/graphql", `{ "operationName":"IntrospectionQuery", "query":"query IntrospectionQuery { __schema { queryType { name } mutationType { name }}}"}`)
+		require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+		require.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+
+		require.Equal(t, 2, stats.ComplexityLimit)
+		require.Equal(t, 9, stats.Complexity)
+	})
 }
 
 func doRequest(handler http.Handler, method string, target string, body string) *httptest.ResponseRecorder {


### PR DESCRIPTION
Don't impose complexity limits on Introspection Queries

Resolves: https://github.com/99designs/gqlgen/issues/462
