### PR TITLE
Cleaning up extra return in federation generated code

### DIFF
--- a/example/federation/accounts/graph/generated/federation.go
+++ b/example/federation/accounts/graph/generated/federation.go
@@ -125,8 +125,6 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 		default:
 			return errors.New("unknown type: " + typeName)
 		}
-
-		return nil
 	}
 
 	resolveEntityGroup := func(typeName string, reps []map[string]interface{}, idx []int) {
@@ -176,6 +174,4 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 		g.Wait()
 		return list
 	}
-
-	return list
 }

--- a/example/federation/products/graph/generated/federation.go
+++ b/example/federation/products/graph/generated/federation.go
@@ -129,8 +129,6 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 		default:
 			return errors.New("unknown type: " + typeName)
 		}
-
-		return nil
 	}
 
 	resolveEntityGroup := func(typeName string, reps []map[string]interface{}, idx []int) {
@@ -180,6 +178,4 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 		g.Wait()
 		return list
 	}
-
-	return list
 }

--- a/example/federation/reviews/graph/generated/federation.go
+++ b/example/federation/reviews/graph/generated/federation.go
@@ -139,8 +139,6 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 		default:
 			return errors.New("unknown type: " + typeName)
 		}
-
-		return nil
 	}
 
 	resolveEntityGroup := func(typeName string, reps []map[string]interface{}, idx []int) {
@@ -190,6 +188,4 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 		g.Wait()
 		return list
 	}
-
-	return list
 }

--- a/plugin/federation/federation.gotpl
+++ b/plugin/federation/federation.gotpl
@@ -160,14 +160,13 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 						{{- end -}}
 						list[idx[i]] = entity
 					}
+					return nil
 				{{ end }}
-			{{- end }}
+			{{ end }}
 		{{- end }}
 		default:
 			return errors.New("unknown type: "+typeName)
 		}
-
-		return nil
 	}
 
 	resolveEntityGroup := func(typeName string, reps []map[string]interface{}, idx []int) {
@@ -217,7 +216,5 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 		g.Wait()
 		return list
 	}
-
-	return list
 }
 {{end}}

--- a/plugin/federation/federation_entityresolver_test.go
+++ b/plugin/federation/federation_entityresolver_test.go
@@ -1,3 +1,4 @@
+//go:generate go run ../../testdata/gqlgen.go -config testdata/entityresolver/gqlgen.yml
 package federation
 
 import (

--- a/plugin/federation/readme.md
+++ b/plugin/federation/readme.md
@@ -9,7 +9,7 @@ There are several different tests. Some will process the configuration file dire
 
 Running entity resolver tests.
 1. Go to `plugin/federation`
-2. Run the command `go run github.com/99designs/gqlgen --config testdata/entityresolver/gqlgen.yml`
+2. Run the command `go generate`
 3. Run the tests with `go test ./...`.
 
 # Architecture
@@ -33,7 +33,7 @@ That allows the federation plugin to generate `GetMany` resolver function that c
 From that entity type, the resolver function would be
 
 ```
-func (r *entityResolver) FindManyMultiHellosByName(ctx context.Context, reps []*generated.EntityResolverfindManyMultiHellosByNameInput) ([]*generated.MultiHello, error) {
+func (r *entityResolver) FindManyMultiHellosByName(ctx context.Context, reps []*generated.ManyMultiHellosByNameInput) ([]*generated.MultiHello, error) {
   /// <Your code to resolve the list of items>
 }
 ```

--- a/plugin/federation/testdata/entityresolver/generated/federation.go
+++ b/plugin/federation/testdata/entityresolver/generated/federation.go
@@ -179,6 +179,7 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 		}()
 
 		switch typeName {
+
 		case "MultiHello":
 			_reps := make([]*MultiHelloByNamesInput, len(reps))
 
@@ -201,6 +202,8 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 			for i, entity := range entities {
 				list[idx[i]] = entity
 			}
+			return nil
+
 		case "MultiHelloWithError":
 			_reps := make([]*MultiHelloWithErrorByNamesInput, len(reps))
 
@@ -223,12 +226,11 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 			for i, entity := range entities {
 				list[idx[i]] = entity
 			}
+			return nil
 
 		default:
 			return errors.New("unknown type: " + typeName)
 		}
-
-		return nil
 	}
 
 	resolveEntityGroup := func(typeName string, reps []map[string]interface{}, idx []int) {
@@ -278,6 +280,4 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 		g.Wait()
 		return list
 	}
-
-	return list
 }


### PR DESCRIPTION
In PR 1709, I introduced GetMany semantics for resolving federated entities.  But I left a couple of extra return statements in the generated code that are not necessary. So Im just cleaning those up here.

Also added `go:generate` in federation entity resolver tests to make it simpler to test.

To test:
```
go generate ./... && cd example/ && go generate ./... && cd ..
go test -race ./... && cd example && go test -race ./... && cd ..
```

Describe your PR and link to any relevant issues. 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
