### PR TITLE
Fix #1862 entityResolver directive breaks resolving of required nested fields

### DIFF
--- a/plugin/federation/federation.gotpl
+++ b/plugin/federation/federation.gotpl
@@ -157,7 +157,7 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 
 						for i, entity := range entities {
 							{{- range $entity.Requires }}
-									entity.{{.Field.JoinGo `.`}}, err = ec.{{.Type.UnmarshalFunc}}(ctx, reps[i]["{{.Name}}"])
+									entity.{{.Field.JoinGo `.`}}, err = ec.{{.Type.UnmarshalFunc}}(ctx, reps[i]["{{.Field.Join `"].(map[string]interface{})["`}}"])
 									if err != nil {
 										return err
 									}

--- a/plugin/federation/federation_entityresolver_test.go
+++ b/plugin/federation/federation_entityresolver_test.go
@@ -544,6 +544,47 @@ func TestMultiEntityResolver(t *testing.T) {
 		require.Equal(t, resp.Entities[1].Key1, "key1 - 2")
 		require.Equal(t, resp.Entities[1].Key2, "key2 - 2")
 	})
+
+	t.Run("MultiPlanetRequiresNested entities with requires directive having nested field", func(t *testing.T) {
+		representations := []map[string]interface{}{
+			{
+				"__typename": "MultiPlanetRequiresNested",
+				"name":       "earth",
+				"world": map[string]interface{}{
+					"foo": "A",
+				},
+			}, {
+				"__typename": "MultiPlanetRequiresNested",
+				"name":       "mars",
+				"world": map[string]interface{}{
+					"foo": "B",
+				},
+			},
+		}
+
+		var resp struct {
+			Entities []struct {
+				Name  string `json:"name"`
+				World struct {
+					Foo string `json:"foo"`
+				} `json:"world"`
+			} `json:"_entities"`
+		}
+
+		err := c.Post(
+			entityQuery([]string{
+				"MultiPlanetRequiresNested {name, world { foo }}",
+			}),
+			&resp,
+			client.Var("representations", representations),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, resp.Entities[0].Name, "earth")
+		require.Equal(t, resp.Entities[0].World.Foo, "A")
+		require.Equal(t, resp.Entities[1].Name, "mars")
+		require.Equal(t, resp.Entities[1].World.Foo, "B")
+	})
 }
 
 func entityQuery(queries []string) string {

--- a/plugin/federation/testdata/entityresolver/entity.resolvers.go
+++ b/plugin/federation/testdata/entityresolver/entity.resolvers.go
@@ -72,6 +72,34 @@ func (r *entityResolver) FindManyMultiHelloWithErrorByNames(ctx context.Context,
 	return nil, fmt.Errorf("error resolving MultiHelloWorldWithError")
 }
 
+func (r *entityResolver) FindManyMultiPlanetRequiresNestedByNames(ctx context.Context, reps []*generated.MultiPlanetRequiresNestedByNamesInput) ([]*generated.MultiPlanetRequiresNested, error) {
+	worlds := map[string]*generated.World{
+		"earth": {
+			Foo: "A",
+		},
+		"mars": {
+			Foo: "B",
+		},
+	}
+
+	results := make([]*generated.MultiPlanetRequiresNested, len(reps))
+
+	for i := range reps {
+		name := reps[i].Name
+		world, ok := worlds[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown planet: %s", name)
+		}
+
+		results[i] = &generated.MultiPlanetRequiresNested{
+			Name:  name,
+			World: world,
+		}
+	}
+
+	return results, nil
+}
+
 func (r *entityResolver) FindPlanetMultipleRequiresByName(ctx context.Context, name string) (*generated.PlanetMultipleRequires, error) {
 	return &generated.PlanetMultipleRequires{Name: name}, nil
 }

--- a/plugin/federation/testdata/entityresolver/generated/federation.go
+++ b/plugin/federation/testdata/entityresolver/generated/federation.go
@@ -73,6 +73,8 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 			return true
 		case "MultiHelloWithError":
 			return true
+		case "MultiPlanetRequiresNested":
+			return true
 		default:
 			return false
 		}
@@ -432,6 +434,34 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 			}
 			return nil
 
+		case "MultiPlanetRequiresNested":
+			_reps := make([]*MultiPlanetRequiresNestedByNamesInput, len(reps))
+
+			for i, rep := range reps {
+				id0, err := ec.unmarshalNString2string(ctx, rep["name"])
+				if err != nil {
+					return errors.New(fmt.Sprintf("Field %s undefined in schema.", "name"))
+				}
+
+				_reps[i] = &MultiPlanetRequiresNestedByNamesInput{
+					Name: id0,
+				}
+			}
+
+			entities, err := ec.resolvers.Entity().FindManyMultiPlanetRequiresNestedByNames(ctx, _reps)
+			if err != nil {
+				return err
+			}
+
+			for i, entity := range entities {
+				entity.World.Foo, err = ec.unmarshalNString2string(ctx, reps[i]["world"].(map[string]interface{})["foo"])
+				if err != nil {
+					return err
+				}
+				list[idx[i]] = entity
+			}
+			return nil
+
 		default:
 			return errors.New("unknown type: " + typeName)
 		}
@@ -606,6 +636,23 @@ func entityResolverNameForMultiHelloWithError(ctx context.Context, rep map[strin
 		return "findManyMultiHelloWithErrorByNames", nil
 	}
 	return "", fmt.Errorf("%w for MultiHelloWithError", ErrTypeNotFound)
+}
+
+func entityResolverNameForMultiPlanetRequiresNested(ctx context.Context, rep map[string]interface{}) (string, error) {
+	for {
+		var (
+			m   map[string]interface{}
+			val interface{}
+			ok  bool
+		)
+		_ = val
+		m = rep
+		if _, ok = m["name"]; !ok {
+			break
+		}
+		return "findManyMultiPlanetRequiresNestedByNames", nil
+	}
+	return "", fmt.Errorf("%w for MultiPlanetRequiresNested", ErrTypeNotFound)
 }
 
 func entityResolverNameForPlanetMultipleRequires(ctx context.Context, rep map[string]interface{}) (string, error) {

--- a/plugin/federation/testdata/entityresolver/generated/models.go
+++ b/plugin/federation/testdata/entityresolver/generated/models.go
@@ -67,6 +67,18 @@ type MultiHelloWithErrorByNamesInput struct {
 	Name string `json:"Name"`
 }
 
+type MultiPlanetRequiresNested struct {
+	Name  string `json:"name"`
+	World *World `json:"world"`
+	Size  int    `json:"size"`
+}
+
+func (MultiPlanetRequiresNested) IsEntity() {}
+
+type MultiPlanetRequiresNestedByNamesInput struct {
+	Name string `json:"Name"`
+}
+
 type PlanetMultipleRequires struct {
 	Name     string `json:"name"`
 	Diameter int    `json:"diameter"`

--- a/plugin/federation/testdata/entityresolver/schema.graphql
+++ b/plugin/federation/testdata/entityresolver/schema.graphql
@@ -44,6 +44,12 @@ type PlanetRequiresNested @key(fields: "name") {
     size: Int! @requires(fields: "world{ foo }")
 }
 
+type MultiPlanetRequiresNested @key(fields: "name") @entityResolver(multi: true) {
+    name: String! @external
+    world: World! @external
+    size: Int! @requires(fields: "world{ foo }")
+}
+
 type MultiHello @key(fields: "name") @entityResolver(multi: true) {
     name: String!
 }


### PR DESCRIPTION
Fix #1862 `entityResolver` directive breaks resolving of required nested fields

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
