### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/content/reference/changesets.md
+++ b/docs/content/reference/changesets.md
@@ -13,7 +13,7 @@ type Mutation {
 	updateUser(id: ID!, changes: UserChanges!): User
 }
 
-type UserChanges {
+input UserChanges {
 	name: String
 	email: String
 }


### PR DESCRIPTION
fixes #1951 
 - [x] Fixed typo in docs (see [changesets.md ](https://github.com/99designs/gqlgen/docs/content/reference/changesets.md))
