### PR TITLE
transport: implement `graphql-transport-ws` ws sub-protocol  

### DIFF
--- a/example/chat/package.json
+++ b/example/chat/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@apollo/client": "^3.2.3",
     "apollo-cache-inmemory": "^1.3.11",
-    "apollo-link-ws": "^1.0.10",
     "apollo-utilities": "^1.0.26",
     "graphql": "^14.0.2",
     "graphql-tag": "^2.10.0",

--- a/example/chat/package.json
+++ b/example/chat/package.json
@@ -16,6 +16,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "start:graphql-transport-ws": "REACT_APP_WS_PROTOCOL=graphql-transport-ws npm run start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"

--- a/example/chat/package.json
+++ b/example/chat/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.2.3",
-    "@apollo/react-hooks": "^4.0.0",
     "apollo-cache-inmemory": "^1.3.11",
     "apollo-link-ws": "^1.0.10",
     "apollo-utilities": "^1.0.26",

--- a/example/chat/readme.md
+++ b/example/chat/readme.md
@@ -22,7 +22,7 @@ Then to run the app with the `apollo-link-ws` implementation do
 npm run start
 ```
 
-or to run the app with the `graphql-ws` implementation do
+or to run the app with the `graphql-ws` implementation (and the newer `graphql-transport-ws` protocol) do
 ```bash
 npm run start:graphql-transport-ws
 ```

--- a/example/chat/readme.md
+++ b/example/chat/readme.md
@@ -1,14 +1,28 @@
-### chat app
+# Chat App
 
 Example app using subscriptions to build a chat room.
 
-to run this server
+### Server
 ```bash
 go run ./server/server.go
 ```
 
-to run the react app
+### Client
+The react app uses two different implementation for the websocket link
+- [apollo-link-ws](https://www.apollographql.com/docs/react/api/link/apollo-link-ws) which uses the deprecated [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws) library
+- [graphql-ws](https://github.com/enisdenjo/graphql-ws)
+
+First you need to install the dependencies
 ```bash
 npm install 
+```
+
+Then to run the app with the `apollo-link-ws` implementation do
+```bash
 npm run start
+```
+
+or to run the app with the `graphql-ws` implementation do
+```bash
+npm run start:graphql-transport-ws
 ```

--- a/example/chat/src/Room.js
+++ b/example/chat/src/Room.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import gql from 'graphql-tag';
-import { useQuery, useMutation } from '@apollo/react-hooks';
+import { useQuery, useMutation } from '@apollo/client';
 import { Chat, ChatContainer, Message, MessageReceived } from './components/room';
 
 export const Room = ({ channel, name }) => {

--- a/example/chat/src/graphql-ws.js
+++ b/example/chat/src/graphql-ws.js
@@ -1,0 +1,46 @@
+import { createClient } from 'graphql-ws';
+import { print } from 'graphql';
+import { ApolloLink, Observable } from '@apollo/client';
+
+export class WebSocketLink extends ApolloLink {
+  client;
+
+  constructor(options) {
+    super();
+    this.client = createClient(options);
+  }
+
+  request(operation) {
+    return new Observable((sink) => {
+      return this.client.subscribe(
+        { ...operation, query: print(operation.query) },
+        {
+          next: sink.next.bind(sink),
+          complete: sink.complete.bind(sink),
+          error: (err) => {
+            if (err instanceof Error) {
+              return sink.error(err);
+            }
+
+            if (err instanceof CloseEvent) {
+              return sink.error(
+                // reason will be available on clean closes
+                new Error(
+                  `Socket closed with event ${err.code} ${err.reason || ''}`,
+                ),
+              );
+            }
+
+            return sink.error(
+              new Error(
+                err
+                  .map(({ message }) => message)
+                  .join(', '),
+              ),
+            );
+          },
+        },
+      );
+    });
+  }
+}

--- a/example/chat/src/index.js
+++ b/example/chat/src/index.js
@@ -7,16 +7,24 @@ import {
     split,
 } from '@apollo/client';
 import { InMemoryCache } from 'apollo-cache-inmemory';
-import { WebSocketLink } from '@apollo/client/link/ws';
+import { WebSocketLink as ApolloWebSocketLink} from '@apollo/client/link/ws';
 import { getMainDefinition } from 'apollo-utilities';
 import { App } from './App';
+import { WebSocketLink as GraphQLWSWebSocketLink } from './graphql-ws'
 
-const wsLink = new WebSocketLink({
-    uri: `ws://localhost:8085/query`,
-    options: {
-        reconnect: true
-    }
-});
+let wsLink;
+if (process.env.REACT_APP_WS_PROTOCOL === 'graphql-transport-ws') {
+    wsLink = new GraphQLWSWebSocketLink({
+        url: `ws://localhost:8085/query`
+    });
+} else {
+    wsLink = new ApolloWebSocketLink({
+        uri: `ws://localhost:8085/query`,
+        options: {
+            reconnect: true
+        }
+    });
+}
 
 const httpLink = new HttpLink({ uri: 'http://localhost:8085/query' });
 

--- a/example/chat/src/index.js
+++ b/example/chat/src/index.js
@@ -7,7 +7,7 @@ import {
     split,
 } from '@apollo/client';
 import { InMemoryCache } from 'apollo-cache-inmemory';
-import { WebSocketLink } from 'apollo-link-ws';
+import { WebSocketLink } from '@apollo/client/link/ws';
 import { getMainDefinition } from 'apollo-utilities';
 import { App } from './App';
 

--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -63,7 +63,7 @@ func (t Websocket) Do(w http.ResponseWriter, r *http.Request, exec graphql.Graph
 		ws.WriteMessage(websocket.CloseMessage, msg)
 		return
 	case "":
-		// clients are required to send a subprotocol, to be backward compatible with the previous implemementation we select
+		// clients are required to send a subprotocol, to be backward compatible with the previous implementation we select
 		// "graphql-ws" by default
 		me = graphqlwsMessageExchanger{c: ws}
 	case graphqlwsSubprotocol:

--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -62,12 +62,12 @@ func (t Websocket) Do(w http.ResponseWriter, r *http.Request, exec graphql.Graph
 		msg := websocket.FormatCloseMessage(websocket.CloseProtocolError, fmt.Sprintf("unsupported negotiated subprotocol %s", ws.Subprotocol()))
 		ws.WriteMessage(websocket.CloseMessage, msg)
 		return
-	case "":
+	case graphqlwsSubprotocol, "":
 		// clients are required to send a subprotocol, to be backward compatible with the previous implementation we select
 		// "graphql-ws" by default
 		me = graphqlwsMessageExchanger{c: ws}
-	case graphqlwsSubprotocol:
-		me = graphqlwsMessageExchanger{c: ws}
+	case graphqltransportwsSubprotocol:
+		me = graphqltransportwsMessageExchanger{c: ws}
 	}
 
 	conn := wsConnection{

--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -37,11 +37,7 @@ type (
 
 		initPayload InitPayload
 	}
-	operationMessage struct {
-		Payload json.RawMessage `json:"payload,omitempty"`
-		ID      string          `json:"id,omitempty"`
-		Type    string          `json:"type"`
-	}
+
 	WebsocketInitFunc func(ctx context.Context, initPayload InitPayload) (context.Context, error)
 )
 

--- a/graphql/handler/transport/websocket_graphql_transport_ws.go
+++ b/graphql/handler/transport/websocket_graphql_transport_ws.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+// https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md
 const (
 	graphqltransportwsSubprotocol = "graphql-transport-ws"
 

--- a/graphql/handler/transport/websocket_graphql_transport_ws.go
+++ b/graphql/handler/transport/websocket_graphql_transport_ws.go
@@ -1,0 +1,138 @@
+package transport
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	graphqltransportwsSubprotocol = "graphql-transport-ws"
+
+	graphqltransportwsConnectionInitMsg = graphqltransportwsMessageType("connection_init")
+	graphqltransportwsConnectionAckMsg  = graphqltransportwsMessageType("connection_ack")
+	graphqltransportwsSubscribeMsg      = graphqltransportwsMessageType("subscribe")
+	graphqltransportwsNextMsg           = graphqltransportwsMessageType("next")
+	graphqltransportwsErrorMsg          = graphqltransportwsMessageType("error")
+	graphqltransportwsCompleteMsg       = graphqltransportwsMessageType("complete")
+)
+
+var (
+	allGraphqltransportwsMessageTypes = []graphqltransportwsMessageType{
+		graphqltransportwsConnectionInitMsg,
+		graphqltransportwsConnectionAckMsg,
+		graphqltransportwsSubscribeMsg,
+		graphqltransportwsNextMsg,
+		graphqltransportwsErrorMsg,
+		graphqltransportwsCompleteMsg,
+	}
+)
+
+type (
+	graphqltransportwsMessageExchanger struct {
+		c *websocket.Conn
+	}
+
+	graphqltransportwsMessage struct {
+		Payload json.RawMessage               `json:"payload,omitempty"`
+		ID      string                        `json:"id,omitempty"`
+		Type    graphqltransportwsMessageType `json:"type"`
+		noOp    bool
+	}
+
+	graphqltransportwsMessageType string
+)
+
+func (me graphqltransportwsMessageExchanger) NextMessage() (message, error) {
+	_, r, err := me.c.NextReader()
+	if err != nil {
+		return message{}, handleNextReaderError(err)
+	}
+
+	var graphqltransportwsMessage graphqltransportwsMessage
+	if err := jsonDecode(r, &graphqltransportwsMessage); err != nil {
+		return message{}, errInvalidMsg
+	}
+
+	return graphqltransportwsMessage.toMessage()
+}
+
+func (me graphqltransportwsMessageExchanger) Send(m *message) error {
+	msg := &graphqltransportwsMessage{}
+	if err := msg.fromMessage(m); err != nil {
+		return err
+	}
+
+	if msg.noOp {
+		return nil
+	}
+
+	return me.c.WriteJSON(msg)
+}
+
+func (t *graphqltransportwsMessageType) UnmarshalText(text []byte) (err error) {
+	var found bool
+	for _, candidate := range allGraphqltransportwsMessageTypes {
+		if string(candidate) == string(text) {
+			*t = candidate
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		err = fmt.Errorf("invalid message type %s", string(text))
+	}
+
+	return err
+}
+
+func (t graphqltransportwsMessageType) MarshalText() ([]byte, error) {
+	return []byte(string(t)), nil
+}
+
+func (m graphqltransportwsMessage) toMessage() (message, error) {
+	var t messageType
+	var err error
+	switch m.Type {
+	default:
+		err = fmt.Errorf("invalid client->server message type %s", m.Type)
+	case graphqltransportwsConnectionInitMsg:
+		t = initMessageType
+	case graphqltransportwsSubscribeMsg:
+		t = startMessageType
+	case graphqltransportwsCompleteMsg:
+		t = stopMessageType
+	}
+
+	return message{
+		payload: m.Payload,
+		id:      m.ID,
+		t:       t,
+	}, err
+}
+
+func (m *graphqltransportwsMessage) fromMessage(msg *message) (err error) {
+	m.ID = msg.id
+	m.Payload = msg.payload
+
+	switch msg.t {
+	default:
+		err = fmt.Errorf("invalid server->client message type %s", msg.t)
+	case connectionAckMessageType:
+		m.Type = graphqltransportwsConnectionAckMsg
+	case keepAliveMessageType:
+		m.noOp = true
+	case connectionErrorMessageType:
+		m.noOp = true
+	case dataMessageType:
+		m.Type = graphqltransportwsNextMsg
+	case completeMessageType:
+		m.Type = graphqltransportwsCompleteMsg
+	case errorMessageType:
+		m.Type = graphqltransportwsErrorMsg
+	}
+
+	return err
+}

--- a/graphql/handler/transport/websocket_graphqlws.go
+++ b/graphql/handler/transport/websocket_graphqlws.go
@@ -1,0 +1,200 @@
+package transport
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	graphqlwsSubprotocol = "graphql-ws"
+
+	graphqlwsConnectionInitMsg = iota
+	graphqlwsConnectionTerminateMsg
+	graphqlwsStartMsg
+	graphqlwsStopMsg
+	graphqlwsConnectionAckMsg
+	graphqlwsConnectionErrorMsg
+	graphqlwsDataMsg
+	graphqlwsErrorMsg
+	graphqlwsCompleteMsg
+	graphqlwsConnectionKeepAliveMsg
+)
+
+type (
+	graphqlwsMessageExchanger struct {
+		c *websocket.Conn
+	}
+
+	graphqlwsMessage struct {
+		Payload json.RawMessage      `json:"payload,omitempty"`
+		ID      string               `json:"id,omitempty"`
+		Type    graphqlwsMessageType `json:"type"`
+	}
+
+	graphqlwsMessageType int
+)
+
+func (me graphqlwsMessageExchanger) NextMessage() (message, error) {
+	_, r, err := me.c.NextReader()
+	if err != nil {
+		// TODO: should we consider all closure scenarios here for the ws connection?
+		// for now we only list the error codes from the original code
+		if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseNoStatusReceived) {
+			err = errWsConnClosed
+		}
+
+		return message{}, err
+	}
+
+	var graphqlwsMessage graphqlwsMessage
+	if err := jsonDecode(r, &graphqlwsMessage); err != nil {
+		return message{}, errInvalidMsg
+	}
+
+	return graphqlwsMessage.toMessage()
+}
+
+func (me graphqlwsMessageExchanger) Send(m *message) error {
+	msg := &graphqlwsMessage{}
+	if err := msg.fromMessage(m); err != nil {
+		return err
+	}
+
+	return me.c.WriteJSON(msg)
+}
+
+func (t *graphqlwsMessageType) UnmarshalText(text []byte) (err error) {
+	switch string(text) {
+	default:
+		err = fmt.Errorf("invalid message type %s", string(text))
+	case "connection_init":
+		*t = graphqlwsConnectionInitMsg
+	case "connection_terminate":
+		*t = graphqlwsConnectionTerminateMsg
+	case "start":
+		*t = graphqlwsStartMsg
+	case "stop":
+		*t = graphqlwsStopMsg
+	case "connection_ack":
+		*t = graphqlwsConnectionAckMsg
+	case "connection_error":
+		*t = graphqlwsConnectionErrorMsg
+	case "data":
+		*t = graphqlwsDataMsg
+	case "error":
+		*t = graphqlwsErrorMsg
+	case "complete":
+		*t = graphqlwsCompleteMsg
+	case "ka":
+		*t = graphqlwsConnectionKeepAliveMsg
+	}
+
+	return err
+}
+
+func (t graphqlwsMessageType) MarshalText() ([]byte, error) {
+	var text string
+	var err error
+	switch t {
+	default:
+		err = fmt.Errorf("no text representation for message type %d", t)
+	case graphqlwsConnectionInitMsg:
+		text = "connection_init"
+	case graphqlwsConnectionTerminateMsg:
+		text = "connection_terminate"
+	case graphqlwsStartMsg:
+		text = "start"
+	case graphqlwsStopMsg:
+		text = "stop"
+	case graphqlwsConnectionAckMsg:
+		text = "connection_ack"
+	case graphqlwsConnectionErrorMsg:
+		text = "connection_error"
+	case graphqlwsDataMsg:
+		text = "data"
+	case graphqlwsErrorMsg:
+		text = "error"
+	case graphqlwsCompleteMsg:
+		text = "complete"
+	case graphqlwsConnectionKeepAliveMsg:
+		text = "ka"
+	}
+
+	return []byte(text), err
+}
+
+func (t graphqlwsMessageType) toMessageType() (mt messageType, err error) {
+	switch t {
+	default:
+		err = fmt.Errorf("unknown message type mapping for %d", t)
+	case graphqlwsConnectionInitMsg:
+		mt = initMessageType
+	case graphqlwsConnectionTerminateMsg:
+		mt = connectionCloseMessageType
+	case graphqlwsStartMsg:
+		mt = startMessageType
+	case graphqlwsStopMsg:
+		mt = stopMessageType
+	case graphqlwsConnectionAckMsg:
+		mt = connectionAckMessageType
+	case graphqlwsConnectionErrorMsg:
+		mt = connectionErrorMessageType
+	case graphqlwsDataMsg:
+		mt = dataMessageType
+	case graphqlwsErrorMsg:
+		mt = errorMessageType
+	case graphqlwsCompleteMsg:
+		mt = completeMessageType
+	case graphqlwsConnectionKeepAliveMsg:
+		mt = keepAliveMessageType
+	}
+
+	return mt, err
+}
+
+func (t *graphqlwsMessageType) fromMessageType(mt messageType) (err error) {
+	switch mt {
+	default:
+		err = fmt.Errorf("failed to convert message %s to %s subprotocol", mt, graphqlwsSubprotocol)
+	case initMessageType:
+		*t = graphqlwsConnectionInitMsg
+	case connectionAckMessageType:
+		*t = graphqlwsConnectionAckMsg
+	case keepAliveMessageType:
+		*t = graphqlwsConnectionKeepAliveMsg
+	case connectionErrorMessageType:
+		*t = graphqlwsConnectionErrorMsg
+	case connectionCloseMessageType:
+		*t = graphqlwsConnectionTerminateMsg
+	case startMessageType:
+		*t = graphqlwsStartMsg
+	case stopMessageType:
+		*t = graphqlwsStopMsg
+	case dataMessageType:
+		*t = graphqlwsDataMsg
+	case completeMessageType:
+		*t = graphqlwsCompleteMsg
+	case errorMessageType:
+		*t = graphqlwsErrorMsg
+	}
+
+	return err
+}
+
+func (m graphqlwsMessage) toMessage() (message, error) {
+	mt, err := m.Type.toMessageType()
+	return message{
+		payload: m.Payload,
+		id:      m.ID,
+		t:       mt,
+	}, err
+}
+
+func (m *graphqlwsMessage) fromMessage(msg *message) (err error) {
+	err = m.Type.fromMessageType(msg.t)
+	m.ID = msg.id
+	m.Payload = msg.payload
+	return err
+}

--- a/graphql/handler/transport/websocket_graphqlws.go
+++ b/graphql/handler/transport/websocket_graphqlws.go
@@ -40,7 +40,7 @@ func (me graphqlwsMessageExchanger) NextMessage() (message, error) {
 	_, r, err := me.c.NextReader()
 	if err != nil {
 		// TODO: should we consider all closure scenarios here for the ws connection?
-		// for now we only list the error codes from the original code
+		// for now we only list the error codes from the previous implementation
 		if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseNoStatusReceived) {
 			err = errWsConnClosed
 		}

--- a/graphql/handler/transport/websocket_graphqlws.go
+++ b/graphql/handler/transport/websocket_graphqlws.go
@@ -54,13 +54,7 @@ type (
 func (me graphqlwsMessageExchanger) NextMessage() (message, error) {
 	_, r, err := me.c.NextReader()
 	if err != nil {
-		// TODO: should we consider all closure scenarios here for the ws connection?
-		// for now we only list the error codes from the previous implementation
-		if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseNoStatusReceived) {
-			err = errWsConnClosed
-		}
-
-		return message{}, err
+		return message{}, handleNextReaderError(err)
 	}
 
 	var graphqlwsMessage graphqlwsMessage

--- a/graphql/handler/transport/websocket_graphqlws.go
+++ b/graphql/handler/transport/websocket_graphqlws.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+// https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md
 const (
 	graphqlwsSubprotocol = "graphql-ws"
 

--- a/graphql/handler/transport/websocket_subprotocol.go
+++ b/graphql/handler/transport/websocket_subprotocol.go
@@ -1,0 +1,97 @@
+package transport
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+const (
+	initMessageType messageType = iota
+	connectionAckMessageType
+	keepAliveMessageType
+	connectionErrorMessageType
+	connectionCloseMessageType
+	startMessageType
+	stopMessageType
+	dataMessageType
+	completeMessageType
+	errorMessageType
+)
+
+var (
+	supportedSubprotocols = []string{
+		graphqlwsSubprotocol,
+	}
+
+	errWsConnClosed = errors.New("websocket connection closed")
+	errInvalidMsg   = errors.New("invalid message received")
+)
+
+type (
+	messageType int
+	message     struct {
+		payload json.RawMessage
+		id      string
+		t       messageType
+	}
+	messageExchanger interface {
+		NextMessage() (message, error)
+		Send(m *message) error
+	}
+)
+
+func (t messageType) String() string {
+	var text string
+	switch t {
+	default:
+		text = "unknown"
+	case initMessageType:
+		text = "init"
+	case connectionAckMessageType:
+		text = "connection ack"
+	case keepAliveMessageType:
+		text = "keep alive"
+	case connectionErrorMessageType:
+		text = "connection error"
+	case connectionCloseMessageType:
+		text = "connection close"
+	case startMessageType:
+		text = "start"
+	case stopMessageType:
+		text = "stop subscription"
+	case dataMessageType:
+		text = "data"
+	case completeMessageType:
+		text = "complete"
+	case errorMessageType:
+		text = "error"
+	}
+	return text
+}
+
+func contains(list []string, elem string) bool {
+	for _, e := range list {
+		if e == elem {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (t *Websocket) injectGraphQLWSSubprotocols() {
+	// the list of subprotocols is specified by the consumer of the Websocket struct,
+	// in order to preserve backward compatibility, we inject the graphql specific subprotocols
+	// at runtime
+	if !t.didInjectSubprotocols {
+		defer func() {
+			t.didInjectSubprotocols = true
+		}()
+
+		for _, subprotocol := range supportedSubprotocols {
+			if !contains(t.Upgrader.Subprotocols, subprotocol) {
+				t.Upgrader.Subprotocols = append(t.Upgrader.Subprotocols, subprotocol)
+			}
+		}
+	}
+}

--- a/graphql/handler/transport/websocket_subprotocol.go
+++ b/graphql/handler/transport/websocket_subprotocol.go
@@ -3,6 +3,8 @@ package transport
 import (
 	"encoding/json"
 	"errors"
+
+	"github.com/gorilla/websocket"
 )
 
 const (
@@ -21,6 +23,7 @@ const (
 var (
 	supportedSubprotocols = []string{
 		graphqlwsSubprotocol,
+		graphqltransportwsSubprotocol,
 	}
 
 	errWsConnClosed = errors.New("websocket connection closed")
@@ -94,4 +97,14 @@ func (t *Websocket) injectGraphQLWSSubprotocols() {
 			}
 		}
 	}
+}
+
+func handleNextReaderError(err error) error {
+	// TODO: should we consider all closure scenarios here for the ws connection?
+	// for now we only list the error codes from the previous implementation
+	if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseNoStatusReceived) {
+		return errWsConnClosed
+	}
+
+	return err
 }

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -374,7 +374,6 @@ const (
 	graphqltransportwsConnectionAckMsg  = "connection_ack"
 	graphqltransportwsSubscribeMsg      = "subscribe"
 	graphqltransportwsNextMsg           = "next"
-	graphqltransportwsErrorMsg          = "error"
 	graphqltransportwsCompleteMsg       = "complete"
 )
 

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -318,6 +318,7 @@ func TestWebsocketGraphqltransportwsSubprotocol(t *testing.T) {
 }
 
 func wsConnect(url string) *websocket.Conn {
+
 	return wsConnectWithSubprocotol(url, "")
 }
 
@@ -327,7 +328,7 @@ func wsConnectWithSubprocotol(url, subprocotol string) *websocket.Conn {
 		h.Add("Sec-WebSocket-Protocol", subprocotol)
 	}
 
-	c, resp, err := websocket.DefaultDialer.Dial(strings.Replace(url, "http://", "ws://", -1), h)
+	c, resp, err := websocket.DefaultDialer.Dial(strings.ReplaceAll(url, "http://", "ws://"), h)
 	if err != nil {
 		panic(err)
 	}

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -267,8 +268,66 @@ func TestWebsocketInitFunc(t *testing.T) {
 	})
 }
 
+func TestWebsocketGraphqltransportwsSubprotocol(t *testing.T) {
+	handler := testserver.New()
+	handler.AddTransport(transport.Websocket{})
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	t.Run("server acks init", func(t *testing.T) {
+		c := wsConnectWithSubprocotol(srv.URL, graphqltransportwsSubprotocol)
+		defer c.Close()
+
+		require.NoError(t, c.WriteJSON(&operationMessage{Type: graphqltransportwsConnectionInitMsg}))
+
+		assert.Equal(t, graphqltransportwsConnectionAckMsg, readOp(c).Type)
+	})
+
+	t.Run("client can receive data", func(t *testing.T) {
+		c := wsConnectWithSubprocotol(srv.URL, graphqltransportwsSubprotocol)
+		defer c.Close()
+
+		require.NoError(t, c.WriteJSON(&operationMessage{Type: graphqltransportwsConnectionInitMsg}))
+		assert.Equal(t, graphqltransportwsConnectionAckMsg, readOp(c).Type)
+
+		require.NoError(t, c.WriteJSON(&operationMessage{
+			Type:    graphqltransportwsSubscribeMsg,
+			ID:      "test_1",
+			Payload: json.RawMessage(`{"query": "subscription { name }"}`),
+		}))
+
+		handler.SendNextSubscriptionMessage()
+		msg := readOp(c)
+		require.Equal(t, graphqltransportwsNextMsg, msg.Type, string(msg.Payload))
+		require.Equal(t, "test_1", msg.ID, string(msg.Payload))
+		require.Equal(t, `{"data":{"name":"test"}}`, string(msg.Payload))
+
+		handler.SendNextSubscriptionMessage()
+		msg = readOp(c)
+		require.Equal(t, graphqltransportwsNextMsg, msg.Type, string(msg.Payload))
+		require.Equal(t, "test_1", msg.ID, string(msg.Payload))
+		require.Equal(t, `{"data":{"name":"test"}}`, string(msg.Payload))
+
+		require.NoError(t, c.WriteJSON(&operationMessage{Type: graphqltransportwsCompleteMsg, ID: "test_1"}))
+
+		msg = readOp(c)
+		require.Equal(t, graphqltransportwsCompleteMsg, msg.Type)
+		require.Equal(t, "test_1", msg.ID)
+	})
+}
+
 func wsConnect(url string) *websocket.Conn {
-	c, resp, err := websocket.DefaultDialer.Dial(strings.ReplaceAll(url, "http://", "ws://"), nil)
+	return wsConnectWithSubprocotol(url, "")
+}
+
+func wsConnectWithSubprocotol(url, subprocotol string) *websocket.Conn {
+	h := make(http.Header)
+	if subprocotol != "" {
+		h.Add("Sec-WebSocket-Protocol", subprocotol)
+	}
+
+	c, resp, err := websocket.DefaultDialer.Dial(strings.Replace(url, "http://", "ws://", -1), h)
 	if err != nil {
 		panic(err)
 	}
@@ -291,7 +350,7 @@ func readOp(conn *websocket.Conn) operationMessage {
 	return msg
 }
 
-// copied out from weboscket.go to keep these private
+// copied out from websocket_graphqlws.go to keep these private
 
 const (
 	connectionInitMsg      = "connection_init"      // Client -> Server
@@ -304,6 +363,19 @@ const (
 	errorMsg               = "error"                // Server -> Client
 	completeMsg            = "complete"             // Server -> Client
 	connectionKeepAliveMsg = "ka"                   // Server -> Client
+)
+
+// copied out from websocket_graphql_transport_ws.go to keep these private
+
+const (
+	graphqltransportwsSubprotocol = "graphql-transport-ws"
+
+	graphqltransportwsConnectionInitMsg = "connection_init"
+	graphqltransportwsConnectionAckMsg  = "connection_ack"
+	graphqltransportwsSubscribeMsg      = "subscribe"
+	graphqltransportwsNextMsg           = "next"
+	graphqltransportwsErrorMsg          = "error"
+	graphqltransportwsCompleteMsg       = "complete"
 )
 
 type operationMessage struct {


### PR DESCRIPTION
This implements the [`graphql-transport-ws`](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md) websocket sub-protocol.

I have refactored the sub-protocol message parsing by creating a generic message `message` and a `messageExchanger` interface defined in the file _websocket_subprotocol.go_.

The previously supported [`graphql-ws`](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md) sub-protocol is implemented in the file _websocket_graphqlws.go_. The new protocol is implemented in the _websocket_graphql_transport_ws.go_.

I've aimed to keep this change as much backward compatible as possible, the default sub-protocol selected is `graphql-ws`, even if the ws client does not explicitly request it. I am also not requiring the consumer of the `Transport` struct to provide the list of supported sub-protocols, and they are injected at runtime instead.

In addition to that, I have fixed some libraries version mismatch in the `example/chat` example project. I have included another implementation of the websocket link that uses the newly supported sub-protocol.

Closes #1430 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
