### PR TITLE
Revert "Fix plugin addition"

### DIFF
--- a/api/option.go
+++ b/api/option.go
@@ -15,7 +15,7 @@ func NoPlugins() Option {
 
 func AddPlugin(p plugin.Plugin) Option {
 	return func(cfg *config.Config, plugins *[]plugin.Plugin) {
-		*plugins = append([]plugin.Plugin{p}, *plugins...)
+		*plugins = append(*plugins, p)
 	}
 }
 


### PR DESCRIPTION
Reverts 99designs/gqlgen#1717

- Some plugins that worked in versions prior to v0.15, which generated code based on a previously generated model, no longer work above v0.15.
  - https://github.com/99designs/gqlgen/blob/8b25c9e005c44ae3730eca83445fa7f7223481d1/api/generate.go#L21-L32
- I think we shouldn't implicit breaking changes should be made
- If we want to achieve the behavior he claims, we should create a new API.
  - e.g. `func PrependPlugin`