### PR TITLE
Update errors to use go1.13 semantics

### DIFF
--- a/api/generate.go
+++ b/api/generate.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"syscall"
 
 	"github.com/99designs/gqlgen/codegen"
@@ -9,7 +10,6 @@ import (
 	"github.com/99designs/gqlgen/plugin/federation"
 	"github.com/99designs/gqlgen/plugin/modelgen"
 	"github.com/99designs/gqlgen/plugin/resolvergen"
-	"github.com/pkg/errors"
 )
 
 func Generate(cfg *config.Config, option ...Option) error {
@@ -40,7 +40,7 @@ func Generate(cfg *config.Config, option ...Option) error {
 	}
 
 	if err := cfg.LoadSchema(); err != nil {
-		return errors.Wrap(err, "failed to load schema")
+		return fmt.Errorf("failed to load schema: %w", err)
 	}
 
 	for _, p := range plugins {
@@ -53,50 +53,50 @@ func Generate(cfg *config.Config, option ...Option) error {
 
 	// LoadSchema again now we have everything
 	if err := cfg.LoadSchema(); err != nil {
-		return errors.Wrap(err, "failed to load schema")
+		return fmt.Errorf("failed to load schema: %w", err)
 	}
 
 	if err := cfg.Init(); err != nil {
-		return errors.Wrap(err, "generating core failed")
+		return fmt.Errorf("generating core failed: %w", err)
 	}
 
 	for _, p := range plugins {
 		if mut, ok := p.(plugin.ConfigMutator); ok {
 			err := mut.MutateConfig(cfg)
 			if err != nil {
-				return errors.Wrap(err, p.Name())
+				return fmt.Errorf("%s: %w", p.Name(), err)
 			}
 		}
 	}
 	// Merge again now that the generated models have been injected into the typemap
 	data, err := codegen.BuildData(cfg)
 	if err != nil {
-		return errors.Wrap(err, "merging type systems failed")
+		return fmt.Errorf("merging type systems failed: %w", err)
 	}
 
 	if err = codegen.GenerateCode(data); err != nil {
-		return errors.Wrap(err, "generating core failed")
+		return fmt.Errorf("generating core failed: %w", err)
 	}
 	if err = cfg.Packages.ModTidy(); err != nil {
-		return errors.Wrap(err, "tidy failed")
+		return fmt.Errorf("tidy failed: %w", err)
 	}
 
 	for _, p := range plugins {
 		if mut, ok := p.(plugin.CodeGenerator); ok {
 			err := mut.GenerateCode(data)
 			if err != nil {
-				return errors.Wrap(err, p.Name())
+				return fmt.Errorf("%s: %w", p.Name(), err)
 			}
 		}
 	}
 
 	if err = codegen.GenerateCode(data); err != nil {
-		return errors.Wrap(err, "generating core failed")
+		return fmt.Errorf("generating core failed: %w", err)
 	}
 
 	if !cfg.SkipValidation {
 		if err := validate(cfg); err != nil {
-			return errors.Wrap(err, "validation failed")
+			return fmt.Errorf("validation failed: %w", err)
 		}
 	}
 

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 
 	"github.com/99designs/gqlgen/api"
 	"github.com/99designs/gqlgen/codegen/config"
-	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 )
 
@@ -26,7 +26,7 @@ var genCmd = &cli.Command{
 			}
 		} else {
 			cfg, err = config.LoadConfigFromDefaultLocations()
-			if os.IsNotExist(errors.Cause(err)) {
+			if os.IsNotExist(errors.Unwrap(err)) {
 				cfg, err = config.LoadDefaultConfig()
 			}
 

--- a/codegen/args.go
+++ b/codegen/args.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/99designs/gqlgen/codegen/templates"
-	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
@@ -67,7 +66,7 @@ func (b *builder) buildArg(obj *Object, arg *ast.ArgumentDefinition) (*FieldArgu
 	if arg.DefaultValue != nil {
 		newArg.Default, err = arg.DefaultValue.Value(nil)
 		if err != nil {
-			return nil, errors.Errorf("default value is not valid: %s", err.Error())
+			return nil, fmt.Errorf("default value is not valid: %w", err)
 		}
 	}
 

--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -1,13 +1,13 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"go/token"
 	"go/types"
 
 	"github.com/99designs/gqlgen/codegen/templates"
 	"github.com/99designs/gqlgen/internal/code"
-	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
@@ -119,9 +119,9 @@ func (b *Binder) FindObject(pkgName string, typeName string) (types.Object, erro
 	if pkg == nil {
 		err := b.pkgs.Errors()
 		if err != nil {
-			return nil, errors.Wrapf(err, "package could not be loaded: %s", fullName)
+			return nil, fmt.Errorf("package could not be loaded: %s: %w", fullName, err)
 		}
-		return nil, errors.Errorf("required package was not loaded: %s", fullName)
+		return nil, fmt.Errorf("required package was not loaded: %s", fullName)
 	}
 
 	// function based marshalers take precedence
@@ -148,7 +148,7 @@ func (b *Binder) FindObject(pkgName string, typeName string) (types.Object, erro
 		}
 	}
 
-	return nil, errors.Errorf("unable to find type %s\n", fullName)
+	return nil, fmt.Errorf("unable to find type %s\n", fullName)
 }
 
 func (b *Binder) PointerTo(ref *TypeReference) *TypeReference {

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/99designs/gqlgen/internal/code"
-	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
 	"gopkg.in/yaml.v2"
@@ -59,7 +58,7 @@ func LoadDefaultConfig() (*Config, error) {
 		var schemaRaw []byte
 		schemaRaw, err = ioutil.ReadFile(filename)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to open schema")
+			return nil, fmt.Errorf("unable to open schema: %w", err)
 		}
 
 		config.Sources = append(config.Sources, &ast.Source{Name: filename, Input: string(schemaRaw)})
@@ -78,7 +77,7 @@ func LoadConfigFromDefaultLocations() (*Config, error) {
 
 	err = os.Chdir(filepath.Dir(cfgFile))
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to enter config dir")
+		return nil, fmt.Errorf("unable to enter config dir: %w", err)
 	}
 	return LoadConfig(cfgFile)
 }
@@ -96,11 +95,11 @@ func LoadConfig(filename string) (*Config, error) {
 
 	b, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to read config")
+		return nil, fmt.Errorf("unable to read config: %w", err)
 	}
 
 	if err := yaml.UnmarshalStrict(b, config); err != nil {
-		return nil, errors.Wrap(err, "unable to parse config")
+		return nil, fmt.Errorf("unable to parse config: %w", err)
 	}
 
 	if err := CompleteConfig(config); err != nil {
@@ -150,13 +149,13 @@ func CompleteConfig(config *Config) error {
 
 				return nil
 			}); err != nil {
-				return errors.Wrapf(err, "failed to walk schema at root %s", pathParts[0])
+				return fmt.Errorf("failed to walk schema at root %s: %w", pathParts[0], err)
 			}
 		} else {
 			var err error
 			matches, err = filepath.Glob(f)
 			if err != nil {
-				return errors.Wrapf(err, "failed to glob schema filename %s", f)
+				return fmt.Errorf("failed to glob schema filename %s: %w", f, err)
 			}
 		}
 
@@ -174,7 +173,7 @@ func CompleteConfig(config *Config) error {
 		var schemaRaw []byte
 		schemaRaw, err = ioutil.ReadFile(filename)
 		if err != nil {
-			return errors.Wrap(err, "unable to open schema")
+			return fmt.Errorf("unable to open schema: %w", err)
 		}
 
 		config.Sources = append(config.Sources, &ast.Source{Name: filename, Input: string(schemaRaw)})
@@ -343,10 +342,10 @@ func (c *Config) check() error {
 	fileList := map[string][]FilenamePackage{}
 
 	if err := c.Models.Check(); err != nil {
-		return errors.Wrap(err, "config.models")
+		return fmt.Errorf("config.models: %w", err)
 	}
 	if err := c.Exec.Check(); err != nil {
-		return errors.Wrap(err, "config.exec")
+		return fmt.Errorf("config.exec: %w", err)
 	}
 	fileList[c.Exec.ImportPath()] = append(fileList[c.Exec.ImportPath()], FilenamePackage{
 		Filename: c.Exec.Filename,
@@ -356,7 +355,7 @@ func (c *Config) check() error {
 
 	if c.Model.IsDefined() {
 		if err := c.Model.Check(); err != nil {
-			return errors.Wrap(err, "config.model")
+			return fmt.Errorf("config.model: %w", err)
 		}
 		fileList[c.Model.ImportPath()] = append(fileList[c.Model.ImportPath()], FilenamePackage{
 			Filename: c.Model.Filename,
@@ -366,7 +365,7 @@ func (c *Config) check() error {
 	}
 	if c.Resolver.IsDefined() {
 		if err := c.Resolver.Check(); err != nil {
-			return errors.Wrap(err, "config.resolver")
+			return fmt.Errorf("config.resolver: %w", err)
 		}
 		fileList[c.Resolver.ImportPath()] = append(fileList[c.Resolver.ImportPath()], FilenamePackage{
 			Filename: c.Resolver.Filename,
@@ -376,7 +375,7 @@ func (c *Config) check() error {
 	}
 	if c.Federation.IsDefined() {
 		if err := c.Federation.Check(); err != nil {
-			return errors.Wrap(err, "config.federation")
+			return fmt.Errorf("config.federation: %w", err)
 		}
 		fileList[c.Federation.ImportPath()] = append(fileList[c.Federation.ImportPath()], FilenamePackage{
 			Filename: c.Federation.Filename,
@@ -480,7 +479,7 @@ func inStrSlice(haystack []string, needle string) bool {
 func findCfg() (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
-		return "", errors.Wrap(err, "unable to get working dir to findCfg")
+		return "", fmt.Errorf("unable to get working dir to findCfg: %w", err)
 	}
 
 	cfg := findCfgInDir(dir)

--- a/codegen/config/config_test.go
+++ b/codegen/config/config_test.go
@@ -1,12 +1,12 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/v2"
@@ -105,7 +105,7 @@ func TestLoadDefaultConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		cfg, err = LoadDefaultConfig()
-		require.True(t, os.IsNotExist(errors.Cause(err)))
+		require.True(t, os.IsNotExist(errors.Unwrap(err)))
 	})
 }
 

--- a/codegen/data.go
+++ b/codegen/data.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/ast"
 
 	"github.com/99designs/gqlgen/codegen/config"
@@ -67,14 +66,14 @@ func BuildData(cfg *config.Config) (*Data, error) {
 		case ast.Object:
 			obj, err := b.buildObject(schemaType)
 			if err != nil {
-				return nil, errors.Wrap(err, "unable to build object definition")
+				return nil, fmt.Errorf("unable to build object definition: %w", err)
 			}
 
 			s.Objects = append(s.Objects, obj)
 		case ast.InputObject:
 			input, err := b.buildObject(schemaType)
 			if err != nil {
-				return nil, errors.Wrap(err, "unable to build input definition")
+				return nil, fmt.Errorf("unable to build input definition: %w", err)
 			}
 
 			s.Inputs = append(s.Inputs, input)
@@ -82,7 +81,7 @@ func BuildData(cfg *config.Config) (*Data, error) {
 		case ast.Union, ast.Interface:
 			s.Interfaces[schemaType.Name], err = b.buildInterface(schemaType)
 			if err != nil {
-				return nil, errors.Wrap(err, "unable to bind to interface")
+				return nil, fmt.Errorf("unable to bind to interface: %w", err)
 			}
 		}
 	}

--- a/codegen/directive.go
+++ b/codegen/directive.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/99designs/gqlgen/codegen/templates"
-	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
@@ -52,7 +51,7 @@ func (b *builder) buildDirectives() (map[string]*Directive, error) {
 
 	for name, dir := range b.Schema.Directives {
 		if _, ok := directives[name]; ok {
-			return nil, errors.Errorf("directive with name %s already exists", name)
+			return nil, fmt.Errorf("directive with name %s already exists", name)
 		}
 
 		var args []*FieldArgument
@@ -72,7 +71,7 @@ func (b *builder) buildDirectives() (map[string]*Directive, error) {
 				var err error
 				newArg.Default, err = arg.DefaultValue.Value(nil)
 				if err != nil {
-					return nil, errors.Errorf("default value for directive argument %s(%s) is not valid: %s", dir.Name, arg.Name, err.Error())
+					return nil, fmt.Errorf("default value for directive argument %s(%s) is not valid: %w", dir.Name, arg.Name, err)
 				}
 			}
 			args = append(args, newArg)

--- a/codegen/field.go
+++ b/codegen/field.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/99designs/gqlgen/codegen/templates"
-	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
@@ -51,7 +50,7 @@ func (b *builder) buildField(obj *Object, field *ast.FieldDefinition) (*Field, e
 		var err error
 		f.Default, err = field.DefaultValue.Value(nil)
 		if err != nil {
-			return nil, errors.Errorf("default value %s is not valid: %s", field.Name, err.Error())
+			return nil, fmt.Errorf("default value %s is not valid: %w", field.Name, err)
 		}
 	}
 
@@ -177,7 +176,7 @@ func (b *builder) bindField(obj *Object, f *Field) (errret error) {
 		}
 
 		if err = b.bindArgs(f, params); err != nil {
-			return errors.Wrapf(err, "%s:%d", pos.Filename, pos.Line)
+			return fmt.Errorf("%s:%d: %w", pos.Filename, pos.Line, err)
 		}
 
 		result := sig.Results().At(0)
@@ -246,7 +245,7 @@ func (b *builder) findBindTarget(t types.Type, name string) (types.Object, error
 		return foundField, nil
 	case foundField != nil && foundMethod != nil:
 		// Error
-		return nil, errors.Errorf("found more than one way to bind for %s", name)
+		return nil, fmt.Errorf("found more than one way to bind for %s", name)
 	}
 
 	// Search embeds
@@ -271,7 +270,7 @@ func (b *builder) findBindStructTagTarget(in types.Type, name string) (types.Obj
 			tags := reflect.StructTag(t.Tag(i))
 			if val, ok := tags.Lookup(b.Config.StructTag); ok && equalFieldName(val, name) {
 				if found != nil {
-					return nil, errors.Errorf("tag %s is ambigious; multiple fields have the same tag value of %s", b.Config.StructTag, val)
+					return nil, fmt.Errorf("tag %s is ambigious; multiple fields have the same tag value of %s", b.Config.StructTag, val)
 				}
 
 				found = field
@@ -309,7 +308,7 @@ func (b *builder) findBindMethoderTarget(methodFunc func(i int) *types.Func, met
 		}
 
 		if found != nil {
-			return nil, errors.Errorf("found more than one matching method to bind for %s", name)
+			return nil, fmt.Errorf("found more than one matching method to bind for %s", name)
 		}
 
 		found = method
@@ -331,7 +330,7 @@ func (b *builder) findBindFieldTarget(in types.Type, name string) (types.Object,
 			}
 
 			if found != nil {
-				return nil, errors.Errorf("found more than one matching field to bind for %s", name)
+				return nil, fmt.Errorf("found more than one matching field to bind for %s", name)
 			}
 
 			found = field
@@ -375,7 +374,7 @@ func (b *builder) findBindStructEmbedsTarget(strukt *types.Struct, name string) 
 		}
 
 		if f != nil && found != nil {
-			return nil, errors.Errorf("found more than one way to bind for %s", name)
+			return nil, fmt.Errorf("found more than one way to bind for %s", name)
 		}
 
 		if f != nil {
@@ -397,7 +396,7 @@ func (b *builder) findBindInterfaceEmbedsTarget(iface *types.Interface, name str
 		}
 
 		if f != nil && found != nil {
-			return nil, errors.Errorf("found more than one way to bind for %s", name)
+			return nil, fmt.Errorf("found more than one way to bind for %s", name)
 		}
 
 		if f != nil {

--- a/codegen/interface.go
+++ b/codegen/interface.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"go/types"
 
-	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/ast"
 
 	"github.com/99designs/gqlgen/codegen/config"
@@ -49,7 +48,7 @@ func (b *builder) buildInterface(typ *ast.Definition) (*Interface, error) {
 
 		implementorType, err := findGoNamedType(obj)
 		if err != nil {
-			return nil, errors.Wrapf(err, "can not find backing go type %s", obj.String())
+			return nil, fmt.Errorf("can not find backing go type %s: %w", obj.String(), err)
 		} else if implementorType == nil {
 			return nil, fmt.Errorf("can not find backing go type %s", obj.String())
 		}

--- a/codegen/object.go
+++ b/codegen/object.go
@@ -1,13 +1,13 @@
 package codegen
 
 import (
+	"fmt"
 	"go/types"
 	"strconv"
 	"strings"
 	"unicode"
 
 	"github.com/99designs/gqlgen/codegen/config"
-	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
@@ -36,7 +36,7 @@ type Object struct {
 func (b *builder) buildObject(typ *ast.Definition) (*Object, error) {
 	dirs, err := b.getDirectives(typ.Directives)
 	if err != nil {
-		return nil, errors.Wrap(err, typ.Name)
+		return nil, fmt.Errorf("%s: %w", typ.Name, err)
 	}
 
 	obj := &Object{

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -18,7 +18,6 @@ import (
 	"github.com/99designs/gqlgen/internal/code"
 
 	"github.com/99designs/gqlgen/internal/imports"
-	"github.com/pkg/errors"
 )
 
 // CurrentImports keeps track of all the import declarations that are needed during the execution of a plugin.
@@ -79,7 +78,7 @@ func Render(cfg Options) error {
 		var err error
 		t, err = t.New("template.gotpl").Parse(cfg.Template)
 		if err != nil {
-			return errors.Wrap(err, "error with provided template")
+			return fmt.Errorf("error with provided template: %w", err)
 		}
 		roots = append(roots, "template.gotpl")
 	} else {
@@ -99,7 +98,7 @@ func Render(cfg Options) error {
 
 			t, err = t.New(name).Parse(string(b))
 			if err != nil {
-				return errors.Wrap(err, cfg.Filename)
+				return fmt.Errorf("%s: %w", cfg.Filename, err)
 			}
 
 			roots = append(roots, name)
@@ -107,7 +106,7 @@ func Render(cfg Options) error {
 			return nil
 		})
 		if err != nil {
-			return errors.Wrap(err, "locating templates")
+			return fmt.Errorf("locating templates: %w", err)
 		}
 	}
 
@@ -129,7 +128,7 @@ func Render(cfg Options) error {
 		}
 		err := t.Lookup(root).Execute(&buf, cfg.Data)
 		if err != nil {
-			return errors.Wrap(err, root)
+			return fmt.Errorf("%s: %w", root, err)
 		}
 		if cfg.RegionTags {
 			buf.WriteString("\n// endregion " + center(70, "*", " "+root+" ") + "\n")
@@ -584,7 +583,7 @@ func render(filename string, tpldata interface{}) (*bytes.Buffer, error) {
 func write(filename string, b []byte, packages *code.Packages) error {
 	err := os.MkdirAll(filepath.Dir(filename), 0755)
 	if err != nil {
-		return errors.Wrap(err, "failed to create directory")
+		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
 	formatted, err := imports.Prune(filename, b, packages)
@@ -595,7 +594,7 @@ func write(filename string, b []byte, packages *code.Packages) error {
 
 	err = ioutil.WriteFile(filename, formatted, 0644)
 	if err != nil {
-		return errors.Wrapf(err, "failed to write %s", filename)
+		return fmt.Errorf("failed to write %s: %w", filename, err)
 	}
 
 	return nil

--- a/codegen/util.go
+++ b/codegen/util.go
@@ -1,10 +1,9 @@
 package codegen
 
 import (
+	"fmt"
 	"go/types"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 func findGoNamedType(def types.Type) (*types.Named, error) {
@@ -14,7 +13,7 @@ func findGoNamedType(def types.Type) (*types.Named, error) {
 
 	namedType, ok := def.(*types.Named)
 	if !ok {
-		return nil, errors.Errorf("expected %s to be a named type, instead found %T\n", def.String(), def)
+		return nil, fmt.Errorf("expected %s to be a named type, instead found %T\n", def.String(), def)
 	}
 
 	return namedType, nil
@@ -34,7 +33,7 @@ func findGoInterface(def types.Type) (*types.Interface, error) {
 
 	underlying, ok := namedType.Underlying().(*types.Interface)
 	if !ok {
-		return nil, errors.Errorf("expected %s to be a named interface, instead found %s", def.String(), namedType.String())
+		return nil, fmt.Errorf("expected %s to be a named interface, instead found %s", def.String(), namedType.String())
 	}
 
 	return underlying, nil

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/99designs/gqlgen
 
-go 1.12
+go 1.13
 
 require (
 	github.com/agnivade/levenshtein v1.1.0 // indirect
@@ -16,7 +16,6 @@ require (
 	github.com/mitchellh/mapstructure v0.0.0-20180203102830-a4e142e9c047
 	github.com/opentracing/basictracer-go v1.0.0 // indirect
 	github.com/opentracing/opentracing-go v1.0.2
-	github.com/pkg/errors v0.8.1
 	github.com/rs/cors v1.6.0
 	github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371 // indirect
 	github.com/shurcooL/vfsgen v0.0.0-20180121065927-ffb13db8def0 // indirect

--- a/internal/code/packages.go
+++ b/internal/code/packages.go
@@ -2,10 +2,11 @@ package code
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"os/exec"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -154,7 +155,7 @@ func (p *Packages) ModTidy() error {
 	p.packages = nil
 	tidyCmd := exec.Command("go", "mod", "tidy")
 	if err := tidyCmd.Run(); err != nil {
-		return errors.Wrap(err, "go mod tidy failed")
+		return fmt.Errorf("go mod tidy failed: %w", err)
 	}
 	return nil
 }

--- a/plugin/resolvergen/resolver.go
+++ b/plugin/resolvergen/resolver.go
@@ -1,6 +1,7 @@
 package resolvergen
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,7 +11,6 @@ import (
 	"github.com/99designs/gqlgen/codegen/templates"
 	"github.com/99designs/gqlgen/internal/rewrite"
 	"github.com/99designs/gqlgen/plugin"
-	"github.com/pkg/errors"
 )
 
 func New() plugin.Plugin {
@@ -144,7 +144,7 @@ func (m *Plugin) generatePerSchema(data *codegen.Data) error {
 		}
 	}
 
-	if _, err := os.Stat(data.Config.Resolver.Filename); os.IsNotExist(errors.Cause(err)) {
+	if _, err := os.Stat(data.Config.Resolver.Filename); os.IsNotExist(errors.Unwrap(err)) {
 		err := templates.Render(templates.Options{
 			PackageName: data.Config.Resolver.Package,
 			FileNotice: `

--- a/plugin/servergen/server.go
+++ b/plugin/servergen/server.go
@@ -1,13 +1,13 @@
 package servergen
 
 import (
+	"errors"
 	"log"
 	"os"
 
 	"github.com/99designs/gqlgen/codegen"
 	"github.com/99designs/gqlgen/codegen/templates"
 	"github.com/99designs/gqlgen/plugin"
-	"github.com/pkg/errors"
 )
 
 func New(filename string) plugin.Plugin {
@@ -29,7 +29,7 @@ func (m *Plugin) GenerateCode(data *codegen.Data) error {
 		ResolverPackageName: data.Config.Resolver.ImportPath(),
 	}
 
-	if _, err := os.Stat(m.filename); os.IsNotExist(errors.Cause(err)) {
+	if _, err := os.Stat(m.filename); os.IsNotExist(errors.Unwrap(err)) {
 		return templates.Render(templates.Options{
 			PackageName: "main",
 			Filename:    m.filename,


### PR DESCRIPTION
Remove [github.com/pkg/errors](https://github.com/pkg/errors) and use [go 1.13 errors](https://go.dev/blog/go1.13-errors) instead

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
