### PR TITLE
Run CI tests on windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,10 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3


### PR DESCRIPTION
I noticed a few PRs (#2197 #2191) go through mentioning windows compatibility.

This adds Windows to Github Actions so that we can ensure gqlgen is working on Windows and write tests specifically targeted at windows if required.

@vikstrous @frederikhors can you ensure that your fixes have appropriate tests?

Fixes #2189