### PR TITLE
Fix for underscore field names fo ToGo/ToGoPrivate

### DIFF
--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -289,7 +289,12 @@ func ToGo(name string) string {
 	if name == "_" {
 		return "_"
 	}
+
 	runes := make([]rune, 0, len(name))
+	for strings.HasPrefix(name, "_") {
+		name = name[1:]
+		runes = append(runes, '_')
+	}
 
 	wordWalker(name, func(info *wordInfo) {
 		word := info.Word
@@ -312,7 +317,12 @@ func ToGoPrivate(name string) string {
 	if name == "_" {
 		return "_"
 	}
+
 	runes := make([]rune, 0, len(name))
+	for strings.HasPrefix(name, "_") {
+		name = name[1:]
+		runes = append(runes, '_')
+	}
 
 	first := true
 	wordWalker(name, func(info *wordInfo) {

--- a/codegen/templates/templates_test.go
+++ b/codegen/templates/templates_test.go
@@ -17,7 +17,7 @@ func TestToGo(t *testing.T) {
 	require.Equal(t, "ToCamel", ToGo("ToCamel"))
 	require.Equal(t, "ToCamel", ToGo("to-camel"))
 	require.Equal(t, "ToCamel", ToGo("-to-camel"))
-	require.Equal(t, "ToCamel", ToGo("_to-camel"))
+	require.Equal(t, "_ToCamel", ToGo("_to-camel"))
 	require.Equal(t, "_", ToGo("_"))
 
 	require.Equal(t, "RelatedURLs", ToGo("RelatedURLs"))


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

We have such case with our graphql schema definition:

```graphql
type Asset @entity {
  "Address (hash)"
  id: ID!

  _Fields: [ID!]!
  Fields: [Field!]! @derivedFrom(field: "field")
}
```
which is templated to:
```go
type Asset struct {
	ID               string            `json:"id"`

	Fields          []string          `json:"_Fields,omitempty"`
	Fields          []*Field         `json:"Fields,omitempty"`
}
```
since "_" is valid variable for golang, I've added small fixed to resolve such case
