### PR TITLE
fixed modelgen test schema

### DIFF
--- a/plugin/modelgen/testdata/schema.graphql
+++ b/plugin/modelgen/testdata/schema.graphql
@@ -126,7 +126,7 @@ interface D implements A & B {
     d: String
 }
 
-type CDImplemented implements C & D {
+type CDImplemented implements C & D & A & B {
     a: String!
     b: Int!
     c: Boolean!


### PR DESCRIPTION
fixed for https://github.com/vektah/gqlparser/pull/202

If we don't merge this fix, tests will fail in the future because of the PR

```
--- FAIL: TestModelGeneration (0.00s)
    models_test.go:22:
                Error Trace:    models_test.go:22
                Error:          Received unexpected error:
                                testdata/schema.graphql:129: Type CDImplemented must implement A because it is implemented by C
                Test:           TestModelGeneration
FAIL
FAIL    github.com/99designs/gqlgen/plugin/modelgen     0.121s
```

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
