### PR TITLE
fix: prevent goroutine leak and CPU spinning at websocket transport

### DIFF
--- a/_examples/chat/chat_test.go
+++ b/_examples/chat/chat_test.go
@@ -1,6 +1,9 @@
 package chat
 
 import (
+	"fmt"
+	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,37 +16,59 @@ import (
 func TestChatSubscriptions(t *testing.T) {
 	c := client.New(handler.NewDefaultServer(NewExecutableSchema(New())))
 
-	sub := c.Websocket(`subscription @user(username:"vektah") { messageAdded(roomName:"#gophers") { text createdBy } }`)
-	defer sub.Close()
+	const batchSize = 16
+	var wg sync.WaitGroup
+	for i := 0; i < 1024; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			sub := c.Websocket(fmt.Sprintf(
+				`subscription @user(username:"vektah") { messageAdded(roomName:"#gophers%d") { text createdBy } }`,
+				i,
+			))
+			defer sub.Close()
 
-	go func() {
-		var resp interface{}
-		time.Sleep(10 * time.Millisecond)
-		err := c.Post(`mutation { 
-				a:post(text:"Hello!", roomName:"#gophers", username:"vektah") { id } 
-				b:post(text:"Hello Vektah!", roomName:"#gophers", username:"andrey") { id } 
-				c:post(text:"Whats up?", roomName:"#gophers", username:"vektah") { id } 
-			}`, &resp)
-		assert.NoError(t, err)
-	}()
+			go func() {
+				var resp interface{}
+				time.Sleep(10 * time.Millisecond)
+				err := c.Post(fmt.Sprintf(`mutation {
+					a:post(text:"Hello!", roomName:"#gophers%d", username:"vektah") { id }
+					b:post(text:"Hello Vektah!", roomName:"#gophers%d", username:"andrey") { id }
+					c:post(text:"Whats up?", roomName:"#gophers%d", username:"vektah") { id }
+				}`, i, i, i), &resp)
+				assert.NoError(t, err)
+			}()
 
-	var msg struct {
-		resp struct {
-			MessageAdded struct {
-				Text      string
-				CreatedBy string
+			var msg struct {
+				resp struct {
+					MessageAdded struct {
+						Text      string
+						CreatedBy string
+					}
+				}
+				err error
 			}
+
+			msg.err = sub.Next(&msg.resp)
+			require.NoError(t, msg.err, "sub.Next")
+			require.Equal(t, "Hello!", msg.resp.MessageAdded.Text)
+			require.Equal(t, "vektah", msg.resp.MessageAdded.CreatedBy)
+
+			msg.err = sub.Next(&msg.resp)
+			require.NoError(t, msg.err, "sub.Next")
+			require.Equal(t, "Whats up?", msg.resp.MessageAdded.Text)
+			require.Equal(t, "vektah", msg.resp.MessageAdded.CreatedBy)
+		}(i)
+		// wait for goroutines to finish every N tests to not get unhandled keepalives while starving on CPU
+		// TODO: add proper handling of keepalives to properly test concurrency?
+		if i%batchSize == 0 {
+			wg.Wait()
 		}
-		err error
 	}
+	wg.Wait()
 
-	msg.err = sub.Next(&msg.resp)
-	require.NoError(t, msg.err, "sub.Next")
-	require.Equal(t, "Hello!", msg.resp.MessageAdded.Text)
-	require.Equal(t, "vektah", msg.resp.MessageAdded.CreatedBy)
-
-	msg.err = sub.Next(&msg.resp)
-	require.NoError(t, msg.err, "sub.Next")
-	require.Equal(t, "Whats up?", msg.resp.MessageAdded.Text)
-	require.Equal(t, "vektah", msg.resp.MessageAdded.CreatedBy)
+	// 1 for the main thread, 1 for the testing package and remainder is reserved for the HTTP server threads
+	// TODO: use something like runtime.Stack to filter out HTTP server threads,
+	// TODO: which is required for proper concurrency and leaks testing
+	require.Less(t, runtime.NumGoroutine(), 1+1+batchSize*2, "goroutine leak")
 }

--- a/_examples/chat/generated.go
+++ b/_examples/chat/generated.go
@@ -1001,17 +1001,21 @@ func (ec *executionContext) _Subscription_messageAdded(ctx context.Context, fiel
 		return nil
 	}
 	return func(ctx context.Context) graphql.Marshaler {
-		res, ok := <-resTmp.(<-chan *Message)
-		if !ok {
+		select {
+		case res, ok := <-resTmp.(<-chan *Message):
+			if !ok {
+				return nil
+			}
+			return graphql.WriterFunc(func(w io.Writer) {
+				w.Write([]byte{'{'})
+				graphql.MarshalString(field.Alias).MarshalGQL(w)
+				w.Write([]byte{':'})
+				ec.marshalNMessage2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋchatᚐMessage(ctx, field.Selections, res).MarshalGQL(w)
+				w.Write([]byte{'}'})
+			})
+		case <-ctx.Done():
 			return nil
 		}
-		return graphql.WriterFunc(func(w io.Writer) {
-			w.Write([]byte{'{'})
-			graphql.MarshalString(field.Alias).MarshalGQL(w)
-			w.Write([]byte{':'})
-			ec.marshalNMessage2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋchatᚐMessage(ctx, field.Selections, res).MarshalGQL(w)
-			w.Write([]byte{'}'})
-		})
 	}
 }
 

--- a/_examples/chat/resolvers.go
+++ b/_examples/chat/resolvers.go
@@ -14,8 +14,7 @@ import (
 type ckey string
 
 type resolver struct {
-	Rooms map[string]*Chatroom
-	mu    sync.Mutex // nolint: structcheck
+	Rooms sync.Map
 }
 
 func (r *resolver) Mutation() MutationResolver {
@@ -33,7 +32,7 @@ func (r *resolver) Subscription() SubscriptionResolver {
 func New() Config {
 	return Config{
 		Resolvers: &resolver{
-			Rooms: map[string]*Chatroom{},
+			Rooms: sync.Map{},
 		},
 		Directives: DirectiveRoot{
 			User: func(ctx context.Context, obj interface{}, next graphql.Resolver, username string) (res interface{}, err error) {
@@ -50,31 +49,21 @@ func getUsername(ctx context.Context) string {
 	return ""
 }
 
+type Observer struct {
+	Username string
+	Message  chan *Message
+}
+
 type Chatroom struct {
 	Name      string
 	Messages  []Message
-	Observers map[string]struct {
-		Username string
-		Message  chan *Message
-	}
+	Observers sync.Map
 }
 
 type mutationResolver struct{ *resolver }
 
 func (r *mutationResolver) Post(ctx context.Context, text string, username string, roomName string) (*Message, error) {
-	r.mu.Lock()
-	room := r.Rooms[roomName]
-	if room == nil {
-		room = &Chatroom{
-			Name: roomName,
-			Observers: map[string]struct {
-				Username string
-				Message  chan *Message
-			}{},
-		}
-		r.Rooms[roomName] = room
-	}
-	r.mu.Unlock()
+	room := r.getRoom(roomName)
 
 	message := Message{
 		ID:        randString(8),
@@ -84,69 +73,47 @@ func (r *mutationResolver) Post(ctx context.Context, text string, username strin
 	}
 
 	room.Messages = append(room.Messages, message)
-	r.mu.Lock()
-	for _, observer := range room.Observers {
+	room.Observers.Range(func(_, v interface{}) bool {
+		observer := v.(*Observer)
 		if observer.Username == "" || observer.Username == message.CreatedBy {
 			observer.Message <- &message
 		}
-	}
-	r.mu.Unlock()
+		return true
+	})
 	return &message, nil
 }
 
 type queryResolver struct{ *resolver }
 
-func (r *queryResolver) Room(ctx context.Context, name string) (*Chatroom, error) {
-	r.mu.Lock()
-	room := r.Rooms[name]
-	if room == nil {
-		room = &Chatroom{
-			Name: name,
-			Observers: map[string]struct {
-				Username string
-				Message  chan *Message
-			}{},
-		}
-		r.Rooms[name] = room
-	}
-	r.mu.Unlock()
+func (r *resolver) getRoom(name string) *Chatroom {
+	room, _ := r.Rooms.LoadOrStore(name, &Chatroom{
+		Name:      name,
+		Observers: sync.Map{},
+	})
+	return room.(*Chatroom)
+}
 
-	return room, nil
+func (r *queryResolver) Room(ctx context.Context, name string) (*Chatroom, error) {
+	return r.getRoom(name), nil
 }
 
 type subscriptionResolver struct{ *resolver }
 
 func (r *subscriptionResolver) MessageAdded(ctx context.Context, roomName string) (<-chan *Message, error) {
-	r.mu.Lock()
-	room := r.Rooms[roomName]
-	if room == nil {
-		room = &Chatroom{
-			Name: roomName,
-			Observers: map[string]struct {
-				Username string
-				Message  chan *Message
-			}{},
-		}
-		r.Rooms[roomName] = room
-	}
-	r.mu.Unlock()
+	room := r.getRoom(roomName)
 
 	id := randString(8)
 	events := make(chan *Message, 1)
 
 	go func() {
 		<-ctx.Done()
-		r.mu.Lock()
-		delete(room.Observers, id)
-		r.mu.Unlock()
+		room.Observers.Delete(id)
 	}()
 
-	r.mu.Lock()
-	room.Observers[id] = struct {
-		Username string
-		Message  chan *Message
-	}{Username: getUsername(ctx), Message: events}
-	r.mu.Unlock()
+	room.Observers.Store(id, &Observer{
+		Username: getUsername(ctx),
+		Message:  events,
+	})
 
 	return events, nil
 }

--- a/_examples/chat/resolvers.go
+++ b/_examples/chat/resolvers.go
@@ -56,7 +56,7 @@ type Observer struct {
 
 type Chatroom struct {
 	Name      string
-	Messages  []*Message
+	Messages  []Message
 	Observers sync.Map
 }
 
@@ -72,7 +72,7 @@ func (r *mutationResolver) Post(ctx context.Context, text string, username strin
 		CreatedBy: username,
 	}
 
-	room.Messages = append(room.Messages, message)
+	room.Messages = append(room.Messages, *message)
 	room.Observers.Range(func(_, v interface{}) bool {
 		observer := v.(*Observer)
 		if observer.Username == "" || observer.Username == message.CreatedBy {

--- a/client/websocket.go
+++ b/client/websocket.go
@@ -50,7 +50,11 @@ func (p *Client) WebsocketOnce(query string, resp interface{}, options ...Option
 	return sock.Next(&resp)
 }
 
-func (p *Client) WebsocketWithPayload(query string, initPayload map[string]interface{}, options ...Option) *Subscription {
+func (p *Client) WebsocketWithPayload(
+	query string,
+	initPayload map[string]interface{},
+	options ...Option,
+) *Subscription {
 	r, err := p.newRequest(query, options...)
 	if err != nil {
 		return errorSubscription(fmt.Errorf("request: %w", err))
@@ -116,11 +120,12 @@ func (p *Client) WebsocketWithPayload(query string, initPayload map[string]inter
 					return err
 				}
 				if op.Type != dataMsg {
-					if op.Type == connectionKaMsg {
+					switch op.Type {
+					case connectionKaMsg:
 						continue
-					} else if op.Type == errorMsg {
+					case errorMsg:
 						return fmt.Errorf(string(op.Payload))
-					} else {
+					default:
 						return fmt.Errorf("expected data message, got %#v", op)
 					}
 				}

--- a/client/websocket.go
+++ b/client/websocket.go
@@ -109,32 +109,36 @@ func (p *Client) WebsocketWithPayload(query string, initPayload map[string]inter
 			return c.Close()
 		},
 		Next: func(response interface{}) error {
-			var op operationMessage
-			err := c.ReadJSON(&op)
-			if err != nil {
-				return err
-			}
-			if op.Type != dataMsg {
-				if op.Type == errorMsg {
-					return fmt.Errorf(string(op.Payload))
-				} else {
-					return fmt.Errorf("expected data message, got %#v", op)
+			for {
+				var op operationMessage
+				err := c.ReadJSON(&op)
+				if err != nil {
+					return err
 				}
-			}
+				if op.Type != dataMsg {
+					if op.Type == connectionKaMsg {
+						continue
+					} else if op.Type == errorMsg {
+						return fmt.Errorf(string(op.Payload))
+					} else {
+						return fmt.Errorf("expected data message, got %#v", op)
+					}
+				}
 
-			var respDataRaw Response
-			err = json.Unmarshal(op.Payload, &respDataRaw)
-			if err != nil {
-				return fmt.Errorf("decode: %w", err)
-			}
+				var respDataRaw Response
+				err = json.Unmarshal(op.Payload, &respDataRaw)
+				if err != nil {
+					return fmt.Errorf("decode: %w", err)
+				}
 
-			// we want to unpack even if there is an error, so we can see partial responses
-			unpackErr := unpack(respDataRaw.Data, response)
+				// we want to unpack even if there is an error, so we can see partial responses
+				unpackErr := unpack(respDataRaw.Data, response)
 
-			if respDataRaw.Errors != nil {
-				return RawJsonError{respDataRaw.Errors}
+				if respDataRaw.Errors != nil {
+					return RawJsonError{respDataRaw.Errors}
+				}
+				return unpackErr
 			}
-			return unpackErr
 		},
 	}
 }

--- a/codegen/field.gotpl
+++ b/codegen/field.gotpl
@@ -39,17 +39,21 @@ func (ec *executionContext) _{{$object.Name}}_{{$field.Name}}(ctx context.Contex
 	}
 	{{- if $object.Stream }}
 		return func(ctx context.Context) graphql.Marshaler {
-			res, ok := <-resTmp.(<-chan {{$field.TypeReference.GO | ref}})
-			if !ok {
+			select {
+			case res, ok := <-resTmp.(<-chan {{$field.TypeReference.GO | ref}}):
+				if !ok {
+					return nil
+				}
+				return graphql.WriterFunc(func(w io.Writer) {
+					w.Write([]byte{'{'})
+					graphql.MarshalString(field.Alias).MarshalGQL(w)
+					w.Write([]byte{':'})
+					ec.{{ $field.TypeReference.MarshalFunc }}(ctx, field.Selections, res).MarshalGQL(w)
+					w.Write([]byte{'}'})
+				})
+			case <-ctx.Done():
 				return nil
 			}
-			return graphql.WriterFunc(func(w io.Writer) {
-				w.Write([]byte{'{'})
-				graphql.MarshalString(field.Alias).MarshalGQL(w)
-				w.Write([]byte{':'})
-				ec.{{ $field.TypeReference.MarshalFunc }}(ctx, field.Selections, res).MarshalGQL(w)
-				w.Write([]byte{'}'})
-			})
 		}
 	{{- else }}
 		res := resTmp.({{$field.TypeReference.GO | ref}})

--- a/codegen/testserver/followschema/schema.generated.go
+++ b/codegen/testserver/followschema/schema.generated.go
@@ -4723,17 +4723,21 @@ func (ec *executionContext) _Subscription_updated(ctx context.Context, field gra
 		return nil
 	}
 	return func(ctx context.Context) graphql.Marshaler {
-		res, ok := <-resTmp.(<-chan string)
-		if !ok {
+		select {
+		case res, ok := <-resTmp.(<-chan string):
+			if !ok {
+				return nil
+			}
+			return graphql.WriterFunc(func(w io.Writer) {
+				w.Write([]byte{'{'})
+				graphql.MarshalString(field.Alias).MarshalGQL(w)
+				w.Write([]byte{':'})
+				ec.marshalNString2string(ctx, field.Selections, res).MarshalGQL(w)
+				w.Write([]byte{'}'})
+			})
+		case <-ctx.Done():
 			return nil
 		}
-		return graphql.WriterFunc(func(w io.Writer) {
-			w.Write([]byte{'{'})
-			graphql.MarshalString(field.Alias).MarshalGQL(w)
-			w.Write([]byte{':'})
-			ec.marshalNString2string(ctx, field.Selections, res).MarshalGQL(w)
-			w.Write([]byte{'}'})
-		})
 	}
 }
 
@@ -4774,17 +4778,21 @@ func (ec *executionContext) _Subscription_initPayload(ctx context.Context, field
 		return nil
 	}
 	return func(ctx context.Context) graphql.Marshaler {
-		res, ok := <-resTmp.(<-chan string)
-		if !ok {
+		select {
+		case res, ok := <-resTmp.(<-chan string):
+			if !ok {
+				return nil
+			}
+			return graphql.WriterFunc(func(w io.Writer) {
+				w.Write([]byte{'{'})
+				graphql.MarshalString(field.Alias).MarshalGQL(w)
+				w.Write([]byte{':'})
+				ec.marshalNString2string(ctx, field.Selections, res).MarshalGQL(w)
+				w.Write([]byte{'}'})
+			})
+		case <-ctx.Done():
 			return nil
 		}
-		return graphql.WriterFunc(func(w io.Writer) {
-			w.Write([]byte{'{'})
-			graphql.MarshalString(field.Alias).MarshalGQL(w)
-			w.Write([]byte{':'})
-			ec.marshalNString2string(ctx, field.Selections, res).MarshalGQL(w)
-			w.Write([]byte{'}'})
-		})
 	}
 }
 
@@ -4822,17 +4830,21 @@ func (ec *executionContext) _Subscription_directiveArg(ctx context.Context, fiel
 		return nil
 	}
 	return func(ctx context.Context) graphql.Marshaler {
-		res, ok := <-resTmp.(<-chan *string)
-		if !ok {
+		select {
+		case res, ok := <-resTmp.(<-chan *string):
+			if !ok {
+				return nil
+			}
+			return graphql.WriterFunc(func(w io.Writer) {
+				w.Write([]byte{'{'})
+				graphql.MarshalString(field.Alias).MarshalGQL(w)
+				w.Write([]byte{':'})
+				ec.marshalOString2ᚖstring(ctx, field.Selections, res).MarshalGQL(w)
+				w.Write([]byte{'}'})
+			})
+		case <-ctx.Done():
 			return nil
 		}
-		return graphql.WriterFunc(func(w io.Writer) {
-			w.Write([]byte{'{'})
-			graphql.MarshalString(field.Alias).MarshalGQL(w)
-			w.Write([]byte{':'})
-			ec.marshalOString2ᚖstring(ctx, field.Selections, res).MarshalGQL(w)
-			w.Write([]byte{'}'})
-		})
 	}
 }
 
@@ -4881,17 +4893,21 @@ func (ec *executionContext) _Subscription_directiveNullableArg(ctx context.Conte
 		return nil
 	}
 	return func(ctx context.Context) graphql.Marshaler {
-		res, ok := <-resTmp.(<-chan *string)
-		if !ok {
+		select {
+		case res, ok := <-resTmp.(<-chan *string):
+			if !ok {
+				return nil
+			}
+			return graphql.WriterFunc(func(w io.Writer) {
+				w.Write([]byte{'{'})
+				graphql.MarshalString(field.Alias).MarshalGQL(w)
+				w.Write([]byte{':'})
+				ec.marshalOString2ᚖstring(ctx, field.Selections, res).MarshalGQL(w)
+				w.Write([]byte{'}'})
+			})
+		case <-ctx.Done():
 			return nil
 		}
-		return graphql.WriterFunc(func(w io.Writer) {
-			w.Write([]byte{'{'})
-			graphql.MarshalString(field.Alias).MarshalGQL(w)
-			w.Write([]byte{':'})
-			ec.marshalOString2ᚖstring(ctx, field.Selections, res).MarshalGQL(w)
-			w.Write([]byte{'}'})
-		})
 	}
 }
 
@@ -4966,17 +4982,21 @@ func (ec *executionContext) _Subscription_directiveDouble(ctx context.Context, f
 		return nil
 	}
 	return func(ctx context.Context) graphql.Marshaler {
-		res, ok := <-resTmp.(<-chan *string)
-		if !ok {
+		select {
+		case res, ok := <-resTmp.(<-chan *string):
+			if !ok {
+				return nil
+			}
+			return graphql.WriterFunc(func(w io.Writer) {
+				w.Write([]byte{'{'})
+				graphql.MarshalString(field.Alias).MarshalGQL(w)
+				w.Write([]byte{':'})
+				ec.marshalOString2ᚖstring(ctx, field.Selections, res).MarshalGQL(w)
+				w.Write([]byte{'}'})
+			})
+		case <-ctx.Done():
 			return nil
 		}
-		return graphql.WriterFunc(func(w io.Writer) {
-			w.Write([]byte{'{'})
-			graphql.MarshalString(field.Alias).MarshalGQL(w)
-			w.Write([]byte{':'})
-			ec.marshalOString2ᚖstring(ctx, field.Selections, res).MarshalGQL(w)
-			w.Write([]byte{'}'})
-		})
 	}
 }
 
@@ -5034,17 +5054,21 @@ func (ec *executionContext) _Subscription_directiveUnimplemented(ctx context.Con
 		return nil
 	}
 	return func(ctx context.Context) graphql.Marshaler {
-		res, ok := <-resTmp.(<-chan *string)
-		if !ok {
+		select {
+		case res, ok := <-resTmp.(<-chan *string):
+			if !ok {
+				return nil
+			}
+			return graphql.WriterFunc(func(w io.Writer) {
+				w.Write([]byte{'{'})
+				graphql.MarshalString(field.Alias).MarshalGQL(w)
+				w.Write([]byte{':'})
+				ec.marshalOString2ᚖstring(ctx, field.Selections, res).MarshalGQL(w)
+				w.Write([]byte{'}'})
+			})
+		case <-ctx.Done():
 			return nil
 		}
-		return graphql.WriterFunc(func(w io.Writer) {
-			w.Write([]byte{'{'})
-			graphql.MarshalString(field.Alias).MarshalGQL(w)
-			w.Write([]byte{':'})
-			ec.marshalOString2ᚖstring(ctx, field.Selections, res).MarshalGQL(w)
-			w.Write([]byte{'}'})
-		})
 	}
 }
 
@@ -5082,17 +5106,21 @@ func (ec *executionContext) _Subscription_issue896b(ctx context.Context, field g
 		return nil
 	}
 	return func(ctx context.Context) graphql.Marshaler {
-		res, ok := <-resTmp.(<-chan []*CheckIssue896)
-		if !ok {
+		select {
+		case res, ok := <-resTmp.(<-chan []*CheckIssue896):
+			if !ok {
+				return nil
+			}
+			return graphql.WriterFunc(func(w io.Writer) {
+				w.Write([]byte{'{'})
+				graphql.MarshalString(field.Alias).MarshalGQL(w)
+				w.Write([]byte{':'})
+				ec.marshalOCheckIssue8962ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐCheckIssue896(ctx, field.Selections, res).MarshalGQL(w)
+				w.Write([]byte{'}'})
+			})
+		case <-ctx.Done():
 			return nil
 		}
-		return graphql.WriterFunc(func(w io.Writer) {
-			w.Write([]byte{'{'})
-			graphql.MarshalString(field.Alias).MarshalGQL(w)
-			w.Write([]byte{':'})
-			ec.marshalOCheckIssue8962ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐCheckIssue896(ctx, field.Selections, res).MarshalGQL(w)
-			w.Write([]byte{'}'})
-		})
 	}
 }
 
@@ -5137,17 +5165,21 @@ func (ec *executionContext) _Subscription_errorRequired(ctx context.Context, fie
 		return nil
 	}
 	return func(ctx context.Context) graphql.Marshaler {
-		res, ok := <-resTmp.(<-chan *Error)
-		if !ok {
+		select {
+		case res, ok := <-resTmp.(<-chan *Error):
+			if !ok {
+				return nil
+			}
+			return graphql.WriterFunc(func(w io.Writer) {
+				w.Write([]byte{'{'})
+				graphql.MarshalString(field.Alias).MarshalGQL(w)
+				w.Write([]byte{':'})
+				ec.marshalNError2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐError(ctx, field.Selections, res).MarshalGQL(w)
+				w.Write([]byte{'}'})
+			})
+		case <-ctx.Done():
 			return nil
 		}
-		return graphql.WriterFunc(func(w io.Writer) {
-			w.Write([]byte{'{'})
-			graphql.MarshalString(field.Alias).MarshalGQL(w)
-			w.Write([]byte{':'})
-			ec.marshalNError2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐError(ctx, field.Selections, res).MarshalGQL(w)
-			w.Write([]byte{'}'})
-		})
 	}
 }
 

--- a/codegen/testserver/singlefile/generated.go
+++ b/codegen/testserver/singlefile/generated.go
@@ -10706,17 +10706,21 @@ func (ec *executionContext) _Subscription_updated(ctx context.Context, field gra
 		return nil
 	}
 	return func(ctx context.Context) graphql.Marshaler {
-		res, ok := <-resTmp.(<-chan string)
-		if !ok {
+		select {
+		case res, ok := <-resTmp.(<-chan string):
+			if !ok {
+				return nil
+			}
+			return graphql.WriterFunc(func(w io.Writer) {
+				w.Write([]byte{'{'})
+				graphql.MarshalString(field.Alias).MarshalGQL(w)
+				w.Write([]byte{':'})
+				ec.marshalNString2string(ctx, field.Selections, res).MarshalGQL(w)
+				w.Write([]byte{'}'})
+			})
+		case <-ctx.Done():
 			return nil
 		}
-		return graphql.WriterFunc(func(w io.Writer) {
-			w.Write([]byte{'{'})
-			graphql.MarshalString(field.Alias).MarshalGQL(w)
-			w.Write([]byte{':'})
-			ec.marshalNString2string(ctx, field.Selections, res).MarshalGQL(w)
-			w.Write([]byte{'}'})
-		})
 	}
 }
 
@@ -10757,17 +10761,21 @@ func (ec *executionContext) _Subscription_initPayload(ctx context.Context, field
 		return nil
 	}
 	return func(ctx context.Context) graphql.Marshaler {
-		res, ok := <-resTmp.(<-chan string)
-		if !ok {
+		select {
+		case res, ok := <-resTmp.(<-chan string):
+			if !ok {
+				return nil
+			}
+			return graphql.WriterFunc(func(w io.Writer) {
+				w.Write([]byte{'{'})
+				graphql.MarshalString(field.Alias).MarshalGQL(w)
+				w.Write([]byte{':'})
+				ec.marshalNString2string(ctx, field.Selections, res).MarshalGQL(w)
+				w.Write([]byte{'}'})
+			})
+		case <-ctx.Done():
 			return nil
 		}
-		return graphql.WriterFunc(func(w io.Writer) {
-			w.Write([]byte{'{'})
-			graphql.MarshalString(field.Alias).MarshalGQL(w)
-			w.Write([]byte{':'})
-			ec.marshalNString2string(ctx, field.Selections, res).MarshalGQL(w)
-			w.Write([]byte{'}'})
-		})
 	}
 }
 
@@ -10805,17 +10813,21 @@ func (ec *executionContext) _Subscription_directiveArg(ctx context.Context, fiel
 		return nil
 	}
 	return func(ctx context.Context) graphql.Marshaler {
-		res, ok := <-resTmp.(<-chan *string)
-		if !ok {
+		select {
+		case res, ok := <-resTmp.(<-chan *string):
+			if !ok {
+				return nil
+			}
+			return graphql.WriterFunc(func(w io.Writer) {
+				w.Write([]byte{'{'})
+				graphql.MarshalString(field.Alias).MarshalGQL(w)
+				w.Write([]byte{':'})
+				ec.marshalOString2ᚖstring(ctx, field.Selections, res).MarshalGQL(w)
+				w.Write([]byte{'}'})
+			})
+		case <-ctx.Done():
 			return nil
 		}
-		return graphql.WriterFunc(func(w io.Writer) {
-			w.Write([]byte{'{'})
-			graphql.MarshalString(field.Alias).MarshalGQL(w)
-			w.Write([]byte{':'})
-			ec.marshalOString2ᚖstring(ctx, field.Selections, res).MarshalGQL(w)
-			w.Write([]byte{'}'})
-		})
 	}
 }
 
@@ -10864,17 +10876,21 @@ func (ec *executionContext) _Subscription_directiveNullableArg(ctx context.Conte
 		return nil
 	}
 	return func(ctx context.Context) graphql.Marshaler {
-		res, ok := <-resTmp.(<-chan *string)
-		if !ok {
+		select {
+		case res, ok := <-resTmp.(<-chan *string):
+			if !ok {
+				return nil
+			}
+			return graphql.WriterFunc(func(w io.Writer) {
+				w.Write([]byte{'{'})
+				graphql.MarshalString(field.Alias).MarshalGQL(w)
+				w.Write([]byte{':'})
+				ec.marshalOString2ᚖstring(ctx, field.Selections, res).MarshalGQL(w)
+				w.Write([]byte{'}'})
+			})
+		case <-ctx.Done():
 			return nil
 		}
-		return graphql.WriterFunc(func(w io.Writer) {
-			w.Write([]byte{'{'})
-			graphql.MarshalString(field.Alias).MarshalGQL(w)
-			w.Write([]byte{':'})
-			ec.marshalOString2ᚖstring(ctx, field.Selections, res).MarshalGQL(w)
-			w.Write([]byte{'}'})
-		})
 	}
 }
 
@@ -10949,17 +10965,21 @@ func (ec *executionContext) _Subscription_directiveDouble(ctx context.Context, f
 		return nil
 	}
 	return func(ctx context.Context) graphql.Marshaler {
-		res, ok := <-resTmp.(<-chan *string)
-		if !ok {
+		select {
+		case res, ok := <-resTmp.(<-chan *string):
+			if !ok {
+				return nil
+			}
+			return graphql.WriterFunc(func(w io.Writer) {
+				w.Write([]byte{'{'})
+				graphql.MarshalString(field.Alias).MarshalGQL(w)
+				w.Write([]byte{':'})
+				ec.marshalOString2ᚖstring(ctx, field.Selections, res).MarshalGQL(w)
+				w.Write([]byte{'}'})
+			})
+		case <-ctx.Done():
 			return nil
 		}
-		return graphql.WriterFunc(func(w io.Writer) {
-			w.Write([]byte{'{'})
-			graphql.MarshalString(field.Alias).MarshalGQL(w)
-			w.Write([]byte{':'})
-			ec.marshalOString2ᚖstring(ctx, field.Selections, res).MarshalGQL(w)
-			w.Write([]byte{'}'})
-		})
 	}
 }
 
@@ -11017,17 +11037,21 @@ func (ec *executionContext) _Subscription_directiveUnimplemented(ctx context.Con
 		return nil
 	}
 	return func(ctx context.Context) graphql.Marshaler {
-		res, ok := <-resTmp.(<-chan *string)
-		if !ok {
+		select {
+		case res, ok := <-resTmp.(<-chan *string):
+			if !ok {
+				return nil
+			}
+			return graphql.WriterFunc(func(w io.Writer) {
+				w.Write([]byte{'{'})
+				graphql.MarshalString(field.Alias).MarshalGQL(w)
+				w.Write([]byte{':'})
+				ec.marshalOString2ᚖstring(ctx, field.Selections, res).MarshalGQL(w)
+				w.Write([]byte{'}'})
+			})
+		case <-ctx.Done():
 			return nil
 		}
-		return graphql.WriterFunc(func(w io.Writer) {
-			w.Write([]byte{'{'})
-			graphql.MarshalString(field.Alias).MarshalGQL(w)
-			w.Write([]byte{':'})
-			ec.marshalOString2ᚖstring(ctx, field.Selections, res).MarshalGQL(w)
-			w.Write([]byte{'}'})
-		})
 	}
 }
 
@@ -11065,17 +11089,21 @@ func (ec *executionContext) _Subscription_issue896b(ctx context.Context, field g
 		return nil
 	}
 	return func(ctx context.Context) graphql.Marshaler {
-		res, ok := <-resTmp.(<-chan []*CheckIssue896)
-		if !ok {
+		select {
+		case res, ok := <-resTmp.(<-chan []*CheckIssue896):
+			if !ok {
+				return nil
+			}
+			return graphql.WriterFunc(func(w io.Writer) {
+				w.Write([]byte{'{'})
+				graphql.MarshalString(field.Alias).MarshalGQL(w)
+				w.Write([]byte{':'})
+				ec.marshalOCheckIssue8962ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐCheckIssue896(ctx, field.Selections, res).MarshalGQL(w)
+				w.Write([]byte{'}'})
+			})
+		case <-ctx.Done():
 			return nil
 		}
-		return graphql.WriterFunc(func(w io.Writer) {
-			w.Write([]byte{'{'})
-			graphql.MarshalString(field.Alias).MarshalGQL(w)
-			w.Write([]byte{':'})
-			ec.marshalOCheckIssue8962ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐCheckIssue896(ctx, field.Selections, res).MarshalGQL(w)
-			w.Write([]byte{'}'})
-		})
 	}
 }
 
@@ -11120,17 +11148,21 @@ func (ec *executionContext) _Subscription_errorRequired(ctx context.Context, fie
 		return nil
 	}
 	return func(ctx context.Context) graphql.Marshaler {
-		res, ok := <-resTmp.(<-chan *Error)
-		if !ok {
+		select {
+		case res, ok := <-resTmp.(<-chan *Error):
+			if !ok {
+				return nil
+			}
+			return graphql.WriterFunc(func(w io.Writer) {
+				w.Write([]byte{'{'})
+				graphql.MarshalString(field.Alias).MarshalGQL(w)
+				w.Write([]byte{':'})
+				ec.marshalNError2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐError(ctx, field.Selections, res).MarshalGQL(w)
+				w.Write([]byte{'}'})
+			})
+		case <-ctx.Done():
 			return nil
 		}
-		return graphql.WriterFunc(func(w io.Writer) {
-			w.Write([]byte{'{'})
-			graphql.MarshalString(field.Alias).MarshalGQL(w)
-			w.Write([]byte{':'})
-			ec.marshalNError2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐError(ctx, field.Selections, res).MarshalGQL(w)
-			w.Write([]byte{'}'})
-		})
 	}
 }
 

--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -371,20 +371,12 @@ func (c *wsConnection) subscribe(start time.Time, msg *message) {
 
 		responses, ctx := c.exec.DispatchOperation(ctx, rc)
 		for {
-			// prevents goroutine leak
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				{
-					response := responses(ctx)
-					if response == nil {
-						break
-					}
-
-					c.sendResponse(msg.id, response)
-				}
+			response := responses(ctx)
+			if response == nil {
+				break
 			}
+
+			c.sendResponse(msg.id, response)
 		}
 
 		// complete and context cancel comes from the defer


### PR DESCRIPTION
This fixes #2167 and removes incorrect code merged from PR #2168.

Explanation: while the mentioned PR stopped calling function `responses` after the context was done, it has introduced a new bug -  it doesn't break out of the for loop in case of `response == nil` because `break` now breaks select, not the for loop, which causes goroutine leak and CPU spinning indefinitely.
*I'm not sure yet how to exactly reproduce this behavior, since it doesn't even properly show up in the Golang profiler, but we could see that in production, and only with the mentioned PR. Closing the returned channel helps in the chat example, but not in the more complicated code.

Repro at [fletcherist/gqlgen-memory-leak](https://github.com/fletcherist/gqlgen-memory-leak) is fundamentally flawed because the subscription resolver there [doesn't care about passed context](https://github.com/fletcherist/gqlgen-memory-leak/blob/337041bb77eba22b889d056ffa2e04c71f20bada/graph/schema.resolvers.go#L24-L38) - it doesn't close returned channel (which was required before this PR) and it doesn't end goroutine created there after context cancellation.

Proposed fix: revert mentioned PR and improve subscription channel usage so that the resolver won't have to close it, which is, for example, not done in the [chat example](https://github.com/99designs/gqlgen/blob/8d9d3f125f13dcd19f59072d3c38366dc520758b/_examples/chat/resolvers.go#L135-L151).
It should still be backwards compatible unless the application depended on the fact that the channel will be read after the context cancellation, which is already a problem.

Test case: improved chat example with a check of the amount of goroutines left after many closed subscriptions.
Easiest way to test - cherry-pick commit with changes to the `chat_test.go` or apply all the changes and revert commit with changes to the example itself.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))