### PR TITLE
Fix 1955: only print message on @key found on interfaces

### DIFF
--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -362,10 +362,14 @@ func isFederatedEntity(schemaType *ast.Definition) ([]*ast.Directive, bool) {
 	case ast.Interface:
 		// TODO: support @key and @extends for interfaces
 		if dir := schemaType.Directives.ForName("key"); dir != nil {
-			panic("@key directive is not currently supported for interfaces.")
+			fmt.Printf("@key directive found on \"interface %s\". Will be ignored.\n", schemaType.Name)
 		}
 		if dir := schemaType.Directives.ForName("extends"); dir != nil {
-			panic("@extends directive is not currently supported for interfaces.")
+			panic(
+				fmt.Sprintf(
+					"@extends directive is not currently supported for interfaces, use \"extend interface %s\" instead.",
+					schemaType.Name,
+				))
 		}
 	default:
 		// ignore

--- a/plugin/federation/federation_test.go
+++ b/plugin/federation/federation_test.go
@@ -87,9 +87,17 @@ func TestNoEntities(t *testing.T) {
 	require.Len(t, f.Entities, 0)
 }
 
-func TestInterfaces(t *testing.T) {
+func TestInterfaceKeyDirective(t *testing.T) {
+	f, cfg := load(t, "testdata/interfaces/key.yml")
+
+	err := f.MutateConfig(cfg)
+	require.NoError(t, err)
+	require.Len(t, f.Entities, 0)
+}
+
+func TestInterfaceExtendsDirective(t *testing.T) {
 	require.Panics(t, func() {
-		load(t, "testdata/interfaces/gqlgen.yml")
+		load(t, "testdata/interfaces/extends.yml")
 	})
 }
 

--- a/plugin/federation/testdata/interfaces/extends.graphqls
+++ b/plugin/federation/testdata/interfaces/extends.graphqls
@@ -1,0 +1,11 @@
+interface Hello @extends {
+    name: String!
+    secondary: String!
+}
+
+extend type World implements Hello @key(fields: "name") {
+    name: String! @external
+    secondary: String!
+
+    tertiary: String!
+}

--- a/plugin/federation/testdata/interfaces/extends.yml
+++ b/plugin/federation/testdata/interfaces/extends.yml
@@ -1,5 +1,5 @@
 schema:
-  - "testdata/interfaces/interfaces.graphqls"
+  - "testdata/interfaces/extends.graphqls"
 exec:
   filename: testdata/interfaces/generated/exec.go
 federation:

--- a/plugin/federation/testdata/interfaces/interfaces.graphqls
+++ b/plugin/federation/testdata/interfaces/interfaces.graphqls
@@ -1,9 +1,0 @@
-interface Hello @key(fields: "name") {
-    name: String!
-    secondary: String!
-}
-
-extend interface World {
-    foo: String! @external
-    bar: Int!
-}

--- a/plugin/federation/testdata/interfaces/key.graphqls
+++ b/plugin/federation/testdata/interfaces/key.graphqls
@@ -1,0 +1,4 @@
+extend interface Hello @key(fields: "name") {
+    name: String!
+    secondary: String!
+}

--- a/plugin/federation/testdata/interfaces/key.yml
+++ b/plugin/federation/testdata/interfaces/key.yml
@@ -1,0 +1,6 @@
+schema:
+  - "testdata/interfaces/key.graphqls"
+exec:
+  filename: testdata/interfaces/generated/exec.go
+federation:
+  filename: testdata/interfaces/generated/federation.go


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 
Fixes #1955 and adds a test for `@extends` handling.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
