### PR TITLE
Fix plugin addition

### DIFF
--- a/api/option.go
+++ b/api/option.go
@@ -15,7 +15,7 @@ func NoPlugins() Option {
 
 func AddPlugin(p plugin.Plugin) Option {
 	return func(cfg *config.Config, plugins *[]plugin.Plugin) {
-		*plugins = append(*plugins, p)
+		*plugins = append([]plugin.Plugin{p}, *plugins...)
 	}
 }
 


### PR DESCRIPTION
As posted in Discord, the api.AddPlugin function appends plugins to the existing array of plugins, this causes the default plugins to run after the custom plugins, overwriting the result. (the modelgen hook example in the documentation does not work)

This fix makes it prepend the new plugin. May or may not be a breaking change for some.
