### PR TITLE
Fix #1765: Sometimes module info not exists or not loaded.

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -531,7 +531,7 @@ func (c *Config) autobind() error {
 		}
 
 		for i, p := range ps {
-			if p == nil || p.Module == nil {
+			if p == nil {
 				return fmt.Errorf("unable to load %s - make sure you're using an import path to a package that exists", c.AutoBind[i])
 			}
 			if t := p.Types.Scope().Lookup(t.Name); t != nil {

--- a/codegen/config/config_test.go
+++ b/codegen/config/config_test.go
@@ -193,21 +193,4 @@ func TestAutobinding(t *testing.T) {
 		require.Equal(t, "github.com/99designs/gqlgen/codegen/config/testdata/autobinding/scalars/model.Banned", cfg.Models["Banned"].Model[0])
 		require.Equal(t, "github.com/99designs/gqlgen/codegen/config/testdata/autobinding/chat.Message", cfg.Models["Message"].Model[0])
 	})
-
-	t.Run("with file path", func(t *testing.T) {
-		cfg := Config{
-			Models: TypeMap{},
-			AutoBind: []string{
-				"../chat",
-			},
-			Packages: &code.Packages{},
-		}
-
-		cfg.Schema = gqlparser.MustLoadSchema(&ast.Source{Name: "TestAutobinding.schema", Input: `
-			scalar Banned
-			type Message { id: ID }
-		`})
-
-		require.EqualError(t, cfg.autobind(), "unable to load ../chat - make sure you're using an import path to a package that exists")
-	})
 }


### PR DESCRIPTION
Fix #1765.

@StevenACoffman but I think this maybe need some discussion. I have two ways to fix this: remove module info checks or just call `packages.Load()` twice. Both can solve this issue. But I prefer the this one.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
