### PR TITLE
fix #1237 remove unreachable types from generated code

### DIFF
--- a/api/generate.go
+++ b/api/generate.go
@@ -53,7 +53,7 @@ func Generate(cfg *config.Config, option ...Option) error {
 		}
 	}
 
-	if err := cfg.LoadSchema(); err != nil {
+	if err := cfg.LoadSchema(false); err != nil {
 		return fmt.Errorf("failed to load schema: %w", err)
 	}
 
@@ -66,7 +66,7 @@ func Generate(cfg *config.Config, option ...Option) error {
 	}
 
 	// LoadSchema again now we have everything
-	if err := cfg.LoadSchema(); err != nil {
+	if err := cfg.LoadSchema(true); err != nil {
 		return fmt.Errorf("failed to load schema: %w", err)
 	}
 

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -189,7 +189,7 @@ func (c *Config) Init() error {
 	}
 
 	if c.Schema == nil {
-		if err := c.LoadSchema(); err != nil {
+		if err := c.LoadSchema(true); err != nil {
 			return err
 		}
 	}
@@ -613,7 +613,7 @@ func (c *Config) injectBuiltins() {
 	}
 }
 
-func (c *Config) LoadSchema() error {
+func (c *Config) LoadSchema(removeUnreachable bool) error {
 	if c.Packages != nil {
 		c.Packages = &code.Packages{}
 	}
@@ -633,6 +633,10 @@ func (c *Config) LoadSchema() error {
 			Name: "Query",
 		}
 		schema.Types["Query"] = schema.Query
+	}
+
+	if removeUnreachable {
+		removeUnreachableTypes(schema)
 	}
 
 	c.Schema = schema

--- a/codegen/config/remove_unreachable.go
+++ b/codegen/config/remove_unreachable.go
@@ -1,0 +1,131 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+type reachabilityCleaner struct {
+	schema    *ast.Schema
+	reachable map[string]*ast.Definition
+	queue     []*ast.Definition
+}
+
+func (r *reachabilityCleaner) addToQueue(def *ast.Definition) {
+	// simplify error handling by acceping nil and ignoring it
+	if def == nil {
+		return
+	}
+	if _, ok := r.reachable[def.Name]; !ok {
+		r.queue = append(r.queue, def)
+	}
+	r.reachable[def.Name] = r.schema.Types[def.Name]
+}
+
+func (r *reachabilityCleaner) findReachableTypes() map[string]*ast.Definition {
+	// Mark all types reachable from the current queue of definitions as reachable
+	for len(r.queue) > 0 {
+		// pop from stack
+		currentType := r.queue[0]
+		r.queue = r.queue[1:]
+
+		referencedFromCurrent := []*ast.Definition{}
+		referencedFromCurrent = append(referencedFromCurrent, r.schema.GetPossibleTypes(currentType)...)
+		referencedFromCurrent = append(referencedFromCurrent, r.schema.GetImplements(currentType)...)
+		for _, t := range currentType.Types {
+			referencedFromCurrent = append(referencedFromCurrent, r.schema.Types[t])
+		}
+		for _, i := range currentType.Interfaces {
+			referencedFromCurrent = append(referencedFromCurrent, r.schema.Types[i])
+		}
+		for _, f := range currentType.Fields {
+			referencedFromCurrent = append(referencedFromCurrent, r.schema.Types[f.Type.Name()])
+			for _, arg := range f.Arguments {
+				referencedFromCurrent = append(referencedFromCurrent, r.schema.Types[arg.Type.Name()])
+				if arg.DefaultValue != nil {
+					referencedFromCurrent = append(referencedFromCurrent, arg.DefaultValue.Definition)
+				}
+			}
+			if f.DefaultValue != nil {
+				referencedFromCurrent = append(referencedFromCurrent, f.DefaultValue.Definition)
+			}
+		}
+		for _, def := range referencedFromCurrent {
+			if def == nil {
+				continue
+			}
+			// If this type hasn't been seen before, make sure we expand it by adding to the queue
+			r.addToQueue(def)
+			// When adding a union or enum to the queue, make sure we also add all its possible implementations
+			for _, pt := range r.schema.PossibleTypes[def.Name] {
+				r.addToQueue(pt)
+			}
+			// When adding an implementation of an interface to the queue, make sure we also add the interface it implements
+			for _, pt := range r.schema.Implements[def.Name] {
+				r.addToQueue(pt)
+			}
+		}
+	}
+
+	// Mark all double underscore types as reachable because they are used for introspection
+	for _, d := range r.schema.Types {
+		if strings.HasPrefix(d.Name, "__") {
+			r.reachable[d.Name] = d
+			for _, pt := range r.schema.PossibleTypes[d.Name] {
+				r.reachable[pt.Name] = pt
+			}
+		}
+	}
+	return r.reachable
+}
+
+func calculateAndWarnOnUnreachableTypes(reachableTypes, allTypes map[string]*ast.Definition) {
+	unreachableTypes := map[string]struct{}{}
+	for all := range allTypes {
+		unreachableTypes[all] = struct{}{}
+	}
+	for r := range reachableTypes {
+		delete(unreachableTypes, r)
+	}
+
+	if len(unreachableTypes) > 0 {
+		unreachableTypesList := []string{}
+		for t := range unreachableTypes {
+			unreachableTypesList = append(unreachableTypesList, t)
+		}
+		sort.Strings(unreachableTypesList)
+		for _, typeName := range unreachableTypesList {
+			if !allTypes[typeName].BuiltIn {
+				fmt.Printf("Warning: unreachable type: %s\n", typeName)
+			}
+		}
+	}
+}
+
+func removeUnreachableTypes(a *ast.Schema) {
+	rc := reachabilityCleaner{
+		reachable: map[string]*ast.Definition{},
+		schema:    a,
+	}
+	rc.addToQueue(a.Query)
+	rc.addToQueue(a.Mutation)
+	rc.addToQueue(a.Subscription)
+	// Entity is a fake type used in the federation plugin to generate resolver interfaces to be implemented
+	// TODO: find a better way to make sure it's considered reachable
+	rc.addToQueue(a.Types["Entity"])
+	// All directive arguments are considered reachable for now. No need to clean these up as aggressively.
+	for _, dd := range a.Directives {
+		for _, arg := range dd.Arguments {
+			rc.addToQueue(a.Types[arg.Type.Name()])
+		}
+	}
+
+	reachable := rc.findReachableTypes()
+
+	calculateAndWarnOnUnreachableTypes(reachable, a.Types)
+
+	a.Types = reachable
+}

--- a/codegen/testserver/followschema/builtinscalar.generated.go
+++ b/codegen/testserver/followschema/builtinscalar.generated.go
@@ -110,4 +110,18 @@ func (ec *executionContext) _Map(ctx context.Context, sel ast.SelectionSet, obj 
 
 // region    ***************************** type.gotpl *****************************
 
+func (ec *executionContext) marshalNMap2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐMap(ctx context.Context, sel ast.SelectionSet, v Map) graphql.Marshaler {
+	return ec._Map(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNMap2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐMap(ctx context.Context, sel ast.SelectionSet, v *Map) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Map(ctx, sel, v)
+}
+
 // endregion ***************************** type.gotpl *****************************

--- a/codegen/testserver/followschema/builtinscalar.graphql
+++ b/codegen/testserver/followschema/builtinscalar.graphql
@@ -1,3 +1,6 @@
+extend type Query {
+    Map: Map!
+}
 
 """
 Since gqlgen defines default implementation for a Map scalar, this tests that the builtin is _not_

--- a/codegen/testserver/followschema/loops.generated.go
+++ b/codegen/testserver/followschema/loops.generated.go
@@ -207,4 +207,11 @@ func (ec *executionContext) marshalNLoopB2ᚖgithubᚗcomᚋ99designsᚋgqlgen�
 	return ec._LoopB(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalOLoopA2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐLoopA(ctx context.Context, sel ast.SelectionSet, v *LoopA) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._LoopA(ctx, sel, v)
+}
+
 // endregion ***************************** type.gotpl *****************************

--- a/codegen/testserver/followschema/loops.graphql
+++ b/codegen/testserver/followschema/loops.graphql
@@ -1,3 +1,7 @@
+extend type Query {
+    LoopA: LoopA
+}
+
 type LoopA {
     b: LoopB!
 }

--- a/codegen/testserver/followschema/resolver.go
+++ b/codegen/testserver/followschema/resolver.go
@@ -140,6 +140,22 @@ func (r *queryResolver) DeprecatedField(ctx context.Context) (string, error) {
 	panic("not implemented")
 }
 
+func (r *queryResolver) EmbeddedPointer(ctx context.Context) (*EmbeddedPointerModel, error) {
+	panic("not implemented")
+}
+
+func (r *queryResolver) ForcedResolver(ctx context.Context) (*ForcedResolver, error) {
+	panic("not implemented")
+}
+
+func (r *queryResolver) Status(ctx context.Context) (Status, error) {
+	panic("not implemented")
+}
+
+func (r *queryResolver) Map(ctx context.Context) (*Map, error) {
+	panic("not implemented")
+}
+
 func (r *queryResolver) Overlapping(ctx context.Context) (*OverlappingFields, error) {
 	panic("not implemented")
 }
@@ -236,6 +252,10 @@ func (r *queryResolver) Issue896a(ctx context.Context) ([]*CheckIssue896, error)
 	panic("not implemented")
 }
 
+func (r *queryResolver) LoopA(ctx context.Context) (*LoopA, error) {
+	panic("not implemented")
+}
+
 func (r *queryResolver) MapStringInterface(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error) {
 	panic("not implemented")
 }
@@ -296,6 +316,10 @@ func (r *queryResolver) DefaultScalar(ctx context.Context, arg string) (string, 
 	panic("not implemented")
 }
 
+func (r *queryResolver) EmbeddedDefaultScalar(ctx context.Context) (*EmbeddedDefaultScalar, error) {
+	panic("not implemented")
+}
+
 func (r *queryResolver) Slices(ctx context.Context) (*Slices, error) {
 	panic("not implemented")
 }
@@ -324,7 +348,35 @@ func (r *queryResolver) ValidType(ctx context.Context) (*ValidType, error) {
 	panic("not implemented")
 }
 
+func (r *queryResolver) ContentChild(ctx context.Context) (ContentChild, error) {
+	panic("not implemented")
+}
+
 func (r *queryResolver) VariadicModel(ctx context.Context) (*VariadicModel, error) {
+	panic("not implemented")
+}
+
+func (r *queryResolver) AsdfIt(ctx context.Context) (*AsdfIt, error) {
+	panic("not implemented")
+}
+
+func (r *queryResolver) AIt(ctx context.Context) (*AIt, error) {
+	panic("not implemented")
+}
+
+func (r *queryResolver) IIt(ctx context.Context) (*IIt, error) {
+	panic("not implemented")
+}
+
+func (r *queryResolver) XXIt(ctx context.Context) (*XXIt, error) {
+	panic("not implemented")
+}
+
+func (r *queryResolver) AbIt(ctx context.Context) (*AbIt, error) {
+	panic("not implemented")
+}
+
+func (r *queryResolver) XxIt(ctx context.Context) (*XxIt, error) {
 	panic("not implemented")
 }
 

--- a/codegen/testserver/followschema/root_.generated.go
+++ b/codegen/testserver/followschema/root_.generated.go
@@ -281,9 +281,13 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
+		AIt                              func(childComplexity int) int
+		AbIt                             func(childComplexity int) int
 		Animal                           func(childComplexity int) int
+		AsdfIt                           func(childComplexity int) int
 		Autobind                         func(childComplexity int) int
 		Collision                        func(childComplexity int) int
+		ContentChild                     func(childComplexity int) int
 		DefaultParameters                func(childComplexity int, falsyBoolean *bool, truthyBoolean *bool) int
 		DefaultScalar                    func(childComplexity int, arg string) int
 		DeprecatedField                  func(childComplexity int) int
@@ -301,17 +305,23 @@ type ComplexityRoot struct {
 		EmbeddedCase1                    func(childComplexity int) int
 		EmbeddedCase2                    func(childComplexity int) int
 		EmbeddedCase3                    func(childComplexity int) int
+		EmbeddedDefaultScalar            func(childComplexity int) int
+		EmbeddedPointer                  func(childComplexity int) int
 		EnumInInput                      func(childComplexity int, input *InputWithEnumValue) int
 		ErrorBubble                      func(childComplexity int) int
 		ErrorBubbleList                  func(childComplexity int) int
 		ErrorList                        func(childComplexity int) int
 		Errors                           func(childComplexity int) int
 		Fallback                         func(childComplexity int, arg FallbackToStringEncoding) int
+		ForcedResolver                   func(childComplexity int) int
+		IIt                              func(childComplexity int) int
 		Infinity                         func(childComplexity int) int
 		InputNullableSlice               func(childComplexity int, arg []string) int
 		InputSlice                       func(childComplexity int, arg []string) int
 		InvalidIdentifier                func(childComplexity int) int
 		Issue896a                        func(childComplexity int) int
+		LoopA                            func(childComplexity int) int
+		Map                              func(childComplexity int) int
 		MapInput                         func(childComplexity int, input map[string]interface{}) int
 		MapNestedStringInterface         func(childComplexity int, in *NestedMapInput) int
 		MapStringInterface               func(childComplexity int, in map[string]interface{}) int
@@ -334,6 +344,7 @@ type ComplexityRoot struct {
 		ShapeUnion                       func(childComplexity int) int
 		Shapes                           func(childComplexity int) int
 		Slices                           func(childComplexity int) int
+		Status                           func(childComplexity int) int
 		StringFromContextFunction        func(childComplexity int) int
 		StringFromContextInterface       func(childComplexity int) int
 		User                             func(childComplexity int, id int) int
@@ -346,6 +357,8 @@ type ComplexityRoot struct {
 		WrappedScalar                    func(childComplexity int) int
 		WrappedSlice                     func(childComplexity int) int
 		WrappedStruct                    func(childComplexity int) int
+		XXIt                             func(childComplexity int) int
+		XxIt                             func(childComplexity int) int
 	}
 
 	Rectangle struct {
@@ -1070,12 +1083,33 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PtrToSliceContainer.PtrToSlice(childComplexity), true
 
+	case "Query.AIt":
+		if e.complexity.Query.AIt == nil {
+			break
+		}
+
+		return e.complexity.Query.AIt(childComplexity), true
+
+	case "Query.AbIt":
+		if e.complexity.Query.AbIt == nil {
+			break
+		}
+
+		return e.complexity.Query.AbIt(childComplexity), true
+
 	case "Query.animal":
 		if e.complexity.Query.Animal == nil {
 			break
 		}
 
 		return e.complexity.Query.Animal(childComplexity), true
+
+	case "Query.asdfIt":
+		if e.complexity.Query.AsdfIt == nil {
+			break
+		}
+
+		return e.complexity.Query.AsdfIt(childComplexity), true
 
 	case "Query.autobind":
 		if e.complexity.Query.Autobind == nil {
@@ -1090,6 +1124,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Collision(childComplexity), true
+
+	case "Query.Content_Child":
+		if e.complexity.Query.ContentChild == nil {
+			break
+		}
+
+		return e.complexity.Query.ContentChild(childComplexity), true
 
 	case "Query.defaultParameters":
 		if e.complexity.Query.DefaultParameters == nil {
@@ -1250,6 +1291,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.EmbeddedCase3(childComplexity), true
 
+	case "Query.EmbeddedDefaultScalar":
+		if e.complexity.Query.EmbeddedDefaultScalar == nil {
+			break
+		}
+
+		return e.complexity.Query.EmbeddedDefaultScalar(childComplexity), true
+
+	case "Query.EmbeddedPointer":
+		if e.complexity.Query.EmbeddedPointer == nil {
+			break
+		}
+
+		return e.complexity.Query.EmbeddedPointer(childComplexity), true
+
 	case "Query.enumInInput":
 		if e.complexity.Query.EnumInInput == nil {
 			break
@@ -1302,6 +1357,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Fallback(childComplexity, args["arg"].(FallbackToStringEncoding)), true
 
+	case "Query.ForcedResolver":
+		if e.complexity.Query.ForcedResolver == nil {
+			break
+		}
+
+		return e.complexity.Query.ForcedResolver(childComplexity), true
+
+	case "Query.iIt":
+		if e.complexity.Query.IIt == nil {
+			break
+		}
+
+		return e.complexity.Query.IIt(childComplexity), true
+
 	case "Query.infinity":
 		if e.complexity.Query.Infinity == nil {
 			break
@@ -1346,6 +1415,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Issue896a(childComplexity), true
+
+	case "Query.LoopA":
+		if e.complexity.Query.LoopA == nil {
+			break
+		}
+
+		return e.complexity.Query.LoopA(childComplexity), true
+
+	case "Query.Map":
+		if e.complexity.Query.Map == nil {
+			break
+		}
+
+		return e.complexity.Query.Map(childComplexity), true
 
 	case "Query.mapInput":
 		if e.complexity.Query.MapInput == nil {
@@ -1531,6 +1614,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Slices(childComplexity), true
 
+	case "Query.Status":
+		if e.complexity.Query.Status == nil {
+			break
+		}
+
+		return e.complexity.Query.Status(childComplexity), true
+
 	case "Query.stringFromContextFunction":
 		if e.complexity.Query.StringFromContextFunction == nil {
 			break
@@ -1619,6 +1709,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.WrappedStruct(childComplexity), true
+
+	case "Query.XXIt":
+		if e.complexity.Query.XXIt == nil {
+			break
+		}
+
+		return e.complexity.Query.XXIt(childComplexity), true
+
+	case "Query.XxIt":
+		if e.complexity.Query.XxIt == nil {
+			break
+		}
+
+		return e.complexity.Query.XxIt(childComplexity), true
 
 	case "Rectangle.area":
 		if e.complexity.Rectangle.Area == nil {
@@ -2010,7 +2114,10 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	{Name: "builtinscalar.graphql", Input: `
+	{Name: "builtinscalar.graphql", Input: `extend type Query {
+    Map: Map!
+}
+
 """
 Since gqlgen defines default implementation for a Map scalar, this tests that the builtin is _not_
 added to the TypeMap
@@ -2228,7 +2335,11 @@ extend type Subscription {
   issue896b: [CheckIssue896] # Note the "!" or lack thereof.
 }
 `, BuiltIn: false},
-	{Name: "loops.graphql", Input: `type LoopA {
+	{Name: "loops.graphql", Input: `extend type Query {
+    LoopA: LoopA
+}
+
+type LoopA {
     b: LoopB!
 }
 
@@ -2370,6 +2481,7 @@ scalar StringFromContextFunction
 `, BuiltIn: false},
 	{Name: "scalar_default.graphql", Input: `extend type Query {
     defaultScalar(arg: DefaultScalarImplementation! = "default"): DefaultScalarImplementation!
+    EmbeddedDefaultScalar: EmbeddedDefaultScalar!
 }
 
 """ This doesnt have an implementation in the typemap, so it should act like a string """
@@ -2403,6 +2515,9 @@ type Query {
     shapeUnion: ShapeUnion!
     autobind: Autobind
     deprecatedField: String! @deprecated(reason: "test deprecated directive")
+    EmbeddedPointer: EmbeddedPointer!
+    ForcedResolver: ForcedResolver!
+    Status: Status!
 }
 
 type Subscription {
@@ -2544,6 +2659,7 @@ type VOkCaseNil @goModel(model:"followschema.VOkCaseNil") {
 `, BuiltIn: false},
 	{Name: "validtypes.graphql", Input: `extend type Query {
     validType: ValidType
+    Content_Child: Content_Child
 }
 
 """ These things are all valid, but without care generate invalid go code """
@@ -2630,6 +2746,15 @@ type VariadicModel {
 }
 `, BuiltIn: false},
 	{Name: "weird_type_cases.graphql", Input: `# regression test for https://github.com/99designs/gqlgen/issues/583
+
+extend type Query {
+    asdfIt: asdfIt!
+    AIt: AIt!
+    iIt: iIt!
+    XXIt: XXIt!
+    AbIt: AbIt!
+    XxIt: XxIt!
+}
 
 type asdfIt { id: ID! }
 type iIt { id: ID! }

--- a/codegen/testserver/followschema/scalar_default.generated.go
+++ b/codegen/testserver/followschema/scalar_default.generated.go
@@ -119,6 +119,20 @@ func (ec *executionContext) marshalNDefaultScalarImplementation2string(ctx conte
 	return res
 }
 
+func (ec *executionContext) marshalNEmbeddedDefaultScalar2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐEmbeddedDefaultScalar(ctx context.Context, sel ast.SelectionSet, v EmbeddedDefaultScalar) graphql.Marshaler {
+	return ec._EmbeddedDefaultScalar(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNEmbeddedDefaultScalar2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐEmbeddedDefaultScalar(ctx context.Context, sel ast.SelectionSet, v *EmbeddedDefaultScalar) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._EmbeddedDefaultScalar(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalODefaultScalarImplementation2ᚖstring(ctx context.Context, v interface{}) (*string, error) {
 	if v == nil {
 		return nil, nil

--- a/codegen/testserver/followschema/scalar_default.graphql
+++ b/codegen/testserver/followschema/scalar_default.graphql
@@ -1,5 +1,6 @@
 extend type Query {
     defaultScalar(arg: DefaultScalarImplementation! = "default"): DefaultScalarImplementation!
+    EmbeddedDefaultScalar: EmbeddedDefaultScalar!
 }
 
 """ This doesnt have an implementation in the typemap, so it should act like a string """

--- a/codegen/testserver/followschema/schema.generated.go
+++ b/codegen/testserver/followschema/schema.generated.go
@@ -46,6 +46,10 @@ type QueryResolver interface {
 	ShapeUnion(ctx context.Context) (ShapeUnion, error)
 	Autobind(ctx context.Context) (*Autobind, error)
 	DeprecatedField(ctx context.Context) (string, error)
+	EmbeddedPointer(ctx context.Context) (*EmbeddedPointerModel, error)
+	ForcedResolver(ctx context.Context) (*ForcedResolver, error)
+	Status(ctx context.Context) (Status, error)
+	Map(ctx context.Context) (*Map, error)
 	Overlapping(ctx context.Context) (*OverlappingFields, error)
 	DefaultParameters(ctx context.Context, falsyBoolean *bool, truthyBoolean *bool) (*DefaultParametersMirror, error)
 	DirectiveArg(ctx context.Context, arg string) (*string, error)
@@ -70,6 +74,7 @@ type QueryResolver interface {
 	Animal(ctx context.Context) (Animal, error)
 	NotAnInterface(ctx context.Context) (BackedByInterface, error)
 	Issue896a(ctx context.Context) ([]*CheckIssue896, error)
+	LoopA(ctx context.Context) (*LoopA, error)
 	MapStringInterface(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error)
 	MapNestedStringInterface(ctx context.Context, in *NestedMapInput) (map[string]interface{}, error)
 	ErrorBubble(ctx context.Context) (*Error, error)
@@ -85,6 +90,7 @@ type QueryResolver interface {
 	StringFromContextInterface(ctx context.Context) (*StringFromContextInterface, error)
 	StringFromContextFunction(ctx context.Context) (string, error)
 	DefaultScalar(ctx context.Context, arg string) (string, error)
+	EmbeddedDefaultScalar(ctx context.Context) (*EmbeddedDefaultScalar, error)
 	Slices(ctx context.Context) (*Slices, error)
 	ScalarSlice(ctx context.Context) ([]byte, error)
 	Fallback(ctx context.Context, arg FallbackToStringEncoding) (FallbackToStringEncoding, error)
@@ -92,7 +98,14 @@ type QueryResolver interface {
 	VOkCaseValue(ctx context.Context) (*VOkCaseValue, error)
 	VOkCaseNil(ctx context.Context) (*VOkCaseNil, error)
 	ValidType(ctx context.Context) (*ValidType, error)
+	ContentChild(ctx context.Context) (ContentChild, error)
 	VariadicModel(ctx context.Context) (*VariadicModel, error)
+	AsdfIt(ctx context.Context) (*AsdfIt, error)
+	AIt(ctx context.Context) (*AIt, error)
+	IIt(ctx context.Context) (*IIt, error)
+	XXIt(ctx context.Context) (*XXIt, error)
+	AbIt(ctx context.Context) (*AbIt, error)
+	XxIt(ctx context.Context) (*XxIt, error)
 	WrappedStruct(ctx context.Context) (*WrappedStruct, error)
 	WrappedScalar(ctx context.Context) (otherpkg.Scalar, error)
 	WrappedMap(ctx context.Context) (WrappedMap, error)
@@ -2084,6 +2097,184 @@ func (ec *executionContext) fieldContext_Query_deprecatedField(ctx context.Conte
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_EmbeddedPointer(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_EmbeddedPointer(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().EmbeddedPointer(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*EmbeddedPointerModel)
+	fc.Result = res
+	return ec.marshalNEmbeddedPointer2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐEmbeddedPointerModel(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_EmbeddedPointer(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "ID":
+				return ec.fieldContext_EmbeddedPointer_ID(ctx, field)
+			case "Title":
+				return ec.fieldContext_EmbeddedPointer_Title(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type EmbeddedPointer", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_ForcedResolver(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_ForcedResolver(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().ForcedResolver(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*ForcedResolver)
+	fc.Result = res
+	return ec.marshalNForcedResolver2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐForcedResolver(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_ForcedResolver(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "field":
+				return ec.fieldContext_ForcedResolver_field(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ForcedResolver", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_Status(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_Status(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Status(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(Status)
+	fc.Result = res
+	return ec.marshalNStatus2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐStatus(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_Status(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Status does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_Map(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_Map(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Map(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*Map)
+	fc.Result = res
+	return ec.marshalNMap2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐMap(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_Map(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Map_id(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Map", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_overlapping(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_overlapping(ctx, field)
 	if err != nil {
@@ -3338,6 +3529,48 @@ func (ec *executionContext) fieldContext_Query_issue896a(ctx context.Context, fi
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_LoopA(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_LoopA(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().LoopA(rctx)
+	})
+
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*LoopA)
+	fc.Result = res
+	return ec.marshalOLoopA2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐLoopA(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_LoopA(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "b":
+				return ec.fieldContext_LoopA_b(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type LoopA", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_mapStringInterface(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_mapStringInterface(ctx, field)
 	if err != nil {
@@ -4045,6 +4278,51 @@ func (ec *executionContext) fieldContext_Query_defaultScalar(ctx context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_EmbeddedDefaultScalar(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_EmbeddedDefaultScalar(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().EmbeddedDefaultScalar(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*EmbeddedDefaultScalar)
+	fc.Result = res
+	return ec.marshalNEmbeddedDefaultScalar2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐEmbeddedDefaultScalar(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_EmbeddedDefaultScalar(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "value":
+				return ec.fieldContext_EmbeddedDefaultScalar_value(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type EmbeddedDefaultScalar", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_slices(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_slices(ctx, field)
 	if err != nil {
@@ -4356,6 +4634,44 @@ func (ec *executionContext) fieldContext_Query_validType(ctx context.Context, fi
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_Content_Child(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_Content_Child(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().ContentChild(rctx)
+	})
+
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(ContentChild)
+	fc.Result = res
+	return ec.marshalOContent_Child2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐContentChild(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_Content_Child(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Content_Child does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_variadicModel(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_variadicModel(ctx, field)
 	if err != nil {
@@ -4393,6 +4709,276 @@ func (ec *executionContext) fieldContext_Query_variadicModel(ctx context.Context
 				return ec.fieldContext_VariadicModel_value(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type VariadicModel", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_asdfIt(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_asdfIt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().AsdfIt(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*AsdfIt)
+	fc.Result = res
+	return ec.marshalNasdfIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐAsdfIt(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_asdfIt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_asdfIt_id(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type asdfIt", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_AIt(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_AIt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().AIt(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*AIt)
+	fc.Result = res
+	return ec.marshalNAIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐAIt(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_AIt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_AIt_id(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AIt", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_iIt(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_iIt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().IIt(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*IIt)
+	fc.Result = res
+	return ec.marshalNiIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐIIt(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_iIt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_iIt_id(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type iIt", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_XXIt(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_XXIt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().XXIt(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*XXIt)
+	fc.Result = res
+	return ec.marshalNXXIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐXXIt(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_XXIt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_XXIt_id(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type XXIt", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_AbIt(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_AbIt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().AbIt(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*AbIt)
+	fc.Result = res
+	return ec.marshalNAbIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐAbIt(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_AbIt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_AbIt_id(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AbIt", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_XxIt(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_XxIt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().XxIt(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*XxIt)
+	fc.Result = res
+	return ec.marshalNXxIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐXxIt(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_XxIt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_XxIt_id(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type XxIt", field.Name)
 		},
 	}
 	return fc, nil
@@ -6145,6 +6731,98 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			out.Concurrently(i, func() graphql.Marshaler {
 				return rrm(innerCtx)
 			})
+		case "EmbeddedPointer":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_EmbeddedPointer(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "ForcedResolver":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_ForcedResolver(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "Status":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_Status(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "Map":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_Map(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
 		case "overlapping":
 			field := field
 
@@ -6637,6 +7315,26 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			out.Concurrently(i, func() graphql.Marshaler {
 				return rrm(innerCtx)
 			})
+		case "LoopA":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_LoopA(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
 		case "mapStringInterface":
 			field := field
 
@@ -6961,6 +7659,29 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			out.Concurrently(i, func() graphql.Marshaler {
 				return rrm(innerCtx)
 			})
+		case "EmbeddedDefaultScalar":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_EmbeddedDefaultScalar(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
 		case "slices":
 			field := field
 
@@ -7107,6 +7828,26 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			out.Concurrently(i, func() graphql.Marshaler {
 				return rrm(innerCtx)
 			})
+		case "Content_Child":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_Content_Child(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
 		case "variadicModel":
 			field := field
 
@@ -7117,6 +7858,144 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_variadicModel(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "asdfIt":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_asdfIt(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "AIt":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_AIt(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "iIt":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_iIt(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "XXIt":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_XXIt(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "AbIt":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_AbIt(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "XxIt":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_XxIt(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
 				return res
 			}
 
@@ -7356,6 +8235,34 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 
 // region    ***************************** type.gotpl *****************************
 
+func (ec *executionContext) marshalNEmbeddedPointer2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐEmbeddedPointerModel(ctx context.Context, sel ast.SelectionSet, v EmbeddedPointerModel) graphql.Marshaler {
+	return ec._EmbeddedPointer(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNEmbeddedPointer2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐEmbeddedPointerModel(ctx context.Context, sel ast.SelectionSet, v *EmbeddedPointerModel) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._EmbeddedPointer(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNForcedResolver2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐForcedResolver(ctx context.Context, sel ast.SelectionSet, v ForcedResolver) graphql.Marshaler {
+	return ec._ForcedResolver(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNForcedResolver2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐForcedResolver(ctx context.Context, sel ast.SelectionSet, v *ForcedResolver) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ForcedResolver(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNInnerInput2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐInnerInput(ctx context.Context, v interface{}) (InnerInput, error) {
 	res, err := ec.unmarshalInputInnerInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -7389,6 +8296,16 @@ func (ec *executionContext) marshalNPet2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋc
 func (ec *executionContext) unmarshalNRecursiveInputSlice2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐRecursiveInputSlice(ctx context.Context, v interface{}) (RecursiveInputSlice, error) {
 	res, err := ec.unmarshalInputRecursiveInputSlice(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNStatus2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐStatus(ctx context.Context, v interface{}) (Status, error) {
+	var res Status
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNStatus2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐStatus(ctx context.Context, sel ast.SelectionSet, v Status) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) unmarshalNTime2timeᚐTime(ctx context.Context, v interface{}) (time.Time, error) {

--- a/codegen/testserver/followschema/schema.graphql
+++ b/codegen/testserver/followschema/schema.graphql
@@ -22,6 +22,9 @@ type Query {
     shapeUnion: ShapeUnion!
     autobind: Autobind
     deprecatedField: String! @deprecated(reason: "test deprecated directive")
+    EmbeddedPointer: EmbeddedPointer!
+    ForcedResolver: ForcedResolver!
+    Status: Status!
 }
 
 type Subscription {

--- a/codegen/testserver/followschema/stub.go
+++ b/codegen/testserver/followschema/stub.go
@@ -64,6 +64,10 @@ type Stub struct {
 		ShapeUnion                       func(ctx context.Context) (ShapeUnion, error)
 		Autobind                         func(ctx context.Context) (*Autobind, error)
 		DeprecatedField                  func(ctx context.Context) (string, error)
+		EmbeddedPointer                  func(ctx context.Context) (*EmbeddedPointerModel, error)
+		ForcedResolver                   func(ctx context.Context) (*ForcedResolver, error)
+		Status                           func(ctx context.Context) (Status, error)
+		Map                              func(ctx context.Context) (*Map, error)
 		Overlapping                      func(ctx context.Context) (*OverlappingFields, error)
 		DefaultParameters                func(ctx context.Context, falsyBoolean *bool, truthyBoolean *bool) (*DefaultParametersMirror, error)
 		DirectiveArg                     func(ctx context.Context, arg string) (*string, error)
@@ -88,6 +92,7 @@ type Stub struct {
 		Animal                           func(ctx context.Context) (Animal, error)
 		NotAnInterface                   func(ctx context.Context) (BackedByInterface, error)
 		Issue896a                        func(ctx context.Context) ([]*CheckIssue896, error)
+		LoopA                            func(ctx context.Context) (*LoopA, error)
 		MapStringInterface               func(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error)
 		MapNestedStringInterface         func(ctx context.Context, in *NestedMapInput) (map[string]interface{}, error)
 		ErrorBubble                      func(ctx context.Context) (*Error, error)
@@ -103,6 +108,7 @@ type Stub struct {
 		StringFromContextInterface       func(ctx context.Context) (*StringFromContextInterface, error)
 		StringFromContextFunction        func(ctx context.Context) (string, error)
 		DefaultScalar                    func(ctx context.Context, arg string) (string, error)
+		EmbeddedDefaultScalar            func(ctx context.Context) (*EmbeddedDefaultScalar, error)
 		Slices                           func(ctx context.Context) (*Slices, error)
 		ScalarSlice                      func(ctx context.Context) ([]byte, error)
 		Fallback                         func(ctx context.Context, arg FallbackToStringEncoding) (FallbackToStringEncoding, error)
@@ -110,7 +116,14 @@ type Stub struct {
 		VOkCaseValue                     func(ctx context.Context) (*VOkCaseValue, error)
 		VOkCaseNil                       func(ctx context.Context) (*VOkCaseNil, error)
 		ValidType                        func(ctx context.Context) (*ValidType, error)
+		ContentChild                     func(ctx context.Context) (ContentChild, error)
 		VariadicModel                    func(ctx context.Context) (*VariadicModel, error)
+		AsdfIt                           func(ctx context.Context) (*AsdfIt, error)
+		AIt                              func(ctx context.Context) (*AIt, error)
+		IIt                              func(ctx context.Context) (*IIt, error)
+		XXIt                             func(ctx context.Context) (*XXIt, error)
+		AbIt                             func(ctx context.Context) (*AbIt, error)
+		XxIt                             func(ctx context.Context) (*XxIt, error)
 		WrappedStruct                    func(ctx context.Context) (*WrappedStruct, error)
 		WrappedScalar                    func(ctx context.Context) (otherpkg.Scalar, error)
 		WrappedMap                       func(ctx context.Context) (WrappedMap, error)
@@ -312,6 +325,18 @@ func (r *stubQuery) Autobind(ctx context.Context) (*Autobind, error) {
 func (r *stubQuery) DeprecatedField(ctx context.Context) (string, error) {
 	return r.QueryResolver.DeprecatedField(ctx)
 }
+func (r *stubQuery) EmbeddedPointer(ctx context.Context) (*EmbeddedPointerModel, error) {
+	return r.QueryResolver.EmbeddedPointer(ctx)
+}
+func (r *stubQuery) ForcedResolver(ctx context.Context) (*ForcedResolver, error) {
+	return r.QueryResolver.ForcedResolver(ctx)
+}
+func (r *stubQuery) Status(ctx context.Context) (Status, error) {
+	return r.QueryResolver.Status(ctx)
+}
+func (r *stubQuery) Map(ctx context.Context) (*Map, error) {
+	return r.QueryResolver.Map(ctx)
+}
 func (r *stubQuery) Overlapping(ctx context.Context) (*OverlappingFields, error) {
 	return r.QueryResolver.Overlapping(ctx)
 }
@@ -384,6 +409,9 @@ func (r *stubQuery) NotAnInterface(ctx context.Context) (BackedByInterface, erro
 func (r *stubQuery) Issue896a(ctx context.Context) ([]*CheckIssue896, error) {
 	return r.QueryResolver.Issue896a(ctx)
 }
+func (r *stubQuery) LoopA(ctx context.Context) (*LoopA, error) {
+	return r.QueryResolver.LoopA(ctx)
+}
 func (r *stubQuery) MapStringInterface(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error) {
 	return r.QueryResolver.MapStringInterface(ctx, in)
 }
@@ -429,6 +457,9 @@ func (r *stubQuery) StringFromContextFunction(ctx context.Context) (string, erro
 func (r *stubQuery) DefaultScalar(ctx context.Context, arg string) (string, error) {
 	return r.QueryResolver.DefaultScalar(ctx, arg)
 }
+func (r *stubQuery) EmbeddedDefaultScalar(ctx context.Context) (*EmbeddedDefaultScalar, error) {
+	return r.QueryResolver.EmbeddedDefaultScalar(ctx)
+}
 func (r *stubQuery) Slices(ctx context.Context) (*Slices, error) {
 	return r.QueryResolver.Slices(ctx)
 }
@@ -450,8 +481,29 @@ func (r *stubQuery) VOkCaseNil(ctx context.Context) (*VOkCaseNil, error) {
 func (r *stubQuery) ValidType(ctx context.Context) (*ValidType, error) {
 	return r.QueryResolver.ValidType(ctx)
 }
+func (r *stubQuery) ContentChild(ctx context.Context) (ContentChild, error) {
+	return r.QueryResolver.ContentChild(ctx)
+}
 func (r *stubQuery) VariadicModel(ctx context.Context) (*VariadicModel, error) {
 	return r.QueryResolver.VariadicModel(ctx)
+}
+func (r *stubQuery) AsdfIt(ctx context.Context) (*AsdfIt, error) {
+	return r.QueryResolver.AsdfIt(ctx)
+}
+func (r *stubQuery) AIt(ctx context.Context) (*AIt, error) {
+	return r.QueryResolver.AIt(ctx)
+}
+func (r *stubQuery) IIt(ctx context.Context) (*IIt, error) {
+	return r.QueryResolver.IIt(ctx)
+}
+func (r *stubQuery) XXIt(ctx context.Context) (*XXIt, error) {
+	return r.QueryResolver.XXIt(ctx)
+}
+func (r *stubQuery) AbIt(ctx context.Context) (*AbIt, error) {
+	return r.QueryResolver.AbIt(ctx)
+}
+func (r *stubQuery) XxIt(ctx context.Context) (*XxIt, error) {
+	return r.QueryResolver.XxIt(ctx)
 }
 func (r *stubQuery) WrappedStruct(ctx context.Context) (*WrappedStruct, error) {
 	return r.QueryResolver.WrappedStruct(ctx)

--- a/codegen/testserver/followschema/validtypes.generated.go
+++ b/codegen/testserver/followschema/validtypes.generated.go
@@ -904,6 +904,13 @@ func (ec *executionContext) _ValidType(ctx context.Context, sel ast.SelectionSet
 
 // region    ***************************** type.gotpl *****************************
 
+func (ec *executionContext) marshalOContent_Child2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐContentChild(ctx context.Context, sel ast.SelectionSet, v ContentChild) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Content_Child(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalOValidInput2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐValidInput(ctx context.Context, v interface{}) (*ValidInput, error) {
 	if v == nil {
 		return nil, nil

--- a/codegen/testserver/followschema/validtypes.graphql
+++ b/codegen/testserver/followschema/validtypes.graphql
@@ -1,5 +1,6 @@
 extend type Query {
     validType: ValidType
+    Content_Child: Content_Child
 }
 
 """ These things are all valid, but without care generate invalid go code """

--- a/codegen/testserver/followschema/weird_type_cases.generated.go
+++ b/codegen/testserver/followschema/weird_type_cases.generated.go
@@ -455,4 +455,88 @@ func (ec *executionContext) _iIt(ctx context.Context, sel ast.SelectionSet, obj 
 
 // region    ***************************** type.gotpl *****************************
 
+func (ec *executionContext) marshalNAIt2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐAIt(ctx context.Context, sel ast.SelectionSet, v AIt) graphql.Marshaler {
+	return ec._AIt(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNAIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐAIt(ctx context.Context, sel ast.SelectionSet, v *AIt) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._AIt(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNAbIt2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐAbIt(ctx context.Context, sel ast.SelectionSet, v AbIt) graphql.Marshaler {
+	return ec._AbIt(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNAbIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐAbIt(ctx context.Context, sel ast.SelectionSet, v *AbIt) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._AbIt(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNXXIt2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐXXIt(ctx context.Context, sel ast.SelectionSet, v XXIt) graphql.Marshaler {
+	return ec._XXIt(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNXXIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐXXIt(ctx context.Context, sel ast.SelectionSet, v *XXIt) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._XXIt(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNXxIt2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐXxIt(ctx context.Context, sel ast.SelectionSet, v XxIt) graphql.Marshaler {
+	return ec._XxIt(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNXxIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐXxIt(ctx context.Context, sel ast.SelectionSet, v *XxIt) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._XxIt(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNasdfIt2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐAsdfIt(ctx context.Context, sel ast.SelectionSet, v AsdfIt) graphql.Marshaler {
+	return ec._asdfIt(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNasdfIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐAsdfIt(ctx context.Context, sel ast.SelectionSet, v *AsdfIt) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._asdfIt(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNiIt2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐIIt(ctx context.Context, sel ast.SelectionSet, v IIt) graphql.Marshaler {
+	return ec._iIt(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNiIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐIIt(ctx context.Context, sel ast.SelectionSet, v *IIt) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._iIt(ctx, sel, v)
+}
+
 // endregion ***************************** type.gotpl *****************************

--- a/codegen/testserver/followschema/weird_type_cases.graphql
+++ b/codegen/testserver/followschema/weird_type_cases.graphql
@@ -1,5 +1,14 @@
 # regression test for https://github.com/99designs/gqlgen/issues/583
 
+extend type Query {
+    asdfIt: asdfIt!
+    AIt: AIt!
+    iIt: iIt!
+    XXIt: XXIt!
+    AbIt: AbIt!
+    XxIt: XxIt!
+}
+
 type asdfIt { id: ID! }
 type iIt { id: ID! }
 type AIt { id: ID! }

--- a/codegen/testserver/singlefile/builtinscalar.graphql
+++ b/codegen/testserver/singlefile/builtinscalar.graphql
@@ -1,3 +1,6 @@
+extend type Query {
+    Map: Map!
+}
 
 """
 Since gqlgen defines default implementation for a Map scalar, this tests that the builtin is _not_

--- a/codegen/testserver/singlefile/generated.go
+++ b/codegen/testserver/singlefile/generated.go
@@ -292,9 +292,13 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
+		AIt                              func(childComplexity int) int
+		AbIt                             func(childComplexity int) int
 		Animal                           func(childComplexity int) int
+		AsdfIt                           func(childComplexity int) int
 		Autobind                         func(childComplexity int) int
 		Collision                        func(childComplexity int) int
+		ContentChild                     func(childComplexity int) int
 		DefaultParameters                func(childComplexity int, falsyBoolean *bool, truthyBoolean *bool) int
 		DefaultScalar                    func(childComplexity int, arg string) int
 		DeprecatedField                  func(childComplexity int) int
@@ -312,17 +316,23 @@ type ComplexityRoot struct {
 		EmbeddedCase1                    func(childComplexity int) int
 		EmbeddedCase2                    func(childComplexity int) int
 		EmbeddedCase3                    func(childComplexity int) int
+		EmbeddedDefaultScalar            func(childComplexity int) int
+		EmbeddedPointer                  func(childComplexity int) int
 		EnumInInput                      func(childComplexity int, input *InputWithEnumValue) int
 		ErrorBubble                      func(childComplexity int) int
 		ErrorBubbleList                  func(childComplexity int) int
 		ErrorList                        func(childComplexity int) int
 		Errors                           func(childComplexity int) int
 		Fallback                         func(childComplexity int, arg FallbackToStringEncoding) int
+		ForcedResolver                   func(childComplexity int) int
+		IIt                              func(childComplexity int) int
 		Infinity                         func(childComplexity int) int
 		InputNullableSlice               func(childComplexity int, arg []string) int
 		InputSlice                       func(childComplexity int, arg []string) int
 		InvalidIdentifier                func(childComplexity int) int
 		Issue896a                        func(childComplexity int) int
+		LoopA                            func(childComplexity int) int
+		Map                              func(childComplexity int) int
 		MapInput                         func(childComplexity int, input map[string]interface{}) int
 		MapNestedStringInterface         func(childComplexity int, in *NestedMapInput) int
 		MapStringInterface               func(childComplexity int, in map[string]interface{}) int
@@ -345,6 +355,7 @@ type ComplexityRoot struct {
 		ShapeUnion                       func(childComplexity int) int
 		Shapes                           func(childComplexity int) int
 		Slices                           func(childComplexity int) int
+		Status                           func(childComplexity int) int
 		StringFromContextFunction        func(childComplexity int) int
 		StringFromContextInterface       func(childComplexity int) int
 		User                             func(childComplexity int, id int) int
@@ -357,6 +368,8 @@ type ComplexityRoot struct {
 		WrappedScalar                    func(childComplexity int) int
 		WrappedSlice                     func(childComplexity int) int
 		WrappedStruct                    func(childComplexity int) int
+		XXIt                             func(childComplexity int) int
+		XxIt                             func(childComplexity int) int
 	}
 
 	Rectangle struct {
@@ -496,6 +509,10 @@ type QueryResolver interface {
 	ShapeUnion(ctx context.Context) (ShapeUnion, error)
 	Autobind(ctx context.Context) (*Autobind, error)
 	DeprecatedField(ctx context.Context) (string, error)
+	EmbeddedPointer(ctx context.Context) (*EmbeddedPointerModel, error)
+	ForcedResolver(ctx context.Context) (*ForcedResolver, error)
+	Status(ctx context.Context) (Status, error)
+	Map(ctx context.Context) (*Map, error)
 	Overlapping(ctx context.Context) (*OverlappingFields, error)
 	DefaultParameters(ctx context.Context, falsyBoolean *bool, truthyBoolean *bool) (*DefaultParametersMirror, error)
 	DirectiveArg(ctx context.Context, arg string) (*string, error)
@@ -520,6 +537,7 @@ type QueryResolver interface {
 	Animal(ctx context.Context) (Animal, error)
 	NotAnInterface(ctx context.Context) (BackedByInterface, error)
 	Issue896a(ctx context.Context) ([]*CheckIssue896, error)
+	LoopA(ctx context.Context) (*LoopA, error)
 	MapStringInterface(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error)
 	MapNestedStringInterface(ctx context.Context, in *NestedMapInput) (map[string]interface{}, error)
 	ErrorBubble(ctx context.Context) (*Error, error)
@@ -535,6 +553,7 @@ type QueryResolver interface {
 	StringFromContextInterface(ctx context.Context) (*StringFromContextInterface, error)
 	StringFromContextFunction(ctx context.Context) (string, error)
 	DefaultScalar(ctx context.Context, arg string) (string, error)
+	EmbeddedDefaultScalar(ctx context.Context) (*EmbeddedDefaultScalar, error)
 	Slices(ctx context.Context) (*Slices, error)
 	ScalarSlice(ctx context.Context) ([]byte, error)
 	Fallback(ctx context.Context, arg FallbackToStringEncoding) (FallbackToStringEncoding, error)
@@ -542,7 +561,14 @@ type QueryResolver interface {
 	VOkCaseValue(ctx context.Context) (*VOkCaseValue, error)
 	VOkCaseNil(ctx context.Context) (*VOkCaseNil, error)
 	ValidType(ctx context.Context) (*ValidType, error)
+	ContentChild(ctx context.Context) (ContentChild, error)
 	VariadicModel(ctx context.Context) (*VariadicModel, error)
+	AsdfIt(ctx context.Context) (*AsdfIt, error)
+	AIt(ctx context.Context) (*AIt, error)
+	IIt(ctx context.Context) (*IIt, error)
+	XXIt(ctx context.Context) (*XXIt, error)
+	AbIt(ctx context.Context) (*AbIt, error)
+	XxIt(ctx context.Context) (*XxIt, error)
 	WrappedStruct(ctx context.Context) (*WrappedStruct, error)
 	WrappedScalar(ctx context.Context) (otherpkg.Scalar, error)
 	WrappedMap(ctx context.Context) (WrappedMap, error)
@@ -1210,12 +1236,33 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PtrToSliceContainer.PtrToSlice(childComplexity), true
 
+	case "Query.AIt":
+		if e.complexity.Query.AIt == nil {
+			break
+		}
+
+		return e.complexity.Query.AIt(childComplexity), true
+
+	case "Query.AbIt":
+		if e.complexity.Query.AbIt == nil {
+			break
+		}
+
+		return e.complexity.Query.AbIt(childComplexity), true
+
 	case "Query.animal":
 		if e.complexity.Query.Animal == nil {
 			break
 		}
 
 		return e.complexity.Query.Animal(childComplexity), true
+
+	case "Query.asdfIt":
+		if e.complexity.Query.AsdfIt == nil {
+			break
+		}
+
+		return e.complexity.Query.AsdfIt(childComplexity), true
 
 	case "Query.autobind":
 		if e.complexity.Query.Autobind == nil {
@@ -1230,6 +1277,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Collision(childComplexity), true
+
+	case "Query.Content_Child":
+		if e.complexity.Query.ContentChild == nil {
+			break
+		}
+
+		return e.complexity.Query.ContentChild(childComplexity), true
 
 	case "Query.defaultParameters":
 		if e.complexity.Query.DefaultParameters == nil {
@@ -1390,6 +1444,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.EmbeddedCase3(childComplexity), true
 
+	case "Query.EmbeddedDefaultScalar":
+		if e.complexity.Query.EmbeddedDefaultScalar == nil {
+			break
+		}
+
+		return e.complexity.Query.EmbeddedDefaultScalar(childComplexity), true
+
+	case "Query.EmbeddedPointer":
+		if e.complexity.Query.EmbeddedPointer == nil {
+			break
+		}
+
+		return e.complexity.Query.EmbeddedPointer(childComplexity), true
+
 	case "Query.enumInInput":
 		if e.complexity.Query.EnumInInput == nil {
 			break
@@ -1442,6 +1510,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Fallback(childComplexity, args["arg"].(FallbackToStringEncoding)), true
 
+	case "Query.ForcedResolver":
+		if e.complexity.Query.ForcedResolver == nil {
+			break
+		}
+
+		return e.complexity.Query.ForcedResolver(childComplexity), true
+
+	case "Query.iIt":
+		if e.complexity.Query.IIt == nil {
+			break
+		}
+
+		return e.complexity.Query.IIt(childComplexity), true
+
 	case "Query.infinity":
 		if e.complexity.Query.Infinity == nil {
 			break
@@ -1486,6 +1568,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Issue896a(childComplexity), true
+
+	case "Query.LoopA":
+		if e.complexity.Query.LoopA == nil {
+			break
+		}
+
+		return e.complexity.Query.LoopA(childComplexity), true
+
+	case "Query.Map":
+		if e.complexity.Query.Map == nil {
+			break
+		}
+
+		return e.complexity.Query.Map(childComplexity), true
 
 	case "Query.mapInput":
 		if e.complexity.Query.MapInput == nil {
@@ -1671,6 +1767,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Slices(childComplexity), true
 
+	case "Query.Status":
+		if e.complexity.Query.Status == nil {
+			break
+		}
+
+		return e.complexity.Query.Status(childComplexity), true
+
 	case "Query.stringFromContextFunction":
 		if e.complexity.Query.StringFromContextFunction == nil {
 			break
@@ -1759,6 +1862,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.WrappedStruct(childComplexity), true
+
+	case "Query.XXIt":
+		if e.complexity.Query.XXIt == nil {
+			break
+		}
+
+		return e.complexity.Query.XXIt(childComplexity), true
+
+	case "Query.XxIt":
+		if e.complexity.Query.XxIt == nil {
+			break
+		}
+
+		return e.complexity.Query.XxIt(childComplexity), true
 
 	case "Rectangle.area":
 		if e.complexity.Rectangle.Area == nil {
@@ -2150,7 +2267,10 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	{Name: "builtinscalar.graphql", Input: `
+	{Name: "builtinscalar.graphql", Input: `extend type Query {
+    Map: Map!
+}
+
 """
 Since gqlgen defines default implementation for a Map scalar, this tests that the builtin is _not_
 added to the TypeMap
@@ -2368,7 +2488,11 @@ extend type Subscription {
   issue896b: [CheckIssue896] # Note the "!" or lack thereof.
 }
 `, BuiltIn: false},
-	{Name: "loops.graphql", Input: `type LoopA {
+	{Name: "loops.graphql", Input: `extend type Query {
+    LoopA: LoopA
+}
+
+type LoopA {
     b: LoopB!
 }
 
@@ -2510,6 +2634,7 @@ scalar StringFromContextFunction
 `, BuiltIn: false},
 	{Name: "scalar_default.graphql", Input: `extend type Query {
     defaultScalar(arg: DefaultScalarImplementation! = "default"): DefaultScalarImplementation!
+    EmbeddedDefaultScalar: EmbeddedDefaultScalar!
 }
 
 """ This doesnt have an implementation in the typemap, so it should act like a string """
@@ -2543,6 +2668,9 @@ type Query {
     shapeUnion: ShapeUnion!
     autobind: Autobind
     deprecatedField: String! @deprecated(reason: "test deprecated directive")
+    EmbeddedPointer: EmbeddedPointer!
+    ForcedResolver: ForcedResolver!
+    Status: Status!
 }
 
 type Subscription {
@@ -2684,6 +2812,7 @@ type VOkCaseNil @goModel(model:"singlefile.VOkCaseNil") {
 `, BuiltIn: false},
 	{Name: "validtypes.graphql", Input: `extend type Query {
     validType: ValidType
+    Content_Child: Content_Child
 }
 
 """ These things are all valid, but without care generate invalid go code """
@@ -2770,6 +2899,15 @@ type VariadicModel {
 }
 `, BuiltIn: false},
 	{Name: "weird_type_cases.graphql", Input: `# regression test for https://github.com/99designs/gqlgen/issues/583
+
+extend type Query {
+    asdfIt: asdfIt!
+    AIt: AIt!
+    iIt: iIt!
+    XXIt: XXIt!
+    AbIt: AbIt!
+    XxIt: XxIt!
+}
 
 type asdfIt { id: ID! }
 type iIt { id: ID! }
@@ -8354,6 +8492,184 @@ func (ec *executionContext) fieldContext_Query_deprecatedField(ctx context.Conte
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_EmbeddedPointer(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_EmbeddedPointer(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().EmbeddedPointer(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*EmbeddedPointerModel)
+	fc.Result = res
+	return ec.marshalNEmbeddedPointer2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐEmbeddedPointerModel(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_EmbeddedPointer(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "ID":
+				return ec.fieldContext_EmbeddedPointer_ID(ctx, field)
+			case "Title":
+				return ec.fieldContext_EmbeddedPointer_Title(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type EmbeddedPointer", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_ForcedResolver(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_ForcedResolver(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().ForcedResolver(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*ForcedResolver)
+	fc.Result = res
+	return ec.marshalNForcedResolver2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐForcedResolver(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_ForcedResolver(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "field":
+				return ec.fieldContext_ForcedResolver_field(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ForcedResolver", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_Status(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_Status(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Status(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(Status)
+	fc.Result = res
+	return ec.marshalNStatus2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐStatus(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_Status(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Status does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_Map(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_Map(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Map(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*Map)
+	fc.Result = res
+	return ec.marshalNMap2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐMap(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_Map(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Map_id(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Map", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_overlapping(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_overlapping(ctx, field)
 	if err != nil {
@@ -9608,6 +9924,48 @@ func (ec *executionContext) fieldContext_Query_issue896a(ctx context.Context, fi
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_LoopA(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_LoopA(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().LoopA(rctx)
+	})
+
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*LoopA)
+	fc.Result = res
+	return ec.marshalOLoopA2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐLoopA(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_LoopA(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "b":
+				return ec.fieldContext_LoopA_b(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type LoopA", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_mapStringInterface(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_mapStringInterface(ctx, field)
 	if err != nil {
@@ -10315,6 +10673,51 @@ func (ec *executionContext) fieldContext_Query_defaultScalar(ctx context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_EmbeddedDefaultScalar(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_EmbeddedDefaultScalar(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().EmbeddedDefaultScalar(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*EmbeddedDefaultScalar)
+	fc.Result = res
+	return ec.marshalNEmbeddedDefaultScalar2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐEmbeddedDefaultScalar(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_EmbeddedDefaultScalar(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "value":
+				return ec.fieldContext_EmbeddedDefaultScalar_value(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type EmbeddedDefaultScalar", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_slices(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_slices(ctx, field)
 	if err != nil {
@@ -10626,6 +11029,44 @@ func (ec *executionContext) fieldContext_Query_validType(ctx context.Context, fi
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_Content_Child(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_Content_Child(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().ContentChild(rctx)
+	})
+
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(ContentChild)
+	fc.Result = res
+	return ec.marshalOContent_Child2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐContentChild(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_Content_Child(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Content_Child does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_variadicModel(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_variadicModel(ctx, field)
 	if err != nil {
@@ -10663,6 +11104,276 @@ func (ec *executionContext) fieldContext_Query_variadicModel(ctx context.Context
 				return ec.fieldContext_VariadicModel_value(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type VariadicModel", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_asdfIt(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_asdfIt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().AsdfIt(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*AsdfIt)
+	fc.Result = res
+	return ec.marshalNasdfIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐAsdfIt(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_asdfIt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_asdfIt_id(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type asdfIt", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_AIt(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_AIt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().AIt(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*AIt)
+	fc.Result = res
+	return ec.marshalNAIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐAIt(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_AIt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_AIt_id(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AIt", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_iIt(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_iIt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().IIt(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*IIt)
+	fc.Result = res
+	return ec.marshalNiIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐIIt(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_iIt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_iIt_id(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type iIt", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_XXIt(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_XXIt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().XXIt(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*XXIt)
+	fc.Result = res
+	return ec.marshalNXXIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐXXIt(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_XXIt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_XXIt_id(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type XXIt", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_AbIt(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_AbIt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().AbIt(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*AbIt)
+	fc.Result = res
+	return ec.marshalNAbIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐAbIt(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_AbIt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_AbIt_id(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AbIt", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_XxIt(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_XxIt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().XxIt(rctx)
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*XxIt)
+	fc.Result = res
+	return ec.marshalNXxIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐXxIt(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_XxIt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_XxIt_id(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type XxIt", field.Name)
 		},
 	}
 	return fc, nil
@@ -17190,6 +17901,98 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			out.Concurrently(i, func() graphql.Marshaler {
 				return rrm(innerCtx)
 			})
+		case "EmbeddedPointer":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_EmbeddedPointer(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "ForcedResolver":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_ForcedResolver(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "Status":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_Status(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "Map":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_Map(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
 		case "overlapping":
 			field := field
 
@@ -17682,6 +18485,26 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			out.Concurrently(i, func() graphql.Marshaler {
 				return rrm(innerCtx)
 			})
+		case "LoopA":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_LoopA(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
 		case "mapStringInterface":
 			field := field
 
@@ -18006,6 +18829,29 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			out.Concurrently(i, func() graphql.Marshaler {
 				return rrm(innerCtx)
 			})
+		case "EmbeddedDefaultScalar":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_EmbeddedDefaultScalar(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
 		case "slices":
 			field := field
 
@@ -18152,6 +18998,26 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			out.Concurrently(i, func() graphql.Marshaler {
 				return rrm(innerCtx)
 			})
+		case "Content_Child":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_Content_Child(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
 		case "variadicModel":
 			field := field
 
@@ -18162,6 +19028,144 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_variadicModel(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "asdfIt":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_asdfIt(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "AIt":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_AIt(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "iIt":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_iIt(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "XXIt":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_XXIt(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "AbIt":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_AbIt(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "XxIt":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_XxIt(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
 				return res
 			}
 
@@ -19158,6 +20162,34 @@ func (ec *executionContext) _iIt(ctx context.Context, sel ast.SelectionSet, obj 
 
 // region    ***************************** type.gotpl *****************************
 
+func (ec *executionContext) marshalNAIt2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐAIt(ctx context.Context, sel ast.SelectionSet, v AIt) graphql.Marshaler {
+	return ec._AIt(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNAIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐAIt(ctx context.Context, sel ast.SelectionSet, v *AIt) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._AIt(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNAbIt2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐAbIt(ctx context.Context, sel ast.SelectionSet, v AbIt) graphql.Marshaler {
+	return ec._AbIt(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNAbIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐAbIt(ctx context.Context, sel ast.SelectionSet, v *AbIt) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._AbIt(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interface{}) (bool, error) {
 	res, err := graphql.UnmarshalBoolean(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -19248,6 +20280,34 @@ func (ec *executionContext) marshalNEmail2githubᚗcomᚋ99designsᚋgqlgenᚋco
 	return v
 }
 
+func (ec *executionContext) marshalNEmbeddedDefaultScalar2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐEmbeddedDefaultScalar(ctx context.Context, sel ast.SelectionSet, v EmbeddedDefaultScalar) graphql.Marshaler {
+	return ec._EmbeddedDefaultScalar(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNEmbeddedDefaultScalar2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐEmbeddedDefaultScalar(ctx context.Context, sel ast.SelectionSet, v *EmbeddedDefaultScalar) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._EmbeddedDefaultScalar(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNEmbeddedPointer2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐEmbeddedPointerModel(ctx context.Context, sel ast.SelectionSet, v EmbeddedPointerModel) graphql.Marshaler {
+	return ec._EmbeddedPointer(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNEmbeddedPointer2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐEmbeddedPointerModel(ctx context.Context, sel ast.SelectionSet, v *EmbeddedPointerModel) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._EmbeddedPointer(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNEnumTest2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐEnumTest(ctx context.Context, v interface{}) (EnumTest, error) {
 	var res EnumTest
 	err := res.UnmarshalGQL(v)
@@ -19301,6 +20361,20 @@ func (ec *executionContext) marshalNFloat2float64(ctx context.Context, sel ast.S
 		}
 	}
 	return graphql.WrapContextMarshaler(ctx, res)
+}
+
+func (ec *executionContext) marshalNForcedResolver2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐForcedResolver(ctx context.Context, sel ast.SelectionSet, v ForcedResolver) graphql.Marshaler {
+	return ec._ForcedResolver(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNForcedResolver2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐForcedResolver(ctx context.Context, sel ast.SelectionSet, v *ForcedResolver) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ForcedResolver(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNID2int(ctx context.Context, v interface{}) (int, error) {
@@ -19426,6 +20500,20 @@ func (ec *executionContext) marshalNLoopB2ᚖgithubᚗcomᚋ99designsᚋgqlgen�
 		return graphql.Null
 	}
 	return ec._LoopB(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNMap2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐMap(ctx context.Context, sel ast.SelectionSet, v Map) graphql.Marshaler {
+	return ec._Map(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNMap2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐMap(ctx context.Context, sel ast.SelectionSet, v *Map) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Map(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNMarshalPanic2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐMarshalPanic(ctx context.Context, v interface{}) (MarshalPanic, error) {
@@ -19637,6 +20725,16 @@ func (ec *executionContext) marshalNShapeUnion2githubᚗcomᚋ99designsᚋgqlgen
 func (ec *executionContext) unmarshalNSpecialInput2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐSpecialInput(ctx context.Context, v interface{}) (SpecialInput, error) {
 	res, err := ec.unmarshalInputSpecialInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNStatus2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐStatus(ctx context.Context, v interface{}) (Status, error) {
+	var res Status
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNStatus2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐStatus(ctx context.Context, sel ast.SelectionSet, v Status) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v interface{}) (string, error) {
@@ -19917,6 +21015,34 @@ func (ec *executionContext) marshalNWrappedStruct2ᚖgithubᚗcomᚋ99designsᚋ
 	return ec._WrappedStruct(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNXXIt2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐXXIt(ctx context.Context, sel ast.SelectionSet, v XXIt) graphql.Marshaler {
+	return ec._XXIt(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNXXIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐXXIt(ctx context.Context, sel ast.SelectionSet, v *XXIt) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._XXIt(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNXxIt2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐXxIt(ctx context.Context, sel ast.SelectionSet, v XxIt) graphql.Marshaler {
+	return ec._XxIt(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNXxIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐXxIt(ctx context.Context, sel ast.SelectionSet, v *XxIt) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._XxIt(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
 	return ec.___Directive(ctx, sel, &v)
 }
@@ -20170,6 +21296,34 @@ func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel a
 	return res
 }
 
+func (ec *executionContext) marshalNasdfIt2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐAsdfIt(ctx context.Context, sel ast.SelectionSet, v AsdfIt) graphql.Marshaler {
+	return ec._asdfIt(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNasdfIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐAsdfIt(ctx context.Context, sel ast.SelectionSet, v *AsdfIt) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._asdfIt(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNiIt2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐIIt(ctx context.Context, sel ast.SelectionSet, v IIt) graphql.Marshaler {
+	return ec._iIt(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNiIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐIIt(ctx context.Context, sel ast.SelectionSet, v *IIt) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._iIt(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalOAnimal2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐAnimal(ctx context.Context, sel ast.SelectionSet, v Animal) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -20324,6 +21478,13 @@ func (ec *executionContext) marshalOCircle2ᚖgithubᚗcomᚋ99designsᚋgqlgen�
 		return graphql.Null
 	}
 	return ec._Circle(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOContent_Child2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐContentChild(ctx context.Context, sel ast.SelectionSet, v ContentChild) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Content_Child(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOCoordinates2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐCoordinates(ctx context.Context, sel ast.SelectionSet, v Coordinates) graphql.Marshaler {
@@ -20531,6 +21692,13 @@ func (ec *executionContext) marshalOIt2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋco
 		return graphql.Null
 	}
 	return ec._It(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOLoopA2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐLoopA(ctx context.Context, sel ast.SelectionSet, v *LoopA) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._LoopA(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOMapStringInterfaceInput2map(ctx context.Context, v interface{}) (map[string]interface{}, error) {

--- a/codegen/testserver/singlefile/loops.graphql
+++ b/codegen/testserver/singlefile/loops.graphql
@@ -1,3 +1,7 @@
+extend type Query {
+    LoopA: LoopA
+}
+
 type LoopA {
     b: LoopB!
 }

--- a/codegen/testserver/singlefile/resolver.go
+++ b/codegen/testserver/singlefile/resolver.go
@@ -140,6 +140,22 @@ func (r *queryResolver) DeprecatedField(ctx context.Context) (string, error) {
 	panic("not implemented")
 }
 
+func (r *queryResolver) EmbeddedPointer(ctx context.Context) (*EmbeddedPointerModel, error) {
+	panic("not implemented")
+}
+
+func (r *queryResolver) ForcedResolver(ctx context.Context) (*ForcedResolver, error) {
+	panic("not implemented")
+}
+
+func (r *queryResolver) Status(ctx context.Context) (Status, error) {
+	panic("not implemented")
+}
+
+func (r *queryResolver) Map(ctx context.Context) (*Map, error) {
+	panic("not implemented")
+}
+
 func (r *queryResolver) Overlapping(ctx context.Context) (*OverlappingFields, error) {
 	panic("not implemented")
 }
@@ -236,6 +252,10 @@ func (r *queryResolver) Issue896a(ctx context.Context) ([]*CheckIssue896, error)
 	panic("not implemented")
 }
 
+func (r *queryResolver) LoopA(ctx context.Context) (*LoopA, error) {
+	panic("not implemented")
+}
+
 func (r *queryResolver) MapStringInterface(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error) {
 	panic("not implemented")
 }
@@ -296,6 +316,10 @@ func (r *queryResolver) DefaultScalar(ctx context.Context, arg string) (string, 
 	panic("not implemented")
 }
 
+func (r *queryResolver) EmbeddedDefaultScalar(ctx context.Context) (*EmbeddedDefaultScalar, error) {
+	panic("not implemented")
+}
+
 func (r *queryResolver) Slices(ctx context.Context) (*Slices, error) {
 	panic("not implemented")
 }
@@ -324,7 +348,35 @@ func (r *queryResolver) ValidType(ctx context.Context) (*ValidType, error) {
 	panic("not implemented")
 }
 
+func (r *queryResolver) ContentChild(ctx context.Context) (ContentChild, error) {
+	panic("not implemented")
+}
+
 func (r *queryResolver) VariadicModel(ctx context.Context) (*VariadicModel, error) {
+	panic("not implemented")
+}
+
+func (r *queryResolver) AsdfIt(ctx context.Context) (*AsdfIt, error) {
+	panic("not implemented")
+}
+
+func (r *queryResolver) AIt(ctx context.Context) (*AIt, error) {
+	panic("not implemented")
+}
+
+func (r *queryResolver) IIt(ctx context.Context) (*IIt, error) {
+	panic("not implemented")
+}
+
+func (r *queryResolver) XXIt(ctx context.Context) (*XXIt, error) {
+	panic("not implemented")
+}
+
+func (r *queryResolver) AbIt(ctx context.Context) (*AbIt, error) {
+	panic("not implemented")
+}
+
+func (r *queryResolver) XxIt(ctx context.Context) (*XxIt, error) {
 	panic("not implemented")
 }
 

--- a/codegen/testserver/singlefile/scalar_default.graphql
+++ b/codegen/testserver/singlefile/scalar_default.graphql
@@ -1,5 +1,6 @@
 extend type Query {
     defaultScalar(arg: DefaultScalarImplementation! = "default"): DefaultScalarImplementation!
+    EmbeddedDefaultScalar: EmbeddedDefaultScalar!
 }
 
 """ This doesnt have an implementation in the typemap, so it should act like a string """

--- a/codegen/testserver/singlefile/schema.graphql
+++ b/codegen/testserver/singlefile/schema.graphql
@@ -22,6 +22,9 @@ type Query {
     shapeUnion: ShapeUnion!
     autobind: Autobind
     deprecatedField: String! @deprecated(reason: "test deprecated directive")
+    EmbeddedPointer: EmbeddedPointer!
+    ForcedResolver: ForcedResolver!
+    Status: Status!
 }
 
 type Subscription {

--- a/codegen/testserver/singlefile/stub.go
+++ b/codegen/testserver/singlefile/stub.go
@@ -64,6 +64,10 @@ type Stub struct {
 		ShapeUnion                       func(ctx context.Context) (ShapeUnion, error)
 		Autobind                         func(ctx context.Context) (*Autobind, error)
 		DeprecatedField                  func(ctx context.Context) (string, error)
+		EmbeddedPointer                  func(ctx context.Context) (*EmbeddedPointerModel, error)
+		ForcedResolver                   func(ctx context.Context) (*ForcedResolver, error)
+		Status                           func(ctx context.Context) (Status, error)
+		Map                              func(ctx context.Context) (*Map, error)
 		Overlapping                      func(ctx context.Context) (*OverlappingFields, error)
 		DefaultParameters                func(ctx context.Context, falsyBoolean *bool, truthyBoolean *bool) (*DefaultParametersMirror, error)
 		DirectiveArg                     func(ctx context.Context, arg string) (*string, error)
@@ -88,6 +92,7 @@ type Stub struct {
 		Animal                           func(ctx context.Context) (Animal, error)
 		NotAnInterface                   func(ctx context.Context) (BackedByInterface, error)
 		Issue896a                        func(ctx context.Context) ([]*CheckIssue896, error)
+		LoopA                            func(ctx context.Context) (*LoopA, error)
 		MapStringInterface               func(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error)
 		MapNestedStringInterface         func(ctx context.Context, in *NestedMapInput) (map[string]interface{}, error)
 		ErrorBubble                      func(ctx context.Context) (*Error, error)
@@ -103,6 +108,7 @@ type Stub struct {
 		StringFromContextInterface       func(ctx context.Context) (*StringFromContextInterface, error)
 		StringFromContextFunction        func(ctx context.Context) (string, error)
 		DefaultScalar                    func(ctx context.Context, arg string) (string, error)
+		EmbeddedDefaultScalar            func(ctx context.Context) (*EmbeddedDefaultScalar, error)
 		Slices                           func(ctx context.Context) (*Slices, error)
 		ScalarSlice                      func(ctx context.Context) ([]byte, error)
 		Fallback                         func(ctx context.Context, arg FallbackToStringEncoding) (FallbackToStringEncoding, error)
@@ -110,7 +116,14 @@ type Stub struct {
 		VOkCaseValue                     func(ctx context.Context) (*VOkCaseValue, error)
 		VOkCaseNil                       func(ctx context.Context) (*VOkCaseNil, error)
 		ValidType                        func(ctx context.Context) (*ValidType, error)
+		ContentChild                     func(ctx context.Context) (ContentChild, error)
 		VariadicModel                    func(ctx context.Context) (*VariadicModel, error)
+		AsdfIt                           func(ctx context.Context) (*AsdfIt, error)
+		AIt                              func(ctx context.Context) (*AIt, error)
+		IIt                              func(ctx context.Context) (*IIt, error)
+		XXIt                             func(ctx context.Context) (*XXIt, error)
+		AbIt                             func(ctx context.Context) (*AbIt, error)
+		XxIt                             func(ctx context.Context) (*XxIt, error)
 		WrappedStruct                    func(ctx context.Context) (*WrappedStruct, error)
 		WrappedScalar                    func(ctx context.Context) (otherpkg.Scalar, error)
 		WrappedMap                       func(ctx context.Context) (WrappedMap, error)
@@ -312,6 +325,18 @@ func (r *stubQuery) Autobind(ctx context.Context) (*Autobind, error) {
 func (r *stubQuery) DeprecatedField(ctx context.Context) (string, error) {
 	return r.QueryResolver.DeprecatedField(ctx)
 }
+func (r *stubQuery) EmbeddedPointer(ctx context.Context) (*EmbeddedPointerModel, error) {
+	return r.QueryResolver.EmbeddedPointer(ctx)
+}
+func (r *stubQuery) ForcedResolver(ctx context.Context) (*ForcedResolver, error) {
+	return r.QueryResolver.ForcedResolver(ctx)
+}
+func (r *stubQuery) Status(ctx context.Context) (Status, error) {
+	return r.QueryResolver.Status(ctx)
+}
+func (r *stubQuery) Map(ctx context.Context) (*Map, error) {
+	return r.QueryResolver.Map(ctx)
+}
 func (r *stubQuery) Overlapping(ctx context.Context) (*OverlappingFields, error) {
 	return r.QueryResolver.Overlapping(ctx)
 }
@@ -384,6 +409,9 @@ func (r *stubQuery) NotAnInterface(ctx context.Context) (BackedByInterface, erro
 func (r *stubQuery) Issue896a(ctx context.Context) ([]*CheckIssue896, error) {
 	return r.QueryResolver.Issue896a(ctx)
 }
+func (r *stubQuery) LoopA(ctx context.Context) (*LoopA, error) {
+	return r.QueryResolver.LoopA(ctx)
+}
 func (r *stubQuery) MapStringInterface(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error) {
 	return r.QueryResolver.MapStringInterface(ctx, in)
 }
@@ -429,6 +457,9 @@ func (r *stubQuery) StringFromContextFunction(ctx context.Context) (string, erro
 func (r *stubQuery) DefaultScalar(ctx context.Context, arg string) (string, error) {
 	return r.QueryResolver.DefaultScalar(ctx, arg)
 }
+func (r *stubQuery) EmbeddedDefaultScalar(ctx context.Context) (*EmbeddedDefaultScalar, error) {
+	return r.QueryResolver.EmbeddedDefaultScalar(ctx)
+}
 func (r *stubQuery) Slices(ctx context.Context) (*Slices, error) {
 	return r.QueryResolver.Slices(ctx)
 }
@@ -450,8 +481,29 @@ func (r *stubQuery) VOkCaseNil(ctx context.Context) (*VOkCaseNil, error) {
 func (r *stubQuery) ValidType(ctx context.Context) (*ValidType, error) {
 	return r.QueryResolver.ValidType(ctx)
 }
+func (r *stubQuery) ContentChild(ctx context.Context) (ContentChild, error) {
+	return r.QueryResolver.ContentChild(ctx)
+}
 func (r *stubQuery) VariadicModel(ctx context.Context) (*VariadicModel, error) {
 	return r.QueryResolver.VariadicModel(ctx)
+}
+func (r *stubQuery) AsdfIt(ctx context.Context) (*AsdfIt, error) {
+	return r.QueryResolver.AsdfIt(ctx)
+}
+func (r *stubQuery) AIt(ctx context.Context) (*AIt, error) {
+	return r.QueryResolver.AIt(ctx)
+}
+func (r *stubQuery) IIt(ctx context.Context) (*IIt, error) {
+	return r.QueryResolver.IIt(ctx)
+}
+func (r *stubQuery) XXIt(ctx context.Context) (*XXIt, error) {
+	return r.QueryResolver.XXIt(ctx)
+}
+func (r *stubQuery) AbIt(ctx context.Context) (*AbIt, error) {
+	return r.QueryResolver.AbIt(ctx)
+}
+func (r *stubQuery) XxIt(ctx context.Context) (*XxIt, error) {
+	return r.QueryResolver.XxIt(ctx)
 }
 func (r *stubQuery) WrappedStruct(ctx context.Context) (*WrappedStruct, error) {
 	return r.QueryResolver.WrappedStruct(ctx)

--- a/codegen/testserver/singlefile/validtypes.graphql
+++ b/codegen/testserver/singlefile/validtypes.graphql
@@ -1,5 +1,6 @@
 extend type Query {
     validType: ValidType
+    Content_Child: Content_Child
 }
 
 """ These things are all valid, but without care generate invalid go code """

--- a/codegen/testserver/singlefile/weird_type_cases.graphql
+++ b/codegen/testserver/singlefile/weird_type_cases.graphql
@@ -1,5 +1,14 @@
 # regression test for https://github.com/99designs/gqlgen/issues/583
 
+extend type Query {
+    asdfIt: asdfIt!
+    AIt: AIt!
+    iIt: iIt!
+    XXIt: XXIt!
+    AbIt: AbIt!
+    XxIt: XxIt!
+}
+
 type asdfIt { id: ID! }
 type iIt { id: ID! }
 type AIt { id: ID! }

--- a/plugin/federation/federation_test.go
+++ b/plugin/federation/federation_test.go
@@ -181,12 +181,12 @@ func load(t *testing.T, name string) (*federation, *config.Config) {
 
 	f := &federation{Version: cfg.Federation.Version}
 	cfg.Sources = append(cfg.Sources, f.InjectSourceEarly())
-	require.NoError(t, cfg.LoadSchema())
+	require.NoError(t, cfg.LoadSchema(false))
 
 	if src := f.InjectSourceLate(cfg.Schema); src != nil {
 		cfg.Sources = append(cfg.Sources, src)
 	}
-	require.NoError(t, cfg.LoadSchema())
+	require.NoError(t, cfg.LoadSchema(true))
 
 	require.NoError(t, cfg.Init())
 	return f, cfg

--- a/plugin/modelgen/testdata/schema.graphql
+++ b/plugin/modelgen/testdata/schema.graphql
@@ -5,6 +5,15 @@ directive @goTag(
 
 type Query {
     thisShoudlntGetGenerated: Boolean
+    ExistingUnion: ExistingUnion!
+    EnumWithDescription: EnumWithDescription!
+    InterfaceWithDescription: InterfaceWithDescription!
+    _Foo_Barr: _Foo_Barr!
+    A: A!
+    B: B!
+    C: C!
+    D(e: ExistingInput!, m: MissingInput): D!
+    FieldMutationHook: FieldMutationHook!
 }
 
 type Mutation {


### PR DESCRIPTION
Rebased and improved #1238

Left to do:
- [ ] Tests for various edge cases. Maybe just make a big file full of unreachable types? https://github.com/99designs/gqlgen/pull/1238/files#diff-41df4b43d528566617cd5b0c3ae5adc68f75a5c2d4fe8a5bb3a5ad10ccad9508
- [ ] Figure out the right way to handle federation (then Entity type)
- [ ] Look into removing unused directives
- [ ] Figure out how to report / not report the warning. Maybe use the "verbose" flag for this? Maybe extend the verbose flag to "log level"?

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
