### PR TITLE
fix: whitelist VERSION and CURRENT_VERSION env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /vendor
 /docs/public
+/docs/.hugo_build.lock
 /example/chat/node_modules
 /integration/node_modules
 /integration/schema-fetched.graphql

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -24,3 +24,10 @@ menu:
     - name: pkg.go.dev →
       parent: reference
       url: https://pkg.go.dev/github.com/99designs/gqlgen
+
+security:
+  funcs:
+    getenv:
+    - '^HUGO_'
+    - 'VERSIONS'
+    - 'CURRENT_VERSION'


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

This PR resolves #1869 and whitelists the `VERSION` and `CURRENT_VERSION` env vars in the hugo docs site. Also adds the hugo lock file to `.gitignore`

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
