### PR TITLE
add PrependPlugin

### DIFF
--- a/api/option.go
+++ b/api/option.go
@@ -19,6 +19,13 @@ func AddPlugin(p plugin.Plugin) Option {
 	}
 }
 
+// PrependPlugin prepends plugin any existing plugins
+func PrependPlugin(p plugin.Plugin) Option {
+	return func(cfg *config.Config, plugins *[]plugin.Plugin) {
+		*plugins = append([]plugin.Plugin{p}, *plugins...)
+	}
+}
+
 // ReplacePlugin replaces any existing plugin with a matching plugin name
 func ReplacePlugin(p plugin.Plugin) Option {
 	return func(cfg *config.Config, plugins *[]plugin.Plugin) {

--- a/api/option_test.go
+++ b/api/option_test.go
@@ -53,3 +53,16 @@ func TestReplacePlugin(t *testing.T) {
 		require.EqualValues(t, expectedPlugin, pg[2])
 	})
 }
+
+func TestPrependPlugin(t *testing.T) {
+	modelgenPlugin := modelgen.New()
+	pg := []plugin.Plugin{
+		modelgenPlugin,
+	}
+
+	expectedPlugin := &testPlugin{}
+	PrependPlugin(expectedPlugin)(config.DefaultConfig(), &pg)
+
+	require.EqualValues(t, expectedPlugin, pg[0])
+	require.EqualValues(t, modelgenPlugin, pg[1])
+}


### PR DESCRIPTION
This PR should only be merged after https://github.com/99designs/gqlgen/pull/1838 is merged. #1838 reverts 99designs/gqlgen#1717

- Some plugins that worked in versions prior to v0.15, which generated code based on a previously generated model, no longer work above v0.15.
  - https://github.com/99designs/gqlgen/blob/8b25c9e005c44ae3730eca83445fa7f7223481d1/api/generate.go#L21-L32
- I think we shouldn't implicit breaking changes should be made
- If we want to achieve the behavior @erwin-k claims, we should create a new API.
  - e.g. `func PrependPlugin`

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
