### PR TITLE
Added support for uint id

### DIFF
--- a/graphql/id.go
+++ b/graphql/id.go
@@ -56,3 +56,26 @@ func UnmarshalIntID(v interface{}) (int, error) {
 		return 0, fmt.Errorf("%T is not an int", v)
 	}
 }
+
+func MarshalUintID(i uint) Marshaler {
+	return WriterFunc(func(w io.Writer) {
+		writeQuotedString(w, strconv.FormatUint(uint64(i), 10))
+	})
+}
+
+func UnmarshalUintID(v interface{}) (uint, error) {
+	switch v := v.(type) {
+	case string:
+		num, err := strconv.ParseUint(v, 10, 0)
+		return uint(num), err
+	case uint:
+		return v, nil
+	case uint64:
+		return uint(v), nil
+	case json.Number:
+		num, err := strconv.ParseUint(string(v), 10, 0)
+		return uint(num), err
+	default:
+		return 0, fmt.Errorf("%T is not an uint", v)
+	}
+}


### PR DESCRIPTION
In almost all projects I use uint type for id. But gqlgen only has int, so I decided to add uint support.