### PR TITLE
Update time format for `Time` scalar

### DIFF
--- a/codegen/testserver/time_test.go
+++ b/codegen/testserver/time_test.go
@@ -45,9 +45,9 @@ func TestTime(t *testing.T) {
 
 	t.Run("with values", func(t *testing.T) {
 		resolvers.QueryResolver.User = func(ctx context.Context, id int) (user *User, e error) {
-			updated := time.Date(2010, 1, 1, 0, 0, 20, 0, time.UTC)
+			updated := time.Date(2010, 1, 1, 0, 0, 20, 1, time.UTC)
 			return &User{
-				Created: time.Date(2010, 1, 1, 0, 0, 10, 0, time.UTC),
+				Created: time.Date(2010, 1, 1, 0, 0, 10, 1, time.UTC),
 				Updated: &updated,
 			}, nil
 		}
@@ -62,7 +62,7 @@ func TestTime(t *testing.T) {
 		err := c.Post(`query { user(id: 1) { created, updated } }`, &resp)
 		require.NoError(t, err)
 
-		require.Equal(t, "2010-01-01T00:00:10Z", resp.User.Created)
-		require.Equal(t, "2010-01-01T00:00:20Z", resp.User.Updated)
+		require.Equal(t, "2010-01-01T00:00:10.000000001Z", resp.User.Created)
+		require.Equal(t, "2010-01-01T00:00:20.000000001Z", resp.User.Updated)
 	})
 }

--- a/docs/content/reference/scalars.md
+++ b/docs/content/reference/scalars.md
@@ -15,7 +15,7 @@ gqlgen ships with some built-in helpers for common custom scalar use-cases, `Tim
 scalar Time
 ```
 
-Maps a `Time` GraphQL scalar to a Go `time.Time` struct.
+Maps a `Time` GraphQL scalar to a Go `time.Time` struct. This scalar adheres to the [time.RFC3339Nano](https://pkg.go.dev/time#pkg-constants) format.
 
 ### Map
 
@@ -157,50 +157,43 @@ The errors that occur as part of custom scalar unmarshaling will return a full p
 For example, given the following schema ...
 
 ```graphql
-extend type Mutation{
-    updateUser(userInput: UserInput!): User!
+extend type Mutation {
+	updateUser(userInput: UserInput!): User!
 }
 
 input UserInput {
-    name: String!
-    primaryContactDetails: ContactDetailsInput!
-    secondaryContactDetails: ContactDetailsInput!
+	name: String!
+	primaryContactDetails: ContactDetailsInput!
+	secondaryContactDetails: ContactDetailsInput!
 }
 
 scalar Email
 input ContactDetailsInput {
-    email: Email!
+	email: Email!
 }
 ```
 
 ... and the following variables:
 
 ```json
-
 {
-  "userInput": {
-    "name": "George",
-    "primaryContactDetails": {
-      "email": "not-an-email"
-    },
-    "secondaryContactDetails": {
-      "email": "george@gmail.com"
-    }
-  }
+	"userInput": {
+		"name": "George",
+		"primaryContactDetails": {
+			"email": "not-an-email"
+		},
+		"secondaryContactDetails": {
+			"email": "george@gmail.com"
+		}
+	}
 }
 ```
 
 ... and an unmarshal function that returns an error if the email is invalid. The mutation will return an error containing the full path:
+
 ```json
 {
-  "message": "email invalid",
-  "path": [
-    "updateUser",
-    "userInput",
-    "primaryContactDetails",
-    "email"
-  ]
+	"message": "email invalid",
+	"path": ["updateUser", "userInput", "primaryContactDetails", "email"]
 }
 ```
-
-

--- a/graphql/time.go
+++ b/graphql/time.go
@@ -13,13 +13,13 @@ func MarshalTime(t time.Time) Marshaler {
 	}
 
 	return WriterFunc(func(w io.Writer) {
-		io.WriteString(w, strconv.Quote(t.Format(time.RFC3339)))
+		io.WriteString(w, strconv.Quote(t.Format(time.RFC3339Nano)))
 	})
 }
 
 func UnmarshalTime(v interface{}) (time.Time, error) {
 	if tmpStr, ok := v.(string); ok {
-		return time.Parse(time.RFC3339, tmpStr)
+		return time.Parse(time.RFC3339Nano, tmpStr)
 	}
-	return time.Time{}, errors.New("time should be RFC3339 formatted string")
+	return time.Time{}, errors.New("time should be RFC3339Nano formatted string")
 }


### PR DESCRIPTION
The built-in `Time` scalar is only precise to the second (see `time.RFC3339` at https://pkg.go.dev/time#pkg-constants). The default behavior should not make `Time` less precise on query. This PR uses `time.RFC3339nano` which is equivalent to `time.RFC3339`, but with nanosecond precision.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
