### PR TITLE
Add support for graphql-transport-ws with duplex ping-pong

### DIFF
--- a/example/chat/readme.md
+++ b/example/chat/readme.md
@@ -3,26 +3,32 @@
 Example app using subscriptions to build a chat room.
 
 ### Server
+
 ```bash
 go run ./server/server.go
 ```
 
 ### Client
+
 The react app uses two different implementation for the websocket link
+
 - [apollo-link-ws](https://www.apollographql.com/docs/react/api/link/apollo-link-ws) which uses the deprecated [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws) library
 - [graphql-ws](https://github.com/enisdenjo/graphql-ws)
 
 First you need to install the dependencies
+
 ```bash
-npm install 
+npm install
 ```
 
 Then to run the app with the `apollo-link-ws` implementation do
+
 ```bash
 npm run start
 ```
 
 or to run the app with the `graphql-ws` implementation (and the newer `graphql-transport-ws` protocol) do
+
 ```bash
 npm run start:graphql-transport-ws
 ```

--- a/graphql/handler/transport/websocket_graphql_transport_ws.go
+++ b/graphql/handler/transport/websocket_graphql_transport_ws.go
@@ -17,16 +17,22 @@ const (
 	graphqltransportwsNextMsg           = graphqltransportwsMessageType("next")
 	graphqltransportwsErrorMsg          = graphqltransportwsMessageType("error")
 	graphqltransportwsCompleteMsg       = graphqltransportwsMessageType("complete")
+	graphqltransportwsPingMsg           = graphqltransportwsMessageType("ping")
+	graphqltransportwsPongMsg           = graphqltransportwsMessageType("pong")
 )
 
-var allGraphqltransportwsMessageTypes = []graphqltransportwsMessageType{
-	graphqltransportwsConnectionInitMsg,
-	graphqltransportwsConnectionAckMsg,
-	graphqltransportwsSubscribeMsg,
-	graphqltransportwsNextMsg,
-	graphqltransportwsErrorMsg,
-	graphqltransportwsCompleteMsg,
-}
+var (
+	allGraphqltransportwsMessageTypes = []graphqltransportwsMessageType{
+		graphqltransportwsConnectionInitMsg,
+		graphqltransportwsConnectionAckMsg,
+		graphqltransportwsSubscribeMsg,
+		graphqltransportwsNextMsg,
+		graphqltransportwsErrorMsg,
+		graphqltransportwsCompleteMsg,
+		graphqltransportwsPingMsg,
+		graphqltransportwsPongMsg,
+	}
+)
 
 type (
 	graphqltransportwsMessageExchanger struct {
@@ -103,6 +109,10 @@ func (m graphqltransportwsMessage) toMessage() (message, error) {
 		t = startMessageType
 	case graphqltransportwsCompleteMsg:
 		t = stopMessageType
+	case graphqltransportwsPingMsg:
+		t = pingMesageType
+	case graphqltransportwsPongMsg:
+		t = pongMessageType
 	}
 
 	return message{
@@ -131,6 +141,10 @@ func (m *graphqltransportwsMessage) fromMessage(msg *message) (err error) {
 		m.Type = graphqltransportwsCompleteMsg
 	case errorMessageType:
 		m.Type = graphqltransportwsErrorMsg
+	case pingMesageType:
+		m.Type = graphqltransportwsPingMsg
+	case pongMessageType:
+		m.Type = graphqltransportwsPongMsg
 	}
 
 	return err

--- a/graphql/handler/transport/websocket_subprotocol.go
+++ b/graphql/handler/transport/websocket_subprotocol.go
@@ -18,6 +18,8 @@ const (
 	dataMessageType
 	completeMessageType
 	errorMessageType
+	pingMesageType
+	pongMessageType
 )
 
 var (
@@ -68,6 +70,10 @@ func (t messageType) String() string {
 		text = "complete"
 	case errorMessageType:
 		text = "error"
+	case pingMesageType:
+		text = "ping"
+	case pongMessageType:
+		text = "pong"
 	}
 	return text
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -29,6 +29,7 @@ func GraphQL(exec graphql.ExecutableSchema, options ...Option) http.HandlerFunc 
 		Upgrader:              cfg.upgrader,
 		InitFunc:              cfg.websocketInitFunc,
 		KeepAlivePingInterval: cfg.connectionKeepAlivePingInterval,
+		PingPongInterval:      cfg.connectionPingPongInterval,
 	})
 	srv.AddTransport(transport.Options{})
 	srv.AddTransport(transport.GET{})
@@ -77,6 +78,7 @@ type Config struct {
 	upgrader                        websocket.Upgrader
 	websocketInitFunc               transport.WebsocketInitFunc
 	connectionKeepAlivePingInterval time.Duration
+	connectionPingPongInterval      time.Duration
 	recover                         graphql.RecoverFunc
 	errorPresenter                  graphql.ErrorPresenterFunc
 	fieldHooks                      []graphql.FieldMiddleware
@@ -207,6 +209,12 @@ func UploadMaxMemory(size int64) Option {
 func WebsocketKeepAliveDuration(duration time.Duration) Option {
 	return func(cfg *Config) {
 		cfg.connectionKeepAlivePingInterval = duration
+	}
+}
+
+func WebsocketPingPongDuration(duration time.Duration) Option {
+	return func(cfg *Config) {
+		cfg.connectionPingPongInterval = duration
 	}
 }
 


### PR DESCRIPTION
Extending this [PR](https://github.com/99designs/gqlgen/pull/1507), included also the duplex ping-pong functionality.

How to use:
```
srv.AddTransport(transport.Websocket{
    PingPongInterval: 5 * time.Second,
    # Other options ...
})

```
Example Apollo client usage:
```
let activeSocket: unknown = null;
let timedOut: unknown = null;

const wsLink = new WebSocketLink({
  url: REACT_APP_GRAPHQL_WS_ENDPOINT as string,
  keepAlive: 10_000, // ping server every 10 seconds
  on: {
    ping: (received) => {
      if (!received) {
        timedOut = setTimeout(() => {
          if (activeSocket && activeSocket.readyState === WebSocket.OPEN) {
            activeSocket.close(4408, 'Request Timeout');
          }
        }, 5_000); // wait 5 seconds for the pong and then close the connection
      }
    },
    pong: (received) => {
      if (received) {
        clearTimeout(timedOut);
      }
    },
  },
});
```