### PR TITLE
fixed model gen for multiple implemented type

### DIFF
--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -110,8 +110,23 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 				Description: schemaType.Description,
 				Name:        schemaType.Name,
 			}
+
+			// If Interface A implements interface B, and Interface C also implements interface B
+			// then both A and C have methods of B.
+			// The reason for checking unique is to prevent the same method B from being generated twice.
+			uniqueMap := map[string]bool{}
 			for _, implementor := range cfg.Schema.GetImplements(schemaType) {
-				it.Implements = append(it.Implements, implementor.Name)
+				if !uniqueMap[implementor.Name] {
+					it.Implements = append(it.Implements, implementor.Name)
+					uniqueMap[implementor.Name] = true
+				}
+				// for interface implements
+				for _, iface := range implementor.Interfaces {
+					if !uniqueMap[iface] {
+						it.Implements = append(it.Implements, iface)
+						uniqueMap[iface] = true
+					}
+				}
 			}
 
 			for _, field := range schemaType.Fields {

--- a/plugin/modelgen/out/generated.go
+++ b/plugin/modelgen/out/generated.go
@@ -49,6 +49,18 @@ type UnionWithDescription interface {
 	IsUnionWithDescription()
 }
 
+type CDImplemented struct {
+	A string  `json:"a" database:"CDImplementeda"`
+	B int     `json:"b" database:"CDImplementedb"`
+	C bool    `json:"c" database:"CDImplementedc"`
+	D *string `json:"d" database:"CDImplementedd"`
+}
+
+func (CDImplemented) IsC() {}
+func (CDImplemented) IsA() {}
+func (CDImplemented) IsD() {}
+func (CDImplemented) IsB() {}
+
 type FieldMutationHook struct {
 	Name     *string       `json:"name" anotherTag:"tag" database:"FieldMutationHookname"`
 	Enum     *ExistingEnum `json:"enum" yetAnotherTag:"12" database:"FieldMutationHookenum"`

--- a/plugin/modelgen/testdata/schema.graphql
+++ b/plugin/modelgen/testdata/schema.graphql
@@ -125,3 +125,10 @@ interface D implements A & B {
     b: Int!
     d: String
 }
+
+type CDImplemented implements C & D {
+    a: String!
+    b: Int!
+    c: Boolean!
+    d: String
+}


### PR DESCRIPTION
I found a bug that when GraphQL type implements multiple interfaces, it does not generate the model methods of the interfaces those interfaces implement.

We would appreciate it if you could merge this fix and release it as version v0.17.1 as soon as possible :bow:

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
