### PR TITLE
fix #2190 - don't use backslash for "embed" paths on windows

### DIFF
--- a/codegen/data.go
+++ b/codegen/data.go
@@ -3,6 +3,7 @@ package codegen
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -177,11 +178,12 @@ func BuildData(cfg *config.Config) (*Data, error) {
 			return nil, fmt.Errorf("failed to get working directory: %w", err)
 		}
 		outputDir := cfg.Exec.Dir()
-		sourcePath := filepath.Join(wd, s.Name)
+		sourcePath := path.Join(wd, s.Name)
 		relative, err := filepath.Rel(outputDir, sourcePath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to compute path of %s relative to %s: %w"+sourcePath, outputDir, err)
 		}
+		relative = filepath.ToSlash(relative)
 		embeddable := true
 		if strings.HasPrefix(relative, "..") {
 			embeddable = false


### PR DESCRIPTION
See #2190
I can't test this change. CI testing on windows would be helpful if there's an easy way to set that up: #2189