### PR TITLE
Allow other formats when unmarshalling time

### DIFF
--- a/graphql/time.go
+++ b/graphql/time.go
@@ -18,8 +18,18 @@ func MarshalTime(t time.Time) Marshaler {
 }
 
 func UnmarshalTime(v interface{}) (time.Time, error) {
-	if tmpStr, ok := v.(string); ok {
-		return time.Parse(time.RFC3339Nano, tmpStr)
+	formats := []string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02",
 	}
-	return time.Time{}, errors.New("time should be RFC3339Nano formatted string")
+	if tmpStr, ok := v.(string); ok {
+		for _, f := range formats {
+			t, err := time.Parse(f, tmpStr)
+			if err == nil {
+				return t, nil
+			}
+		}
+	}
+	return time.Time{}, errors.New("time is not a string in a recognized format")
 }

--- a/graphql/time_test.go
+++ b/graphql/time_test.go
@@ -23,3 +23,67 @@ func TestTime(t *testing.T) {
 		require.True(t, initialTime.Equal(newTime), "expected times %v and %v to equal", initialTime, newTime)
 	})
 }
+
+func TestUnmarshalTime(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      interface{}
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			name:    "RFC3339Nano",
+			in:      "2022-02-10T10:20:30.123456789Z",
+			want:    time.Date(2022, 02, 10, 10, 20, 30, 123456789, time.UTC),
+			wantErr: false,
+		},
+		{
+			name:    "RFC3339",
+			in:      "2022-02-10T10:20:30Z",
+			want:    time.Date(2022, 02, 10, 10, 20, 30, 0, time.UTC),
+			wantErr: false,
+		},
+		{
+			name:    "UTC ISO with time",
+			in:      "2022-02-10 10:20:30",
+			want:    time.Date(2022, 02, 10, 10, 20, 30, 0, time.UTC),
+			wantErr: false,
+		},
+		{
+			name:    "UTC ISO with time and nsec",
+			in:      "2022-02-10 10:20:30.123456789",
+			want:    time.Date(2022, 02, 10, 10, 20, 30, 123456789, time.UTC),
+			wantErr: false,
+		},
+		{
+			name:    "UTC ISO date",
+			in:      "2022-02-10",
+			want:    time.Date(2022, 02, 10, 0, 0, 0, 0, time.UTC),
+			wantErr: false,
+		},
+		{
+			name:    "Invalid format 1",
+			in:      "20220210",
+			want:    time.Time{},
+			wantErr: true,
+		},
+		{
+			name:    "Invalid format 1",
+			in:      "2022-02-33",
+			want:    time.Time{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := UnmarshalTime(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalTime() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("UnmarshalTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR makes the method that unmarshalls times a bit more flexible.

Currently, only dates that are in full RFC339 format are supported, strictly. This adds a couple more formats relaxing the parser:

- `2006-01-02 15:04:05.999999999` -> allows things like `2022-02-10 10:20:30` (nanoseconds are optional)
- `2006-01-02` -> allowing things like `2022-02-10` (which defaults to midnight)

When a time zone is not specified, it defaults to UTC (as the default for `time.Parse`)

I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [X] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
