### PR TITLE
Fix spaces -> tabs typo in authentication.md

### DIFF
--- a/docs/content/recipes/authentication.md
+++ b/docs/content/recipes/authentication.md
@@ -88,7 +88,7 @@ func main() {
 
 	router.Use(auth.Middleware(db))
 
-    srv := handler.NewDefaultServer(starwars.NewExecutableSchema(starwars.NewResolver()))
+	srv := handler.NewDefaultServer(starwars.NewExecutableSchema(starwars.NewResolver()))
 	router.Handle("/", playground.Handler("Starwars", "/query"))
 	router.Handle("/query", srv)
 


### PR DESCRIPTION
The indentation for this line was supposed to be a tab rather than spaces so the readme looked off. 

