### PR TITLE
Update apq.md function definition mismatch

### DIFF
--- a/docs/content/reference/apq.md
+++ b/docs/content/reference/apq.md
@@ -38,7 +38,7 @@ type Cache struct {
 
 const apqPrefix = "apq:"
 
-func NewCache(redisAddress string, password string, ttl time.Duration) (*Cache, error) {
+func NewCache(redisAddress string, ttl time.Duration) (*Cache, error) {
 	client := redis.NewClient(&redis.Options{
 		Addr:     redisAddress,
 	})


### PR DESCRIPTION
line 67:  cache, err := NewCache(cfg.RedisAddress, 24*time.Hour)
line 41: func NewCache(redisAddress string, password string,ttl time.Duration) (*Cache, error)

either password should be removed from 41 or added in line 67
Proposed the first one for now.

Describe your PR and link to any relevant issues. 

I have:
 -  Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
