### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -75,7 +75,7 @@ This will create our suggested package layout. You can modify these paths in gql
 
 gqlgen is a schema-first library — before writing code, you describe your API using the GraphQL
 [Schema Definition Language](http://graphql.org/learn/schema/). By default this goes into a file called
-`schema.graphql` but you can break it up into as many different files as you want.
+`schema.graphqls` but you can break it up into as many different files as you want.
 
 The schema that was generated for us was:
 ```graphql


### PR DESCRIPTION
missing an 's' on quoted filename default

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
