### PR TITLE
raise panic when nested @requires are used on federation

### DIFF
--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -243,7 +243,12 @@ func (f *federation) setEntities(schema *ast.Schema) {
 					if dir == nil {
 						continue
 					}
-					fields := strings.Split(dir.Arguments[0].Value.Raw, " ")
+					args := dir.Arguments[0].Value.Raw
+					if strings.Contains(args, "{") {
+						// TODO: see. https://github.com/99designs/gqlgen/issues/1138
+						panic("Nested fields are not currently supported in @requires declaration.")
+					}
+					fields := strings.Split(args, " ")
 					requireFields := []*RequireField{}
 					for _, f := range fields {
 						requireFields = append(requireFields, &RequireField{


### PR DESCRIPTION
refs #1138
gqlgen is not supported likes `@requires(fields: "metadata { description }")`. but it's not handled properly.

actual:
```
$ go run github.com/99designs/gqlgen
federation: federation.gotpl: template: federation.gotpl:54:51: executing "federation.gotpl" at <.TypeReference.UnmarshalFunc>: error calling UnmarshalFunc: runtime error: invalid memory address or nil pointer dereferenceexit status 1
```

expected:
```
$ go run github.com/99designs/gqlgen
panic: Nested fields are not currently supported in @requires declaration.
```

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
