### PR TITLE
Run go mod tidy after code generation

### DIFF
--- a/.github/workflows/check-init
+++ b/.github/workflows/check-init
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd example/init
+
+go get github.com/99designs/gqlgen
+
+if { go run github.com/99designs/gqlgen init 2>&1 >&3 3>&- | grep '^' >&2; } 3>&1; then
+    echo "gqlgen init failed validation"
+    exit 125
+fi

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,3 +22,11 @@ jobs:
       - run: go mod download
       - run: cd example/federation ; npm install
       - run: .github/workflows/check-federation
+
+  init:
+    runs-on: ubuntu-latest
+    container: golang:1.16-alpine
+    steps:
+      - uses: actions/checkout@v1
+      - run: apk add --no-cache --no-progress alpine-sdk bash
+      - run: .github/workflows/check-init

--- a/api/generate.go
+++ b/api/generate.go
@@ -77,6 +77,9 @@ func Generate(cfg *config.Config, option ...Option) error {
 	if err = codegen.GenerateCode(data); err != nil {
 		return errors.Wrap(err, "generating core failed")
 	}
+	if err = cfg.Packages.ModTidy(); err != nil {
+		return errors.Wrap(err, "tidy failed")
+	}
 
 	for _, p := range plugins {
 		if mut, ok := p.(plugin.CodeGenerator); ok {

--- a/example/init/go.mod
+++ b/example/init/go.mod
@@ -1,0 +1,5 @@
+module gqlgen.com/inittest
+
+go 1.16
+
+replace github.com/99designs/gqlgen => ../..

--- a/internal/code/packages.go
+++ b/internal/code/packages.go
@@ -2,6 +2,7 @@ package code
 
 import (
 	"bytes"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -147,6 +148,15 @@ func (p *Packages) Evict(importPath string) {
 			}
 		}
 	}
+}
+
+func (p *Packages) ModTidy() error {
+	p.packages = nil
+	tidyCmd := exec.Command("go", "mod", "tidy")
+	if err := tidyCmd.Run(); err != nil {
+		return errors.Wrap(err, "go mod tidy failed")
+	}
+	return nil
 }
 
 // Errors returns any errors that were returned by Load, either from the call itself or any of the loaded packages.


### PR DESCRIPTION
Fixes: #1490

Also added an integration test covering `gqlgen init`.

## Questions
- Is this the best way to run `go mod tidy`?
- Is this the only place we need to run tidy?
- What happens in non-module mode? Do we officially support that mode of operation anymore?

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
