### PR TITLE
Fix broken links in docs

### DIFF
--- a/docs/content/feature-comparison.md
+++ b/docs/content/feature-comparison.md
@@ -10,7 +10,7 @@ weight: -1
 | --------: | :-------- | :-------- | :-------- | :-------- |
 | Kind | schema first | schema first | run time types | struct first |
 | Boilerplate | less | more | more | some |
-| Docs | [docs](https://gqlgen.com) & [examples](https://github.com/99designs/gqlgen/tree/master/example) | [examples](https://github.com/graph-gophers/graphql-go/tree/master/_examples/starwars) | [examples](https://github.com/graphql-go/graphql/tree/master/examples) | [examples](https://github.com/samsarahq/thunder/tree/master/example)|
+| Docs | [docs](https://gqlgen.com) & [examples](https://github.com/99designs/gqlgen/tree/master/_examples) | [examples](https://github.com/graph-gophers/graphql-go/tree/master/example/starwars) | [examples](https://github.com/graphql-go/graphql/tree/master/examples) | [examples](https://github.com/samsarahq/thunder/tree/master/example)|
 | Query | 👍 | 👍 | 👍 | 👍 |
 | Mutation | 👍 | 🚧 [pr](https://github.com/graph-gophers/graphql-go/pull/182) | 👍 | 👍 |
 | Subscription | 👍 | 🚧 [pr](https://github.com/graph-gophers/graphql-go/pull/182) | 👍 | 👍 |


### PR DESCRIPTION
I believe the wrong link was changed in #1734. This fixes the links.

This is a documentation only change.