### PR TITLE
Fix example run instructions

### DIFF
--- a/example/chat/readme.md
+++ b/example/chat/readme.md
@@ -4,12 +4,11 @@ Example app using subscriptions to build a chat room.
 
 to run this server
 ```bash
-go run ./example/chat/server/server.go
+go run ./server/server.go
 ```
 
 to run the react app
 ```bash
-cd ./example/chat
 npm install 
 npm run start
 ```

--- a/example/fileupload/readme.md
+++ b/example/fileupload/readme.md
@@ -4,7 +4,7 @@ This server demonstrates how to handle file upload
 
 to run this server
 ```bash
-go run ./example/fileupload/server/server.go
+go run ./server/server.go
 ```
 
 and open http://localhost:8087 in your browser

--- a/example/selection/readme.md
+++ b/example/selection/readme.md
@@ -4,7 +4,7 @@ This is the simplest example of a graphql server.
 
 to run this server
 ```bash
-go run ./example/selection/server/server.go
+go run ./server/server.go
 ```
 
 and open http://localhost:8086 in your browser

--- a/example/starwars/readme.md
+++ b/example/starwars/readme.md
@@ -8,7 +8,7 @@ This server demonstrates a few advanced features of graphql:
 
 to run this server
 ```bash
-go run ./example/starwars/server/server.go
+go run ./server/server.go
 ```
 
 and open http://localhost:8080 in your browser

--- a/example/todo/readme.md
+++ b/example/todo/readme.md
@@ -4,7 +4,7 @@ This is the simplest example of a graphql server.
 
 to run this server
 ```bash
-go run ./example/todo/server/server.go
+go run ./server/server.go
 ```
 
 and open http://localhost:8081 in your browser


### PR DESCRIPTION
Making ./example a separate Go module [1] broke the `go run` invocations
listed in a few example readmes [2]. Using relative paths from the
respective example directory should be clear enough.

[1]: commit f93fb2489285eef0542c4aa7b11341a8479b606a / issue/PR #1607
[2]:
```
example/todo/server/server.go:10:2: no required module provides package github.com/99designs/gqlgen/example/todo; to add it:
	go get github.com/99designs/gqlgen/example/todo
```