### PR TITLE
Add ICMP to common initialisms

### DIFF
--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -459,6 +459,7 @@ var commonInitialisms = map[string]bool{
 	"HTML":  true,
 	"HTTP":  true,
 	"HTTPS": true,
+	"ICMP":  true,
 	"ID":    true,
 	"IP":    true,
 	"JSON":  true,


### PR DESCRIPTION
TCP and UDP are already supported initialisms. This adds ICMP.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
