### PR TITLE
Bump Playground version

### DIFF
--- a/graphql/playground/playground.go
+++ b/graphql/playground/playground.go
@@ -63,8 +63,8 @@ func Handler(title string, endpoint string) http.HandlerFunc {
 			"title":       title,
 			"endpoint":    endpoint,
 			"version":     "1.8.2",
-			"cssSRI":      "sha256-HADQowUuFum02+Ckkv5Yu5ygRoLllHZqg0TFZXY7NHI=",
-			"jsSRI":       "sha256-uHp12yvpXC4PC9+6JmITxKuLYwjlW9crq9ywPE5Rxco=",
+			"cssSRI":      "sha256-CDHiHbYkDSUc3+DS2TU89I9e2W3sJRUOqSmp7JC+LBw=",
+			"jsSRI":       "sha256-X8vqrqZ6Rvvoq4tvRVM3LoMZCQH8jwW92tnX0iPiHPc=",
 			"reactSRI":    "sha256-Ipu/TQ50iCCVZBUsZyNJfxrDk0E2yhaEIz0vqI+kFG8=",
 			"reactDOMSRI": "sha256-nbMykgB6tsOFJ7OdVmPpdqMFVk4ZsqWocT6issAPUF0=",
 		})

--- a/graphql/playground/playground.go
+++ b/graphql/playground/playground.go
@@ -60,7 +60,7 @@ func Handler(title string, endpoint string) http.HandlerFunc {
 		err := page.Execute(w, map[string]string{
 			"title":       title,
 			"endpoint":    endpoint,
-			"version":     "1.5.16",
+			"version":     "1.8.2",
 			"cssSRI":      "sha256-HADQowUuFum02+Ckkv5Yu5ygRoLllHZqg0TFZXY7NHI=",
 			"jsSRI":       "sha256-uHp12yvpXC4PC9+6JmITxKuLYwjlW9crq9ywPE5Rxco=",
 			"reactSRI":    "sha256-Ipu/TQ50iCCVZBUsZyNJfxrDk0E2yhaEIz0vqI+kFG8=",

--- a/graphql/playground/playground.go
+++ b/graphql/playground/playground.go
@@ -44,6 +44,7 @@ var page = template.Must(template.New("graphiql").Parse(`<!DOCTYPE html>
       ReactDOM.render(
         React.createElement(GraphiQL, {
           fetcher: fetcher,
+          tabs: true,
           headerEditorEnabled: true,
           shouldPersistHeaders: true
         }),
@@ -54,6 +55,7 @@ var page = template.Must(template.New("graphiql").Parse(`<!DOCTYPE html>
 </html>
 `))
 
+// Handler responsible for setting up the playground
 func Handler(title string, endpoint string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "text/html")


### PR DESCRIPTION
The switch from the deprecated but far superior GraphQL playground to the new de facto standard GraphiQL playground was a bit rough. The good news is GraphiQL is undergoing rapid development. With this version bump and additional tag, we now have access to multiple tabs in the playground which is very useful. I hope to continue these version bumps as more useful features emerge.

I have:
 - [n/a] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ n/a] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
