### PR TITLE
Test gqlgen generate in CI

### DIFF
--- a/.github/workflows/check-init
+++ b/.github/workflows/check-init
@@ -5,10 +5,17 @@ set -euo pipefail
 gqlgen_dir=$(pwd)
 cd $(mktemp -d)
 go mod init inittest
+printf '// +build tools\npackage tools\nimport _ "github.com/99designs/gqlgen"' | gofmt > tools.go
+go mod tidy
 go mod edit -replace=github.com/99designs/gqlgen="$gqlgen_dir"
-go get -d github.com/99designs/gqlgen
+go mod tidy
 
-if ! go run github.com/99designs/gqlgen init &>/dev/null ; then
+if ! go run github.com/99designs/gqlgen init ; then
     echo "gqlgen init failed"
+    exit 125
+fi
+
+if ! go run github.com/99designs/gqlgen generate ; then
+    echo "gqlgen generate failed"
     exit 125
 fi

--- a/main.go
+++ b/main.go
@@ -191,7 +191,7 @@ var initCmd = &cli.Command{
 		fmt.Println("Creating", serverFilename)
 		fmt.Println("Generating...")
 		if err := api.Generate(cfg, api.AddPlugin(servergen.New(serverFilename))); err != nil {
-			fmt.Fprintln(os.Stderr, err.Error())
+			return err
 		}
 
 		fmt.Printf("\nExec \"go run ./%s\" to start GraphQL server\n", serverFilename)


### PR DESCRIPTION
The `gqlgen init` already tested in CI should be followed up with another `gqlgen generate` to prevent regressions like the one seen in #1849.

`gqlgen init` should also return an error if the generation step fails.