### PR TITLE
Update docs for getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## What is gqlgen?
 
-[gqlgen](https://github.com/99designs/gqlgen) is a Go library for building GraphQL servers without any fuss.<br/> 
+[gqlgen](https://github.com/99designs/gqlgen) is a Go library for building GraphQL servers without any fuss.<br/>
 
 - **gqlgen is based on a Schema first approach** — You get to Define your API using the GraphQL [Schema Definition Language](http://graphql.org/learn/schema/).
 - **gqlgen prioritizes Type safety** — You should never see `map[string]interface{}` here.
@@ -13,13 +13,36 @@
 
 Still not convinced enough to use **gqlgen**? Compare **gqlgen** with other Go graphql [implementations](https://gqlgen.com/feature-comparison/)
 
-## Getting Started
-- To install gqlgen run the command `go get github.com/99designs/gqlgen` in your project directory.<br/> 
-- You could initialize a new project using the recommended folder structure by running this command `go run github.com/99designs/gqlgen init`.
+## Quick start
+```shell
+# Initialise a new go module
+mkdir example
+cd example
+go mod init gqlgen.com/example
 
-You could find a more comprehensive guide to help you get started [here](https://gqlgen.com/getting-started/).<br/>
-We also have a couple of real-world [examples](https://github.com/99designs/gqlgen/tree/master/example) that show how to GraphQL applications with **gqlgen** seamlessly,
-You can see these [examples](https://github.com/99designs/gqlgen/tree/master/example) here or visit [godoc](https://godoc.org/github.com/99designs/gqlgen).
+# Add github.com/99designs/gqlgen to your project's tools.go
+cat <<EOD > tools.go
+// +build tools
+
+package tools
+
+import (
+	_ "github.com/99designs/gqlgen"
+)
+EOD
+go mod tidy
+
+# Initialise gqlgen config
+go run github.com/99designs/gqlgen init
+
+# Start the graphql server
+go run server.go
+```
+
+More help to get started:
+ - [Getting started guide](https://gqlgen.com/getting-started/) - a comprehensive guide to help you get started
+ - [Real-world examples](https://github.com/99designs/gqlgen/tree/master/example) show how to create GraphQL applications
+ - [Reference docs](https://pkg.go.dev/github.com/99designs/gqlgen) for the APIs
 
 ## Reporting Issues
 

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -18,19 +18,33 @@ You can find the finished code for this tutorial [here](https://github.com/vekta
 
 Create a directory for your project, and initialise it as a Go Module:
 
-```sh
-$ mkdir gqlgen-todos
-$ cd gqlgen-todos
-$ go mod init github.com/[username]/gqlgen-todos
-$ go get github.com/99designs/gqlgen
+```shell
+mkdir gqlgen-todos
+cd gqlgen-todos
+go mod init github.com/[username]/gqlgen-todos
+```
+
+Next, add the gqlgen tool as a dependency [using your project's tools.go](https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module)
+
+```shell
+cat <<EOD > tools.go
+// +build tools
+
+package tools
+
+import (
+	_ "github.com/99designs/gqlgen"
+)
+EOD
+go mod tidy
 ```
 
 ## Building the server
 
 ### Create the project skeleton
 
-```bash
-$ go run github.com/99designs/gqlgen init
+```shell
+go run github.com/99designs/gqlgen init
 ```
 
 This will create our suggested package layout. You can modify these paths in gqlgen.yml if you need to.
@@ -86,7 +100,7 @@ type Mutation {
 ### Implement the resolvers
 
 When executed, gqlgen's `generate` command compares the schema file (`graph/schema.graphqls`) with the models `graph/model/*`, and, wherever it
-can, it will bind directly to the model.  That was done alread when `init` was run.  We'll edit the schema later in the tutorial, but for now, let's look at what was generated already. 
+can, it will bind directly to the model.  That was done alread when `init` was run.  We'll edit the schema later in the tutorial, but for now, let's look at what was generated already.
 
 If we take a look in `graph/schema.resolvers.go` we will see all the times that gqlgen couldn't match them up. For us
 it was twice:


### PR DESCRIPTION
Update the docs because the current instructions don't work properly on go1.17 and a `go mod tidy` will subsequently clobber the gqlgen dependency. Fixes #1615. 

I ended up expanding the getting started section in the readme to make it simple for a user to get a running gqlgen by following the commands step by step.
