### PR TITLE
Rename `@extraTag` directive to `@goTag` and make repeatable

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -239,7 +239,7 @@ func (c *Config) injectTypesFromSchema() error {
 		SkipRuntime: true,
 	}
 
-	c.Directives["extraTag"] = DirectiveConfig{
+	c.Directives["goTag"] = DirectiveConfig{
 		SkipRuntime: true,
 	}
 
@@ -266,7 +266,7 @@ func (c *Config) injectTypesFromSchema() error {
 		if schemaType.Kind == ast.Object || schemaType.Kind == ast.InputObject {
 			for _, field := range schemaType.Fields {
 				typeMapField := TypeMapField{
-					ExtraTag:  c.Models[schemaType.Name].Fields[field.Name].ExtraTag,
+					ExtraTags: c.Models[schemaType.Name].Fields[field.Name].ExtraTags,
 					FieldName: c.Models[schemaType.Name].Fields[field.Name].FieldName,
 					Resolver:  c.Models[schemaType.Name].Fields[field.Name].Resolver,
 				}
@@ -292,12 +292,21 @@ func (c *Config) injectTypesFromSchema() error {
 					directive = true
 				}
 
-				if ex := field.Directives.ForName("extraTag"); ex != nil {
-					args := []string{}
-					for _, arg := range ex.Arguments {
-						args = append(args, arg.Name+`:"`+arg.Value.Raw+`"`)
+				for _, goTag := range field.Directives.ForNames("goTag") {
+					var key, value string
+					if arg := goTag.Arguments.ForName("key"); arg != nil {
+						if k, err := arg.Value.Value(nil); err == nil {
+							key = k.(string)
+						}
 					}
-					typeMapField.ExtraTag = strings.Join(args, " ")
+
+					if arg := goTag.Arguments.ForName("value"); arg != nil {
+						if v, err := arg.Value.Value(nil); err == nil {
+							value = v.(string)
+						}
+					}
+
+					typeMapField.ExtraTags = append(typeMapField.ExtraTags, key+":"+value)
 					directive = true
 				}
 
@@ -323,10 +332,10 @@ type TypeMapEntry struct {
 }
 
 type TypeMapField struct {
-	Resolver        bool   `yaml:"resolver"`
-	FieldName       string `yaml:"fieldName"`
-	ExtraTag        string `yaml:"extraTag"`
-	GeneratedMethod string `yaml:"-"`
+	Resolver        bool     `yaml:"resolver"`
+	FieldName       string   `yaml:"fieldName"`
+	ExtraTags       []string `yaml:"extraTags"`
+	GeneratedMethod string   `yaml:"-"`
 }
 
 type StringList []string

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -293,7 +293,8 @@ func (c *Config) injectTypesFromSchema() error {
 				}
 
 				for _, goTag := range field.Directives.ForNames("goTag") {
-					var key, value string
+					key := ""
+					value := field.Name
 					if arg := goTag.Arguments.ForName("key"); arg != nil {
 						if k, err := arg.Value.Value(nil); err == nil {
 							key = k.(string)
@@ -306,7 +307,7 @@ func (c *Config) injectTypesFromSchema() error {
 						}
 					}
 
-					typeMapField.ExtraTags = append(typeMapField.ExtraTags, key+":"+value)
+					typeMapField.ExtraTags = append(typeMapField.ExtraTags, key+":\""+value+"\"")
 					directive = true
 				}
 

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -72,7 +72,6 @@ models:
       - github.com/99designs/gqlgen/graphql.Int
       - github.com/99designs/gqlgen/graphql.Int64
       - github.com/99designs/gqlgen/graphql.Int32
-
 ```
 
 Everything has defaults, so add things as you need.
@@ -84,18 +83,20 @@ gqlgen ships with some builtin directives that make it a little easier to manage
 To start using them you first need to define them:
 
 ```graphql
-directive @goModel(model: String, models: [String!]) on OBJECT
-    | INPUT_OBJECT
-    | SCALAR
-    | ENUM
-    | INTERFACE
-    | UNION
+directive @goModel(
+	model: String
+	models: [String!]
+) on OBJECT | INPUT_OBJECT | SCALAR | ENUM | INTERFACE | UNION
 
-directive @goField(forceResolver: Boolean, name: String) on INPUT_FIELD_DEFINITION
-    | FIELD_DEFINITION
+directive @goField(
+	forceResolver: Boolean
+	name: String
+) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
-directive @extraTag on INPUT_FIELD_DEFINITION
-    | FIELD_DEFINITION
+directive @goTag(
+	key: String!
+	value: String
+) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 ```
 
 > Here be dragons
@@ -107,7 +108,7 @@ Now you can use these directives when defining types in your schema:
 
 ```graphql
 type User @goModel(model: "github.com/my/app/models.User") {
-    id: ID!         @goField(name: "todoId")
-    name: String!   @goField(forceResolver: true) @extraTag(xorm: "-")
+	id: ID! @goField(name: "todoId")
+	name: String! @goField(forceResolver: true) @goTag(xorm: "-")
 }
 ```

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -109,6 +109,9 @@ Now you can use these directives when defining types in your schema:
 ```graphql
 type User @goModel(model: "github.com/my/app/models.User") {
 	id: ID! @goField(name: "todoId")
-	name: String! @goField(forceResolver: true) @goTag(xorm: "-")
+	name: String!
+		@goField(forceResolver: true)
+		@goTag(key: "xorm", value: "-")
+		@goTag(key: "yaml")
 }
 ```

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/types"
 	"sort"
+	"strings"
 
 	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/99designs/gqlgen/codegen/templates"
@@ -18,6 +19,7 @@ type FieldMutateHook = func(td *ast.Definition, fd *ast.FieldDefinition, f *Fiel
 func defaultFieldMutateHook(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Field, error) {
 	return f, nil
 }
+
 func defaultBuildMutateHook(b *ModelBuild) *ModelBuild {
 	return b
 }
@@ -169,16 +171,14 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 					typ = types.NewPointer(typ)
 				}
 
-				tag := `json:"` + field.Name + `"`
-				if extraTag := cfg.Models[schemaType.Name].Fields[field.Name].ExtraTag; extraTag != "" {
-					tag = tag + " " + extraTag
-				}
+				tags := []string{`json:"` + field.Name + `"`}
+				tags = append(tags, cfg.Models[schemaType.Name].Fields[field.Name].ExtraTags...)
 
 				f := &Field{
 					Name:        name,
 					Type:        typ,
 					Description: field.Description,
-					Tag:         tag,
+					Tag:         strings.Join(tags, " "),
 				}
 
 				if m.FieldHook != nil {


### PR DESCRIPTION
- Rename for consistency with `@goField` and `@goModel`
- Allow for repeatable use to bind multiple tag pairs

**edit:** added a comment down below, but contemplating whether it makes sense to have this directive at all given the addition of field-level hooks cc @JohnMaguire

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
