### PR TITLE
Websocket i/o timeout fix

### DIFF
--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -195,7 +195,7 @@ func (c *wsConnection) run() {
 		case connectionCloseMessageType:
 			c.close(websocket.CloseNormalClosure, "terminated")
 			return
-		case pingMesageType:
+		case pingMessageType:
 			c.write(&message{t: pongMessageType, payload: m.payload})
 		case pongMessageType:
 			c.conn.SetReadDeadline(time.Now().UTC().Add(2 * c.PingPongInterval))
@@ -226,7 +226,7 @@ func (c *wsConnection) ping(ctx context.Context) {
 			c.pingPongTicker.Stop()
 			return
 		case <-c.pingPongTicker.C:
-			c.write(&message{t: pingMesageType, payload: json.RawMessage{}})
+			c.write(&message{t: pingMessageType, payload: json.RawMessage{}})
 		}
 	}
 }

--- a/graphql/handler/transport/websocket_graphql_transport_ws.go
+++ b/graphql/handler/transport/websocket_graphql_transport_ws.go
@@ -108,7 +108,7 @@ func (m graphqltransportwsMessage) toMessage() (message, error) {
 	case graphqltransportwsCompleteMsg:
 		t = stopMessageType
 	case graphqltransportwsPingMsg:
-		t = pingMesageType
+		t = pingMessageType
 	case graphqltransportwsPongMsg:
 		t = pongMessageType
 	}
@@ -139,7 +139,7 @@ func (m *graphqltransportwsMessage) fromMessage(msg *message) (err error) {
 		m.Type = graphqltransportwsCompleteMsg
 	case errorMessageType:
 		m.Type = graphqltransportwsErrorMsg
-	case pingMesageType:
+	case pingMessageType:
 		m.Type = graphqltransportwsPingMsg
 	case pongMessageType:
 		m.Type = graphqltransportwsPongMsg

--- a/graphql/handler/transport/websocket_subprotocol.go
+++ b/graphql/handler/transport/websocket_subprotocol.go
@@ -18,7 +18,7 @@ const (
 	dataMessageType
 	completeMessageType
 	errorMessageType
-	pingMesageType
+	pingMessageType
 	pongMessageType
 )
 
@@ -70,7 +70,7 @@ func (t messageType) String() string {
 		text = "complete"
 	case errorMessageType:
 		text = "error"
-	case pingMesageType:
+	case pingMessageType:
 		text = "ping"
 	case pongMessageType:
 		text = "pong"

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -347,7 +347,7 @@ func TestWebsocketGraphqltransportwsSubprotocol(t *testing.T) {
 	})
 
 	t.Run("receives no graphql-ws keep alive messages", func(t *testing.T) {
-		_, srv := initialize(transport.Websocket{KeepAlivePingInterval: 5*time.Millisecond})
+		_, srv := initialize(transport.Websocket{KeepAlivePingInterval: 5 * time.Millisecond})
 		defer srv.Close()
 
 		c := wsConnectWithSubprocotol(srv.URL, graphqltransportwsSubprotocol)
@@ -357,7 +357,7 @@ func TestWebsocketGraphqltransportwsSubprotocol(t *testing.T) {
 		assert.Equal(t, graphqltransportwsConnectionAckMsg, readOp(c).Type)
 
 		// If the keep-alives are sent, this deadline will not be used, and no timeout error will be found
-		c.SetReadDeadline(time.Now().UTC().Add(50*time.Millisecond))
+		c.SetReadDeadline(time.Now().UTC().Add(50 * time.Millisecond))
 		var msg operationMessage
 		err := c.ReadJSON(&msg)
 		require.Error(t, err)
@@ -373,7 +373,7 @@ func TestWebsocketWithPingPongInterval(t *testing.T) {
 	}
 
 	t.Run("client receives ping and responds with pong", func(t *testing.T) {
-		_, srv := initialize(transport.Websocket{PingPongInterval: 10*time.Millisecond})
+		_, srv := initialize(transport.Websocket{PingPongInterval: 10 * time.Millisecond})
 		defer srv.Close()
 
 		c := wsConnectWithSubprocotol(srv.URL, graphqltransportwsSubprotocol)
@@ -388,7 +388,7 @@ func TestWebsocketWithPingPongInterval(t *testing.T) {
 	})
 
 	t.Run("client sends ping and expects pong", func(t *testing.T) {
-		_, srv := initialize(transport.Websocket{PingPongInterval: 10*time.Millisecond})
+		_, srv := initialize(transport.Websocket{PingPongInterval: 10 * time.Millisecond})
 		defer srv.Close()
 
 		c := wsConnectWithSubprocotol(srv.URL, graphqltransportwsSubprotocol)
@@ -408,8 +408,8 @@ func TestWebsocketWithPingPongInterval(t *testing.T) {
 		// But since this message type does not exist in the graphql-ws sub protocol, it would fail
 
 		_, srv := initialize(transport.Websocket{
-			PingPongInterval:      5*time.Millisecond,
-			KeepAlivePingInterval: 10*time.Millisecond,
+			PingPongInterval:      5 * time.Millisecond,
+			KeepAlivePingInterval: 10 * time.Millisecond,
 		})
 		defer srv.Close()
 

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -294,22 +294,27 @@ func TestWebsocketInitFunc(t *testing.T) {
 }
 
 func TestWebsocketGraphqltransportwsSubprotocol(t *testing.T) {
-	handler := testserver.New()
-	handler.AddTransport(transport.Websocket{})
-
-	srv := httptest.NewServer(handler)
-	defer srv.Close()
+	initialize := func(ws transport.Websocket) (*testserver.TestServer, *httptest.Server) {
+		h := testserver.New()
+		h.AddTransport(ws)
+		return h, httptest.NewServer(h)
+	}
 
 	t.Run("server acks init", func(t *testing.T) {
+		_, srv := initialize(transport.Websocket{})
+		defer srv.Close()
+
 		c := wsConnectWithSubprocotol(srv.URL, graphqltransportwsSubprotocol)
 		defer c.Close()
 
 		require.NoError(t, c.WriteJSON(&operationMessage{Type: graphqltransportwsConnectionInitMsg}))
-
 		assert.Equal(t, graphqltransportwsConnectionAckMsg, readOp(c).Type)
 	})
 
 	t.Run("client can receive data", func(t *testing.T) {
+		handler, srv := initialize(transport.Websocket{})
+		defer srv.Close()
+
 		c := wsConnectWithSubprocotol(srv.URL, graphqltransportwsSubprotocol)
 		defer c.Close()
 
@@ -340,18 +345,37 @@ func TestWebsocketGraphqltransportwsSubprotocol(t *testing.T) {
 		require.Equal(t, graphqltransportwsCompleteMsg, msg.Type)
 		require.Equal(t, "test_1", msg.ID)
 	})
+
+	t.Run("receives no graphql-ws keep alive messages", func(t *testing.T) {
+		_, srv := initialize(transport.Websocket{KeepAlivePingInterval: 5*time.Millisecond})
+		defer srv.Close()
+
+		c := wsConnectWithSubprocotol(srv.URL, graphqltransportwsSubprotocol)
+		defer c.Close()
+
+		require.NoError(t, c.WriteJSON(&operationMessage{Type: graphqltransportwsConnectionInitMsg}))
+		assert.Equal(t, graphqltransportwsConnectionAckMsg, readOp(c).Type)
+
+		// If the keep-alives are sent, this deadline will not be used, and no timeout error will be found
+		c.SetReadDeadline(time.Now().UTC().Add(50*time.Millisecond))
+		var msg operationMessage
+		err := c.ReadJSON(&msg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "timeout")
+	})
 }
 
 func TestWebsocketWithPingPongInterval(t *testing.T) {
-	handler := testserver.New()
-	handler.AddTransport(transport.Websocket{
-		PingPongInterval: time.Second * 1,
-	})
-
-	srv := httptest.NewServer(handler)
-	defer srv.Close()
+	initialize := func(ws transport.Websocket) (*testserver.TestServer, *httptest.Server) {
+		h := testserver.New()
+		h.AddTransport(ws)
+		return h, httptest.NewServer(h)
+	}
 
 	t.Run("client receives ping and responds with pong", func(t *testing.T) {
+		_, srv := initialize(transport.Websocket{PingPongInterval: 10*time.Millisecond})
+		defer srv.Close()
+
 		c := wsConnectWithSubprocotol(srv.URL, graphqltransportwsSubprotocol)
 		defer c.Close()
 
@@ -364,6 +388,9 @@ func TestWebsocketWithPingPongInterval(t *testing.T) {
 	})
 
 	t.Run("client sends ping and expects pong", func(t *testing.T) {
+		_, srv := initialize(transport.Websocket{PingPongInterval: 10*time.Millisecond})
+		defer srv.Close()
+
 		c := wsConnectWithSubprocotol(srv.URL, graphqltransportwsSubprotocol)
 		defer c.Close()
 
@@ -372,6 +399,33 @@ func TestWebsocketWithPingPongInterval(t *testing.T) {
 
 		require.NoError(t, c.WriteJSON(&operationMessage{Type: graphqltransportwsPingMsg}))
 		assert.Equal(t, graphqltransportwsPongMsg, readOp(c).Type)
+	})
+
+	t.Run("ping-pongs are not sent when the graphql-ws sub protocol is used", func(t *testing.T) {
+		// Regression test
+		// ---
+		// Before the refactor, the code would try to convert a ping message to a graphql-ws message type
+		// But since this message type does not exist in the graphql-ws sub protocol, it would fail
+
+		_, srv := initialize(transport.Websocket{
+			PingPongInterval:      5*time.Millisecond,
+			KeepAlivePingInterval: 10*time.Millisecond,
+		})
+		defer srv.Close()
+
+		// Create connection
+		c := wsConnect(srv.URL)
+		defer c.Close()
+
+		// Initialize connection
+		require.NoError(t, c.WriteJSON(&operationMessage{Type: connectionInitMsg}))
+		assert.Equal(t, connectionAckMsg, readOp(c).Type)
+		assert.Equal(t, connectionKeepAliveMsg, readOp(c).Type)
+
+		// Wait for a few more keep alives to be sure nothing goes wrong
+		assert.Equal(t, connectionKeepAliveMsg, readOp(c).Type)
+		assert.Equal(t, connectionKeepAliveMsg, readOp(c).Type)
+		assert.Equal(t, connectionKeepAliveMsg, readOp(c).Type)
 	})
 }
 


### PR DESCRIPTION
## Description

When configuring a ping-pong interval on a web socket, it requires each web socket connection to send pings, and receive pongs. To make sure that gqlgen receives the pongs in time, a read deadline is set on the websocket connection. This functions fine as long as the `graphql-transport-ws` sub protocol is used. However, when using the `graphql-ws` sub protocol, it causes i/o timeout errors. 

The reason that there are timeout errors when `graphql-ws` is used with a configured ping-pong interval is quite simple; [`graphql-ws` does not support ping-pong messages](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md).

So, to fix this, we just disable the whole ping-pong mechanism when using `graphql-ws`!

## What does this PR exactly do?

* Fixes a typo (`pingMesageType` => `pingMessageType`)
* Slightly refactors the code in the `websocket_graphqlws.go` file to look more like the code in the `websocket_graphql_transport_ws.go` file (for the sake of consistency)
* Added two extra `if` statements in the websocket code that make sure that the `keepAlive` messages, as well as the ping messages, only get send when their corresponding sub protocol is selected (keep-alive => `graphql-transport-ws`, ping => `graphql-ws`)

## Some extra details

The full server error is `read tcp x.x.x.x:x->x.x.x.x:x: i/o timeout`, and the full client error is `invalid close code`.

---

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))

Not needed:
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
