### PR TITLE
fixed graphql.InputFields to support deprecated directive for input object

### DIFF
--- a/graphql/introspection/introspection.go
+++ b/graphql/introspection/introspection.go
@@ -31,6 +31,7 @@ type (
 		Description  string
 		DefaultValue *string
 		Type         *Type
+		deprecation  *ast.Directive
 	}
 )
 
@@ -65,6 +66,23 @@ func (f *Field) DeprecationReason() *string {
 	}
 
 	reason := f.deprecation.Arguments.ForName("reason")
+	if reason == nil {
+		return nil
+	}
+
+	return &reason.Value.Raw
+}
+
+func (i *InputValue) IsDeprecated() bool {
+	return i.deprecation != nil
+}
+
+func (i *InputValue) DeprecationReason() *string {
+	if i.deprecation == nil {
+		return nil
+	}
+
+	reason := i.deprecation.Arguments.ForName("reason")
 	if reason == nil {
 		return nil
 	}

--- a/graphql/introspection/type.go
+++ b/graphql/introspection/type.go
@@ -81,6 +81,7 @@ func (t *Type) Fields(includeDeprecated bool) []Field {
 				Name:         arg.Name,
 				Description:  arg.Description,
 				DefaultValue: defaultValue(arg.DefaultValue),
+				deprecation:  arg.Directives.ForName("deprecated"),
 			})
 		}
 
@@ -95,18 +96,25 @@ func (t *Type) Fields(includeDeprecated bool) []Field {
 	return fields
 }
 
+// TODO(codehex): update prelude in gqlparser to support deprecated directive for input object type.
+// func (t *Type) InputFields(includeDeprecated bool) []InputValue {
 func (t *Type) InputFields() []InputValue {
+	includeDeprecated := false // remove if updated
 	if t.def == nil || t.def.Kind != ast.InputObject {
 		return []InputValue{}
 	}
 
 	res := []InputValue{}
 	for _, f := range t.def.Fields {
+		if !includeDeprecated && f.Directives.ForName("deprecated") != nil {
+			continue
+		}
 		res = append(res, InputValue{
 			Name:         f.Name,
 			Description:  f.Description,
 			Type:         WrapTypeFromType(t.schema, f.Type),
 			DefaultValue: defaultValue(f.DefaultValue),
+			deprecation:  f.Directives.ForName("deprecated"),
 		})
 	}
 	return res

--- a/graphql/introspection/type_test.go
+++ b/graphql/introspection/type_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
-func TestType(t *testing.T) {
+func TestObjectType(t *testing.T) {
 	schemaType := Type{
 		def: &ast.Definition{
 			Name:        "Query",
@@ -37,10 +37,49 @@ func TestType(t *testing.T) {
 		require.Equal(t, "test", fields[0].Name)
 	})
 
-	t.Run("fields includeDepricated", func(t *testing.T) {
+	t.Run("fields includeDeprecated", func(t *testing.T) {
 		fields := schemaType.Fields(true)
 		require.Len(t, fields, 2)
 		require.Equal(t, "test", fields[0].Name)
 		require.Equal(t, "deprecated", fields[1].Name)
 	})
+}
+
+func TestInputObjectType(t *testing.T) {
+	schemaType := Type{
+		def: &ast.Definition{
+			Name:        "AnyInput",
+			Description: "test description",
+			Fields: ast.FieldList{
+				&ast.FieldDefinition{Name: "test"},
+				&ast.FieldDefinition{Name: "deprecated",
+					Directives: ast.DirectiveList{
+						&ast.Directive{Name: "deprecated"},
+					},
+				},
+			},
+			Kind: ast.InputObject,
+		},
+	}
+
+	t.Run("name", func(t *testing.T) {
+		require.Equal(t, "AnyInput", *schemaType.Name())
+	})
+
+	t.Run("description", func(t *testing.T) {
+		require.Equal(t, "test description", schemaType.Description())
+	})
+
+	t.Run("input fields", func(t *testing.T) {
+		fields := schemaType.InputFields() // change to InputFields(false) if updated prelude
+		require.Len(t, fields, 1)
+		require.Equal(t, "test", fields[0].Name)
+	})
+
+	// t.Run("fields includeDeprecated", func(t *testing.T) {
+	// 	fields := schemaType.InputFields(true)
+	// 	require.Len(t, fields, 2)
+	// 	require.Equal(t, "test", fields[0].Name)
+	// 	require.Equal(t, "deprecated", fields[1].Name)
+	// })
 }


### PR DESCRIPTION
I wrote code to fix https://github.com/99designs/gqlgen/issues/1636 but currently, the prelude is reverted. this code will be able to use prelude is updated.

This change does not affect automatic generation, as we are now maintaining compatibility


Describe your PR and link to any relevant issues. 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
