### PR TITLE
Add instructions for enabling autobinding

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -193,7 +193,17 @@ This example is great, but in the real world fetching most objects is expensive.
 todo unless the user actually asked for it. So lets replace the generated `Todo` model with something slightly more
 realistic.
 
-Create a new file called `graph/model/todo.go`
+First let's enable `autobind`, allowing gqlgen to use your custom models if it can find them rather than generating them. We do this by uncommenting the `autobind` config line in `gqlgen.yml`:
+
+```yml
+# gqlgen will search for any type names in the schema in these go packages
+# if they match it will use them, otherwise it will generate them.
+autobind:
+ - "github.com/[username]/gqlgen-todos/graph/model"
+```
+
+Next, create a new file called `graph/model/todo.go`
+
 ```go
 package model
 
@@ -204,10 +214,6 @@ type Todo struct {
 	User   *User  `json:"user"`
 }
 ```
-
-> Note
->
-> By default gqlgen will use any models in the model directory that match on name, this can be configured in `gqlgen.yml`.
 
 And run `go run github.com/99designs/gqlgen generate`.
 


### PR DESCRIPTION
The _Getting Started_ guide doesn't mention that you need to enable autobinding to follow the final steps.

The `gqlgen.yml` file generated using the `init` command [has autobinding disabled by default](https://github.com/99designs/gqlgen/blob/master/init-templates/gqlgen.yml.gotmpl#L35-L38) instead of enabled as the docs previously stated.

This tiny PR adjusts the guide to address this point.

I have:
 - [ ] ~Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))~
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
