### PR TITLE
Return type loading errors in config.Binder.FindObject

### DIFF
--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -117,6 +117,10 @@ func (b *Binder) FindObject(pkgName string, typeName string) (types.Object, erro
 
 	pkg := b.pkgs.LoadWithTypes(pkgName)
 	if pkg == nil {
+		err := b.pkgs.Errors()
+		if err != nil {
+			return nil, errors.Wrapf(err, "package could not be loaded: %s", fullName)
+		}
 		return nil, errors.Errorf("required package was not loaded: %s", fullName)
 	}
 


### PR DESCRIPTION
Returns errors that might occur when loading packages in config.Binder.FindObject

Fixes https://github.com/99designs/gqlgen/issues/1528

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
