### PR TITLE
Resolve multiple federated entities in a single entityResolve call

### DIFF
--- a/example/federation/accounts/graph/generated/federation.go
+++ b/example/federation/accounts/graph/generated/federation.go
@@ -33,7 +33,39 @@ func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.
 
 func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) []fedruntime.Entity {
 	list := make([]fedruntime.Entity, len(representations))
-	resolveEntity := func(ctx context.Context, i int, rep map[string]interface{}) (err error) {
+
+	repsMap := map[string]struct {
+		i []int
+		r []map[string]interface{}
+	}{}
+
+	// We group entities by typename so that we can parallelize their resolution.
+	// This is particularly helpful when there are entity groups in multi mode.
+	buildRepresentationGroups := func(reps []map[string]interface{}) {
+		for i, rep := range reps {
+			typeName, ok := rep["__typename"].(string)
+			if !ok {
+				// If there is no __typename, we just skip the representation;
+				// we just won't be resolving these unknown types.
+				ec.Error(ctx, errors.New("__typename must be an existing string"))
+				continue
+			}
+
+			_r := repsMap[typeName]
+			_r.i = append(_r.i, i)
+			_r.r = append(_r.r, rep)
+			repsMap[typeName] = _r
+		}
+	}
+
+	isMulti := func(typeName string) bool {
+		switch typeName {
+		default:
+			return false
+		}
+	}
+
+	resolveEntity := func(ctx context.Context, typeName string, rep map[string]interface{}, idx []int, i int) (err error) {
 		// we need to do our own panic handling, because we may be called in a
 		// goroutine, where the usual panic handling can't catch us
 		defer func() {
@@ -42,10 +74,6 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 			}
 		}()
 
-		typeName, ok := rep["__typename"].(string)
-		if !ok {
-			return errors.New("__typename must be an existing string")
-		}
 		switch typeName {
 
 		case "EmailHost":
@@ -60,7 +88,7 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 				return err
 			}
 
-			list[i] = entity
+			list[idx[i]] = entity
 			return nil
 
 		case "User":
@@ -75,7 +103,7 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 				return err
 			}
 
-			list[i] = entity
+			list[idx[i]] = entity
 			return nil
 
 		default:
@@ -83,30 +111,71 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 		}
 	}
 
-	// if there are multiple entities to resolve, parallelize (similar to
-	// graphql.FieldSet.Dispatch)
-	switch len(representations) {
+	resolveManyEntities := func(ctx context.Context, typeName string, reps []map[string]interface{}, idx []int) (err error) {
+		// we need to do our own panic handling, because we may be called in a
+		// goroutine, where the usual panic handling can't catch us
+		defer func() {
+			if r := recover(); r != nil {
+				err = ec.Recover(ctx, r)
+			}
+		}()
+
+		switch typeName {
+
+		default:
+			return errors.New("unknown type: " + typeName)
+		}
+
+		return nil
+	}
+
+	resolveEntityGroup := func(typeName string, reps []map[string]interface{}, idx []int) {
+		if isMulti(typeName) {
+			err := resolveManyEntities(ctx, typeName, reps, idx)
+			if err != nil {
+				ec.Error(ctx, err)
+			}
+		} else {
+			// if there are multiple entities to resolve, parallelize (similar to
+			// graphql.FieldSet.Dispatch)
+			var e sync.WaitGroup
+			e.Add(len(reps))
+			for i, rep := range reps {
+				i, rep := i, rep
+				go func(i int, rep map[string]interface{}) {
+					err := resolveEntity(ctx, typeName, rep, idx, i)
+					if err != nil {
+						ec.Error(ctx, err)
+					}
+					e.Done()
+				}(i, rep)
+			}
+			e.Wait()
+		}
+	}
+
+	buildRepresentationGroups(representations)
+
+	switch len(repsMap) {
 	case 0:
 		return list
 	case 1:
-		err := resolveEntity(ctx, 0, representations[0])
-		if err != nil {
-			ec.Error(ctx, err)
+		for typeName, reps := range repsMap {
+			resolveEntityGroup(typeName, reps.r, reps.i)
 		}
 		return list
 	default:
 		var g sync.WaitGroup
-		g.Add(len(representations))
-		for i, rep := range representations {
-			go func(i int, rep map[string]interface{}) {
-				err := resolveEntity(ctx, i, rep)
-				if err != nil {
-					ec.Error(ctx, err)
-				}
+		g.Add(len(repsMap))
+		for typeName, reps := range repsMap {
+			go func(typeName string, reps []map[string]interface{}, idx []int) {
+				resolveEntityGroup(typeName, reps, idx)
 				g.Done()
-			}(i, rep)
+			}(typeName, reps.r, reps.i)
 		}
 		g.Wait()
 		return list
 	}
+
+	return list
 }

--- a/example/federation/reviews/graph/generated/federation.go
+++ b/example/federation/reviews/graph/generated/federation.go
@@ -33,7 +33,39 @@ func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.
 
 func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) []fedruntime.Entity {
 	list := make([]fedruntime.Entity, len(representations))
-	resolveEntity := func(ctx context.Context, i int, rep map[string]interface{}) (err error) {
+
+	repsMap := map[string]struct {
+		i []int
+		r []map[string]interface{}
+	}{}
+
+	// We group entities by typename so that we can parallelize their resolution.
+	// This is particularly helpful when there are entity groups in multi mode.
+	buildRepresentationGroups := func(reps []map[string]interface{}) {
+		for i, rep := range reps {
+			typeName, ok := rep["__typename"].(string)
+			if !ok {
+				// If there is no __typename, we just skip the representation;
+				// we just won't be resolving these unknown types.
+				ec.Error(ctx, errors.New("__typename must be an existing string"))
+				continue
+			}
+
+			_r := repsMap[typeName]
+			_r.i = append(_r.i, i)
+			_r.r = append(_r.r, rep)
+			repsMap[typeName] = _r
+		}
+	}
+
+	isMulti := func(typeName string) bool {
+		switch typeName {
+		default:
+			return false
+		}
+	}
+
+	resolveEntity := func(ctx context.Context, typeName string, rep map[string]interface{}, idx []int, i int) (err error) {
 		// we need to do our own panic handling, because we may be called in a
 		// goroutine, where the usual panic handling can't catch us
 		defer func() {
@@ -42,10 +74,6 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 			}
 		}()
 
-		typeName, ok := rep["__typename"].(string)
-		if !ok {
-			return errors.New("__typename must be an existing string")
-		}
 		switch typeName {
 
 		case "Product":
@@ -64,7 +92,7 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 				return err
 			}
 
-			list[i] = entity
+			list[idx[i]] = entity
 			return nil
 
 		case "User":
@@ -89,7 +117,7 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 				return err
 			}
 
-			list[i] = entity
+			list[idx[i]] = entity
 			return nil
 
 		default:
@@ -97,30 +125,71 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 		}
 	}
 
-	// if there are multiple entities to resolve, parallelize (similar to
-	// graphql.FieldSet.Dispatch)
-	switch len(representations) {
+	resolveManyEntities := func(ctx context.Context, typeName string, reps []map[string]interface{}, idx []int) (err error) {
+		// we need to do our own panic handling, because we may be called in a
+		// goroutine, where the usual panic handling can't catch us
+		defer func() {
+			if r := recover(); r != nil {
+				err = ec.Recover(ctx, r)
+			}
+		}()
+
+		switch typeName {
+
+		default:
+			return errors.New("unknown type: " + typeName)
+		}
+
+		return nil
+	}
+
+	resolveEntityGroup := func(typeName string, reps []map[string]interface{}, idx []int) {
+		if isMulti(typeName) {
+			err := resolveManyEntities(ctx, typeName, reps, idx)
+			if err != nil {
+				ec.Error(ctx, err)
+			}
+		} else {
+			// if there are multiple entities to resolve, parallelize (similar to
+			// graphql.FieldSet.Dispatch)
+			var e sync.WaitGroup
+			e.Add(len(reps))
+			for i, rep := range reps {
+				i, rep := i, rep
+				go func(i int, rep map[string]interface{}) {
+					err := resolveEntity(ctx, typeName, rep, idx, i)
+					if err != nil {
+						ec.Error(ctx, err)
+					}
+					e.Done()
+				}(i, rep)
+			}
+			e.Wait()
+		}
+	}
+
+	buildRepresentationGroups(representations)
+
+	switch len(repsMap) {
 	case 0:
 		return list
 	case 1:
-		err := resolveEntity(ctx, 0, representations[0])
-		if err != nil {
-			ec.Error(ctx, err)
+		for typeName, reps := range repsMap {
+			resolveEntityGroup(typeName, reps.r, reps.i)
 		}
 		return list
 	default:
 		var g sync.WaitGroup
-		g.Add(len(representations))
-		for i, rep := range representations {
-			go func(i int, rep map[string]interface{}) {
-				err := resolveEntity(ctx, i, rep)
-				if err != nil {
-					ec.Error(ctx, err)
-				}
+		g.Add(len(repsMap))
+		for typeName, reps := range repsMap {
+			go func(typeName string, reps []map[string]interface{}, idx []int) {
+				resolveEntityGroup(typeName, reps, idx)
 				g.Done()
-			}(i, rep)
+			}(typeName, reps.r, reps.i)
 		}
 		g.Wait()
 		return list
 	}
+
+	return list
 }

--- a/example/tools.go
+++ b/example/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package main

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -3,6 +3,7 @@ package federation
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/vektah/gqlparser/v2/ast"
 
@@ -98,13 +99,12 @@ func (f *federation) InjectSourceLate(schema *ast.Schema) *ast.Source {
 
 		if e.ResolverName != "" {
 			if e.Multi {
-				entityResolverInputTypeName := "EntityResolver" + e.ResolverName + "Input"
-				entityResolverInputDefinitions += "input " + entityResolverInputTypeName + " {\n"
+				entityResolverInputDefinitions += "input " + e.InputType + " {\n"
 				for _, keyField := range e.KeyFields {
 					entityResolverInputDefinitions += fmt.Sprintf("\t%s: %s\n", keyField.Field.ToGo(), keyField.Definition.Type.String())
 				}
 				entityResolverInputDefinitions += "}\n"
-				resolvers += fmt.Sprintf("\t%s(reps: [%s!]!): [%s]\n", e.ResolverName, entityResolverInputTypeName, e.Name)
+				resolvers += fmt.Sprintf("\t%s(reps: [%s!]!): [%s]\n", e.ResolverName, e.InputType, e.Name)
 			} else {
 				resolverArgs := ""
 				for _, keyField := range e.KeyFields {
@@ -154,9 +154,13 @@ extend type Query {
 // Entity represents a federated type
 // that was declared in the GQL schema.
 type Entity struct {
+	// TODO(miguel): encapsulate resolver information in its own
+	// struct for future work to support multiple federated keys.
+
 	Name         string      // The same name as the type declaration
 	KeyFields    []*KeyField // The fields declared in @key.
 	ResolverName string      // The resolver name, such as FindUserByID
+	InputType    string      // The Go generated input type for multi entity resolvers
 	Def          *ast.Definition
 	Requires     []*Requires
 	Multi        bool
@@ -315,22 +319,20 @@ func (f *federation) setEntities(schema *ast.Schema) {
 				//       id: ID @external
 				//    }
 				if !e.allFieldsAreExternal() {
-					resolverName := ""
+					resolverFields := []string{}
+					for _, f := range e.KeyFields {
+						resolverFields = append(resolverFields, f.Field.ToGo())
+					}
 
+					resolverFieldsToGo := schemaType.Name + "By" + strings.Join(resolverFields, "And")
 					if e.Multi {
-						resolverName = fmt.Sprintf("findMany%ssBy", schemaType.Name)
+						resolverFieldsToGo += "s" // Pluralize for better API readability
+						e.ResolverName = fmt.Sprintf("findMany%s", resolverFieldsToGo)
 					} else {
-						resolverName = fmt.Sprintf("find%sBy", schemaType.Name)
+						e.ResolverName = fmt.Sprintf("find%s", resolverFieldsToGo)
 					}
 
-					for i, f := range e.KeyFields {
-						if i > 0 {
-							resolverName += "And"
-						}
-						resolverName += f.Field.ToGo()
-					}
-
-					e.ResolverName = resolverName
+					e.InputType = resolverFieldsToGo + "Input"
 				}
 
 				f.Entities = append(f.Entities, e)

--- a/plugin/federation/federation.gotpl
+++ b/plugin/federation/federation.gotpl
@@ -28,7 +28,47 @@ func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.
 {{if .Entities}}
 func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) []fedruntime.Entity {
 	list := make([]fedruntime.Entity, len(representations))
-	resolveEntity := func(ctx context.Context, i int, rep map[string]interface{}) (err error) {
+
+	repsMap := map[string]struct {
+		i []int
+		r []map[string]interface{}
+	}{}
+
+	// We group entities by typename so that we can parallelize their resolution.
+	// This is particularly helpful when there are entity groups in multi mode.
+	buildRepresentationGroups := func(reps []map[string]interface{}) {
+		for i, rep := range reps {
+			typeName, ok := rep["__typename"].(string)
+			if !ok {
+				// If there is no __typename, we just skip the representation;
+				// we just won't be resolving these unknown types.
+				ec.Error(ctx, errors.New("__typename must be an existing string"))
+				continue
+			}
+
+			_r := repsMap[typeName]
+			_r.i = append(_r.i, i)
+			_r.r = append(_r.r, rep)
+			repsMap[typeName] = _r
+		}
+	}
+
+	isMulti := func(typeName string) bool {
+		switch typeName {
+		{{- range .Entities -}}
+			{{- if .ResolverName -}}
+				{{- if .Multi -}}
+			case "{{.Def.Name}}":
+				return true
+				{{ end }}
+			{{- end -}}
+		{{- end -}}
+		default:
+			return false
+		}
+	}
+
+	resolveEntity := func(ctx context.Context, typeName string, rep map[string]interface{}, idx []int, i int) (err error) {
 		// we need to do our own panic handling, because we may be called in a
 		// goroutine, where the usual panic handling can't catch us
 		defer func () {
@@ -37,13 +77,11 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 			}
 		}()
 
-		typeName, ok := rep["__typename"].(string)
-		if !ok {
-			return errors.New("__typename must be an existing string")
-		}
 		switch typeName {
 		{{ range .Entities }}
 			{{ if .ResolverName }}
+				{{ if not .Multi -}}
+
 			case "{{.Def.Name}}":
 				{{ range $i, $keyField := .KeyFields -}}
 					id{{$i}}, err := ec.{{.Type.UnmarshalFunc}}(ctx, rep["{{.Field.Join `"].(map[string]interface{})["`}}"])
@@ -64,37 +102,117 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 						return err
 					}
 				{{ end }}
-				list[i] = entity
+
+				list[idx[i]] = entity
 				return nil
+				{{ end }}
 			{{ end }}
-		{{ end }}
+		{{- end }}
 		default:
 			return errors.New("unknown type: "+typeName)
 		}
 	}
+	
+	resolveManyEntities := func(ctx context.Context, typeName string, reps []map[string]interface{}, idx []int) (err error) {
+		// we need to do our own panic handling, because we may be called in a
+		// goroutine, where the usual panic handling can't catch us
+		defer func () {
+			if r := recover(); r != nil {
+				err = ec.Recover(ctx, r)
+			}
+		}()
 
-	// if there are multiple entities to resolve, parallelize (similar to
-	// graphql.FieldSet.Dispatch)
-	switch len(representations) {
+		switch typeName {
+		{{ range .Entities -}}
+			{{ if .ResolverName -}}
+				{{ if .Multi -}}
+				case "{{.Def.Name}}":
+					_reps := make([]*EntityResolver{{.ResolverName}}Input, len(reps))
+
+					for i, rep := range reps {
+						{{ range $i, $keyField := .KeyFields -}}
+							id{{$i}}, err := ec.{{.Type.UnmarshalFunc}}(ctx, rep["{{.Field.Join `"].(map[string]interface{})["`}}"])
+							if err != nil {
+								return errors.New(fmt.Sprintf("Field %s undefined in schema.", "{{.Definition.Name}}"))
+							}
+						{{end}}
+
+						_reps[i] = &EntityResolver{{.ResolverName}}Input {
+						{{ range $i, $keyField := .KeyFields -}}
+							{{$keyField.Field.ToGo}}: id{{$i}},
+						{{end}}
+						}
+					}
+
+					entities, err := ec.resolvers.Entity().{{.ResolverName | go}}(ctx, _reps)
+					if err != nil {
+						return err
+					}
+
+					for i, entity := range entities {
+						{{- range .Requires -}}
+							{{- range .Fields -}}
+								entity.{{.NameGo}}, err = ec.{{.TypeReference.UnmarshalFunc}}(ctx, reps[i]["{{.Name}}"])
+								if err != nil {
+									return err
+								}
+							{{- end -}}
+						{{- end -}}
+						list[idx[i]] = entity
+					}
+				{{ end }}
+			{{- end }}
+		{{- end }}
+		default:
+			return errors.New("unknown type: "+typeName)
+		}
+
+		return nil
+	}
+
+	resolveEntityGroup := func(typeName string, reps []map[string]interface{}, idx []int) {
+		if isMulti(typeName) {
+			err := resolveManyEntities(ctx, typeName, reps, idx)
+			if err != nil {
+				ec.Error(ctx, err)
+			}
+		} else {
+			// if there are multiple entities to resolve, parallelize (similar to
+			// graphql.FieldSet.Dispatch)
+			var e sync.WaitGroup
+			e.Add(len(reps))
+			for i, rep := range reps {
+				i, rep := i, rep
+				go func(i int, rep map[string]interface{}) {
+					err := resolveEntity(ctx, typeName, rep, idx, i)
+					if err != nil {
+						ec.Error(ctx, err)
+					}
+					e.Done()
+				}(i, rep)
+			}
+			e.Wait()
+		}
+	}
+ 
+	buildRepresentationGroups(representations)
+
+	switch len(repsMap) {
 	case 0:
 		return list
 	case 1:
-		err := resolveEntity(ctx, 0, representations[0])
-		if err != nil {
-			ec.Error(ctx, err)
+		for typeName, reps := range repsMap {
+			resolveEntityGroup(typeName, reps.r, reps.i)
 		}
 		return list
 	default:
 		var g sync.WaitGroup
-		g.Add(len(representations))
-		for i, rep := range representations {
-			go func(i int, rep map[string]interface{}) {
-				err := resolveEntity(ctx, i, rep)
-				if err != nil {
-					ec.Error(ctx, err)
-				}
+		g.Add(len(repsMap))
+		for typeName, reps := range repsMap {
+			go func(typeName string, reps []map[string]interface{}, idx []int) {
+				resolveEntityGroup(typeName, reps, idx)
 				g.Done()
-			}(i, rep)
+			}(typeName, reps.r, reps.i)
 		}
 		g.Wait()
 		return list

--- a/plugin/federation/federation.gotpl
+++ b/plugin/federation/federation.gotpl
@@ -127,7 +127,7 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 			{{ if .ResolverName -}}
 				{{ if .Multi -}}
 				case "{{.Def.Name}}":
-					_reps := make([]*EntityResolver{{.ResolverName}}Input, len(reps))
+					_reps := make([]*{{.InputType}}, len(reps))
 
 					for i, rep := range reps {
 						{{ range $i, $keyField := .KeyFields -}}
@@ -137,7 +137,7 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 							}
 						{{end}}
 
-						_reps[i] = &EntityResolver{{.ResolverName}}Input {
+						_reps[i] = &{{.InputType}} {
 						{{ range $i, $keyField := .KeyFields -}}
 							{{$keyField.Field.ToGo}}: id{{$i}},
 						{{end}}
@@ -217,5 +217,7 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 		g.Wait()
 		return list
 	}
+
+	return list
 }
 {{end}}

--- a/plugin/federation/readme.md
+++ b/plugin/federation/readme.md
@@ -15,3 +15,25 @@ Running entity resolver tests.
 # Architecture
 
 TODO(miguel): add details.
+
+# Entity resolvers - GetMany entities
+
+The federation plugin implements `GetMany` semantics in which entity resolvers get the entire list of representations that need to be resolved. This functionality is currently optin tho, and to enable it you need to specify the directive `@entityResolver` in the federated entity you want this feature for.  E.g.
+
+```
+directive @entityResolver(multi: Boolean) on OBJECT
+
+type MultiHello @key(fields: "name") @entityResolver(multi: true) {
+    name: String!
+}
+```
+
+That allows the federation plugin to generate `GetMany` resolver function that can take a list of representations to be resolved.
+
+From that entity type, the resolver function would be
+
+```
+func (r *entityResolver) FindManyMultiHellosByName(ctx context.Context, reps []*generated.EntityResolverfindManyMultiHellosByNameInput) ([]*generated.MultiHello, error) {
+  /// <Your code to resolve the list of items>
+}
+```

--- a/plugin/federation/testdata/entityresolver/entity.resolvers.go
+++ b/plugin/federation/testdata/entityresolver/entity.resolvers.go
@@ -28,6 +28,22 @@ func (r *entityResolver) FindHelloWithErrorsByName(ctx context.Context, name str
 	}, nil
 }
 
+func (r *entityResolver) FindManyMultiHellosByName(ctx context.Context, reps []*generated.EntityResolverfindManyMultiHellosByNameInput) ([]*generated.MultiHello, error) {
+	results := []*generated.MultiHello{}
+
+	for _, item := range reps {
+		results = append(results, &generated.MultiHello{
+			Name: item.Name + " - from multiget",
+		})
+	}
+
+	return results, nil
+}
+
+func (r *entityResolver) FindManyMultiHelloWithErrorsByName(ctx context.Context, reps []*generated.EntityResolverfindManyMultiHelloWithErrorsByNameInput) ([]*generated.MultiHelloWithError, error) {
+	return nil, fmt.Errorf("error resolving MultiHelloWorldWithError")
+}
+
 func (r *entityResolver) FindPlanetRequiresByName(ctx context.Context, name string) (*generated.PlanetRequires, error) {
 	return &generated.PlanetRequires{
 		Name: name,

--- a/plugin/federation/testdata/entityresolver/entity.resolvers.go
+++ b/plugin/federation/testdata/entityresolver/entity.resolvers.go
@@ -28,7 +28,7 @@ func (r *entityResolver) FindHelloWithErrorsByName(ctx context.Context, name str
 	}, nil
 }
 
-func (r *entityResolver) FindManyMultiHellosByName(ctx context.Context, reps []*generated.EntityResolverfindManyMultiHellosByNameInput) ([]*generated.MultiHello, error) {
+func (r *entityResolver) FindManyMultiHelloByNames(ctx context.Context, reps []*generated.MultiHelloByNamesInput) ([]*generated.MultiHello, error) {
 	results := []*generated.MultiHello{}
 
 	for _, item := range reps {
@@ -40,7 +40,7 @@ func (r *entityResolver) FindManyMultiHellosByName(ctx context.Context, reps []*
 	return results, nil
 }
 
-func (r *entityResolver) FindManyMultiHelloWithErrorsByName(ctx context.Context, reps []*generated.EntityResolverfindManyMultiHelloWithErrorsByNameInput) ([]*generated.MultiHelloWithError, error) {
+func (r *entityResolver) FindManyMultiHelloWithErrorByNames(ctx context.Context, reps []*generated.MultiHelloWithErrorByNamesInput) ([]*generated.MultiHelloWithError, error) {
 	return nil, fmt.Errorf("error resolving MultiHelloWorldWithError")
 }
 

--- a/plugin/federation/testdata/entityresolver/generated/exec.go
+++ b/plugin/federation/testdata/entityresolver/generated/exec.go
@@ -47,8 +47,8 @@ type ComplexityRoot struct {
 	Entity struct {
 		FindHelloByName                    func(childComplexity int, name string) int
 		FindHelloWithErrorsByName          func(childComplexity int, name string) int
-		FindManyMultiHelloWithErrorsByName func(childComplexity int, reps []*EntityResolverfindManyMultiHelloWithErrorsByNameInput) int
-		FindManyMultiHellosByName          func(childComplexity int, reps []*EntityResolverfindManyMultiHellosByNameInput) int
+		FindManyMultiHelloByNames          func(childComplexity int, reps []*MultiHelloByNamesInput) int
+		FindManyMultiHelloWithErrorByNames func(childComplexity int, reps []*MultiHelloWithErrorByNamesInput) int
 		FindPlanetRequiresByName           func(childComplexity int, name string) int
 		FindWorldByHelloNameAndFoo         func(childComplexity int, helloName string, foo string) int
 		FindWorldNameByName                func(childComplexity int, name string) int
@@ -100,8 +100,8 @@ type ComplexityRoot struct {
 type EntityResolver interface {
 	FindHelloByName(ctx context.Context, name string) (*Hello, error)
 	FindHelloWithErrorsByName(ctx context.Context, name string) (*HelloWithErrors, error)
-	FindManyMultiHellosByName(ctx context.Context, reps []*EntityResolverfindManyMultiHellosByNameInput) ([]*MultiHello, error)
-	FindManyMultiHelloWithErrorsByName(ctx context.Context, reps []*EntityResolverfindManyMultiHelloWithErrorsByNameInput) ([]*MultiHelloWithError, error)
+	FindManyMultiHelloByNames(ctx context.Context, reps []*MultiHelloByNamesInput) ([]*MultiHello, error)
+	FindManyMultiHelloWithErrorByNames(ctx context.Context, reps []*MultiHelloWithErrorByNamesInput) ([]*MultiHelloWithError, error)
 	FindPlanetRequiresByName(ctx context.Context, name string) (*PlanetRequires, error)
 	FindWorldByHelloNameAndFoo(ctx context.Context, helloName string, foo string) (*World, error)
 	FindWorldNameByName(ctx context.Context, name string) (*WorldName, error)
@@ -146,29 +146,29 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Entity.FindHelloWithErrorsByName(childComplexity, args["name"].(string)), true
 
-	case "Entity.findManyMultiHelloWithErrorsByName":
-		if e.complexity.Entity.FindManyMultiHelloWithErrorsByName == nil {
+	case "Entity.findManyMultiHelloByNames":
+		if e.complexity.Entity.FindManyMultiHelloByNames == nil {
 			break
 		}
 
-		args, err := ec.field_Entity_findManyMultiHelloWithErrorsByName_args(context.TODO(), rawArgs)
+		args, err := ec.field_Entity_findManyMultiHelloByNames_args(context.TODO(), rawArgs)
 		if err != nil {
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindManyMultiHelloWithErrorsByName(childComplexity, args["reps"].([]*EntityResolverfindManyMultiHelloWithErrorsByNameInput)), true
+		return e.complexity.Entity.FindManyMultiHelloByNames(childComplexity, args["reps"].([]*MultiHelloByNamesInput)), true
 
-	case "Entity.findManyMultiHellosByName":
-		if e.complexity.Entity.FindManyMultiHellosByName == nil {
+	case "Entity.findManyMultiHelloWithErrorByNames":
+		if e.complexity.Entity.FindManyMultiHelloWithErrorByNames == nil {
 			break
 		}
 
-		args, err := ec.field_Entity_findManyMultiHellosByName_args(context.TODO(), rawArgs)
+		args, err := ec.field_Entity_findManyMultiHelloWithErrorByNames_args(context.TODO(), rawArgs)
 		if err != nil {
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindManyMultiHellosByName(childComplexity, args["reps"].([]*EntityResolverfindManyMultiHellosByNameInput)), true
+		return e.complexity.Entity.FindManyMultiHelloWithErrorByNames(childComplexity, args["reps"].([]*MultiHelloWithErrorByNamesInput)), true
 
 	case "Entity.findPlanetRequiresByName":
 		if e.complexity.Entity.FindPlanetRequiresByName == nil {
@@ -414,10 +414,10 @@ directive @extends on OBJECT | INTERFACE
 	{Name: "federation/entity.graphql", Input: `
 # a union of all types that use the @key directive
 union _Entity = Hello | HelloWithErrors | MultiHello | MultiHelloWithError | PlanetRequires | World | WorldName
-input EntityResolverfindManyMultiHellosByNameInput {
+input MultiHelloByNamesInput {
 	Name: String!
 }
-input EntityResolverfindManyMultiHelloWithErrorsByNameInput {
+input MultiHelloWithErrorByNamesInput {
 	Name: String!
 }
 
@@ -425,8 +425,8 @@ input EntityResolverfindManyMultiHelloWithErrorsByNameInput {
 type Entity {
 		findHelloByName(name: String!,): Hello!
 	findHelloWithErrorsByName(name: String!,): HelloWithErrors!
-	findManyMultiHellosByName(reps: [EntityResolverfindManyMultiHellosByNameInput!]!): [MultiHello]
-	findManyMultiHelloWithErrorsByName(reps: [EntityResolverfindManyMultiHelloWithErrorsByNameInput!]!): [MultiHelloWithError]
+	findManyMultiHelloByNames(reps: [MultiHelloByNamesInput!]!): [MultiHello]
+	findManyMultiHelloWithErrorByNames(reps: [MultiHelloWithErrorByNamesInput!]!): [MultiHelloWithError]
 	findPlanetRequiresByName(name: String!,): PlanetRequires!
 	findWorldByHelloNameAndFoo(helloName: String!,foo: String!,): World!
 	findWorldNameByName(name: String!,): WorldName!
@@ -494,13 +494,13 @@ func (ec *executionContext) field_Entity_findHelloWithErrorsByName_args(ctx cont
 	return args, nil
 }
 
-func (ec *executionContext) field_Entity_findManyMultiHelloWithErrorsByName_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+func (ec *executionContext) field_Entity_findManyMultiHelloByNames_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
-	var arg0 []*EntityResolverfindManyMultiHelloWithErrorsByNameInput
+	var arg0 []*MultiHelloByNamesInput
 	if tmp, ok := rawArgs["reps"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("reps"))
-		arg0, err = ec.unmarshalNEntityResolverfindManyMultiHelloWithErrorsByNameInput2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐEntityResolverfindManyMultiHelloWithErrorsByNameInputᚄ(ctx, tmp)
+		arg0, err = ec.unmarshalNMultiHelloByNamesInput2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐMultiHelloByNamesInputᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -509,13 +509,13 @@ func (ec *executionContext) field_Entity_findManyMultiHelloWithErrorsByName_args
 	return args, nil
 }
 
-func (ec *executionContext) field_Entity_findManyMultiHellosByName_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+func (ec *executionContext) field_Entity_findManyMultiHelloWithErrorByNames_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
-	var arg0 []*EntityResolverfindManyMultiHellosByNameInput
+	var arg0 []*MultiHelloWithErrorByNamesInput
 	if tmp, ok := rawArgs["reps"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("reps"))
-		arg0, err = ec.unmarshalNEntityResolverfindManyMultiHellosByNameInput2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐEntityResolverfindManyMultiHellosByNameInputᚄ(ctx, tmp)
+		arg0, err = ec.unmarshalNMultiHelloWithErrorByNamesInput2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐMultiHelloWithErrorByNamesInputᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -730,7 +730,7 @@ func (ec *executionContext) _Entity_findHelloWithErrorsByName(ctx context.Contex
 	return ec.marshalNHelloWithErrors2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐHelloWithErrors(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Entity_findManyMultiHellosByName(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+func (ec *executionContext) _Entity_findManyMultiHelloByNames(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
@@ -747,7 +747,7 @@ func (ec *executionContext) _Entity_findManyMultiHellosByName(ctx context.Contex
 
 	ctx = graphql.WithFieldContext(ctx, fc)
 	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Entity_findManyMultiHellosByName_args(ctx, rawArgs)
+	args, err := ec.field_Entity_findManyMultiHelloByNames_args(ctx, rawArgs)
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
@@ -756,7 +756,7 @@ func (ec *executionContext) _Entity_findManyMultiHellosByName(ctx context.Contex
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		directive0 := func(rctx context.Context) (interface{}, error) {
 			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Entity().FindManyMultiHellosByName(rctx, args["reps"].([]*EntityResolverfindManyMultiHellosByNameInput))
+			return ec.resolvers.Entity().FindManyMultiHelloByNames(rctx, args["reps"].([]*MultiHelloByNamesInput))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
 			multi, err := ec.unmarshalOBoolean2ᚖbool(ctx, true)
@@ -793,7 +793,7 @@ func (ec *executionContext) _Entity_findManyMultiHellosByName(ctx context.Contex
 	return ec.marshalOMultiHello2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐMultiHello(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Entity_findManyMultiHelloWithErrorsByName(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+func (ec *executionContext) _Entity_findManyMultiHelloWithErrorByNames(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
@@ -810,7 +810,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloWithErrorsByName(ctx conte
 
 	ctx = graphql.WithFieldContext(ctx, fc)
 	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Entity_findManyMultiHelloWithErrorsByName_args(ctx, rawArgs)
+	args, err := ec.field_Entity_findManyMultiHelloWithErrorByNames_args(ctx, rawArgs)
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
@@ -819,7 +819,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloWithErrorsByName(ctx conte
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		directive0 := func(rctx context.Context) (interface{}, error) {
 			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Entity().FindManyMultiHelloWithErrorsByName(rctx, args["reps"].([]*EntityResolverfindManyMultiHelloWithErrorsByNameInput))
+			return ec.resolvers.Entity().FindManyMultiHelloWithErrorByNames(rctx, args["reps"].([]*MultiHelloWithErrorByNamesInput))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
 			multi, err := ec.unmarshalOBoolean2ᚖbool(ctx, true)
@@ -2701,8 +2701,8 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 
 // region    **************************** input.gotpl *****************************
 
-func (ec *executionContext) unmarshalInputEntityResolverfindManyMultiHelloWithErrorsByNameInput(ctx context.Context, obj interface{}) (EntityResolverfindManyMultiHelloWithErrorsByNameInput, error) {
-	var it EntityResolverfindManyMultiHelloWithErrorsByNameInput
+func (ec *executionContext) unmarshalInputMultiHelloByNamesInput(ctx context.Context, obj interface{}) (MultiHelloByNamesInput, error) {
+	var it MultiHelloByNamesInput
 	asMap := map[string]interface{}{}
 	for k, v := range obj.(map[string]interface{}) {
 		asMap[k] = v
@@ -2724,8 +2724,8 @@ func (ec *executionContext) unmarshalInputEntityResolverfindManyMultiHelloWithEr
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputEntityResolverfindManyMultiHellosByNameInput(ctx context.Context, obj interface{}) (EntityResolverfindManyMultiHellosByNameInput, error) {
-	var it EntityResolverfindManyMultiHellosByNameInput
+func (ec *executionContext) unmarshalInputMultiHelloWithErrorByNamesInput(ctx context.Context, obj interface{}) (MultiHelloWithErrorByNamesInput, error) {
+	var it MultiHelloWithErrorByNamesInput
 	asMap := map[string]interface{}{}
 	for k, v := range obj.(map[string]interface{}) {
 		asMap[k] = v
@@ -2878,7 +2878,7 @@ func (ec *executionContext) _Entity(ctx context.Context, sel ast.SelectionSet) g
 			out.Concurrently(i, func() graphql.Marshaler {
 				return rrm(innerCtx)
 			})
-		case "findManyMultiHellosByName":
+		case "findManyMultiHelloByNames":
 			field := field
 
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
@@ -2887,7 +2887,7 @@ func (ec *executionContext) _Entity(ctx context.Context, sel ast.SelectionSet) g
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Entity_findManyMultiHellosByName(ctx, field)
+				res = ec._Entity_findManyMultiHelloByNames(ctx, field)
 				return res
 			}
 
@@ -2898,7 +2898,7 @@ func (ec *executionContext) _Entity(ctx context.Context, sel ast.SelectionSet) g
 			out.Concurrently(i, func() graphql.Marshaler {
 				return rrm(innerCtx)
 			})
-		case "findManyMultiHelloWithErrorsByName":
+		case "findManyMultiHelloWithErrorByNames":
 			field := field
 
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
@@ -2907,7 +2907,7 @@ func (ec *executionContext) _Entity(ctx context.Context, sel ast.SelectionSet) g
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Entity_findManyMultiHelloWithErrorsByName(ctx, field)
+				res = ec._Entity_findManyMultiHelloWithErrorByNames(ctx, field)
 				return res
 			}
 
@@ -3804,58 +3804,6 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 	return res
 }
 
-func (ec *executionContext) unmarshalNEntityResolverfindManyMultiHelloWithErrorsByNameInput2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐEntityResolverfindManyMultiHelloWithErrorsByNameInputᚄ(ctx context.Context, v interface{}) ([]*EntityResolverfindManyMultiHelloWithErrorsByNameInput, error) {
-	var vSlice []interface{}
-	if v != nil {
-		if tmp1, ok := v.([]interface{}); ok {
-			vSlice = tmp1
-		} else {
-			vSlice = []interface{}{v}
-		}
-	}
-	var err error
-	res := make([]*EntityResolverfindManyMultiHelloWithErrorsByNameInput, len(vSlice))
-	for i := range vSlice {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNEntityResolverfindManyMultiHelloWithErrorsByNameInput2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐEntityResolverfindManyMultiHelloWithErrorsByNameInput(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
-}
-
-func (ec *executionContext) unmarshalNEntityResolverfindManyMultiHelloWithErrorsByNameInput2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐEntityResolverfindManyMultiHelloWithErrorsByNameInput(ctx context.Context, v interface{}) (*EntityResolverfindManyMultiHelloWithErrorsByNameInput, error) {
-	res, err := ec.unmarshalInputEntityResolverfindManyMultiHelloWithErrorsByNameInput(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) unmarshalNEntityResolverfindManyMultiHellosByNameInput2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐEntityResolverfindManyMultiHellosByNameInputᚄ(ctx context.Context, v interface{}) ([]*EntityResolverfindManyMultiHellosByNameInput, error) {
-	var vSlice []interface{}
-	if v != nil {
-		if tmp1, ok := v.([]interface{}); ok {
-			vSlice = tmp1
-		} else {
-			vSlice = []interface{}{v}
-		}
-	}
-	var err error
-	res := make([]*EntityResolverfindManyMultiHellosByNameInput, len(vSlice))
-	for i := range vSlice {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNEntityResolverfindManyMultiHellosByNameInput2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐEntityResolverfindManyMultiHellosByNameInput(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
-}
-
-func (ec *executionContext) unmarshalNEntityResolverfindManyMultiHellosByNameInput2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐEntityResolverfindManyMultiHellosByNameInput(ctx context.Context, v interface{}) (*EntityResolverfindManyMultiHellosByNameInput, error) {
-	res, err := ec.unmarshalInputEntityResolverfindManyMultiHellosByNameInput(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
 func (ec *executionContext) marshalNHello2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐHello(ctx context.Context, sel ast.SelectionSet, v Hello) graphql.Marshaler {
 	return ec._Hello(ctx, sel, &v)
 }
@@ -3897,6 +3845,58 @@ func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.Selecti
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNMultiHelloByNamesInput2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐMultiHelloByNamesInputᚄ(ctx context.Context, v interface{}) ([]*MultiHelloByNamesInput, error) {
+	var vSlice []interface{}
+	if v != nil {
+		if tmp1, ok := v.([]interface{}); ok {
+			vSlice = tmp1
+		} else {
+			vSlice = []interface{}{v}
+		}
+	}
+	var err error
+	res := make([]*MultiHelloByNamesInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNMultiHelloByNamesInput2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐMultiHelloByNamesInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalNMultiHelloByNamesInput2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐMultiHelloByNamesInput(ctx context.Context, v interface{}) (*MultiHelloByNamesInput, error) {
+	res, err := ec.unmarshalInputMultiHelloByNamesInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNMultiHelloWithErrorByNamesInput2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐMultiHelloWithErrorByNamesInputᚄ(ctx context.Context, v interface{}) ([]*MultiHelloWithErrorByNamesInput, error) {
+	var vSlice []interface{}
+	if v != nil {
+		if tmp1, ok := v.([]interface{}); ok {
+			vSlice = tmp1
+		} else {
+			vSlice = []interface{}{v}
+		}
+	}
+	var err error
+	res := make([]*MultiHelloWithErrorByNamesInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNMultiHelloWithErrorByNamesInput2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐMultiHelloWithErrorByNamesInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalNMultiHelloWithErrorByNamesInput2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐMultiHelloWithErrorByNamesInput(ctx context.Context, v interface{}) (*MultiHelloWithErrorByNamesInput, error) {
+	res, err := ec.unmarshalInputMultiHelloWithErrorByNamesInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalNPlanetRequires2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚐPlanetRequires(ctx context.Context, sel ast.SelectionSet, v PlanetRequires) graphql.Marshaler {

--- a/plugin/federation/testdata/entityresolver/generated/federation.go
+++ b/plugin/federation/testdata/entityresolver/generated/federation.go
@@ -33,7 +33,43 @@ func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.
 
 func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) []fedruntime.Entity {
 	list := make([]fedruntime.Entity, len(representations))
-	resolveEntity := func(ctx context.Context, i int, rep map[string]interface{}) (err error) {
+
+	repsMap := map[string]struct {
+		i []int
+		r []map[string]interface{}
+	}{}
+
+	// We group entities by typename so that we can parallelize their resolution.
+	// This is particularly helpful when there are entity groups in multi mode.
+	buildRepresentationGroups := func(reps []map[string]interface{}) {
+		for i, rep := range reps {
+			typeName, ok := rep["__typename"].(string)
+			if !ok {
+				// If there is no __typename, we just skip the representation;
+				// we just won't be resolving these unknown types.
+				ec.Error(ctx, errors.New("__typename must be an existing string"))
+				continue
+			}
+
+			_r := repsMap[typeName]
+			_r.i = append(_r.i, i)
+			_r.r = append(_r.r, rep)
+			repsMap[typeName] = _r
+		}
+	}
+
+	isMulti := func(typeName string) bool {
+		switch typeName {
+		case "MultiHello":
+			return true
+		case "MultiHelloWithError":
+			return true
+		default:
+			return false
+		}
+	}
+
+	resolveEntity := func(ctx context.Context, typeName string, rep map[string]interface{}, idx []int, i int) (err error) {
 		// we need to do our own panic handling, because we may be called in a
 		// goroutine, where the usual panic handling can't catch us
 		defer func() {
@@ -42,10 +78,6 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 			}
 		}()
 
-		typeName, ok := rep["__typename"].(string)
-		if !ok {
-			return errors.New("__typename must be an existing string")
-		}
 		switch typeName {
 
 		case "Hello":
@@ -60,7 +92,7 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 				return err
 			}
 
-			list[i] = entity
+			list[idx[i]] = entity
 			return nil
 
 		case "HelloWithErrors":
@@ -75,7 +107,7 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 				return err
 			}
 
-			list[i] = entity
+			list[idx[i]] = entity
 			return nil
 
 		case "PlanetRequires":
@@ -95,7 +127,7 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 				return err
 			}
 
-			list[i] = entity
+			list[idx[i]] = entity
 			return nil
 
 		case "World":
@@ -114,7 +146,7 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 				return err
 			}
 
-			list[i] = entity
+			list[idx[i]] = entity
 			return nil
 
 		case "WorldName":
@@ -129,7 +161,7 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 				return err
 			}
 
-			list[i] = entity
+			list[idx[i]] = entity
 			return nil
 
 		default:
@@ -137,28 +169,111 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 		}
 	}
 
-	// if there are multiple entities to resolve, parallelize (similar to
-	// graphql.FieldSet.Dispatch)
-	switch len(representations) {
+	resolveManyEntities := func(ctx context.Context, typeName string, reps []map[string]interface{}, idx []int) (err error) {
+		// we need to do our own panic handling, because we may be called in a
+		// goroutine, where the usual panic handling can't catch us
+		defer func() {
+			if r := recover(); r != nil {
+				err = ec.Recover(ctx, r)
+			}
+		}()
+
+		switch typeName {
+		case "MultiHello":
+			_reps := make([]*EntityResolverfindManyMultiHellosByNameInput, len(reps))
+
+			for i, rep := range reps {
+				id0, err := ec.unmarshalNString2string(ctx, rep["name"])
+				if err != nil {
+					return errors.New(fmt.Sprintf("Field %s undefined in schema.", "name"))
+				}
+
+				_reps[i] = &EntityResolverfindManyMultiHellosByNameInput{
+					Name: id0,
+				}
+			}
+
+			entities, err := ec.resolvers.Entity().FindManyMultiHellosByName(ctx, _reps)
+			if err != nil {
+				return err
+			}
+
+			for i, entity := range entities {
+				list[idx[i]] = entity
+			}
+		case "MultiHelloWithError":
+			_reps := make([]*EntityResolverfindManyMultiHelloWithErrorsByNameInput, len(reps))
+
+			for i, rep := range reps {
+				id0, err := ec.unmarshalNString2string(ctx, rep["name"])
+				if err != nil {
+					return errors.New(fmt.Sprintf("Field %s undefined in schema.", "name"))
+				}
+
+				_reps[i] = &EntityResolverfindManyMultiHelloWithErrorsByNameInput{
+					Name: id0,
+				}
+			}
+
+			entities, err := ec.resolvers.Entity().FindManyMultiHelloWithErrorsByName(ctx, _reps)
+			if err != nil {
+				return err
+			}
+
+			for i, entity := range entities {
+				list[idx[i]] = entity
+			}
+
+		default:
+			return errors.New("unknown type: " + typeName)
+		}
+
+		return nil
+	}
+
+	resolveEntityGroup := func(typeName string, reps []map[string]interface{}, idx []int) {
+		if isMulti(typeName) {
+			err := resolveManyEntities(ctx, typeName, reps, idx)
+			if err != nil {
+				ec.Error(ctx, err)
+			}
+		} else {
+			// if there are multiple entities to resolve, parallelize (similar to
+			// graphql.FieldSet.Dispatch)
+			var e sync.WaitGroup
+			e.Add(len(reps))
+			for i, rep := range reps {
+				i, rep := i, rep
+				go func(i int, rep map[string]interface{}) {
+					err := resolveEntity(ctx, typeName, rep, idx, i)
+					if err != nil {
+						ec.Error(ctx, err)
+					}
+					e.Done()
+				}(i, rep)
+			}
+			e.Wait()
+		}
+	}
+
+	buildRepresentationGroups(representations)
+
+	switch len(repsMap) {
 	case 0:
 		return list
 	case 1:
-		err := resolveEntity(ctx, 0, representations[0])
-		if err != nil {
-			ec.Error(ctx, err)
+		for typeName, reps := range repsMap {
+			resolveEntityGroup(typeName, reps.r, reps.i)
 		}
 		return list
 	default:
 		var g sync.WaitGroup
-		g.Add(len(representations))
-		for i, rep := range representations {
-			go func(i int, rep map[string]interface{}) {
-				err := resolveEntity(ctx, i, rep)
-				if err != nil {
-					ec.Error(ctx, err)
-				}
+		g.Add(len(repsMap))
+		for typeName, reps := range repsMap {
+			go func(typeName string, reps []map[string]interface{}, idx []int) {
+				resolveEntityGroup(typeName, reps, idx)
 				g.Done()
-			}(i, rep)
+			}(typeName, reps.r, reps.i)
 		}
 		g.Wait()
 		return list

--- a/plugin/federation/testdata/entityresolver/generated/federation.go
+++ b/plugin/federation/testdata/entityresolver/generated/federation.go
@@ -180,7 +180,7 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 
 		switch typeName {
 		case "MultiHello":
-			_reps := make([]*EntityResolverfindManyMultiHellosByNameInput, len(reps))
+			_reps := make([]*MultiHelloByNamesInput, len(reps))
 
 			for i, rep := range reps {
 				id0, err := ec.unmarshalNString2string(ctx, rep["name"])
@@ -188,12 +188,12 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 					return errors.New(fmt.Sprintf("Field %s undefined in schema.", "name"))
 				}
 
-				_reps[i] = &EntityResolverfindManyMultiHellosByNameInput{
+				_reps[i] = &MultiHelloByNamesInput{
 					Name: id0,
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHellosByName(ctx, _reps)
+			entities, err := ec.resolvers.Entity().FindManyMultiHelloByNames(ctx, _reps)
 			if err != nil {
 				return err
 			}
@@ -202,7 +202,7 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 				list[idx[i]] = entity
 			}
 		case "MultiHelloWithError":
-			_reps := make([]*EntityResolverfindManyMultiHelloWithErrorsByNameInput, len(reps))
+			_reps := make([]*MultiHelloWithErrorByNamesInput, len(reps))
 
 			for i, rep := range reps {
 				id0, err := ec.unmarshalNString2string(ctx, rep["name"])
@@ -210,12 +210,12 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 					return errors.New(fmt.Sprintf("Field %s undefined in schema.", "name"))
 				}
 
-				_reps[i] = &EntityResolverfindManyMultiHelloWithErrorsByNameInput{
+				_reps[i] = &MultiHelloWithErrorByNamesInput{
 					Name: id0,
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloWithErrorsByName(ctx, _reps)
+			entities, err := ec.resolvers.Entity().FindManyMultiHelloWithErrorByNames(ctx, _reps)
 			if err != nil {
 				return err
 			}
@@ -278,4 +278,6 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 		g.Wait()
 		return list
 	}
+
+	return list
 }

--- a/plugin/federation/testdata/entityresolver/generated/models.go
+++ b/plugin/federation/testdata/entityresolver/generated/models.go
@@ -2,14 +2,6 @@
 
 package generated
 
-type EntityResolverfindManyMultiHelloWithErrorsByNameInput struct {
-	Name string `json:"Name"`
-}
-
-type EntityResolverfindManyMultiHellosByNameInput struct {
-	Name string `json:"Name"`
-}
-
 type Hello struct {
 	Name      string `json:"name"`
 	Secondary string `json:"secondary"`
@@ -29,11 +21,19 @@ type MultiHello struct {
 
 func (MultiHello) IsEntity() {}
 
+type MultiHelloByNamesInput struct {
+	Name string `json:"Name"`
+}
+
 type MultiHelloWithError struct {
 	Name string `json:"name"`
 }
 
 func (MultiHelloWithError) IsEntity() {}
+
+type MultiHelloWithErrorByNamesInput struct {
+	Name string `json:"Name"`
+}
 
 type PlanetRequires struct {
 	Name     string `json:"name"`

--- a/plugin/federation/testdata/entityresolver/generated/models.go
+++ b/plugin/federation/testdata/entityresolver/generated/models.go
@@ -2,6 +2,14 @@
 
 package generated
 
+type EntityResolverfindManyMultiHelloWithErrorsByNameInput struct {
+	Name string `json:"Name"`
+}
+
+type EntityResolverfindManyMultiHellosByNameInput struct {
+	Name string `json:"Name"`
+}
+
 type Hello struct {
 	Name      string `json:"name"`
 	Secondary string `json:"secondary"`
@@ -14,6 +22,18 @@ type HelloWithErrors struct {
 }
 
 func (HelloWithErrors) IsEntity() {}
+
+type MultiHello struct {
+	Name string `json:"name"`
+}
+
+func (MultiHello) IsEntity() {}
+
+type MultiHelloWithError struct {
+	Name string `json:"name"`
+}
+
+func (MultiHelloWithError) IsEntity() {}
 
 type PlanetRequires struct {
 	Name     string `json:"name"`

--- a/plugin/federation/testdata/entityresolver/schema.graphql
+++ b/plugin/federation/testdata/entityresolver/schema.graphql
@@ -1,3 +1,5 @@
+directive @entityResolver(multi: Boolean) on OBJECT
+
 type Hello @key(fields: "name") {
     name: String!
     secondary: String!
@@ -23,7 +25,10 @@ type PlanetRequires @key(fields: "name") {
     diameter: Int!
 }
 
-type Query {
-    hello: Hello!
-    world: World!
+type MultiHello @key(fields: "name") @entityResolver(multi: true) {
+    name: String!
+}
+
+type MultiHelloWithError @key(fields: "name") @entityResolver(multi: true) {
+    name: String!
 }

--- a/plugin/federation/testdata/entityresolver/schema.resolvers.go
+++ b/plugin/federation/testdata/entityresolver/schema.resolvers.go
@@ -2,23 +2,3 @@ package entityresolver
 
 // This file will be automatically regenerated based on the schema, any resolver implementations
 // will be copied through when generating and any unknown code will be moved to the end.
-
-import (
-	"context"
-	"fmt"
-
-	"github.com/99designs/gqlgen/plugin/federation/testdata/entityresolver/generated"
-)
-
-func (r *queryResolver) Hello(ctx context.Context) (*generated.Hello, error) {
-	panic(fmt.Errorf("not implemented"))
-}
-
-func (r *queryResolver) World(ctx context.Context) (*generated.World, error) {
-	panic(fmt.Errorf("not implemented"))
-}
-
-// Query returns generated.QueryResolver implementation.
-func (r *Resolver) Query() generated.QueryResolver { return &queryResolver{r} }
-
-type queryResolver struct{ *Resolver }


### PR DESCRIPTION
Entity resolver functions can only process one entity at a time. But often we want to resolve all the entities at once so that we can optimize things like database calls. And to do that you need to add you'd need to add batching with abstractions like dataloadgen or batchloader. The drawback here is that the resolver code (the domain logic) gets more complex to implement, test, and debug.

An alternative is to have entity resolvers that can process all the representations in a single call so that domain logic can have access to all the representations up front, which is what Im adding in this PR.

There are a few moving pieces here:
1. We need to define the directive `directive @entityResolver(multi: Boolean) on OBJECT`.
2. Then federated entities need to be annotated to enable the functionality.  E.g. `type MultiHello @key(fields: "name") @entityResolver(multi: true)`
3. When that's configured, the federation plugin will create an entity resolver that will take a list of representations.

Please note that this is very specific to federation and entity resolvers. This does not add support for resolving fields in an entity.

Some of the implementation details worth noting. In order to efficiently process batches of entities, I group them by type so that we can process groups of entities at the same time. The resolution of groups of entities run concurrently in Go routines.  If there is _only_ one type, then that's just processed without concurrency. Entities that don't have multiget enabled will still continue to resolve concurrently with Go routines, and entities that have multiget enabled just get the entire list of representations.

The list of representations that are passed to entity resolvers are strongly types, and the type is generated for you.

There are lots of new tests to ensure that there are no regressions and that the new functionality still functions as expected. To test:
1. Go to `plugin/federation`
2. Generate files with `go run github.com/99designs/gqlgen --config testdata/entityresolver/gqlgen.yml`
3. And run `go test ./...`. Verify they all pass.

You can look at the federated code in [`plugin/federation/testdata/entityresolver/gederated/federation.go`](https://github.com/99designs/gqlgen/blob/2bad1b6cb29671da3cf77f399f7e8c3969fa6a6d/plugin/federation/testdata/entityresolver/generated/federation.go)

Describe your PR and link to any relevant issues. 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

https://github.com/99designs/gqlgen/issues/1686