### PR TITLE
Bypass complexity limit on __Schema queries. 

### DIFF
--- a/complexity/complexity.go
+++ b/complexity/complexity.go
@@ -26,6 +26,11 @@ func (cw complexityWalker) selectionSetComplexity(selectionSet ast.SelectionSet)
 		switch s := selection.(type) {
 		case *ast.Field:
 			fieldDefinition := cw.schema.Types[s.Definition.Type.Name()]
+
+			if fieldDefinition.Name == "__Schema" {
+				continue
+			}
+
 			var childComplexity int
 			switch fieldDefinition.Kind {
 			case ast.Object, ast.Interface, ast.Union:

--- a/graphql/handler/extension/complexity_test.go
+++ b/graphql/handler/extension/complexity_test.go
@@ -95,6 +95,16 @@ func TestFixedComplexity(t *testing.T) {
 		require.Equal(t, 2, stats.ComplexityLimit)
 		require.Equal(t, 4, stats.Complexity)
 	})
+
+	t.Run("bypass __schema field", func(t *testing.T) {
+		h.SetCalculatedComplexity(4)
+		resp := doRequest(h, "POST", "/graphql", `{ "operationName":"IntrospectionQuery", "query":"query IntrospectionQuery { __schema { queryType { name } mutationType { name }}}"}`)
+		require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+		require.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+
+		require.Equal(t, 2, stats.ComplexityLimit)
+		require.Equal(t, 0, stats.Complexity)
+	})
 }
 
 func doRequest(handler http.Handler, method string, target string, body string) *httptest.ResponseRecorder {


### PR DESCRIPTION
Bypass complexity limit on __Schema queries. 

Resolves: #462

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
