### PR TITLE
Migrate playgrounds to GraphiQL

### DIFF
--- a/graphql/playground/playground.go
+++ b/graphql/playground/playground.go
@@ -60,7 +60,7 @@ func Handler(title string, endpoint string) http.HandlerFunc {
 			"version":     "1.5.16",
 			"cssSRI":      "sha256-HADQowUuFum02+Ckkv5Yu5ygRoLllHZqg0TFZXY7NHI=",
 			"jsSRI":       "sha256-uHp12yvpXC4PC9+6JmITxKuLYwjlW9crq9ywPE5Rxco=",
-			"reactSRI":	   "sha256-Ipu/TQ50iCCVZBUsZyNJfxrDk0E2yhaEIz0vqI+kFG8=",
+			"reactSRI":    "sha256-Ipu/TQ50iCCVZBUsZyNJfxrDk0E2yhaEIz0vqI+kFG8=",
 			"reactDOMSRI": "sha256-nbMykgB6tsOFJ7OdVmPpdqMFVk4ZsqWocT6issAPUF0=",
 		})
 		if err != nil {

--- a/graphql/playground/playground.go
+++ b/graphql/playground/playground.go
@@ -7,39 +7,47 @@ import (
 
 var page = template.Must(template.New("graphiql").Parse(`<!DOCTYPE html>
 <html>
-<head>
-	<meta charset=utf-8/>
-	<meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphql-playground-react@{{ .version }}/build/static/css/index.css"
-		integrity="{{ .cssSRI }}" crossorigin="anonymous"/>
-	<link rel="shortcut icon" href="https://cdn.jsdelivr.net/npm/graphql-playground-react@{{ .version }}/build/favicon.png"
-		integrity="{{ .faviconSRI }}" crossorigin="anonymous"/>
-	<script src="https://cdn.jsdelivr.net/npm/graphql-playground-react@{{ .version }}/build/static/js/middleware.js"
-		integrity="{{ .jsSRI }}" crossorigin="anonymous"></script>
-	<title>{{.title}}</title>
-</head>
-<body>
-<style type="text/css">
-	html { font-family: "Open Sans", sans-serif; overflow: hidden; }
-	body { margin: 0; background: #172a3a; }
-</style>
-<div id="root"/>
-<script type="text/javascript">
-	window.addEventListener('load', function (event) {
-		const root = document.getElementById('root');
-		root.classList.add('playgroundIn');
-		const wsProto = location.protocol == 'https:' ? 'wss:' : 'ws:'
-		GraphQLPlayground.init(root, {
-			endpoint: location.protocol + '//' + location.host + '{{.endpoint}}',
-			subscriptionsEndpoint: wsProto + '//' + location.host + '{{.endpoint }}',
-           shareEnabled: true,
-			settings: {
-				'request.credentials': 'same-origin'
-			}
-		})
-	})
-</script>
-</body>
+  <head>
+    <title>{{.title}}</title>
+    <link
+		rel="stylesheet"
+		href="https://cdn.jsdelivr.net/npm/graphiql@{{.version}}/graphiql.min.css"
+		integrity="{{.cssSRI}}"
+		crossorigin="anonymous"
+	/>
+  </head>
+  <body style="margin: 0;">
+    <div id="graphiql" style="height: 100vh;"></div>
+
+	<script
+		src="https://cdn.jsdelivr.net/npm/react@17.0.2/umd/react.production.min.js"
+		integrity="{{.reactSRI}}"
+		crossorigin="anonymous"
+	></script>
+	<script
+		src="https://cdn.jsdelivr.net/npm/react-dom@17.0.2/umd/react-dom.production.min.js"
+		integrity="{{.reactDOMSRI}}"
+		crossorigin="anonymous"
+	></script>
+	<script
+		src="https://cdn.jsdelivr.net/npm/graphiql@{{.version}}/graphiql.min.js"
+		integrity="{{.jsSRI}}"
+		crossorigin="anonymous"
+	></script>
+
+    <script>
+      const url = location.protocol + '//' + location.host + '{{.endpoint}}';
+      const wsProto = location.protocol == 'https:' ? 'wss:' : 'ws:';
+      const subscriptionUrl = wsProto + '//' + location.host + '{{.endpoint}}';
+
+      const fetcher = GraphiQL.createFetcher({ url, subscriptionUrl });
+
+      ReactDOM.render(
+        React.createElement(GraphiQL, { fetcher: fetcher }),
+        document.getElementById('graphiql'),
+      );
+    </script>
+  </body>
 </html>
 `))
 
@@ -47,12 +55,13 @@ func Handler(title string, endpoint string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "text/html")
 		err := page.Execute(w, map[string]string{
-			"title":      title,
-			"endpoint":   endpoint,
-			"version":    "1.7.26",
-			"cssSRI":     "sha256-dKnNLEFwKSVFpkpjRWe+o/jQDM6n/JsvQ0J3l5Dk3fc=",
-			"faviconSRI": "sha256-GhTyE+McTU79R4+pRO6ih+4TfsTOrpPwD8ReKFzb3PM=",
-			"jsSRI":      "sha256-SG9YAy4eywTcLckwij7V4oSCG3hOdV1m+2e1XuNxIgk=",
+			"title":       title,
+			"endpoint":    endpoint,
+			"version":     "1.5.16",
+			"cssSRI":      "sha256-HADQowUuFum02+Ckkv5Yu5ygRoLllHZqg0TFZXY7NHI=",
+			"jsSRI":       "sha256-uHp12yvpXC4PC9+6JmITxKuLYwjlW9crq9ywPE5Rxco=",
+			"reactSRI":	   "sha256-Ipu/TQ50iCCVZBUsZyNJfxrDk0E2yhaEIz0vqI+kFG8=",
+			"reactDOMSRI": "sha256-nbMykgB6tsOFJ7OdVmPpdqMFVk4ZsqWocT6issAPUF0=",
 		})
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Closes https://github.com/99designs/gqlgen/issues/1367

This PR migrates the default Playground to [`GraphiQL`](https://github.com/graphql/graphiql) since [`graphql-playground`](https://github.com/graphql/graphql-playground) is being [deprecated](https://github.com/graphql/graphql-playground/issues/1143). 

How I tested this PR:
- Ran the `dataloader` example to ensure that queries were still functioning.
- Ran the `chat` example to ensure that mutations + WS subscriptions were still functioning. 

<!--
I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
-->
