### PR TITLE
Reimplement goTag using FieldMutateHook

### DIFF
--- a/docs/content/recipes/modelgen-hook.md
+++ b/docs/content/recipes/modelgen-hook.md
@@ -154,9 +154,11 @@ type ObjectInput struct {
 }
 ```
 
-If a constraint being used during generation shoud not be published during introspection, the directive should be listed with `skip_runtime:true` in gqlgen.yml
+If a constraint being used during generation should not be published during introspection, the directive should be listed with `skip_runtime:true` in gqlgen.yml
 ```yaml
 directives:
   constraint:
     skip_runtime: true
 ```
+
+The built-in directive `@goTag` is implemented using the FieldMutateHook. See: `plugin/modelgen/models.go` function `GoTagFieldHook`

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -76,6 +76,7 @@ func TestModelGeneration(t *testing.T) {
 			`json:"name" anotherTag:"tag"`,
 			`json:"enum" yetAnotherTag:"12"`,
 			`json:"noVal" yaml:"noVal"`,
+			`json:"repeated" someTag:"value" repeated:"true"`,
 		}
 
 		for _, tag := range expectedTags {

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/vektah/gqlparser/v2/ast"
-
 	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/99designs/gqlgen/plugin/modelgen/out"
 	"github.com/stretchr/testify/require"
@@ -20,7 +18,7 @@ func TestModelGeneration(t *testing.T) {
 	require.NoError(t, cfg.Init())
 	p := Plugin{
 		MutateHook: mutateHook,
-		FieldHook:  mutateFieldHook,
+		FieldHook:  defaultFieldMutateHook,
 	}
 	require.NoError(t, p.MutateConfig(cfg))
 
@@ -77,6 +75,7 @@ func TestModelGeneration(t *testing.T) {
 		expectedTags := []string{
 			`json:"name" anotherTag:"tag"`,
 			`json:"enum" yetAnotherTag:"12"`,
+			`json:"noVal" yaml:"noVal"`,
 		}
 
 		for _, tag := range expectedTags {
@@ -97,20 +96,4 @@ func mutateHook(b *ModelBuild) *ModelBuild {
 	}
 
 	return b
-}
-
-func mutateFieldHook(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Field, error) {
-
-	if fd.Directives == nil || td.Name != "FieldMutationHook" {
-		return f, nil
-	}
-
-	directive := fd.Directives.ForName("addTag")
-	if directive != nil {
-		args := directive.ArgumentMap(map[string]interface{}{})
-		if tag, ok := args["tag"]; ok {
-			f.Tag += " " + tag.(string)
-		}
-	}
-	return f, nil
 }

--- a/plugin/modelgen/out/generated.go
+++ b/plugin/modelgen/out/generated.go
@@ -31,9 +31,10 @@ type UnionWithDescription interface {
 }
 
 type FieldMutationHook struct {
-	Name  *string       `json:"name" anotherTag:"tag" database:"FieldMutationHookname"`
-	Enum  *ExistingEnum `json:"enum" yetAnotherTag:"12" database:"FieldMutationHookenum"`
-	NoVal *string       `json:"noVal" yaml:"noVal" database:"FieldMutationHooknoVal"`
+	Name     *string       `json:"name" anotherTag:"tag" database:"FieldMutationHookname"`
+	Enum     *ExistingEnum `json:"enum" yetAnotherTag:"12" database:"FieldMutationHookenum"`
+	NoVal    *string       `json:"noVal" yaml:"noVal" repeated:"true" database:"FieldMutationHooknoVal"`
+	Repeated *string       `json:"repeated" someTag:"value" repeated:"true" database:"FieldMutationHookrepeated"`
 }
 
 type MissingInput struct {

--- a/plugin/modelgen/out/generated.go
+++ b/plugin/modelgen/out/generated.go
@@ -31,8 +31,9 @@ type UnionWithDescription interface {
 }
 
 type FieldMutationHook struct {
-	Name *string       `json:"name" anotherTag:"tag" database:"FieldMutationHookname"`
-	Enum *ExistingEnum `json:"enum" yetAnotherTag:"12" database:"FieldMutationHookenum"`
+	Name  *string       `json:"name" anotherTag:"tag" database:"FieldMutationHookname"`
+	Enum  *ExistingEnum `json:"enum" yetAnotherTag:"12" database:"FieldMutationHookenum"`
+	NoVal *string       `json:"noVal" yaml:"noVal" database:"FieldMutationHooknoVal"`
 }
 
 type MissingInput struct {

--- a/plugin/modelgen/testdata/schema.graphql
+++ b/plugin/modelgen/testdata/schema.graphql
@@ -62,7 +62,9 @@ input ExistingInput {
 type FieldMutationHook {
     name: String @goTag(key :"anotherTag", value: "tag")
     enum: ExistingEnum @goTag(key: "yetAnotherTag", value: "12")
-    noVal: String @goTag(key: "yaml")
+    noVal: String @goTag(key: "yaml") @goTag(key : "repeated", value: "true")
+    repeated: String @goTag(key: "someTag", value: "value") @goTag(key : "repeated", value: "true")
+
 }
 
 enum ExistingEnum {

--- a/plugin/modelgen/testdata/schema.graphql
+++ b/plugin/modelgen/testdata/schema.graphql
@@ -1,5 +1,7 @@
-directive @addTag(tag: String!) on INPUT_FIELD_DEFINITION
-    | FIELD_DEFINITION
+directive @goTag(
+    key: String!
+    value: String
+) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 type Query {
     thisShoudlntGetGenerated: Boolean
@@ -58,8 +60,9 @@ input ExistingInput {
 }
 
 type FieldMutationHook {
-    name: String @addTag(tag :"anotherTag:\"tag\"")
-    enum: ExistingEnum @addTag(tag: "yetAnotherTag:\"12\"")
+    name: String @goTag(key :"anotherTag", value: "tag")
+    enum: ExistingEnum @goTag(key: "yetAnotherTag", value: "12")
+    noVal: String @goTag(key: "yaml")
 }
 
 enum ExistingEnum {


### PR DESCRIPTION
This PR reimplements the extraTags/goTag directive as a fieldMutateHook and applies it as the default hook for the modelgen Plugin. This has been done as a request off the back of #1680. 

I did notice that some functionality did change during the renaming of `@extraTag` to `@goTag`. e.g. if the value argument is not passed the value of the tag is set to the field name. e.g. ` testField String @goTag( key:"yaml")` sets the tag `json:"testField" yaml:"testField"`.  Though this was not mentioned in the PR, I assumed that this is the intended behaviour and this has also been implemented in the FieldMutateHook. 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
