### PR TITLE
Use Github API to update the docs

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -3,25 +3,13 @@
 # This was adapted from https://github.com/dgraph-io/dgraph/blob/master/wiki/scripts/build.sh
 #
 
-set -e
-
 GREEN='\033[32;1m'
 RESET='\033[0m'
 HOST=https://gqlgen.com
 
-VERSIONS_ARRAY=(
-    'v0.16.0'
-    'v0.15.1'
-    'origin/master'
-    'v0.15.0'
-    'v0.14.0'
-    'v0.13.0'
-    'v0.12.2'
-    'v0.11.3'
-    'v0.10.2'
-    'v0.9.3'
-    'v0.8.3'
-)
+IFS=$'\n' read -r -d '' -a VERSIONS_ARRAY < <(curl -s -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/99designs/gqlgen/releases?per_page=20" | jq -r '.[].tag_name')
+
+VERSIONS_ARRAY+=( "origin/master" )
 
 joinVersions() {
 	versions=$(printf ",%s" "${VERSIONS_ARRAY[@]}" | sed 's/origin\/master/master/')

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -3,11 +3,13 @@
 # This was adapted from https://github.com/dgraph-io/dgraph/blob/master/wiki/scripts/build.sh
 #
 
+set -e
+
 GREEN='\033[32;1m'
 RESET='\033[0m'
 HOST=https://gqlgen.com
 
-IFS=$'\n' read -r -d '' -a VERSIONS_ARRAY < <(curl -s -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/99designs/gqlgen/releases?per_page=20" | jq -r '.[].tag_name')
+IFS=$'\n' read -r -d '' -a VERSIONS_ARRAY < <(curl -s -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/99designs/gqlgen/releases?per_page=20" | jq -r '.[].tag_name' ) || true
 
 VERSIONS_ARRAY+=( "origin/master" )
 


### PR DESCRIPTION
Instead of a hard-coded version of the docs we want to realease, this
uses the Github API to get the last 20 versions and publish those. This
will allow any script invoking this to make sure to always have the
latest version of the docs