### PR TITLE
Optimize performance for binder, imports and packages (Rebased from sbalabanov/master)

### DIFF
--- a/api/option_test.go
+++ b/api/option_test.go
@@ -11,8 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type testPlugin struct {
-}
+type testPlugin struct{}
 
 // Name returns the plugin name
 func (t *testPlugin) Name() string {
@@ -25,7 +24,6 @@ func (t *testPlugin) MutateConfig(_ *config.Config) error {
 }
 
 func TestReplacePlugin(t *testing.T) {
-
 	t.Run("replace plugin if exists", func(t *testing.T) {
 		pg := []plugin.Plugin{
 			federation.New(),
@@ -54,5 +52,4 @@ func TestReplacePlugin(t *testing.T) {
 		require.EqualValues(t, resolvergen.New(), pg[1])
 		require.EqualValues(t, expectedPlugin, pg[2])
 	})
-
 }

--- a/client/websocket.go
+++ b/client/websocket.go
@@ -64,7 +64,6 @@ func (p *Client) WebsocketWithPayload(query string, initPayload map[string]inter
 	srv := httptest.NewServer(p.h)
 	host := strings.ReplaceAll(srv.URL, "http://", "ws://")
 	c, _, err := websocket.DefaultDialer.Dial(host+r.URL.Path, r.Header)
-
 	if err != nil {
 		return errorSubscription(fmt.Errorf("dial: %w", err))
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -187,10 +187,10 @@ func fileExists(filename string) bool {
 }
 
 func initFile(filename, contents string) error {
-	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filename), 0o755); err != nil {
 		return fmt.Errorf("unable to create directory for file '%s': %w\n", filename, err)
 	}
-	if err := ioutil.WriteFile(filename, []byte(contents), 0644); err != nil {
+	if err := ioutil.WriteFile(filename, []byte(contents), 0o644); err != nil {
 		return fmt.Errorf("unable to write file '%s': %w\n", filename, err)
 	}
 

--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"go/token"
 	"go/types"
+
 	"golang.org/x/tools/go/packages"
 
 	"github.com/99designs/gqlgen/codegen/templates"
@@ -80,8 +81,10 @@ func (b *Binder) FindType(pkgName string, typeName string) (types.Type, error) {
 	return obj.Type(), nil
 }
 
-var MapType = types.NewMap(types.Typ[types.String], types.NewInterfaceType(nil, nil).Complete())
-var InterfaceType = types.NewInterfaceType(nil, nil)
+var (
+	MapType       = types.NewMap(types.Typ[types.String], types.NewInterfaceType(nil, nil).Complete())
+	InterfaceType = types.NewInterfaceType(nil, nil)
+)
 
 func (b *Binder) DefaultUserObject(name string) (types.Type, error) {
 	models := b.cfg.Models[name].Model
@@ -147,7 +150,6 @@ func (b *Binder) FindObject(pkgName string, typeName string) (types.Object, erro
 }
 
 func indexDefs(pkg *packages.Package) map[string]types.Object {
-
 	res := make(map[string]types.Object)
 
 	scope := pkg.Types.Scope()
@@ -255,12 +257,12 @@ func (t *TypeReference) IsScalar() bool {
 }
 
 func (t *TypeReference) UniquenessKey() string {
-	var nullability = "O"
+	nullability := "O"
 	if t.GQL.NonNull {
 		nullability = "N"
 	}
 
-	var elemNullability = ""
+	elemNullability := ""
 	if t.GQL.Elem != nil && t.GQL.Elem.NonNull {
 		// Fix for #896
 		elemNullability = "ᚄ"

--- a/codegen/config/config_test.go
+++ b/codegen/config/config_test.go
@@ -128,7 +128,6 @@ func TestReferencedPackages(t *testing.T) {
 
 		assert.Equal(t, []string{"github.com/test", "github.com/otherpkg"}, pkgs)
 	})
-
 }
 
 func TestConfigCheck(t *testing.T) {

--- a/codegen/templates/import_test.go
+++ b/codegen/templates/import_test.go
@@ -54,7 +54,6 @@ func TestImports(t *testing.T) {
 				require.Equal(t, fmt.Sprintf("bar%d", i), a.Lookup(cBar))
 			} else {
 				require.Equal(t, "bar", a.Lookup(cBar))
-
 			}
 		}
 	})
@@ -89,5 +88,4 @@ turtles "github.com/99designs/gqlgen/codegen/templates/testdata/pkg_mismatch"`,
 		require.Equal(t, `abar "github.com/99designs/gqlgen/codegen/templates/testdata/a/bar"
 bbar "github.com/99designs/gqlgen/codegen/templates/testdata/b/bar"`, a.String())
 	})
-
 }

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -589,7 +589,7 @@ func render(filename string, tpldata interface{}) (*bytes.Buffer, error) {
 }
 
 func write(filename string, b []byte, packages *code.Packages) error {
-	err := os.MkdirAll(filepath.Dir(filename), 0755)
+	err := os.MkdirAll(filepath.Dir(filename), 0o755)
 	if err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
@@ -600,7 +600,7 @@ func write(filename string, b []byte, packages *code.Packages) error {
 		formatted = b
 	}
 
-	err = ioutil.WriteFile(filename, formatted, 0644)
+	err = ioutil.WriteFile(filename, formatted, 0o644)
 	if err != nil {
 		return fmt.Errorf("failed to write %s: %w", filename, err)
 	}

--- a/codegen/templates/templates_test.go
+++ b/codegen/templates/templates_test.go
@@ -70,7 +70,6 @@ func TestToGoPrivate(t *testing.T) {
 }
 
 func Test_wordWalker(t *testing.T) {
-
 	helper := func(str string) []*wordInfo {
 		resultList := []*wordInfo{}
 		wordWalker(str, func(info *wordInfo) {

--- a/codegen/testserver/followschema/middleware_test.go
+++ b/codegen/testserver/followschema/middleware_test.go
@@ -106,5 +106,4 @@ func TestMiddleware(t *testing.T) {
 
 	require.NoError(t, err)
 	require.True(t, called)
-
 }

--- a/codegen/testserver/followschema/models.go
+++ b/codegen/testserver/followschema/models.go
@@ -10,8 +10,7 @@ type ForcedResolver struct {
 	Field Circle
 }
 
-type ModelMethods struct {
-}
+type ModelMethods struct{}
 
 func (m ModelMethods) NoContext() bool {
 	return true
@@ -58,8 +57,7 @@ func (m MarshalPanic) MarshalGQL(w io.Writer) {
 	panic("BOOM")
 }
 
-type Panics struct {
-}
+type Panics struct{}
 
 func (p *Panics) FieldFuncMarshal(ctx context.Context, u []MarshalPanic) []MarshalPanic {
 	return []MarshalPanic{MarshalPanic("aa"), MarshalPanic("bb")}

--- a/codegen/testserver/followschema/ptr_to_slice_test.go
+++ b/codegen/testserver/followschema/ptr_to_slice_test.go
@@ -32,6 +32,5 @@ func TestPtrToSlice(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, []string{"hello"}, resp.PtrToSliceContainer.PtrToSlice)
-
 	})
 }

--- a/codegen/testserver/followschema/scalar_context.go
+++ b/codegen/testserver/followschema/scalar_context.go
@@ -12,13 +12,16 @@ type StringFromContextInterface struct {
 	OperationName string
 }
 
-var _ graphql.ContextMarshaler = StringFromContextInterface{}
-var _ graphql.ContextUnmarshaler = (*StringFromContextInterface)(nil)
+var (
+	_ graphql.ContextMarshaler   = StringFromContextInterface{}
+	_ graphql.ContextUnmarshaler = (*StringFromContextInterface)(nil)
+)
 
 func (StringFromContextInterface) MarshalGQLContext(ctx context.Context, w io.Writer) error {
 	io.WriteString(w, strconv.Quote(graphql.GetFieldContext(ctx).Field.Name))
 	return nil
 }
+
 func (i *StringFromContextInterface) UnmarshalGQLContext(ctx context.Context, v interface{}) error {
 	i.OperationName = graphql.GetFieldContext(ctx).Field.Name
 	return nil

--- a/codegen/testserver/followschema/scalar_context_test.go
+++ b/codegen/testserver/followschema/scalar_context_test.go
@@ -23,7 +23,6 @@ func TestFloatInfAndNaN(t *testing.T) {
 		err := c.Post(`query { infinity }`, nil)
 		require.Error(t, err)
 	})
-
 }
 
 func TestContextPassedToMarshal(t *testing.T) {

--- a/codegen/testserver/followschema/v-ok.go
+++ b/codegen/testserver/followschema/v-ok.go
@@ -1,16 +1,14 @@
 package followschema
 
 // VOkCaseValue model
-type VOkCaseValue struct {
-}
+type VOkCaseValue struct{}
 
 func (v VOkCaseValue) Value() (string, bool) {
 	return "hi", true
 }
 
 // VOkCaseNil model
-type VOkCaseNil struct {
-}
+type VOkCaseNil struct{}
 
 func (v VOkCaseNil) Value() (string, bool) {
 	return "", false

--- a/codegen/testserver/followschema/wrapped_type.go
+++ b/codegen/testserver/followschema/wrapped_type.go
@@ -2,7 +2,9 @@ package followschema
 
 import "github.com/99designs/gqlgen/codegen/testserver/followschema/otherpkg"
 
-type WrappedScalar = otherpkg.Scalar
-type WrappedStruct otherpkg.Struct
-type WrappedMap otherpkg.Map
-type WrappedSlice otherpkg.Slice
+type (
+	WrappedScalar = otherpkg.Scalar
+	WrappedStruct otherpkg.Struct
+	WrappedMap    otherpkg.Map
+	WrappedSlice  otherpkg.Slice
+)

--- a/codegen/testserver/singlefile/middleware_test.go
+++ b/codegen/testserver/singlefile/middleware_test.go
@@ -106,5 +106,4 @@ func TestMiddleware(t *testing.T) {
 
 	require.NoError(t, err)
 	require.True(t, called)
-
 }

--- a/codegen/testserver/singlefile/models.go
+++ b/codegen/testserver/singlefile/models.go
@@ -10,8 +10,7 @@ type ForcedResolver struct {
 	Field Circle
 }
 
-type ModelMethods struct {
-}
+type ModelMethods struct{}
 
 func (m ModelMethods) NoContext() bool {
 	return true
@@ -58,8 +57,7 @@ func (m MarshalPanic) MarshalGQL(w io.Writer) {
 	panic("BOOM")
 }
 
-type Panics struct {
-}
+type Panics struct{}
 
 func (p *Panics) FieldFuncMarshal(ctx context.Context, u []MarshalPanic) []MarshalPanic {
 	return []MarshalPanic{MarshalPanic("aa"), MarshalPanic("bb")}

--- a/codegen/testserver/singlefile/ptr_to_slice_test.go
+++ b/codegen/testserver/singlefile/ptr_to_slice_test.go
@@ -32,6 +32,5 @@ func TestPtrToSlice(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, []string{"hello"}, resp.PtrToSliceContainer.PtrToSlice)
-
 	})
 }

--- a/codegen/testserver/singlefile/scalar_context.go
+++ b/codegen/testserver/singlefile/scalar_context.go
@@ -12,13 +12,16 @@ type StringFromContextInterface struct {
 	OperationName string
 }
 
-var _ graphql.ContextMarshaler = StringFromContextInterface{}
-var _ graphql.ContextUnmarshaler = (*StringFromContextInterface)(nil)
+var (
+	_ graphql.ContextMarshaler   = StringFromContextInterface{}
+	_ graphql.ContextUnmarshaler = (*StringFromContextInterface)(nil)
+)
 
 func (StringFromContextInterface) MarshalGQLContext(ctx context.Context, w io.Writer) error {
 	io.WriteString(w, strconv.Quote(graphql.GetFieldContext(ctx).Field.Name))
 	return nil
 }
+
 func (i *StringFromContextInterface) UnmarshalGQLContext(ctx context.Context, v interface{}) error {
 	i.OperationName = graphql.GetFieldContext(ctx).Field.Name
 	return nil

--- a/codegen/testserver/singlefile/scalar_context_test.go
+++ b/codegen/testserver/singlefile/scalar_context_test.go
@@ -23,7 +23,6 @@ func TestFloatInfAndNaN(t *testing.T) {
 		err := c.Post(`query { infinity }`, nil)
 		require.Error(t, err)
 	})
-
 }
 
 func TestContextPassedToMarshal(t *testing.T) {

--- a/codegen/testserver/singlefile/v-ok.go
+++ b/codegen/testserver/singlefile/v-ok.go
@@ -1,16 +1,14 @@
 package singlefile
 
 // VOkCaseValue model
-type VOkCaseValue struct {
-}
+type VOkCaseValue struct{}
 
 func (v VOkCaseValue) Value() (string, bool) {
 	return "hi", true
 }
 
 // VOkCaseNil model
-type VOkCaseNil struct {
-}
+type VOkCaseNil struct{}
 
 func (v VOkCaseNil) Value() (string, bool) {
 	return "", false

--- a/codegen/testserver/singlefile/wrapped_type.go
+++ b/codegen/testserver/singlefile/wrapped_type.go
@@ -2,7 +2,9 @@ package singlefile
 
 import "github.com/99designs/gqlgen/codegen/testserver/singlefile/otherpkg"
 
-type WrappedScalar = otherpkg.Scalar
-type WrappedStruct otherpkg.Struct
-type WrappedMap otherpkg.Map
-type WrappedSlice otherpkg.Slice
+type (
+	WrappedScalar = otherpkg.Scalar
+	WrappedStruct otherpkg.Struct
+	WrappedMap    otherpkg.Map
+	WrappedSlice  otherpkg.Slice
+)

--- a/example/dataloader/dataloader_test.go
+++ b/example/dataloader/dataloader_test.go
@@ -84,5 +84,4 @@ func TestTodo(t *testing.T) {
 
 		require.EqualError(t, err, "[{\"message\":\"map[string]interface {} is not an int\",\"path\":[\"torture2d\",\"customerIds\",0,0]}]")
 	})
-
 }

--- a/example/dataloader/resolvers.go
+++ b/example/dataloader/resolvers.go
@@ -14,6 +14,7 @@ type Customer struct {
 	Name      string `json:"name"`
 	AddressID int
 }
+
 type Order struct {
 	ID     int       `json:"id"`
 	Date   time.Time `json:"date"`

--- a/example/scalars/resolvers.go
+++ b/example/scalars/resolvers.go
@@ -11,8 +11,7 @@ import (
 	"github.com/99designs/gqlgen/example/scalars/model"
 )
 
-type Resolver struct {
-}
+type Resolver struct{}
 
 func (r *Resolver) Query() QueryResolver {
 	return &queryResolver{r}

--- a/example/todo/todo.go
+++ b/example/todo/todo.go
@@ -12,8 +12,10 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-var you = &User{ID: 1, Name: "You"}
-var them = &User{ID: 2, Name: "Them"}
+var (
+	you  = &User{ID: 1, Name: "You"}
+	them = &User{ID: 2, Name: "Them"}
+)
 
 type ckey string
 

--- a/graphql/context_field_test.go
+++ b/graphql/context_field_test.go
@@ -16,7 +16,6 @@ func TestGetResolverContext(t *testing.T) {
 }
 
 func testContext(sel ast.SelectionSet) context.Context {
-
 	ctx := context.Background()
 
 	rqCtx := &OperationContext{}

--- a/graphql/errcode/codes.go
+++ b/graphql/errcode/codes.go
@@ -4,8 +4,10 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
-const ValidationFailed = "GRAPHQL_VALIDATION_FAILED"
-const ParseFailed = "GRAPHQL_PARSE_FAILED"
+const (
+	ValidationFailed = "GRAPHQL_VALIDATION_FAILED"
+	ParseFailed      = "GRAPHQL_PARSE_FAILED"
+)
 
 type ErrorKind int
 

--- a/graphql/executor/executor_test.go
+++ b/graphql/executor/executor_test.go
@@ -214,7 +214,6 @@ func query(exec *testexecutor.TestExecutor, op, q string) *graphql.Response {
 			End:   now,
 		},
 	})
-
 	if err != nil {
 		return exec.DispatchError(ctx, err)
 	}

--- a/graphql/executor/testexecutor/testexecutor.go
+++ b/graphql/executor/testexecutor/testexecutor.go
@@ -25,7 +25,6 @@ func (mr *MockResponse) UnmarshalGQL(v interface{}) error {
 func (mr *MockResponse) MarshalGQL(w io.Writer) {
 	buf := new(bytes.Buffer)
 	err := json.NewEncoder(buf).Encode(mr)
-
 	if err != nil {
 		panic(err)
 	}
@@ -84,7 +83,6 @@ func New() *TestExecutor {
 							// return &graphql.Response{Data: []byte(`{"name":"test"}`)}, nil
 							return &MockResponse{Name: "test"}, nil
 						})
-
 						if err != nil {
 							panic(err)
 						}

--- a/graphql/handler/debug/tracer.go
+++ b/graphql/handler/debug/tracer.go
@@ -67,5 +67,4 @@ func (a Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 	fmt.Fprintln(a.out, "}")
 	fmt.Fprintln(a.out)
 	return resp
-
 }

--- a/graphql/handler/extension/apq.go
+++ b/graphql/handler/extension/apq.go
@@ -14,8 +14,10 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-const errPersistedQueryNotFound = "PersistedQueryNotFound"
-const errPersistedQueryNotFoundCode = "PERSISTED_QUERY_NOT_FOUND"
+const (
+	errPersistedQueryNotFound     = "PersistedQueryNotFound"
+	errPersistedQueryNotFoundCode = "PERSISTED_QUERY_NOT_FOUND"
+)
 
 // AutomaticPersistedQuery saves client upload by optimistically sending only the hashes of queries, if the server
 // does not yet know what the query is for the hash it will respond telling the client to send the query along with the

--- a/graphql/handler/transport/http_form.go
+++ b/graphql/handler/transport/http_form.go
@@ -83,7 +83,7 @@ func (f MultipartForm) Do(w http.ResponseWriter, r *http.Request, exec graphql.G
 		return
 	}
 
-	var uploadsMap = map[string][]string{}
+	uploadsMap := map[string][]string{}
 	if err = json.Unmarshal([]byte(r.Form.Get("map")), &uploadsMap); err != nil {
 		w.WriteHeader(http.StatusUnprocessableEntity)
 		writeJsonError(w, "map form field could not be decoded")

--- a/graphql/handler/transport/http_get_test.go
+++ b/graphql/handler/transport/http_get_test.go
@@ -47,5 +47,4 @@ func TestGET(t *testing.T) {
 		assert.Equal(t, http.StatusNotAcceptable, resp.Code, resp.Body.String())
 		assert.Equal(t, `{"errors":[{"message":"GET requests only allow query operations"}],"data":null}`, resp.Body.String())
 	})
-
 }

--- a/graphql/handler/transport/websocket_graphql_transport_ws.go
+++ b/graphql/handler/transport/websocket_graphql_transport_ws.go
@@ -19,16 +19,14 @@ const (
 	graphqltransportwsCompleteMsg       = graphqltransportwsMessageType("complete")
 )
 
-var (
-	allGraphqltransportwsMessageTypes = []graphqltransportwsMessageType{
-		graphqltransportwsConnectionInitMsg,
-		graphqltransportwsConnectionAckMsg,
-		graphqltransportwsSubscribeMsg,
-		graphqltransportwsNextMsg,
-		graphqltransportwsErrorMsg,
-		graphqltransportwsCompleteMsg,
-	}
-)
+var allGraphqltransportwsMessageTypes = []graphqltransportwsMessageType{
+	graphqltransportwsConnectionInitMsg,
+	graphqltransportwsConnectionAckMsg,
+	graphqltransportwsSubscribeMsg,
+	graphqltransportwsNextMsg,
+	graphqltransportwsErrorMsg,
+	graphqltransportwsCompleteMsg,
+}
 
 type (
 	graphqltransportwsMessageExchanger struct {

--- a/graphql/handler/transport/websocket_graphqlws.go
+++ b/graphql/handler/transport/websocket_graphqlws.go
@@ -23,20 +23,18 @@ const (
 	graphqlwsConnectionKeepAliveMsg = graphqlwsMessageType("ka")
 )
 
-var (
-	allGraphqlwsMessageTypes = []graphqlwsMessageType{
-		graphqlwsConnectionInitMsg,
-		graphqlwsConnectionTerminateMsg,
-		graphqlwsStartMsg,
-		graphqlwsStopMsg,
-		graphqlwsConnectionAckMsg,
-		graphqlwsConnectionErrorMsg,
-		graphqlwsDataMsg,
-		graphqlwsErrorMsg,
-		graphqlwsCompleteMsg,
-		graphqlwsConnectionKeepAliveMsg,
-	}
-)
+var allGraphqlwsMessageTypes = []graphqlwsMessageType{
+	graphqlwsConnectionInitMsg,
+	graphqlwsConnectionTerminateMsg,
+	graphqlwsStartMsg,
+	graphqlwsStopMsg,
+	graphqlwsConnectionAckMsg,
+	graphqlwsConnectionErrorMsg,
+	graphqlwsDataMsg,
+	graphqlwsErrorMsg,
+	graphqlwsCompleteMsg,
+	graphqlwsConnectionKeepAliveMsg,
+}
 
 type (
 	graphqlwsMessageExchanger struct {

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -141,7 +141,6 @@ func TestWebsocket(t *testing.T) {
 }
 
 func TestWebsocketWithKeepAlive(t *testing.T) {
-
 	h := testserver.New()
 	h.AddTransport(transport.Websocket{
 		KeepAlivePingInterval: 100 * time.Millisecond,
@@ -318,7 +317,6 @@ func TestWebsocketGraphqltransportwsSubprotocol(t *testing.T) {
 }
 
 func wsConnect(url string) *websocket.Conn {
-
 	return wsConnectWithSubprocotol(url, "")
 }
 

--- a/graphql/id.go
+++ b/graphql/id.go
@@ -10,6 +10,7 @@ import (
 func MarshalID(s string) Marshaler {
 	return MarshalString(s)
 }
+
 func UnmarshalID(v interface{}) (string, error) {
 	switch v := v.(type) {
 	case string:

--- a/graphql/jsonw.go
+++ b/graphql/jsonw.go
@@ -5,19 +5,23 @@ import (
 	"io"
 )
 
-var nullLit = []byte(`null`)
-var trueLit = []byte(`true`)
-var falseLit = []byte(`false`)
-var openBrace = []byte(`{`)
-var closeBrace = []byte(`}`)
-var openBracket = []byte(`[`)
-var closeBracket = []byte(`]`)
-var colon = []byte(`:`)
-var comma = []byte(`,`)
+var (
+	nullLit      = []byte(`null`)
+	trueLit      = []byte(`true`)
+	falseLit     = []byte(`false`)
+	openBrace    = []byte(`{`)
+	closeBrace   = []byte(`}`)
+	openBracket  = []byte(`[`)
+	closeBracket = []byte(`]`)
+	colon        = []byte(`:`)
+	comma        = []byte(`,`)
+)
 
-var Null = &lit{nullLit}
-var True = &lit{trueLit}
-var False = &lit{falseLit}
+var (
+	Null  = &lit{nullLit}
+	True  = &lit{trueLit}
+	False = &lit{falseLit}
+)
 
 type Marshaler interface {
 	MarshalGQL(w io.Writer)

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -229,6 +229,7 @@ type apqAdapter struct {
 func (a apqAdapter) Get(ctx context.Context, key string) (value interface{}, ok bool) {
 	return a.PersistedQueryCache.Get(ctx, key)
 }
+
 func (a apqAdapter) Add(ctx context.Context, key string, value interface{}) {
 	a.PersistedQueryCache.Add(ctx, key, value.(string))
 }

--- a/internal/code/compare.go
+++ b/internal/code/compare.go
@@ -7,7 +7,6 @@ import (
 
 // CompatibleTypes isnt a strict comparison, it allows for pointer differences
 func CompatibleTypes(expected types.Type, actual types.Type) error {
-
 	// Special case to deal with pointer mismatches
 	{
 		expectedPtr, expectedIsPtr := expected.(*types.Pointer)

--- a/internal/code/imports.go
+++ b/internal/code/imports.go
@@ -45,6 +45,14 @@ func NameForDir(dir string) string {
 	return SanitizePackageName(filepath.Base(dir))
 }
 
+type goModuleSearchResult struct {
+	path       string
+	goModPath  string
+	moduleName string
+}
+
+var goModuleRootCache = map[string]goModuleSearchResult{}
+
 // goModuleRoot returns the root of the current go module if there is a go.mod file in the directory tree
 // If not, it returns false
 func goModuleRoot(dir string) (string, bool) {
@@ -53,28 +61,69 @@ func goModuleRoot(dir string) (string, bool) {
 		panic(err)
 	}
 	dir = filepath.ToSlash(dir)
-	modDir := dir
-	assumedPart := ""
+
+	var dirs = []string{dir}
+	result := goModuleSearchResult{}
+
 	for {
-		f, err := ioutil.ReadFile(filepath.Join(modDir, "go.mod"))
-		if err == nil {
-			// found it, stop searching
-			return string(modregex.FindSubmatch(f)[1]) + assumedPart, true
-		}
+		modDir := dirs[len(dirs)-1]
 
-		assumedPart = "/" + filepath.Base(modDir) + assumedPart
-		parentDir, err := filepath.Abs(filepath.Join(modDir, ".."))
-		if err != nil {
-			panic(err)
-		}
-
-		if parentDir == modDir {
-			// Walked all the way to the root and didnt find anything :'(
+		if val, ok := goModuleRootCache[dir]; ok {
+			result = val
 			break
 		}
-		modDir = parentDir
+
+		if content, err := ioutil.ReadFile(filepath.Join(modDir, "go.mod")); err == nil {
+			moduleName := string(modregex.FindSubmatch(content)[1])
+			result = goModuleSearchResult{
+				path:       moduleName,
+				goModPath:  modDir,
+				moduleName: moduleName,
+			}
+			goModuleRootCache[modDir] = result
+			break
+		}
+
+		if modDir == "" || modDir == "." || modDir == "/" || strings.HasSuffix(modDir, "\\") {
+			// Reached the top of the file tree which means go.mod file is not found
+			// Set root folder with a sentinel cache value
+			goModuleRootCache[modDir] = result
+			break
+		}
+
+		dirs = append(dirs, filepath.Dir(modDir))
 	}
-	return "", false
+
+	// create a cache for each path in a tree traversed, except the top one as it is already cached
+	for _, d := range dirs[:len(dirs)-1] {
+		if result.moduleName == "" {
+			// go.mod is not found in the tree, so the same sentinel value fits all the directories in a tree
+			goModuleRootCache[d] = result
+		} else {
+			if relPath, err := filepath.Rel(result.goModPath, d); err != nil {
+				panic(err)
+			} else {
+				path := result.moduleName
+				relPath := filepath.ToSlash(relPath)
+				if !strings.HasSuffix(relPath, "/") {
+					path += "/"
+				}
+				path += relPath
+
+				goModuleRootCache[d] = goModuleSearchResult{
+					path:       path,
+					goModPath:  result.goModPath,
+					moduleName: result.moduleName,
+				}
+			}
+		}
+	}
+
+	res := goModuleRootCache[dir]
+	if res.moduleName == "" {
+		return "", false
+	}
+	return res.path, true
 }
 
 // ImportPathForDir takes a path and returns a golang import path for the package

--- a/internal/code/imports.go
+++ b/internal/code/imports.go
@@ -62,7 +62,7 @@ func goModuleRoot(dir string) (string, bool) {
 	}
 	dir = filepath.ToSlash(dir)
 
-	var dirs = []string{dir}
+	dirs := []string{dir}
 	result := goModuleSearchResult{}
 
 	for {
@@ -129,7 +129,6 @@ func goModuleRoot(dir string) (string, bool) {
 // ImportPathForDir takes a path and returns a golang import path for the package
 func ImportPathForDir(dir string) (res string) {
 	dir, err := filepath.Abs(dir)
-
 	if err != nil {
 		panic(err)
 	}

--- a/internal/code/packages.go
+++ b/internal/code/packages.go
@@ -190,6 +190,10 @@ func (p *Packages) Errors() PkgErrors {
 	return res
 }
 
+func (p *Packages) Count() int {
+	return len(p.packages)
+}
+
 type PkgErrors []error
 
 func (p PkgErrors) Error() string {

--- a/internal/code/packages.go
+++ b/internal/code/packages.go
@@ -83,6 +83,13 @@ func (p *Packages) addToCache(pkg *packages.Package) {
 
 // Load works the same as LoadAll, except a single package at a time.
 func (p *Packages) Load(importPath string) *packages.Package {
+	// Quick cache check first to avoid expensive allocations of LoadAll()
+	if p.packages != nil {
+		if pkg, ok := p.packages[importPath]; ok {
+			return pkg
+		}
+	}
+
 	pkgs := p.LoadAll(importPath)
 	if len(pkgs) == 0 {
 		return nil

--- a/internal/rewrite/rewriter_test.go
+++ b/internal/rewrite/rewriter_test.go
@@ -35,7 +35,6 @@ func TestRewriter(t *testing.T) {
 				ImportPath: "bytes",
 			},
 		}, imps)
-
 	})
 
 	t.Run("out of scope dir", func(t *testing.T) {

--- a/plugin/federation/federation_entityresolver_test.go
+++ b/plugin/federation/federation_entityresolver_test.go
@@ -17,7 +17,8 @@ import (
 func TestEntityResolver(t *testing.T) {
 	c := client.New(handler.NewDefaultServer(
 		generated.NewExecutableSchema(generated.Config{
-			Resolvers: &entityresolver.Resolver{}}),
+			Resolvers: &entityresolver.Resolver{},
+		}),
 	))
 
 	t.Run("Hello entities", func(t *testing.T) {
@@ -234,7 +235,8 @@ func TestEntityResolver(t *testing.T) {
 func TestMultiEntityResolver(t *testing.T) {
 	c := client.New(handler.NewDefaultServer(
 		generated.NewExecutableSchema(generated.Config{
-			Resolvers: &entityresolver.Resolver{}}),
+			Resolvers: &entityresolver.Resolver{},
+		}),
 	))
 
 	t.Run("MultiHello entities", func(t *testing.T) {

--- a/plugin/federation/fieldset/fieldset_test.go
+++ b/plugin/federation/fieldset/fieldset_test.go
@@ -58,7 +58,6 @@ func TestWithPrefix(t *testing.T) {
 }
 
 func TestInvalid(t *testing.T) {
-
 	require.Panics(t, func() {
 		New("foo bar{baz", nil)
 	})

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -20,6 +20,7 @@ type FieldMutateHook = func(td *ast.Definition, fd *ast.FieldDefinition, f *Fiel
 func defaultFieldMutateHook(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Field, error) {
 	return GoTagFieldHook(td, fd, f)
 }
+
 func defaultBuildMutateHook(b *ModelBuild) *ModelBuild {
 	return b
 }

--- a/plugin/resolvergen/resolver_test.go
+++ b/plugin/resolvergen/resolver_test.go
@@ -55,7 +55,6 @@ func TestLayoutFollowSchemaWithCustomFilename(t *testing.T) {
 }
 
 func TestLayoutInvalidModelPath(t *testing.T) {
-
 	cfg, err := config.LoadConfig("testdata/invalid_model_path/gqlgen.yml")
 	require.NoError(t, err)
 
@@ -63,7 +62,6 @@ func TestLayoutInvalidModelPath(t *testing.T) {
 
 	_, err = codegen.BuildData(cfg)
 	require.Error(t, err)
-
 }
 
 func testFollowSchemaPersistence(t *testing.T, dir string) {

--- a/plugin/resolvergen/testdata/filetemplate/out/model.go
+++ b/plugin/resolvergen/testdata/filetemplate/out/model.go
@@ -2,8 +2,7 @@ package customresolver
 
 import "context"
 
-type Resolver struct {
-}
+type Resolver struct{}
 
 type QueryResolver interface {
 	Resolver(ctx context.Context) (*Resolver, error)

--- a/plugin/resolvergen/testdata/followschema/out/model.go
+++ b/plugin/resolvergen/testdata/followschema/out/model.go
@@ -2,8 +2,7 @@ package customresolver
 
 import "context"
 
-type Resolver struct {
-}
+type Resolver struct{}
 
 type QueryResolver interface {
 	Resolver(ctx context.Context) (*Resolver, error)

--- a/plugin/resolvergen/testdata/singlefile/out/model.go
+++ b/plugin/resolvergen/testdata/singlefile/out/model.go
@@ -2,8 +2,7 @@ package customresolver
 
 import "context"
 
-type Resolver struct {
-}
+type Resolver struct{}
 
 type QueryResolver interface {
 	Resolver(ctx context.Context) (*Resolver, error)

--- a/plugin/servergen/server.go
+++ b/plugin/servergen/server.go
@@ -24,6 +24,7 @@ var _ plugin.CodeGenerator = &Plugin{}
 func (m *Plugin) Name() string {
 	return "servergen"
 }
+
 func (m *Plugin) GenerateCode(data *codegen.Data) error {
 	serverBuild := &ServerBuild{
 		ExecPackageName:     data.Config.Exec.ImportPath(),

--- a/plugin/stubgen/stubs.go
+++ b/plugin/stubgen/stubs.go
@@ -21,8 +21,10 @@ type Plugin struct {
 	typeName string
 }
 
-var _ plugin.CodeGenerator = &Plugin{}
-var _ plugin.ConfigMutator = &Plugin{}
+var (
+	_ plugin.CodeGenerator = &Plugin{}
+	_ plugin.ConfigMutator = &Plugin{}
+)
 
 func (m *Plugin) Name() string {
 	return "stubgen"


### PR DESCRIPTION
This is not my work. I just rebased #1702 against master.
---
This PR consists of multiple commits and is pure refactoring. It should maintain full backwards compatibility with the origin.

- `imports.goModuleRoot` is called for every type resolution. It tries to find go.mod file in the directory tree making a gazillion of requests to open file. While someone more familiar with the application design can come up with a better architecture to avoid this altogether, I added a caching layer on top of this function to only traverse file system once.
- `binder.FindObject` traverses all definitions in a package and for all needed types it is effectively O(n^2). Make it to O(n) by caching all package top-level definitions in a hashtable.
- `packages.Load` calls 'packages.LoadAll' which allocates a slice from the heap even when a single package is required. Added a fast path by checking a cache map before calling to `packages.LoadAll` to avoid that. A possibly better solution is to refactor  common parts of `packages.Load` and `packages.LoadAll` into a separate function.

For the targeted use case we achieved ~20% speed optimizations after those improvements.

Because functionality did not change, existing tests should cover it all so no new tests added.
