### PR TITLE
Add ZIP code to common initialisms

### DIFF
--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -16,7 +16,6 @@ import (
 	"unicode"
 
 	"github.com/99designs/gqlgen/internal/code"
-
 	"github.com/99designs/gqlgen/internal/imports"
 )
 
@@ -493,6 +492,7 @@ var commonInitialisms = map[string]bool{
 	"XMPP":  true,
 	"XSRF":  true,
 	"XSS":   true,
+	"ZIP":   true,
 }
 
 func rawQuote(s string) string {


### PR DESCRIPTION
Add ZIP code to common initialisms.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
