### PR TITLE
Fixes #1653: update docs and wrap error if not *gqlerror.Error

### DIFF
--- a/docs/content/reference/errors.md
+++ b/docs/content/reference/errors.md
@@ -114,7 +114,7 @@ server := handler.NewDefaultServer(MakeExecutableSchema(resolvers)
 server.SetRecoverFunc(func(ctx context.Context, err interface{}) error {
     // notify bug tracker...
 
-    return errors.New("Internal server error!")
+		return gqlerror.Errorf("Internal server error!")
 })
 ```
 

--- a/graphql/error.go
+++ b/graphql/error.go
@@ -10,19 +10,23 @@ import (
 type ErrorPresenterFunc func(ctx context.Context, err error) *gqlerror.Error
 
 func DefaultErrorPresenter(ctx context.Context, err error) *gqlerror.Error {
-	return err.(*gqlerror.Error)
+	var gqlErr *gqlerror.Error
+	if errors.As(err, &gqlErr) {
+		return gqlErr
+	}
+	return gqlerror.WrapPath(GetPath(ctx), err)
 }
 
 func ErrorOnPath(ctx context.Context, err error) error {
 	if err == nil {
 		return nil
 	}
-	var gqlerr *gqlerror.Error
-	if errors.As(err, &gqlerr) {
-		if gqlerr.Path == nil {
-			gqlerr.Path = GetPath(ctx)
+	var gqlErr *gqlerror.Error
+	if errors.As(err, &gqlErr) {
+		if gqlErr.Path == nil {
+			gqlErr.Path = GetPath(ctx)
 		}
-		return gqlerr
+		return gqlErr
 	}
 	return gqlerror.WrapPath(GetPath(ctx), err)
 }


### PR DESCRIPTION
Signed-off-by: Steve Coffman <steve@khanacademy.org>

This will update the documentation and avoid panics per #1653

The [default recover func ](https://github.com/99designs/gqlgen/blob/master/graphql/recovery.go#L14-L20) was modified in https://github.com/99designs/gqlgen/pull/1394 but the documentation was not updated to reflect that.

The documentation to fix is here: https://github.com/99designs/gqlgen/blob/master/docs/content/reference/errors.md?plain=1#L112-L119

Also, the [DefaultErrorPresenter](https://github.com/99designs/gqlgen/blob/master/graphql/error.go#L12-L14) needed to be modified to wrap non-gqlgqn errors to handle this better.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
