### PR TITLE
Fix #1834: Implement federation correctly

### DIFF
--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -88,9 +88,7 @@ directive @extends on OBJECT | INTERFACE
 func (f *federation) InjectSourceLate(schema *ast.Schema) *ast.Source {
 	f.setEntities(schema)
 
-	entities := ""
-	resolvers := ""
-	entityResolverInputDefinitions := ""
+	var entities, resolvers, entityResolverInputDefinitions string
 	for i, e := range f.Entities {
 		if i != 0 {
 			entities += " | "
@@ -99,11 +97,14 @@ func (f *federation) InjectSourceLate(schema *ast.Schema) *ast.Source {
 
 		for _, r := range e.Resolvers {
 			if e.Multi {
+				if entityResolverInputDefinitions != "" {
+					entityResolverInputDefinitions += "\n\n"
+				}
 				entityResolverInputDefinitions += "input " + r.InputType + " {\n"
 				for _, keyField := range r.KeyFields {
 					entityResolverInputDefinitions += fmt.Sprintf("\t%s: %s\n", keyField.Field.ToGo(), keyField.Definition.Type.String())
 				}
-				entityResolverInputDefinitions += "}\n"
+				entityResolverInputDefinitions += "}"
 				resolvers += fmt.Sprintf("\t%s(reps: [%s!]!): [%s]\n", r.ResolverName, r.InputType, e.Name)
 			} else {
 				resolverArgs := ""
@@ -115,50 +116,51 @@ func (f *federation) InjectSourceLate(schema *ast.Schema) *ast.Source {
 		}
 	}
 
+	var blocks []string
 	if entities != "" {
-		entities = `
-# a union of all types that use the @key directive
+		entities = `# a union of all types that use the @key directive
 union _Entity = ` + entities
+		blocks = append(blocks, entities)
 	}
 
 	// resolvers can be empty if a service defines only "empty
 	// extend" types.  This should be rare.
 	if resolvers != "" {
-		resolvers = entityResolverInputDefinitions + `
-# fake type to build resolver interfaces for users to implement
+		if entityResolverInputDefinitions != "" {
+			blocks = append(blocks, entityResolverInputDefinitions)
+		}
+		resolvers = `# fake type to build resolver interfaces for users to implement
 type Entity {
 	` + resolvers + `
-}
-`
+}`
+		blocks = append(blocks, resolvers)
 	}
 
-	_serviceTypeDef := `
-type _Service {
+	_serviceTypeDef := `type _Service {
   sdl: String
 }`
-	additionalQueryFields := ``
+	blocks = append(blocks, _serviceTypeDef)
+
+	var additionalQueryFields string
 	// Quote from the Apollo Federation subgraph specification:
 	// If no types are annotated with the key directive, then the
-	// _Entity union and Query._entities field should be removed from the schema
+	// _Entity union and _entities field should be removed from the schema
 	if len(f.Entities) > 0 {
 		additionalQueryFields += `  _entities(representations: [_Any!]!): [_Entity]!
 `
 	}
-	// Query._service is required in any case
+	// _service field is required in any case
 	additionalQueryFields += `  _service: _Service!`
 
-	extendTypeQueryDef := `
-extend type ` + schema.Query.Name + ` {
+	extendTypeQueryDef := `extend type ` + schema.Query.Name + ` {
 ` + additionalQueryFields + `
-}
-`
+}`
+	blocks = append(blocks, extendTypeQueryDef)
+
 	return &ast.Source{
 		Name:    "federation/entity.graphql",
 		BuiltIn: true,
-		Input: entities + `
-` + resolvers + `
-` + _serviceTypeDef + `
-` + extendTypeQueryDef,
+		Input:   "\n" + strings.Join(blocks, "\n\n") + "\n",
 	}
 }
 

--- a/plugin/federation/testdata/entityresolver/generated/exec.go
+++ b/plugin/federation/testdata/entityresolver/generated/exec.go
@@ -560,9 +560,11 @@ directive @extends on OBJECT | INTERFACE
 	{Name: "federation/entity.graphql", Input: `
 # a union of all types that use the @key directive
 union _Entity = Hello | HelloMultiSingleKeys | HelloWithErrors | MultiHello | MultiHelloWithError | PlanetRequires | PlanetRequiresNested | World | WorldName | WorldWithMultipleKeys
+
 input MultiHelloByNamesInput {
 	Name: String!
 }
+
 input MultiHelloWithErrorByNamesInput {
 	Name: String!
 }

--- a/plugin/federation/testdata/schema/customquerytype.graphql
+++ b/plugin/federation/testdata/schema/customquerytype.graphql
@@ -1,0 +1,12 @@
+schema {
+    query: CustomQuery
+}
+
+type Hello {
+  name: String!
+}
+
+type CustomQuery {
+  hello: Hello!
+}
+

--- a/plugin/federation/testdata/schema/customquerytype.yml
+++ b/plugin/federation/testdata/schema/customquerytype.yml
@@ -1,0 +1,9 @@
+schema:
+  - "testdata/schema/customquerytype.graphql"
+exec:
+  filename: testdata/schema/generated/exec.go
+federation:
+  filename: testdata/schema/generated/federation.go
+
+autobind:
+  - "github.com/99designs/gqlgen/plugin/federation/test_data/model"


### PR DESCRIPTION
Fix #1834
Fix #1724
Fix #1090
See also #1192

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))

---

There are several issues in federation implementation according to the [Apollo Federation subgraph specification](https://www.apollographql.com/docs/federation/federation-spec):
1. When customizing root query type, _service is not generated in customized query struct. Then Apollo gateway cannot get service definition in subgraph.
2. If @key directive is not used in graphql schema, both _service and _entities are not generated.

### What did you expect?
1. _service is generated in customized query struct.
2. _service is generated in any case, while _entities is generated only when @key directive exists.

### Minimal graphql.schema and models to reproduce
```
schema {
    query: CustomQuery
}

type Hello {
  name: String!
}

type CustomQuery {
  hello: Hello!
}
```

### versions
 - `gqlgen version` 0.15.1
 - `go version` 1.17
 - dep or go modules? go modules
