### PR TITLE
Web Socket initialization message timeout

### DIFF
--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -329,7 +329,7 @@ func TestWebSocketInitTimeout(t *testing.T) {
 
 		select {
 		case <-done:
-			assert.Fail(t, "")
+			assert.Fail(t, "web socket read operation finished while it shouldn't have")
 		case <-time.After(100 * time.Millisecond):
 			// Success! I guess? Can't really wait forever to see if the read waits forever...
 		}


### PR DESCRIPTION
Adds an optional timeout to the web socket initialization message read operation. 

This way, clients cannot occupy connections that are not ready to be used until the earth dries out! ✨

---

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))

Not needed:
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
