### PR TITLE
remove redundant WithOperationContext call

### DIFF
--- a/graphql/handler/transport/http_post.go
+++ b/graphql/handler/transport/http_post.go
@@ -48,7 +48,6 @@ func (h POST) Do(w http.ResponseWriter, r *http.Request, exec graphql.GraphExecu
 		writeJson(w, resp)
 		return
 	}
-	ctx := graphql.WithOperationContext(r.Context(), rc)
-	responses, ctx := exec.DispatchOperation(ctx, rc)
+	responses, ctx := exec.DispatchOperation(r.Context(), rc)
 	writeJson(w, responses(ctx))
 }


### PR DESCRIPTION
resolve issue https://github.com/99designs/gqlgen/issues/1592. \
no need to call on WithOperationContext on https://github.com/99designs/gqlgen/blob/master/graphql/handler/transport/http_post.go#L51 because it already done by
 https://github.com/99designs/gqlgen/blob/master/graphql/executor/executor.go#L90
I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
