### PR TITLE
remove autobind example from init commands

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -55,7 +55,7 @@ resolver:
 # gqlgen will search for any type names in the schema in these go packages
 # if they match it will use them, otherwise it will generate them.
 autobind:
-  - "{{.}}/graph/model"
+#  - "{{.}}/graph/model"
 
 # This section declares type mapping between the GraphQL and go type systems
 #


### PR DESCRIPTION
When developers are running `init` for the first time to generate base configs and files, an example is included in the autobind section that points to `- "{{.}}/graph/model`. The problem with this is that developers likely won't already have external types in this directory so any subsequent `generate` commands will fail with the error `make sure you're using an import path to a package that exists`. I've commented this field out from the configTemplate so that developers following simple tutorials online aren't immediately blocked when running `init` followed by `generate`. Leaving this commented out would still show how a developer could reference external/already-defined types elsewhere. 

Should fix errors users are seeing for this: https://github.com/99designs/gqlgen/issues/1765

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 (Not really needed)
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
 (Not really needed)
