### PR TITLE
fix: automatically register built-in directive goTag

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -239,6 +239,10 @@ func (c *Config) injectTypesFromSchema() error {
 		SkipRuntime: true,
 	}
 
+	c.Directives["goTag"] = DirectiveConfig{
+		SkipRuntime: true,
+	}
+
 	for _, schemaType := range c.Schema.Types {
 		if schemaType == c.Schema.Query || schemaType == c.Schema.Mutation || schemaType == c.Schema.Subscription {
 			continue

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -115,3 +115,16 @@ type User @goModel(model: "github.com/my/app/models.User") {
 		@goTag(key: "yaml")
 }
 ```
+
+The builtin directives `goField`, `goModel` and `goTag` are automatically registered to `skip_runtime`. Any directives registered as `skip_runtime` will not exposed during introspection and are used during code generation only. 
+
+If you have created a new code generation plugin using a directive which does not require runtime execution, the directive will need to be set to `skip_runtime`.
+
+e.g. a custom directive called `constraint` would be set as `skip_runtime` using the following configuration
+```yml
+# custom directives which are not exposed during introspection. These directives are
+# used for code generation only
+directives:
+  constraint:
+    skip_runtime: true
+```


### PR DESCRIPTION
Fixes #1736 

The built-in directive `goTag` was not automatically registered as a runtime directive causing a directive to be generated when it is not required. This change adds the directive as a runtime directive as default. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
