### PR TITLE
Fix the ability of websockets to get errors

### DIFF
--- a/_examples/chat/generated.go
+++ b/_examples/chat/generated.go
@@ -220,7 +220,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		var buf bytes.Buffer
 		return func(ctx context.Context) *graphql.Response {
 			buf.Reset()
-			data := next()
+			data := next(ctx)
 
 			if data == nil {
 				return nil
@@ -419,7 +419,7 @@ func (ec *executionContext) field___Type_fields_args(ctx context.Context, rawArg
 
 // region    ************************** directives.gotpl **************************
 
-func (ec *executionContext) _subscriptionMiddleware(ctx context.Context, obj *ast.OperationDefinition, next func(ctx context.Context) (interface{}, error)) func() graphql.Marshaler {
+func (ec *executionContext) _subscriptionMiddleware(ctx context.Context, obj *ast.OperationDefinition, next func(ctx context.Context) (interface{}, error)) func(ctx context.Context) graphql.Marshaler {
 	for _, d := range obj.Directives {
 		switch d.Name {
 		case "user":
@@ -427,7 +427,7 @@ func (ec *executionContext) _subscriptionMiddleware(ctx context.Context, obj *as
 			args, err := ec.dir_user_args(ctx, rawArgs)
 			if err != nil {
 				ec.Error(ctx, err)
-				return func() graphql.Marshaler {
+				return func(ctx context.Context) graphql.Marshaler {
 					return graphql.Null
 				}
 			}
@@ -443,15 +443,15 @@ func (ec *executionContext) _subscriptionMiddleware(ctx context.Context, obj *as
 	tmp, err := next(ctx)
 	if err != nil {
 		ec.Error(ctx, err)
-		return func() graphql.Marshaler {
+		return func(ctx context.Context) graphql.Marshaler {
 			return graphql.Null
 		}
 	}
-	if data, ok := tmp.(func() graphql.Marshaler); ok {
+	if data, ok := tmp.(func(ctx context.Context) graphql.Marshaler); ok {
 		return data
 	}
 	ec.Errorf(ctx, `unexpected type %T from directive, should be graphql.Marshaler`, tmp)
-	return func() graphql.Marshaler {
+	return func(ctx context.Context) graphql.Marshaler {
 		return graphql.Null
 	}
 }
@@ -986,7 +986,7 @@ func (ec *executionContext) fieldContext_Query___schema(ctx context.Context, fie
 	return fc, nil
 }
 
-func (ec *executionContext) _Subscription_messageAdded(ctx context.Context, field graphql.CollectedField) (ret func() graphql.Marshaler) {
+func (ec *executionContext) _Subscription_messageAdded(ctx context.Context, field graphql.CollectedField) (ret func(ctx context.Context) graphql.Marshaler) {
 	fc, err := ec.fieldContext_Subscription_messageAdded(ctx, field)
 	if err != nil {
 		return nil
@@ -1012,7 +1012,7 @@ func (ec *executionContext) _Subscription_messageAdded(ctx context.Context, fiel
 		}
 		return nil
 	}
-	return func() graphql.Marshaler {
+	return func(ctx context.Context) graphql.Marshaler {
 		res, ok := <-resTmp.(<-chan *Message)
 		if !ok {
 			return nil
@@ -3050,7 +3050,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 
 var subscriptionImplementors = []string{"Subscription"}
 
-func (ec *executionContext) _Subscription(ctx context.Context, sel ast.SelectionSet) func() graphql.Marshaler {
+func (ec *executionContext) _Subscription(ctx context.Context, sel ast.SelectionSet) func(ctx context.Context) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, subscriptionImplementors)
 	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
 		Object: "Subscription",

--- a/codegen/directives.gotpl
+++ b/codegen/directives.gotpl
@@ -70,7 +70,7 @@ func (ec *executionContext) _mutationMiddleware(ctx context.Context, obj *ast.Op
 {{ end }}
 
 {{ if .Directives.LocationDirectives "SUBSCRIPTION" }}
-func (ec *executionContext) _subscriptionMiddleware(ctx context.Context, obj *ast.OperationDefinition, next func(ctx context.Context) (interface{}, error)) func() graphql.Marshaler {
+func (ec *executionContext) _subscriptionMiddleware(ctx context.Context, obj *ast.OperationDefinition, next func(ctx context.Context) (interface{}, error)) func(ctx context.Context) graphql.Marshaler {
 	for _, d := range obj.Directives {
 		switch d.Name {
 		{{- range $directive := .Directives.LocationDirectives "SUBSCRIPTION" }}
@@ -80,7 +80,7 @@ func (ec *executionContext) _subscriptionMiddleware(ctx context.Context, obj *as
 				args, err := ec.{{ $directive.ArgsFunc }}(ctx,rawArgs)
 				if err != nil {
 					ec.Error(ctx, err)
-					return func() graphql.Marshaler {
+					return func(ctx context.Context) graphql.Marshaler {
 						return graphql.Null
 					}
 				}
@@ -98,15 +98,15 @@ func (ec *executionContext) _subscriptionMiddleware(ctx context.Context, obj *as
 	tmp, err := next(ctx)
 	if err != nil {
 		ec.Error(ctx, err)
-		return func() graphql.Marshaler {
+		return func(ctx context.Context) graphql.Marshaler {
 			return graphql.Null
 		}
 	}
-	if data, ok := tmp.(func() graphql.Marshaler); ok {
+	if data, ok := tmp.(func(ctx context.Context) graphql.Marshaler); ok {
 		return data
 	}
 	ec.Errorf(ctx, `unexpected type %T from directive, should be graphql.Marshaler`, tmp)
-	return func() graphql.Marshaler {
+	return func(ctx context.Context) graphql.Marshaler {
 		return graphql.Null
 	}
 }

--- a/codegen/field.gotpl
+++ b/codegen/field.gotpl
@@ -1,6 +1,6 @@
 {{- range $object := .Objects }}{{- range $field := $object.Fields }}
 
-func (ec *executionContext) _{{$object.Name}}_{{$field.Name}}(ctx context.Context, field graphql.CollectedField{{ if not $object.Root }}, obj {{$object.Reference | ref}}{{end}}) (ret {{ if $object.Stream }}func(){{ end }}graphql.Marshaler) {
+func (ec *executionContext) _{{$object.Name}}_{{$field.Name}}(ctx context.Context, field graphql.CollectedField{{ if not $object.Root }}, obj {{$object.Reference | ref}}{{end}}) (ret {{ if $object.Stream }}func(ctx context.Context){{ end }}graphql.Marshaler) {
 	{{- $null := "graphql.Null" }}
 	{{- if $object.Stream }}
 		{{- $null = "nil" }}
@@ -38,7 +38,7 @@ func (ec *executionContext) _{{$object.Name}}_{{$field.Name}}(ctx context.Contex
 		return {{ $null }}
 	}
 	{{- if $object.Stream }}
-		return func() graphql.Marshaler {
+		return func(ctx context.Context) graphql.Marshaler {
 			res, ok := <-resTmp.(<-chan {{$field.TypeReference.GO | ref}})
 			if !ok {
 				return nil

--- a/codegen/generated!.gotpl
+++ b/codegen/generated!.gotpl
@@ -190,7 +190,7 @@
 			var buf bytes.Buffer
 			return func(ctx context.Context) *graphql.Response {
 				buf.Reset()
-				data := next()
+				data := next(ctx)
 
 				if data == nil {
 					return nil

--- a/codegen/object.gotpl
+++ b/codegen/object.gotpl
@@ -3,7 +3,7 @@
 var {{ $object.Name|lcFirst}}Implementors = {{$object.Implementors}}
 
 {{- if .Stream }}
-func (ec *executionContext) _{{$object.Name}}(ctx context.Context, sel ast.SelectionSet) func() graphql.Marshaler {
+func (ec *executionContext) _{{$object.Name}}(ctx context.Context, sel ast.SelectionSet) func(ctx context.Context) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, {{$object.Name|lcFirst}}Implementors)
 	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
 		Object: {{$object.Name|quote}},

--- a/codegen/root_.gotpl
+++ b/codegen/root_.gotpl
@@ -157,7 +157,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		var buf bytes.Buffer
 		return func(ctx context.Context) *graphql.Response {
 			buf.Reset()
-			data := next()
+			data := next(ctx)
 
 			if data == nil {
 				return nil

--- a/codegen/testserver/followschema/nulls.graphql
+++ b/codegen/testserver/followschema/nulls.graphql
@@ -6,6 +6,10 @@ extend type Query {
     valid: String!
 }
 
+extend type Subscription {
+	errorRequired: Error!
+}
+
 type Errors {
     a: Error!
     b: Error!

--- a/codegen/testserver/followschema/resolver.go
+++ b/codegen/testserver/followschema/resolver.go
@@ -372,6 +372,10 @@ func (r *subscriptionResolver) Issue896b(ctx context.Context) (<-chan []*CheckIs
 	panic("not implemented")
 }
 
+func (r *subscriptionResolver) ErrorRequired(ctx context.Context) (<-chan *Error, error) {
+	panic("not implemented")
+}
+
 func (r *userResolver) Friends(ctx context.Context, obj *User) ([]*User, error) {
 	panic("not implemented")
 }

--- a/codegen/testserver/followschema/root_.generated.go
+++ b/codegen/testserver/followschema/root_.generated.go
@@ -367,6 +367,7 @@ type ComplexityRoot struct {
 		DirectiveDouble        func(childComplexity int) int
 		DirectiveNullableArg   func(childComplexity int, arg *int, arg2 *int, arg3 *string) int
 		DirectiveUnimplemented func(childComplexity int) int
+		ErrorRequired          func(childComplexity int) int
 		InitPayload            func(childComplexity int) int
 		Issue896b              func(childComplexity int) int
 		Updated                func(childComplexity int) int
@@ -1713,6 +1714,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Subscription.DirectiveUnimplemented(childComplexity), true
 
+	case "Subscription.errorRequired":
+		if e.complexity.Subscription.ErrorRequired == nil {
+			break
+		}
+
+		return e.complexity.Subscription.ErrorRequired(childComplexity), true
+
 	case "Subscription.initPayload":
 		if e.complexity.Subscription.InitPayload == nil {
 			break
@@ -1948,7 +1956,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		var buf bytes.Buffer
 		return func(ctx context.Context) *graphql.Response {
 			buf.Reset()
-			data := next()
+			data := next(ctx)
 
 			if data == nil {
 				return nil
@@ -2250,6 +2258,10 @@ input NestedInput {
     errorList: [Error]
     errors: Errors
     valid: String!
+}
+
+extend type Subscription {
+	errorRequired: Error!
 }
 
 type Errors {

--- a/codegen/testserver/followschema/schema.generated.go
+++ b/codegen/testserver/followschema/schema.generated.go
@@ -106,6 +106,7 @@ type SubscriptionResolver interface {
 	DirectiveDouble(ctx context.Context) (<-chan *string, error)
 	DirectiveUnimplemented(ctx context.Context) (<-chan *string, error)
 	Issue896b(ctx context.Context) (<-chan []*CheckIssue896, error)
+	ErrorRequired(ctx context.Context) (<-chan *Error, error)
 }
 type UserResolver interface {
 	Friends(ctx context.Context, obj *User) ([]*User, error)
@@ -4698,7 +4699,7 @@ func (ec *executionContext) fieldContext_Query___schema(ctx context.Context, fie
 	return fc, nil
 }
 
-func (ec *executionContext) _Subscription_updated(ctx context.Context, field graphql.CollectedField) (ret func() graphql.Marshaler) {
+func (ec *executionContext) _Subscription_updated(ctx context.Context, field graphql.CollectedField) (ret func(ctx context.Context) graphql.Marshaler) {
 	fc, err := ec.fieldContext_Subscription_updated(ctx, field)
 	if err != nil {
 		return nil
@@ -4721,7 +4722,7 @@ func (ec *executionContext) _Subscription_updated(ctx context.Context, field gra
 		}
 		return nil
 	}
-	return func() graphql.Marshaler {
+	return func(ctx context.Context) graphql.Marshaler {
 		res, ok := <-resTmp.(<-chan string)
 		if !ok {
 			return nil
@@ -4749,7 +4750,7 @@ func (ec *executionContext) fieldContext_Subscription_updated(ctx context.Contex
 	return fc, nil
 }
 
-func (ec *executionContext) _Subscription_initPayload(ctx context.Context, field graphql.CollectedField) (ret func() graphql.Marshaler) {
+func (ec *executionContext) _Subscription_initPayload(ctx context.Context, field graphql.CollectedField) (ret func(ctx context.Context) graphql.Marshaler) {
 	fc, err := ec.fieldContext_Subscription_initPayload(ctx, field)
 	if err != nil {
 		return nil
@@ -4772,7 +4773,7 @@ func (ec *executionContext) _Subscription_initPayload(ctx context.Context, field
 		}
 		return nil
 	}
-	return func() graphql.Marshaler {
+	return func(ctx context.Context) graphql.Marshaler {
 		res, ok := <-resTmp.(<-chan string)
 		if !ok {
 			return nil
@@ -4800,7 +4801,7 @@ func (ec *executionContext) fieldContext_Subscription_initPayload(ctx context.Co
 	return fc, nil
 }
 
-func (ec *executionContext) _Subscription_directiveArg(ctx context.Context, field graphql.CollectedField) (ret func() graphql.Marshaler) {
+func (ec *executionContext) _Subscription_directiveArg(ctx context.Context, field graphql.CollectedField) (ret func(ctx context.Context) graphql.Marshaler) {
 	fc, err := ec.fieldContext_Subscription_directiveArg(ctx, field)
 	if err != nil {
 		return nil
@@ -4820,7 +4821,7 @@ func (ec *executionContext) _Subscription_directiveArg(ctx context.Context, fiel
 	if resTmp == nil {
 		return nil
 	}
-	return func() graphql.Marshaler {
+	return func(ctx context.Context) graphql.Marshaler {
 		res, ok := <-resTmp.(<-chan *string)
 		if !ok {
 			return nil
@@ -4859,7 +4860,7 @@ func (ec *executionContext) fieldContext_Subscription_directiveArg(ctx context.C
 	return fc, nil
 }
 
-func (ec *executionContext) _Subscription_directiveNullableArg(ctx context.Context, field graphql.CollectedField) (ret func() graphql.Marshaler) {
+func (ec *executionContext) _Subscription_directiveNullableArg(ctx context.Context, field graphql.CollectedField) (ret func(ctx context.Context) graphql.Marshaler) {
 	fc, err := ec.fieldContext_Subscription_directiveNullableArg(ctx, field)
 	if err != nil {
 		return nil
@@ -4879,7 +4880,7 @@ func (ec *executionContext) _Subscription_directiveNullableArg(ctx context.Conte
 	if resTmp == nil {
 		return nil
 	}
-	return func() graphql.Marshaler {
+	return func(ctx context.Context) graphql.Marshaler {
 		res, ok := <-resTmp.(<-chan *string)
 		if !ok {
 			return nil
@@ -4918,7 +4919,7 @@ func (ec *executionContext) fieldContext_Subscription_directiveNullableArg(ctx c
 	return fc, nil
 }
 
-func (ec *executionContext) _Subscription_directiveDouble(ctx context.Context, field graphql.CollectedField) (ret func() graphql.Marshaler) {
+func (ec *executionContext) _Subscription_directiveDouble(ctx context.Context, field graphql.CollectedField) (ret func(ctx context.Context) graphql.Marshaler) {
 	fc, err := ec.fieldContext_Subscription_directiveDouble(ctx, field)
 	if err != nil {
 		return nil
@@ -4964,7 +4965,7 @@ func (ec *executionContext) _Subscription_directiveDouble(ctx context.Context, f
 	if resTmp == nil {
 		return nil
 	}
-	return func() graphql.Marshaler {
+	return func(ctx context.Context) graphql.Marshaler {
 		res, ok := <-resTmp.(<-chan *string)
 		if !ok {
 			return nil
@@ -4992,7 +4993,7 @@ func (ec *executionContext) fieldContext_Subscription_directiveDouble(ctx contex
 	return fc, nil
 }
 
-func (ec *executionContext) _Subscription_directiveUnimplemented(ctx context.Context, field graphql.CollectedField) (ret func() graphql.Marshaler) {
+func (ec *executionContext) _Subscription_directiveUnimplemented(ctx context.Context, field graphql.CollectedField) (ret func(ctx context.Context) graphql.Marshaler) {
 	fc, err := ec.fieldContext_Subscription_directiveUnimplemented(ctx, field)
 	if err != nil {
 		return nil
@@ -5032,7 +5033,7 @@ func (ec *executionContext) _Subscription_directiveUnimplemented(ctx context.Con
 	if resTmp == nil {
 		return nil
 	}
-	return func() graphql.Marshaler {
+	return func(ctx context.Context) graphql.Marshaler {
 		res, ok := <-resTmp.(<-chan *string)
 		if !ok {
 			return nil
@@ -5060,7 +5061,7 @@ func (ec *executionContext) fieldContext_Subscription_directiveUnimplemented(ctx
 	return fc, nil
 }
 
-func (ec *executionContext) _Subscription_issue896b(ctx context.Context, field graphql.CollectedField) (ret func() graphql.Marshaler) {
+func (ec *executionContext) _Subscription_issue896b(ctx context.Context, field graphql.CollectedField) (ret func(ctx context.Context) graphql.Marshaler) {
 	fc, err := ec.fieldContext_Subscription_issue896b(ctx, field)
 	if err != nil {
 		return nil
@@ -5080,7 +5081,7 @@ func (ec *executionContext) _Subscription_issue896b(ctx context.Context, field g
 	if resTmp == nil {
 		return nil
 	}
-	return func() graphql.Marshaler {
+	return func(ctx context.Context) graphql.Marshaler {
 		res, ok := <-resTmp.(<-chan []*CheckIssue896)
 		if !ok {
 			return nil
@@ -5107,6 +5108,67 @@ func (ec *executionContext) fieldContext_Subscription_issue896b(ctx context.Cont
 				return ec.fieldContext_CheckIssue896_id(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type CheckIssue896", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Subscription_errorRequired(ctx context.Context, field graphql.CollectedField) (ret func(ctx context.Context) graphql.Marshaler) {
+	fc, err := ec.fieldContext_Subscription_errorRequired(ctx, field)
+	if err != nil {
+		return nil
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = nil
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Subscription().ErrorRequired(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return nil
+	}
+	return func(ctx context.Context) graphql.Marshaler {
+		res, ok := <-resTmp.(<-chan *Error)
+		if !ok {
+			return nil
+		}
+		return graphql.WriterFunc(func(w io.Writer) {
+			w.Write([]byte{'{'})
+			graphql.MarshalString(field.Alias).MarshalGQL(w)
+			w.Write([]byte{':'})
+			ec.marshalNError2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐError(ctx, field.Selections, res).MarshalGQL(w)
+			w.Write([]byte{'}'})
+		})
+	}
+}
+
+func (ec *executionContext) fieldContext_Subscription_errorRequired(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Subscription",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Error_id(ctx, field)
+			case "errorOnNonRequiredField":
+				return ec.fieldContext_Error_errorOnNonRequiredField(ctx, field)
+			case "errorOnRequiredField":
+				return ec.fieldContext_Error_errorOnRequiredField(ctx, field)
+			case "nilOnRequiredField":
+				return ec.fieldContext_Error_nilOnRequiredField(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Error", field.Name)
 		},
 	}
 	return fc, nil
@@ -7223,7 +7285,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 
 var subscriptionImplementors = []string{"Subscription"}
 
-func (ec *executionContext) _Subscription(ctx context.Context, sel ast.SelectionSet) func() graphql.Marshaler {
+func (ec *executionContext) _Subscription(ctx context.Context, sel ast.SelectionSet) func(ctx context.Context) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, subscriptionImplementors)
 	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
 		Object: "Subscription",
@@ -7248,6 +7310,8 @@ func (ec *executionContext) _Subscription(ctx context.Context, sel ast.Selection
 		return ec._Subscription_directiveUnimplemented(ctx, fields[0])
 	case "issue896b":
 		return ec._Subscription_issue896b(ctx, fields[0])
+	case "errorRequired":
+		return ec._Subscription_errorRequired(ctx, fields[0])
 	default:
 		panic("unknown field " + strconv.Quote(fields[0].Name))
 	}

--- a/codegen/testserver/followschema/stub.go
+++ b/codegen/testserver/followschema/stub.go
@@ -124,6 +124,7 @@ type Stub struct {
 		DirectiveDouble        func(ctx context.Context) (<-chan *string, error)
 		DirectiveUnimplemented func(ctx context.Context) (<-chan *string, error)
 		Issue896b              func(ctx context.Context) (<-chan []*CheckIssue896, error)
+		ErrorRequired          func(ctx context.Context) (<-chan *Error, error)
 	}
 	UserResolver struct {
 		Friends func(ctx context.Context, obj *User) ([]*User, error)
@@ -487,6 +488,9 @@ func (r *stubSubscription) DirectiveUnimplemented(ctx context.Context) (<-chan *
 }
 func (r *stubSubscription) Issue896b(ctx context.Context) (<-chan []*CheckIssue896, error) {
 	return r.SubscriptionResolver.Issue896b(ctx)
+}
+func (r *stubSubscription) ErrorRequired(ctx context.Context) (<-chan *Error, error) {
+	return r.SubscriptionResolver.ErrorRequired(ctx)
 }
 
 type stubUser struct{ *Stub }

--- a/codegen/testserver/singlefile/nulls.graphql
+++ b/codegen/testserver/singlefile/nulls.graphql
@@ -6,6 +6,10 @@ extend type Query {
     valid: String!
 }
 
+extend type Subscription {
+	errorRequired: Error!
+}
+
 type Errors {
     a: Error!
     b: Error!

--- a/codegen/testserver/singlefile/resolver.go
+++ b/codegen/testserver/singlefile/resolver.go
@@ -372,6 +372,10 @@ func (r *subscriptionResolver) Issue896b(ctx context.Context) (<-chan []*CheckIs
 	panic("not implemented")
 }
 
+func (r *subscriptionResolver) ErrorRequired(ctx context.Context) (<-chan *Error, error) {
+	panic("not implemented")
+}
+
 func (r *userResolver) Friends(ctx context.Context, obj *User) ([]*User, error) {
 	panic("not implemented")
 }

--- a/codegen/testserver/singlefile/stub.go
+++ b/codegen/testserver/singlefile/stub.go
@@ -124,6 +124,7 @@ type Stub struct {
 		DirectiveDouble        func(ctx context.Context) (<-chan *string, error)
 		DirectiveUnimplemented func(ctx context.Context) (<-chan *string, error)
 		Issue896b              func(ctx context.Context) (<-chan []*CheckIssue896, error)
+		ErrorRequired          func(ctx context.Context) (<-chan *Error, error)
 	}
 	UserResolver struct {
 		Friends func(ctx context.Context, obj *User) ([]*User, error)
@@ -487,6 +488,9 @@ func (r *stubSubscription) DirectiveUnimplemented(ctx context.Context) (<-chan *
 }
 func (r *stubSubscription) Issue896b(ctx context.Context) (<-chan []*CheckIssue896, error) {
 	return r.SubscriptionResolver.Issue896b(ctx)
+}
+func (r *stubSubscription) ErrorRequired(ctx context.Context) (<-chan *Error, error) {
+	return r.SubscriptionResolver.ErrorRequired(ctx)
 }
 
 type stubUser struct{ *Stub }


### PR DESCRIPTION
For WebSockets, the flow and contexts involved were such that the errors in marshaling were always dropped rather than sent as part of the response. 

This happened because in a new subscription:
-  The subscribe transport handler creates an operation context which is then passed to:
   -  DispatchOperation then creates tempResponseContext, which is passed into Exec (to get the responses function)
       -  Exec then uses tempResponseContext in _Subscription to (to get the next function)
          -  _Subscription will then use tempResponseContext in the generated handlers 
          - Which will return a function that uses tempResponseContext as the only context passed into marshaling functions.
       - Exec wraps the next() function inside of another function that is returned.
   - The returned function from exec is the responses function which is then wrapped in another function that accepts context but always creates a new Response context. Then retrieves the errors from that context before returning the response.
 - The subscribe transport handler also calls the return from DistpatchOperation response and when using it passes in the context returned by DispatchOperation.
 - Because the inner function bound into `next()` in exec captured the `tempResponseContext`, none of the errors generated when calling `next()` are ever populated on the context inside the function returned by `DispatchOperation` that collects the errors. 

To solve this I added a context to the `next(`) call so that the response context from the DispatchOperation returned function is passed all the way down and can appropriately accumulate errors as expected.

Added a unit test for this as well.

For reference in the content of subscriptions the caller of DispatchOperation and its returned function is here:
https://github.com/99designs/gqlgen/blob/master/graphql/handler/transport/websocket.go#L352


I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
