### PR TITLE
Don't overwrite field arguments when none match

### DIFF
--- a/codegen/args.go
+++ b/codegen/args.go
@@ -73,7 +73,7 @@ func (b *builder) buildArg(obj *Object, arg *ast.ArgumentDefinition) (*FieldArgu
 	return &newArg, nil
 }
 
-func (b *builder) bindArgs(field *Field, params *types.Tuple) error {
+func (b *builder) bindArgs(field *Field, params *types.Tuple) ([]*FieldArgument, error) {
 	var newArgs []*FieldArgument
 
 nextArg:
@@ -83,7 +83,7 @@ nextArg:
 			if strings.EqualFold(oldArg.Name, param.Name()) {
 				tr, err := b.Binder.TypeReference(oldArg.Type, param.Type())
 				if err != nil {
-					return err
+					return nil, err
 				}
 				oldArg.TypeReference = tr
 
@@ -93,11 +93,10 @@ nextArg:
 		}
 
 		// no matching arg found, abort
-		return fmt.Errorf("arg %s not in schema", param.Name())
+		return nil, fmt.Errorf("arg %s not in schema", param.Name())
 	}
 
-	field.Args = newArgs
-	return nil
+	return newArgs, nil
 }
 
 func (a *Data) Args() map[string][]*FieldArgument {

--- a/codegen/field.go
+++ b/codegen/field.go
@@ -179,10 +179,13 @@ func (b *builder) bindField(obj *Object, f *Field) (errret error) {
 			params = types.NewTuple(vars...)
 		}
 
-		if err = b.bindArgs(f, params); err != nil {
+		// Try to match target function's arguments with GraphQL field arguments
+		newArgs, err := b.bindArgs(f, params)
+		if err != nil {
 			return fmt.Errorf("%s:%d: %w", pos.Filename, pos.Line, err)
 		}
 
+		// Try to match target function's return types with GraphQL field return type
 		result := sig.Results().At(0)
 		tr, err := b.Binder.TypeReference(f.Type, result.Type())
 		if err != nil {
@@ -193,6 +196,7 @@ func (b *builder) bindField(obj *Object, f *Field) (errret error) {
 		f.GoFieldType = GoFieldMethod
 		f.GoReceiverName = "obj"
 		f.GoFieldName = target.Name()
+		f.Args = newArgs
 		f.TypeReference = tr
 
 		return nil


### PR DESCRIPTION
Problem: during GraphQL field binding, when there's matching Golang method, yet without any arguments besides `ctx`, a resolver with no arguments from the original GraphQL schema will be generated.

Solution: don't overwrite field's arguments until we're sure we've got a perfect match.

Resolves #1319.