### PR TITLE
allow more than 10 different import sources with types

### DIFF
--- a/codegen/templates/import.go
+++ b/codegen/templates/import.go
@@ -105,7 +105,7 @@ func (s *Imports) Lookup(path string) string {
 	for s.findByAlias(alias) != nil {
 		alias = imp.Name + strconv.Itoa(i)
 		i++
-		if i > 10 {
+		if i > 1000 {
 			panic(fmt.Errorf("too many collisions, last attempt was %s", alias))
 		}
 	}

--- a/codegen/templates/import_test.go
+++ b/codegen/templates/import_test.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"fmt"
 	"go/types"
 	"os"
 	"testing"
@@ -43,6 +44,19 @@ func TestImports(t *testing.T) {
 		t.Run("additionial calls get decollisioned name", func(t *testing.T) {
 			require.Equal(t, "bar1", a.Lookup(bBar))
 		})
+	})
+
+	t.Run("duplicates above 10 are decollisioned", func(t *testing.T) {
+		a := Imports{destDir: wd, packages: &code.Packages{}}
+		for i := 0; i < 100; i++ {
+			cBar := fmt.Sprintf("github.com/99designs/gqlgen/codegen/templates/testdata/%d/bar", i)
+			if i > 0 {
+				require.Equal(t, fmt.Sprintf("bar%d", i), a.Lookup(cBar))
+			} else {
+				require.Equal(t, "bar", a.Lookup(cBar))
+
+			}
+		}
 	})
 
 	t.Run("package name defined in code will be used", func(t *testing.T) {


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

We had an issue when importing from multiple */pkg/types.*, causing error with `error calling call: too many collisions, last attempt was types10`. I could not find any particular reason to why there is a hard limit of 10 for aliasing imports so this pr bumps that number. 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
