### PR TITLE
feat: added graphql.UnmarshalInputFromContext

### DIFF
--- a/_examples/chat/generated.go
+++ b/_examples/chat/generated.go
@@ -181,7 +181,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
-	inputUnmarshalMap := graphql.BuildMap()
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap()
 	first := true
 
 	switch rc.Operation.Operation {

--- a/_examples/chat/generated.go
+++ b/_examples/chat/generated.go
@@ -181,6 +181,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
+	inputUnmarshalMap := graphql.BuildMap()
 	first := true
 
 	switch rc.Operation.Operation {
@@ -190,6 +191,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Query(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)
@@ -204,6 +206,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Mutation(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)

--- a/_examples/config/generated.go
+++ b/_examples/config/generated.go
@@ -189,6 +189,9 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
+	inputUnmarshalMap := graphql.BuildMap(
+		ec.unmarshalInputNewTodo,
+	)
 	first := true
 
 	switch rc.Operation.Operation {
@@ -198,6 +201,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Query(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)
@@ -212,6 +216,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Mutation(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)

--- a/_examples/config/generated.go
+++ b/_examples/config/generated.go
@@ -189,7 +189,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
-	inputUnmarshalMap := graphql.BuildMap(
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputNewTodo,
 	)
 	first := true

--- a/_examples/dataloader/generated.go
+++ b/_examples/dataloader/generated.go
@@ -226,7 +226,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
-	inputUnmarshalMap := graphql.BuildMap()
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap()
 	first := true
 
 	switch rc.Operation.Operation {

--- a/_examples/dataloader/generated.go
+++ b/_examples/dataloader/generated.go
@@ -226,6 +226,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
+	inputUnmarshalMap := graphql.BuildMap()
 	first := true
 
 	switch rc.Operation.Operation {
@@ -235,6 +236,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Query(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)

--- a/_examples/federation/accounts/graph/generated/generated.go
+++ b/_examples/federation/accounts/graph/generated/generated.go
@@ -202,7 +202,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
-	inputUnmarshalMap := graphql.BuildMap()
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap()
 	first := true
 
 	switch rc.Operation.Operation {

--- a/_examples/federation/accounts/graph/generated/generated.go
+++ b/_examples/federation/accounts/graph/generated/generated.go
@@ -202,6 +202,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
+	inputUnmarshalMap := graphql.BuildMap()
 	first := true
 
 	switch rc.Operation.Operation {
@@ -211,6 +212,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Query(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)

--- a/_examples/federation/products/graph/generated/generated.go
+++ b/_examples/federation/products/graph/generated/generated.go
@@ -229,6 +229,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
+	inputUnmarshalMap := graphql.BuildMap()
 	first := true
 
 	switch rc.Operation.Operation {
@@ -238,6 +239,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Query(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)

--- a/_examples/federation/products/graph/generated/generated.go
+++ b/_examples/federation/products/graph/generated/generated.go
@@ -229,7 +229,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
-	inputUnmarshalMap := graphql.BuildMap()
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap()
 	first := true
 
 	switch rc.Operation.Operation {

--- a/_examples/federation/reviews/graph/generated/generated.go
+++ b/_examples/federation/reviews/graph/generated/generated.go
@@ -251,6 +251,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
+	inputUnmarshalMap := graphql.BuildMap()
 	first := true
 
 	switch rc.Operation.Operation {
@@ -260,6 +261,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Query(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)

--- a/_examples/federation/reviews/graph/generated/generated.go
+++ b/_examples/federation/reviews/graph/generated/generated.go
@@ -251,7 +251,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
-	inputUnmarshalMap := graphql.BuildMap()
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap()
 	first := true
 
 	switch rc.Operation.Operation {

--- a/_examples/fileupload/generated.go
+++ b/_examples/fileupload/generated.go
@@ -178,6 +178,9 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
+	inputUnmarshalMap := graphql.BuildMap(
+		ec.unmarshalInputUploadFile,
+	)
 	first := true
 
 	switch rc.Operation.Operation {
@@ -187,6 +190,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Query(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)
@@ -201,6 +205,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Mutation(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)

--- a/_examples/fileupload/generated.go
+++ b/_examples/fileupload/generated.go
@@ -178,7 +178,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
-	inputUnmarshalMap := graphql.BuildMap(
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputUploadFile,
 	)
 	first := true

--- a/_examples/scalars/generated.go
+++ b/_examples/scalars/generated.go
@@ -231,6 +231,9 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
+	inputUnmarshalMap := graphql.BuildMap(
+		ec.unmarshalInputSearchArgs,
+	)
 	first := true
 
 	switch rc.Operation.Operation {
@@ -240,6 +243,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Query(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)

--- a/_examples/scalars/generated.go
+++ b/_examples/scalars/generated.go
@@ -231,7 +231,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
-	inputUnmarshalMap := graphql.BuildMap(
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputSearchArgs,
 	)
 	first := true

--- a/_examples/selection/generated.go
+++ b/_examples/selection/generated.go
@@ -150,7 +150,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
-	inputUnmarshalMap := graphql.BuildMap()
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap()
 	first := true
 
 	switch rc.Operation.Operation {

--- a/_examples/selection/generated.go
+++ b/_examples/selection/generated.go
@@ -150,6 +150,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
+	inputUnmarshalMap := graphql.BuildMap()
 	first := true
 
 	switch rc.Operation.Operation {
@@ -159,6 +160,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Query(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)

--- a/_examples/starwars/generated/exec.go
+++ b/_examples/starwars/generated/exec.go
@@ -493,7 +493,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
-	inputUnmarshalMap := graphql.BuildMap(
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputReviewInput,
 	)
 	first := true

--- a/_examples/starwars/generated/exec.go
+++ b/_examples/starwars/generated/exec.go
@@ -493,6 +493,9 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
+	inputUnmarshalMap := graphql.BuildMap(
+		ec.unmarshalInputReviewInput,
+	)
 	first := true
 
 	switch rc.Operation.Operation {
@@ -502,6 +505,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Query(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)
@@ -516,6 +520,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Mutation(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)

--- a/_examples/todo/generated.go
+++ b/_examples/todo/generated.go
@@ -166,6 +166,9 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
+	inputUnmarshalMap := graphql.BuildMap(
+		ec.unmarshalInputTodoInput,
+	)
 	first := true
 
 	switch rc.Operation.Operation {
@@ -175,6 +178,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._queryMiddleware(ctx, rc.Operation, func(ctx context.Context) (interface{}, error) {
 				return ec._MyQuery(ctx, rc.Operation.SelectionSet), nil
 			})
@@ -191,6 +195,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._mutationMiddleware(ctx, rc.Operation, func(ctx context.Context) (interface{}, error) {
 				return ec._MyMutation(ctx, rc.Operation.SelectionSet), nil
 			})

--- a/_examples/todo/generated.go
+++ b/_examples/todo/generated.go
@@ -166,7 +166,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
-	inputUnmarshalMap := graphql.BuildMap(
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputTodoInput,
 	)
 	first := true

--- a/_examples/type-system-extension/generated.go
+++ b/_examples/type-system-extension/generated.go
@@ -156,7 +156,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
-	inputUnmarshalMap := graphql.BuildMap(
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputTodoInput,
 	)
 	first := true

--- a/_examples/type-system-extension/generated.go
+++ b/_examples/type-system-extension/generated.go
@@ -156,6 +156,9 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
+	inputUnmarshalMap := graphql.BuildMap(
+		ec.unmarshalInputTodoInput,
+	)
 	first := true
 
 	switch rc.Operation.Operation {
@@ -165,6 +168,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._MyQuery(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)
@@ -179,6 +183,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._MyMutation(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)

--- a/codegen/generated!.gotpl
+++ b/codegen/generated!.gotpl
@@ -135,6 +135,13 @@
 	func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		rc := graphql.GetOperationContext(ctx)
 		ec := executionContext{rc, e}
+		inputUnmarshalMap := graphql.BuildMap(
+			{{- range $input := .Inputs -}}
+			{{ if not $input.HasUnmarshal }}
+			ec.unmarshalInput{{ $input.Name }},
+			{{- end }}
+			{{- end }}
+		)
 		first := true
 
 		switch rc.Operation.Operation {
@@ -142,6 +149,7 @@
 			return func(ctx context.Context) *graphql.Response {
 				if !first { return nil }
 				first = false
+				ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 				{{ if .Directives.LocationDirectives "QUERY" -}}
 					data := ec._queryMiddleware(ctx, rc.Operation, func(ctx context.Context) (interface{}, error){
 						return ec._{{.QueryRoot.Name}}(ctx, rc.Operation.SelectionSet), nil
@@ -162,6 +170,7 @@
 			return func(ctx context.Context) *graphql.Response {
 				if !first { return nil }
 				first = false
+				ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 				{{ if .Directives.LocationDirectives "MUTATION" -}}
 					data := ec._mutationMiddleware(ctx, rc.Operation, func(ctx context.Context) (interface{}, error){
 						return ec._{{.MutationRoot.Name}}(ctx, rc.Operation.SelectionSet), nil

--- a/codegen/generated!.gotpl
+++ b/codegen/generated!.gotpl
@@ -135,11 +135,11 @@
 	func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		rc := graphql.GetOperationContext(ctx)
 		ec := executionContext{rc, e}
-		inputUnmarshalMap := graphql.BuildMap(
+		inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 			{{- range $input := .Inputs -}}
-			{{ if not $input.HasUnmarshal }}
-			ec.unmarshalInput{{ $input.Name }},
-			{{- end }}
+				{{ if not $input.HasUnmarshal }}
+					ec.unmarshalInput{{ $input.Name }},
+				{{- end }}
 			{{- end }}
 		)
 		first := true

--- a/codegen/root_.gotpl
+++ b/codegen/root_.gotpl
@@ -102,6 +102,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
+		{{- range $input := .Inputs -}}
+			{{ if not $input.HasUnmarshal }}
+				ec.unmarshalInput{{ $input.Name }},
+			{{- end }}
+		{{- end }}
+	)
 	first := true
 
 	switch rc.Operation.Operation {
@@ -109,6 +116,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		return func(ctx context.Context) *graphql.Response {
 			if !first { return nil }
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			{{ if .Directives.LocationDirectives "QUERY" -}}
 				data := ec._queryMiddleware(ctx, rc.Operation, func(ctx context.Context) (interface{}, error){
 					return ec._{{.QueryRoot.Name}}(ctx, rc.Operation.SelectionSet), nil
@@ -129,6 +137,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		return func(ctx context.Context) *graphql.Response {
 			if !first { return nil }
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			{{ if .Directives.LocationDirectives "MUTATION" -}}
 				data := ec._mutationMiddleware(ctx, rc.Operation, func(ctx context.Context) (interface{}, error){
 					return ec._{{.MutationRoot.Name}}(ctx, rc.Operation.SelectionSet), nil

--- a/codegen/testserver/followschema/root_.generated.go
+++ b/codegen/testserver/followschema/root_.generated.go
@@ -1919,6 +1919,21 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
+		ec.unmarshalInputDefaultInput,
+		ec.unmarshalInputInnerDirectives,
+		ec.unmarshalInputInnerInput,
+		ec.unmarshalInputInputDirectives,
+		ec.unmarshalInputInputWithEnumValue,
+		ec.unmarshalInputNestedInput,
+		ec.unmarshalInputNestedMapInput,
+		ec.unmarshalInputOuterInput,
+		ec.unmarshalInputRecursiveInputSlice,
+		ec.unmarshalInputSpecialInput,
+		ec.unmarshalInputUpdatePtrToPtrInner,
+		ec.unmarshalInputUpdatePtrToPtrOuter,
+		ec.unmarshalInputValidInput,
+	)
 	first := true
 
 	switch rc.Operation.Operation {
@@ -1928,6 +1943,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Query(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)
@@ -1942,6 +1958,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Mutation(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)

--- a/codegen/testserver/singlefile/generated.go
+++ b/codegen/testserver/singlefile/generated.go
@@ -2059,7 +2059,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
-	inputUnmarshalMap := graphql.BuildMap(
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputDefaultInput,
 		ec.unmarshalInputInnerDirectives,
 		ec.unmarshalInputInnerInput,

--- a/codegen/testserver/singlefile/generated.go
+++ b/codegen/testserver/singlefile/generated.go
@@ -2059,6 +2059,21 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
+	inputUnmarshalMap := graphql.BuildMap(
+		ec.unmarshalInputDefaultInput,
+		ec.unmarshalInputInnerDirectives,
+		ec.unmarshalInputInnerInput,
+		ec.unmarshalInputInputDirectives,
+		ec.unmarshalInputInputWithEnumValue,
+		ec.unmarshalInputNestedInput,
+		ec.unmarshalInputNestedMapInput,
+		ec.unmarshalInputOuterInput,
+		ec.unmarshalInputRecursiveInputSlice,
+		ec.unmarshalInputSpecialInput,
+		ec.unmarshalInputUpdatePtrToPtrInner,
+		ec.unmarshalInputUpdatePtrToPtrOuter,
+		ec.unmarshalInputValidInput,
+	)
 	first := true
 
 	switch rc.Operation.Operation {
@@ -2068,6 +2083,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Query(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)
@@ -2082,6 +2098,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Mutation(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)

--- a/graphql/input.go
+++ b/graphql/input.go
@@ -8,15 +8,15 @@ import (
 
 const unmarshalInputCtx key = "unmarshal_input_context"
 
-func BuildMap(unmarshaler ...interface{}) map[reflect.Type]reflect.Value {
+// BuildUnmarshalerMap returns a map of unmarshal functions of the ExecutableContext
+// to use with the WithUnmarshalerMap function.
+func BuildUnmarshalerMap(unmarshaler ...interface{}) map[reflect.Type]reflect.Value {
 	maps := make(map[reflect.Type]reflect.Value)
 	for _, v := range unmarshaler {
 		ft := reflect.TypeOf(v)
-		if ft.Kind() != reflect.Func {
-			panic("unmarshaler must be a function")
+		if ft.Kind() == reflect.Func {
+			maps[ft.Out(0)] = reflect.ValueOf(v)
 		}
-
-		maps[ft.Out(0)] = reflect.ValueOf(v)
 	}
 
 	return maps
@@ -26,20 +26,21 @@ func WithUnmarshalerMap(ctx context.Context, maps map[reflect.Type]reflect.Value
 	return context.WithValue(ctx, unmarshalInputCtx, maps)
 }
 
-func UnmarshalInputFromContext(ctx context.Context, data, input interface{}) error {
+// UnmarshalInputFromContext allows unmarshaling input object from a context.
+func UnmarshalInputFromContext(ctx context.Context, raw, inputObj interface{}) error {
 	m, ok := ctx.Value(unmarshalInputCtx).(map[reflect.Type]reflect.Value)
 	if m == nil || !ok {
 		return nil
 	}
 
-	out := reflect.ValueOf(input)
+	out := reflect.ValueOf(inputObj)
 	if out.Kind() != reflect.Ptr {
 		return errors.New("input must be a pointer")
 	}
 	if fn, ok := m[out.Elem().Type()]; ok {
 		res := fn.Call([]reflect.Value{
 			reflect.ValueOf(ctx),
-			reflect.ValueOf(data),
+			reflect.ValueOf(raw),
 		})
 		if v := res[1].Interface(); v != nil {
 			return v.(error)

--- a/graphql/input.go
+++ b/graphql/input.go
@@ -22,7 +22,7 @@ func BuildUnmarshalerMap(unmarshaler ...interface{}) map[reflect.Type]reflect.Va
 	return maps
 }
 
-// WithUnmarshalerMap returns a new context with InputMaps attached
+// WithUnmarshalerMap returns a new context with a map from input types to their unmarshaler functions.
 func WithUnmarshalerMap(ctx context.Context, maps map[reflect.Type]reflect.Value) context.Context {
 	return context.WithValue(ctx, unmarshalInputCtx, maps)
 }

--- a/graphql/input.go
+++ b/graphql/input.go
@@ -22,6 +22,7 @@ func BuildUnmarshalerMap(unmarshaler ...interface{}) map[reflect.Type]reflect.Va
 	return maps
 }
 
+// WithUnmarshalerMap returns a new context with InputMaps attached
 func WithUnmarshalerMap(ctx context.Context, maps map[reflect.Type]reflect.Value) context.Context {
 	return context.WithValue(ctx, unmarshalInputCtx, maps)
 }

--- a/graphql/input.go
+++ b/graphql/input.go
@@ -1,0 +1,53 @@
+package graphql
+
+import (
+	"context"
+	"errors"
+	"reflect"
+)
+
+const unmarshalInputCtx key = "unmarshal_input_context"
+
+func BuildMap(unmarshaler ...interface{}) map[reflect.Type]reflect.Value {
+	maps := make(map[reflect.Type]reflect.Value)
+	for _, v := range unmarshaler {
+		ft := reflect.TypeOf(v)
+		if ft.Kind() != reflect.Func {
+			panic("unmarshaler must be a function")
+		}
+
+		maps[ft.Out(0)] = reflect.ValueOf(v)
+	}
+
+	return maps
+}
+
+func WithUnmarshalerMap(ctx context.Context, maps map[reflect.Type]reflect.Value) context.Context {
+	return context.WithValue(ctx, unmarshalInputCtx, maps)
+}
+
+func UnmarshalInputFromContext(ctx context.Context, data, input interface{}) error {
+	m, ok := ctx.Value(unmarshalInputCtx).(map[reflect.Type]reflect.Value)
+	if m == nil || !ok {
+		return nil
+	}
+
+	out := reflect.ValueOf(input)
+	if out.Kind() != reflect.Ptr {
+		return errors.New("input must be a pointer")
+	}
+	if fn, ok := m[out.Elem().Type()]; ok {
+		res := fn.Call([]reflect.Value{
+			reflect.ValueOf(ctx),
+			reflect.ValueOf(data),
+		})
+		if v := res[1].Interface(); v != nil {
+			return v.(error)
+		}
+
+		out.Elem().Set(res[0])
+		return nil
+	}
+
+	return nil
+}

--- a/integration/generated.go
+++ b/integration/generated.go
@@ -224,7 +224,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
-	inputUnmarshalMap := graphql.BuildMap(
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputDateFilter,
 		ec.unmarshalInputListCoercion,
 	)

--- a/integration/generated.go
+++ b/integration/generated.go
@@ -224,6 +224,10 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
+	inputUnmarshalMap := graphql.BuildMap(
+		ec.unmarshalInputDateFilter,
+		ec.unmarshalInputListCoercion,
+	)
 	first := true
 
 	switch rc.Operation.Operation {
@@ -233,6 +237,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Query(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)

--- a/plugin/federation/testdata/entityresolver/generated/exec.go
+++ b/plugin/federation/testdata/entityresolver/generated/exec.go
@@ -632,6 +632,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
+	inputUnmarshalMap := graphql.BuildMap(
+		ec.unmarshalInputMultiHelloByNamesInput,
+		ec.unmarshalInputMultiHelloMultipleRequiresByNamesInput,
+		ec.unmarshalInputMultiHelloRequiresByNamesInput,
+		ec.unmarshalInputMultiHelloWithErrorByNamesInput,
+		ec.unmarshalInputMultiPlanetRequiresNestedByNamesInput,
+	)
 	first := true
 
 	switch rc.Operation.Operation {
@@ -641,6 +648,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				return nil
 			}
 			first = false
+			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Query(ctx, rc.Operation.SelectionSet)
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)

--- a/plugin/federation/testdata/entityresolver/generated/exec.go
+++ b/plugin/federation/testdata/entityresolver/generated/exec.go
@@ -632,7 +632,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
-	inputUnmarshalMap := graphql.BuildMap(
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputMultiHelloByNamesInput,
 		ec.unmarshalInputMultiHelloMultipleRequiresByNamesInput,
 		ec.unmarshalInputMultiHelloRequiresByNamesInput,


### PR DESCRIPTION
This allows unmarshaling the input object from a context.

This PR is the support for ent/contrib#297: entgql: Unmarshal whereInput using graphql package

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
