### PR TITLE
Check only direct dependencies

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,5 +12,5 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
-      - run: go mod download && go list -json -m all > go.list
+      - run: go mod download && go list -json -deps all > go.list
       - uses: sonatype-nexus-community/nancy-github-action@main


### PR DESCRIPTION
Checking only direct dependencies is less restrictive and more future proof solution, while it's still sufficient. More info from the nancy repo: https://github.com/sonatype-nexus-community/nancy#what-is-the-best-usage-of-nancy