### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -139,9 +139,10 @@ Returning to `graph/schema.resolvers.go`, let's implement the bodies of those au
 
 ```go
 func (r *mutationResolver) CreateTodo(ctx context.Context, input model.NewTodo) (*model.Todo, error) {
+	rndInt, _ := rand.Int(rand.Reader, big.NewInt(256)) 
 	todo := &model.Todo{
 		Text:   input.Text,
-		ID:     fmt.Sprintf("T%d", rand.Int()),
+		ID:     fmt.Sprintf("T%d", rndInt),
 		User: &model.User{ID: input.UserID, Name: "user " + input.UserID},
 	}
 	r.todos = append(r.todos, todo)


### PR DESCRIPTION
function rand.Int requires two parameters and returns two value in golang version 1.18.1.

I have:
 - [ ] Fixed document error in golang 1.18.1. (see [docs](https://github.com/99designs/gqlgen/blob/master/README.md))
