### PR TITLE
Optimize performance for binder, imports and packages

### DIFF
--- a/internal/code/imports.go
+++ b/internal/code/imports.go
@@ -45,6 +45,14 @@ func NameForDir(dir string) string {
 	return SanitizePackageName(filepath.Base(dir))
 }
 
+type goModuleSearchResult struct {
+	path       string
+	goModPath  string
+	moduleName string
+}
+
+var goModuleRootCache = map[string]goModuleSearchResult{}
+
 // goModuleRoot returns the root of the current go module if there is a go.mod file in the directory tree
 // If not, it returns false
 func goModuleRoot(dir string) (string, bool) {
@@ -53,28 +61,69 @@ func goModuleRoot(dir string) (string, bool) {
 		panic(err)
 	}
 	dir = filepath.ToSlash(dir)
-	modDir := dir
-	assumedPart := ""
+
+	var dirs = []string{dir}
+	result := goModuleSearchResult{}
+
 	for {
-		f, err := ioutil.ReadFile(filepath.Join(modDir, "go.mod"))
-		if err == nil {
-			// found it, stop searching
-			return string(modregex.FindSubmatch(f)[1]) + assumedPart, true
-		}
+		modDir := dirs[len(dirs)-1]
 
-		assumedPart = "/" + filepath.Base(modDir) + assumedPart
-		parentDir, err := filepath.Abs(filepath.Join(modDir, ".."))
-		if err != nil {
-			panic(err)
-		}
-
-		if parentDir == modDir {
-			// Walked all the way to the root and didnt find anything :'(
+		if val, ok := goModuleRootCache[dir]; ok {
+			result = val
 			break
 		}
-		modDir = parentDir
+
+		if content, err := ioutil.ReadFile(filepath.Join(modDir, "go.mod")); err == nil {
+			moduleName := string(modregex.FindSubmatch(content)[1])
+			result = goModuleSearchResult{
+				path:       moduleName,
+				goModPath:  modDir,
+				moduleName: moduleName,
+			}
+			goModuleRootCache[modDir] = result
+			break
+		}
+
+		if modDir == "" || modDir == "." || modDir == "/" || strings.HasSuffix(modDir, "\\") {
+			// Reached the top of the file tree which means go.mod file is not found
+			// Set root folder with a sentinel cache value
+			goModuleRootCache[modDir] = result
+			break
+		}
+
+		dirs = append(dirs, filepath.Dir(modDir))
 	}
-	return "", false
+
+	// create a cache for each path in a tree traversed, except the top one as it is already cached
+	for _, d := range dirs[:len(dirs)-1] {
+		if result.moduleName == "" {
+			// go.mod is not found in the tree, so the same sentinel value fits all the directories in a tree
+			goModuleRootCache[d] = result
+		} else {
+			if relPath, err := filepath.Rel(result.goModPath, d); err != nil {
+				panic(err)
+			} else {
+				path := result.moduleName
+				relPath := filepath.ToSlash(relPath)
+				if !strings.HasSuffix(relPath, "/") {
+					path += "/"
+				}
+				path += relPath
+
+				goModuleRootCache[d] = goModuleSearchResult{
+					path:       path,
+					goModPath:  result.goModPath,
+					moduleName: result.moduleName,
+				}
+			}
+		}
+	}
+
+	res := goModuleRootCache[dir]
+	if res.moduleName == "" {
+		return "", false
+	}
+	return res.path, true
 }
 
 // ImportPathForDir takes a path and returns a golang import path for the package

--- a/internal/code/packages.go
+++ b/internal/code/packages.go
@@ -190,6 +190,10 @@ func (p *Packages) Errors() PkgErrors {
 	return res
 }
 
+func (p *Packages) Count() int {
+	return len(p.packages)
+}
+
 type PkgErrors []error
 
 func (p PkgErrors) Error() string {

--- a/internal/code/packages.go
+++ b/internal/code/packages.go
@@ -83,6 +83,13 @@ func (p *Packages) addToCache(pkg *packages.Package) {
 
 // Load works the same as LoadAll, except a single package at a time.
 func (p *Packages) Load(importPath string) *packages.Package {
+	// Quick cache check first to avoid expensive allocations of LoadAll()
+	if p.packages != nil {
+		if pkg, ok := p.packages[importPath]; ok {
+			return pkg
+		}
+	}
+
 	pkgs := p.LoadAll(importPath)
 	if len(pkgs) == 0 {
 		return nil


### PR DESCRIPTION
This PR consists of multiple commits and is pure refactoring. It should maintain full backwards compatibility with the origin.

- `imports.goModuleRoot` is called for every type resolution. It tries to find go.mod file in the directory tree making a gazillion of requests to open file. While someone more familiar with the application design can come up with a better architecture to avoid this altogether, I added a caching layer on top of this function to only traverse file system once.
- `binder.FindObject` traverses all definitions in a package and for all needed types it is effectively O(n^2). Make it to O(n) by caching all package top-level definitions in a hashtable.
- `packages.Load` calls 'packages.LoadAll' which allocates a slice from the heap even when a single package is required. Added a fast path by checking a cache map before calling to `packages.LoadAll` to avoid that. A possibly better solution is to refactor  common parts of `packages.Load` and `packages.LoadAll` into a separate function.

For the targeted use case we achieved ~20% speed optimizations after those improvements.

Because functionality did not change, existing tests should cover it all so no new tests added.
