### PR TITLE
fix Options response header

### DIFF
--- a/graphql/handler/transport/options.go
+++ b/graphql/handler/transport/options.go
@@ -18,8 +18,8 @@ func (o Options) Supports(r *http.Request) bool {
 func (o Options) Do(w http.ResponseWriter, r *http.Request, exec graphql.GraphExecutor) {
 	switch r.Method {
 	case http.MethodOptions:
-		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Allow", "OPTIONS, GET, POST")
+		w.WriteHeader(http.StatusOK)
 	case http.MethodHead:
 		w.WriteHeader(http.StatusMethodNotAllowed)
 	}


### PR DESCRIPTION
I noticed that the client quey with options method, the head of response  not show the Allow : OPTIONS, GET, POST.

because of operating the header of ResponseWriter after  WriteHeader called
