### PR TITLE
Fix #1776 : Edit and persist headers in GraphiQL

### DIFF
--- a/graphql/playground/playground.go
+++ b/graphql/playground/playground.go
@@ -41,9 +41,12 @@ var page = template.Must(template.New("graphiql").Parse(`<!DOCTYPE html>
       const subscriptionUrl = wsProto + '//' + location.host + '{{.endpoint}}';
 
       const fetcher = GraphiQL.createFetcher({ url, subscriptionUrl });
-
       ReactDOM.render(
-        React.createElement(GraphiQL, { fetcher: fetcher }),
+        React.createElement(GraphiQL, {
+          fetcher: fetcher,
+          headerEditorEnabled: true,
+          shouldPersistHeaders: true
+        }),
         document.getElementById('graphiql'),
       );
     </script>


### PR DESCRIPTION
The switch to GraphiQL had the config such that we weren't persisting headers.


