### PR TITLE
Add support to preload Go roots

### DIFF
--- a/api/generate.go
+++ b/api/generate.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/99designs/gqlgen/codegen"
 	"github.com/99designs/gqlgen/codegen/config"
+	"github.com/99designs/gqlgen/internal/code"
 	"github.com/99designs/gqlgen/plugin"
 	"github.com/99designs/gqlgen/plugin/federation"
 	"github.com/99designs/gqlgen/plugin/modelgen"
@@ -43,6 +44,19 @@ func Generate(cfg *config.Config, option ...Option) error {
 
 	for _, o := range option {
 		o(cfg, &plugins)
+	}
+
+	for _, p := range plugins {
+		if inj, ok := p.(plugin.GoRootInjector); ok {
+			roots := inj.GoRoots()
+			for _, root := range roots {
+				code.AddGoRoot(code.GoModuleSearchResult{
+					Path:       root.Path,
+					GoModPath:  root.GoModPath,
+					ModuleName: root.ModuleName,
+				})
+			}
+		}
 	}
 
 	for _, p := range plugins {

--- a/internal/code/imports.go
+++ b/internal/code/imports.go
@@ -58,7 +58,7 @@ var goModuleRootCache = map[string]GoModuleSearchResult{}
 // with default roots. This helps with environments like Bazel where
 // you may not have a go.mod file.
 func AddGoRoot(root GoModuleSearchResult) {
-	goModuleRootCache[root.Path] = root
+	goModuleRootCache[root.GoModPath] = root
 }
 
 // goModuleRoot returns the root of the current go module if there is a go.mod file in the directory tree

--- a/internal/code/imports.go
+++ b/internal/code/imports.go
@@ -76,7 +76,7 @@ func goModuleRoot(dir string) (string, bool) {
 	for {
 		modDir := dirs[len(dirs)-1]
 
-		if val, ok := goModuleRootCache[dir]; ok {
+		if val, ok := goModuleRootCache[modDir]; ok {
 			result = val
 			break
 		}

--- a/internal/code/imports_test.go
+++ b/internal/code/imports_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestImportPathForDir(t *testing.T) {
+	goModuleRootCache = map[string]GoModuleSearchResult{}
+
 	wd, err := os.Getwd()
 
 	require.NoError(t, err)
@@ -35,6 +37,8 @@ func TestImportPathForDir(t *testing.T) {
 }
 
 func TestImportPathForDirCustomRoot(t *testing.T) {
+	goModuleRootCache = map[string]GoModuleSearchResult{}
+
 	AddGoRoot(GoModuleSearchResult{
 		Path:       "go.code.root",
 		GoModPath:  "/home/user/go.code.root",
@@ -45,6 +49,8 @@ func TestImportPathForDirCustomRoot(t *testing.T) {
 }
 
 func TestNameForDir(t *testing.T) {
+	goModuleRootCache = map[string]GoModuleSearchResult{}
+
 	wd, err := os.Getwd()
 	require.NoError(t, err)
 
@@ -55,6 +61,8 @@ func TestNameForDir(t *testing.T) {
 }
 
 func TestAddGoRoot(t *testing.T) {
+	goModuleRootCache = map[string]GoModuleSearchResult{}
+
 	AddGoRoot(GoModuleSearchResult{
 		Path:       "go.code.root",
 		GoModPath:  "/home/user/go.code.root",

--- a/internal/code/imports_test.go
+++ b/internal/code/imports_test.go
@@ -34,6 +34,16 @@ func TestImportPathForDir(t *testing.T) {
 	}
 }
 
+func TestImportPathForDirCustomRoot(t *testing.T) {
+	AddGoRoot(GoModuleSearchResult{
+		Path:       "go.code.root",
+		GoModPath:  "/home/user/go.code.root",
+		ModuleName: "go.code.root",
+	})
+
+	assert.Equal(t, "go.code.root/99designs", ImportPathForDir("/home/user/go.code.root/99designs"))
+}
+
 func TestNameForDir(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
@@ -42,4 +52,14 @@ func TestNameForDir(t *testing.T) {
 	assert.Equal(t, "code", NameForDir(wd))
 	assert.Equal(t, "internal", NameForDir(wd+"/.."))
 	assert.Equal(t, "main", NameForDir(wd+"/../.."))
+}
+
+func TestAddGoRoot(t *testing.T) {
+	AddGoRoot(GoModuleSearchResult{
+		Path:       "go.code.root",
+		GoModPath:  "/home/user/go.code.root",
+		ModuleName: "go.code.root",
+	})
+
+	assert.Equal(t, 1, len(goModuleRootCache))
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -8,6 +8,13 @@ import (
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
+// GoModuleSearchResult describes a root path
+type GoModuleSearchResult struct {
+	Path       string
+	GoModPath  string
+	ModuleName string
+}
+
 type Plugin interface {
 	Name() string
 }
@@ -28,4 +35,9 @@ type EarlySourceInjector interface {
 // LateSourceInjector is used to inject more sources, after we have loaded the users schema.
 type LateSourceInjector interface {
 	InjectSourceLate(schema *ast.Schema) *ast.Source
+}
+
+// GoRootInjector is used to inject more sources, after we have loaded the users schema.
+type GoRootInjector interface {
+	GoRoots() []GoModuleSearchResult
 }


### PR DESCRIPTION
Doing this means you don't need to rely on assumptions about the project environment (ie every root has a go.mod file).

Fixes #2169 