### PR TITLE
Fix #1762: Reload packages before merging type systems

### DIFF
--- a/codegen/data.go
+++ b/codegen/data.go
@@ -54,6 +54,9 @@ func (d *Data) Directives() DirectiveList {
 }
 
 func BuildData(cfg *config.Config) (*Data, error) {
+	// We reload all packages to allow packages to be compared correctly.
+	cfg.ReloadAllPackages()
+	
 	b := builder{
 		Config: cfg,
 		Schema: cfg.Schema,

--- a/codegen/data.go
+++ b/codegen/data.go
@@ -56,7 +56,7 @@ func (d *Data) Directives() DirectiveList {
 func BuildData(cfg *config.Config) (*Data, error) {
 	// We reload all packages to allow packages to be compared correctly.
 	cfg.ReloadAllPackages()
-	
+
 	b := builder{
 		Config: cfg,
 		Schema: cfg.Schema,


### PR DESCRIPTION
Fixes #1762  `cfg.ReloadAllPackages()` should be called before merging type systems.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
