### PR TITLE
Forward `go mod tidy` stdout/stderr

### DIFF
--- a/internal/code/packages.go
+++ b/internal/code/packages.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 
@@ -155,6 +156,8 @@ func (p *Packages) Evict(importPath string) {
 func (p *Packages) ModTidy() error {
 	p.packages = nil
 	tidyCmd := exec.Command("go", "mod", "tidy")
+	tidyCmd.Stdout = os.Stdout
+	tidyCmd.Stderr = os.Stdout
 	if err := tidyCmd.Run(); err != nil {
 		return fmt.Errorf("go mod tidy failed: %w", err)
 	}


### PR DESCRIPTION
This is a command that can fail (in my case I think for stupid reasons
in a hell of my own construction, but nonetheless).  Right now we just
get
```
$ go run github.com/Khan/webapp/dev/cmd/gqlgen
tidy failed: go mod tidy failed: exit status 1
exit status 3
```
which is not the most informative.  Now, instead, we'll forward its
output to our own stdout/stderr rather than devnull.

I have:
 - [ ] (n/a) Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] (n/a) Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
