### PR TITLE
Adding entity resolver tests for errors, entities with different type…

### DIFF
--- a/plugin/federation/federation_entityresolver_test.go
+++ b/plugin/federation/federation_entityresolver_test.go
@@ -88,8 +88,13 @@ func TestEntityResolver(t *testing.T) {
 		entityErrors, err := getEntityErrors(err)
 		require.NoError(t, err)
 		require.Len(t, entityErrors, 2)
-		require.Equal(t, entityErrors[0].Message, "error resolving HelloWithErrorsByName. empty key")
-		require.Equal(t, entityErrors[1].Message, "error resolving HelloWithErrorsByName")
+		errMessages := []string{
+			entityErrors[0].Message,
+			entityErrors[1].Message,
+		}
+
+		require.Contains(t, errMessages, "error (empty key) resolving HelloWithErrorsByName")
+		require.Contains(t, errMessages, "error resolving HelloWithErrorsByName")
 
 		require.Len(t, resp.Entities, 5)
 		require.Equal(t, resp.Entities[0].Name, "first name - 1")

--- a/plugin/federation/testdata/entityresolver/entity.resolvers.go
+++ b/plugin/federation/testdata/entityresolver/entity.resolvers.go
@@ -20,7 +20,7 @@ func (r *entityResolver) FindHelloWithErrorsByName(ctx context.Context, name str
 	if name == "inject error" {
 		return nil, fmt.Errorf("error resolving HelloWithErrorsByName")
 	} else if name == "" {
-		return nil, fmt.Errorf("error resolving HelloWithErrorsByName. empty key")
+		return nil, fmt.Errorf("error (empty key) resolving HelloWithErrorsByName")
 	}
 
 	return &generated.HelloWithErrors{

--- a/plugin/federation/testdata/entityresolver/entity.resolvers.go
+++ b/plugin/federation/testdata/entityresolver/entity.resolvers.go
@@ -5,6 +5,7 @@ package entityresolver
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/99designs/gqlgen/plugin/federation/testdata/entityresolver/generated"
 )
@@ -15,12 +16,36 @@ func (r *entityResolver) FindHelloByName(ctx context.Context, name string) (*gen
 	}, nil
 }
 
+func (r *entityResolver) FindHelloWithErrorsByName(ctx context.Context, name string) (*generated.HelloWithErrors, error) {
+	if name == "inject error" {
+		return nil, fmt.Errorf("error resolving HelloWithErrorsByName")
+	} else if name == "" {
+		return nil, fmt.Errorf("error resolving HelloWithErrorsByName. empty key")
+	}
+
+	return &generated.HelloWithErrors{
+		Name: name,
+	}, nil
+}
+
+func (r *entityResolver) FindPlanetRequiresByName(ctx context.Context, name string) (*generated.PlanetRequires, error) {
+	return &generated.PlanetRequires{
+		Name: name,
+	}, nil
+}
+
 func (r *entityResolver) FindWorldByHelloNameAndFoo(ctx context.Context, helloName string, foo string) (*generated.World, error) {
 	return &generated.World{
 		Hello: &generated.Hello{
 			Name: helloName,
 		},
 		Foo: foo,
+	}, nil
+}
+
+func (r *entityResolver) FindWorldNameByName(ctx context.Context, name string) (*generated.WorldName, error) {
+	return &generated.WorldName{
+		Name: name,
 	}, nil
 }
 

--- a/plugin/federation/testdata/entityresolver/generated/federation.go
+++ b/plugin/federation/testdata/entityresolver/generated/federation.go
@@ -63,6 +63,41 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 			list[i] = entity
 			return nil
 
+		case "HelloWithErrors":
+			id0, err := ec.unmarshalNString2string(ctx, rep["name"])
+			if err != nil {
+				return errors.New(fmt.Sprintf("Field %s undefined in schema.", "name"))
+			}
+
+			entity, err := ec.resolvers.Entity().FindHelloWithErrorsByName(ctx,
+				id0)
+			if err != nil {
+				return err
+			}
+
+			list[i] = entity
+			return nil
+
+		case "PlanetRequires":
+			id0, err := ec.unmarshalNString2string(ctx, rep["name"])
+			if err != nil {
+				return errors.New(fmt.Sprintf("Field %s undefined in schema.", "name"))
+			}
+
+			entity, err := ec.resolvers.Entity().FindPlanetRequiresByName(ctx,
+				id0)
+			if err != nil {
+				return err
+			}
+
+			entity.Diameter, err = ec.unmarshalNInt2int(ctx, rep["diameter"])
+			if err != nil {
+				return err
+			}
+
+			list[i] = entity
+			return nil
+
 		case "World":
 			id0, err := ec.unmarshalNString2string(ctx, rep["hello"].(map[string]interface{})["name"])
 			if err != nil {
@@ -75,6 +110,21 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 
 			entity, err := ec.resolvers.Entity().FindWorldByHelloNameAndFoo(ctx,
 				id0, id1)
+			if err != nil {
+				return err
+			}
+
+			list[i] = entity
+			return nil
+
+		case "WorldName":
+			id0, err := ec.unmarshalNString2string(ctx, rep["name"])
+			if err != nil {
+				return errors.New(fmt.Sprintf("Field %s undefined in schema.", "name"))
+			}
+
+			entity, err := ec.resolvers.Entity().FindWorldNameByName(ctx,
+				id0)
 			if err != nil {
 				return err
 			}

--- a/plugin/federation/testdata/entityresolver/generated/models.go
+++ b/plugin/federation/testdata/entityresolver/generated/models.go
@@ -9,6 +9,20 @@ type Hello struct {
 
 func (Hello) IsEntity() {}
 
+type HelloWithErrors struct {
+	Name string `json:"name"`
+}
+
+func (HelloWithErrors) IsEntity() {}
+
+type PlanetRequires struct {
+	Name     string `json:"name"`
+	Size     int    `json:"size"`
+	Diameter int    `json:"diameter"`
+}
+
+func (PlanetRequires) IsEntity() {}
+
 type World struct {
 	Foo   string `json:"foo"`
 	Bar   int    `json:"bar"`
@@ -16,3 +30,9 @@ type World struct {
 }
 
 func (World) IsEntity() {}
+
+type WorldName struct {
+	Name string `json:"name"`
+}
+
+func (WorldName) IsEntity() {}

--- a/plugin/federation/testdata/entityresolver/schema.graphql
+++ b/plugin/federation/testdata/entityresolver/schema.graphql
@@ -9,6 +9,20 @@ type World @key(fields: "hello { name } foo   ") {
     hello: Hello
 }
 
+type WorldName @key(fields: "name") {
+    name: String!
+}
+
+type HelloWithErrors @key(fields: "name") {
+    name: String!
+}
+
+type PlanetRequires @key(fields: "name") {
+    name: String!
+    size: Int! @requires(fields: "diameter")
+    diameter: Int!
+}
+
 type Query {
     hello: Hello!
     world: World!


### PR DESCRIPTION
…s, and requires

The tests in this PR are for ensuring we get the expected errors from entity resolvers, that we also handle resolving entities where the representations are for different types, and that requires directive works correctly.

To run tests:
1. Go to `plugin/federation`
2. Generate files with `go run github.com/99designs/gqlgen --config testdata/entityresolver/gqlgen.yml`
3. And run `go test ./...`.  Verify they all pass.

Describe your PR and link to any relevant issues. 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
