### PR TITLE
Use MultipartReader to parse file uploads

### DIFF
--- a/graphql/handler/transport/http_form.go
+++ b/graphql/handler/transport/http_form.go
@@ -7,7 +7,6 @@ import (
 	"mime"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/99designs/gqlgen/graphql"
 )
@@ -64,131 +63,141 @@ func (f MultipartForm) Do(w http.ResponseWriter, r *http.Request, exec graphql.G
 		return
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, f.maxUploadSize())
-	if err = r.ParseMultipartForm(f.maxMemory()); err != nil {
+	defer r.Body.Close()
+
+	mr, err := r.MultipartReader()
+	if err != nil {
 		w.WriteHeader(http.StatusUnprocessableEntity)
-		if strings.Contains(err.Error(), "request body too large") {
-			writeJsonError(w, "failed to parse multipart form, request body too large")
-			return
-		}
 		writeJsonError(w, "failed to parse multipart form")
 		return
 	}
-	defer r.Body.Close()
+
+	part, err := mr.NextPart()
+	if err != nil || part.FormName() != "operations" {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		writeJsonError(w, "first part must be operations")
+		return
+	}
 
 	var params graphql.RawParams
-
-	if err = jsonDecode(strings.NewReader(r.Form.Get("operations")), &params); err != nil {
+	if err = jsonDecode(part, &params); err != nil {
 		w.WriteHeader(http.StatusUnprocessableEntity)
 		writeJsonError(w, "operations form field could not be decoded")
 		return
 	}
 
+	part, err = mr.NextPart()
+	if err != nil || part.FormName() != "map" {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		writeJsonError(w, "second part must be map")
+		return
+	}
+
 	uploadsMap := map[string][]string{}
-	if err = json.Unmarshal([]byte(r.Form.Get("map")), &uploadsMap); err != nil {
+	if err = json.NewDecoder(part).Decode(&uploadsMap); err != nil {
 		w.WriteHeader(http.StatusUnprocessableEntity)
 		writeJsonError(w, "map form field could not be decoded")
 		return
 	}
 
-	var upload graphql.Upload
-	for key, paths := range uploadsMap {
+	for {
+		part, err = mr.NextPart()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			writeJsonErrorf(w, "failed to parse part")
+			return
+		}
+
+		key := part.FormName()
+		filename := part.FileName()
+		contentType := part.Header.Get("Content-Type")
+
+		paths := uploadsMap[key]
 		if len(paths) == 0 {
 			w.WriteHeader(http.StatusUnprocessableEntity)
 			writeJsonErrorf(w, "invalid empty operations paths list for key %s", key)
 			return
 		}
-		file, header, err := r.FormFile(key)
-		if err != nil {
-			w.WriteHeader(http.StatusUnprocessableEntity)
-			writeJsonErrorf(w, "failed to get key %s from form", key)
-			return
-		}
-		defer file.Close()
+		delete(uploadsMap, key)
 
-		if len(paths) == 1 {
-			upload = graphql.Upload{
-				File:        file,
-				Size:        header.Size,
-				Filename:    header.Filename,
-				ContentType: header.Header.Get("Content-Type"),
-			}
-
-			if err := params.AddUpload(upload, key, paths[0]); err != nil {
+		var upload graphql.Upload
+		if r.ContentLength < f.maxMemory() {
+			fileBytes, err := ioutil.ReadAll(part)
+			if err != nil {
 				w.WriteHeader(http.StatusUnprocessableEntity)
-				writeJsonGraphqlError(w, err)
+				writeJsonErrorf(w, "failed to read file for key %s", key)
 				return
 			}
+			for _, path := range paths {
+				upload = graphql.Upload{
+					File:        &bytesReader{s: &fileBytes, i: 0, prevRune: -1},
+					Size:        int64(len(fileBytes)),
+					Filename:    filename,
+					ContentType: contentType,
+				}
+
+				if err := params.AddUpload(upload, key, path); err != nil {
+					w.WriteHeader(http.StatusUnprocessableEntity)
+					writeJsonGraphqlError(w, err)
+					return
+				}
+			}
 		} else {
-			if r.ContentLength < f.maxMemory() {
-				fileBytes, err := ioutil.ReadAll(file)
-				if err != nil {
-					w.WriteHeader(http.StatusUnprocessableEntity)
-					writeJsonErrorf(w, "failed to read file for key %s", key)
-					return
-				}
-				for _, path := range paths {
-					upload = graphql.Upload{
-						File:        &bytesReader{s: &fileBytes, i: 0, prevRune: -1},
-						Size:        header.Size,
-						Filename:    header.Filename,
-						ContentType: header.Header.Get("Content-Type"),
-					}
-
-					if err := params.AddUpload(upload, key, path); err != nil {
-						w.WriteHeader(http.StatusUnprocessableEntity)
-						writeJsonGraphqlError(w, err)
-						return
-					}
-				}
-			} else {
-				tmpFile, err := ioutil.TempFile(os.TempDir(), "gqlgen-")
-				if err != nil {
-					w.WriteHeader(http.StatusUnprocessableEntity)
-					writeJsonErrorf(w, "failed to create temp file for key %s", key)
-					return
-				}
-				tmpName := tmpFile.Name()
-				defer func() {
-					_ = os.Remove(tmpName)
-				}()
-				_, err = io.Copy(tmpFile, file)
-				if err != nil {
-					w.WriteHeader(http.StatusUnprocessableEntity)
-					if err := tmpFile.Close(); err != nil {
-						writeJsonErrorf(w, "failed to copy to temp file and close temp file for key %s", key)
-						return
-					}
-					writeJsonErrorf(w, "failed to copy to temp file for key %s", key)
-					return
-				}
+			tmpFile, err := ioutil.TempFile(os.TempDir(), "gqlgen-")
+			if err != nil {
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				writeJsonErrorf(w, "failed to create temp file for key %s", key)
+				return
+			}
+			tmpName := tmpFile.Name()
+			defer func() {
+				_ = os.Remove(tmpName)
+			}()
+			fileSize, err := io.Copy(tmpFile, part)
+			if err != nil {
+				w.WriteHeader(http.StatusUnprocessableEntity)
 				if err := tmpFile.Close(); err != nil {
-					w.WriteHeader(http.StatusUnprocessableEntity)
-					writeJsonErrorf(w, "failed to close temp file for key %s", key)
+					writeJsonErrorf(w, "failed to copy to temp file and close temp file for key %s", key)
 					return
 				}
-				for _, path := range paths {
-					pathTmpFile, err := os.Open(tmpName)
-					if err != nil {
-						w.WriteHeader(http.StatusUnprocessableEntity)
-						writeJsonErrorf(w, "failed to open temp file for key %s", key)
-						return
-					}
-					defer pathTmpFile.Close()
-					upload = graphql.Upload{
-						File:        pathTmpFile,
-						Size:        header.Size,
-						Filename:    header.Filename,
-						ContentType: header.Header.Get("Content-Type"),
-					}
+				writeJsonErrorf(w, "failed to copy to temp file for key %s", key)
+				return
+			}
+			if err := tmpFile.Close(); err != nil {
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				writeJsonErrorf(w, "failed to close temp file for key %s", key)
+				return
+			}
+			for _, path := range paths {
+				pathTmpFile, err := os.Open(tmpName)
+				if err != nil {
+					w.WriteHeader(http.StatusUnprocessableEntity)
+					writeJsonErrorf(w, "failed to open temp file for key %s", key)
+					return
+				}
+				defer pathTmpFile.Close()
+				upload = graphql.Upload{
+					File:        pathTmpFile,
+					Size:        fileSize,
+					Filename:    filename,
+					ContentType: contentType,
+				}
 
-					if err := params.AddUpload(upload, key, path); err != nil {
-						w.WriteHeader(http.StatusUnprocessableEntity)
-						writeJsonGraphqlError(w, err)
-						return
-					}
+				if err := params.AddUpload(upload, key, path); err != nil {
+					w.WriteHeader(http.StatusUnprocessableEntity)
+					writeJsonGraphqlError(w, err)
+					return
 				}
 			}
 		}
+	}
+
+	for key := range uploadsMap {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		writeJsonErrorf(w, "failed to get key %s from form", key)
+		return
 	}
 
 	params.Headers = r.Header

--- a/graphql/handler/transport/http_form_test.go
+++ b/graphql/handler/transport/http_form_test.go
@@ -206,7 +206,7 @@ func TestFileUpload(t *testing.T) {
 		},
 	}
 
-	t.Run("failed to parse multipart", func(t *testing.T) {
+	t.Run("failed invalid multipart", func(t *testing.T) {
 		req := &http.Request{
 			Method: "POST",
 			Header: http.Header{"Content-Type": {`multipart/form-data; boundary="foo123"`}},
@@ -215,7 +215,7 @@ func TestFileUpload(t *testing.T) {
 		resp := httptest.NewRecorder()
 		h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
-		require.Equal(t, `{"errors":[{"message":"failed to parse multipart form"}],"data":null}`, resp.Body.String())
+		require.Equal(t, `{"errors":[{"message":"first part must be operations"}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("fail parse operation", func(t *testing.T) {


### PR DESCRIPTION
Use a streaming MultipartReader to parse requests with file
uploads. The GraphQL multipart request specification guarantees
that the operations and map form fields will come first.

There are two reasons motivating this change:

- This allows for file uploads without specifying a specific
  filename.
- This avoids unnecessary copies for requests with more than one
  file. Go's ParseForm already copies the request's body into
  memory or on disk. We were also doing this manually as a second
  step.

I have:
 - [x] (N/A) Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] (N/A) Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
