### PR TITLE
Ignore generated files from test coverage

### DIFF
--- a/.github/workflows/check-coverage
+++ b/.github/workflows/check-coverage
@@ -4,4 +4,4 @@ set -euo pipefail
 GO111MODULE=off go get github.com/mattn/goveralls
 
 go test -covermode atomic -coverprofile=/tmp/coverage.out -coverpkg=./... $(go list github.com/99designs/gqlgen/... | grep -v example)
-goveralls -coverprofile=/tmp/coverage.out -service=github -ignore='example/*/*,example/*/*/*,integration/*,integration/*/*,codegen/testserver/*'
+goveralls -coverprofile=/tmp/coverage.out -service=github -ignore='example/*/*,example/*/*/*,integration/*,integration/*/*,codegen/testserver/*/*,plugin/federation/testdata/*/*/*,*/generated.go,*/*/generated.go,*/*/*/generated.go,graphql/executable_schema_mock.go'


### PR DESCRIPTION
We were not ignoring a number of generated files from the test coverage reports, giving a false impression of lower coverage.

Signed-off-by: Steve Coffman <steve@khanacademy.org>
