### PR TITLE
fix: chat example frontend race condition

### DIFF
--- a/_examples/chat/.gitignore
+++ b/_examples/chat/.gitignore
@@ -5,6 +5,7 @@
 
 # testing
 /coverage
+/corpus
 
 # production
 /build

--- a/_examples/chat/package.json
+++ b/_examples/chat/package.json
@@ -4,15 +4,14 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.2.3",
-    "apollo-cache-inmemory": "^1.3.11",
     "apollo-utilities": "^1.0.26",
     "graphql": "^14.0.2",
     "graphql-tag": "^2.10.0",
+    "graphql-ws": "^5.8.1",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
     "react-scripts": "^2.1.1",
     "styled-components": "^5.2.0",
-    "graphql-ws": "^5.8.1",
     "subscriptions-transport-ws": "^0.9.5"
   },
   "scripts": {

--- a/_examples/chat/src/index.js
+++ b/_examples/chat/src/index.js
@@ -5,8 +5,8 @@ import {
     ApolloProvider,
     HttpLink,
     split,
+    InMemoryCache,
 } from '@apollo/client';
-import { InMemoryCache } from 'apollo-cache-inmemory';
 import { WebSocketLink as ApolloWebSocketLink} from '@apollo/client/link/ws';
 import { getMainDefinition } from 'apollo-utilities';
 import { App } from './App';


### PR DESCRIPTION
This fixes the race condition bug revealed by #2209.
I have also noticed [`this.cache.batch`](https://stackoverflow.com/q/68608132) error that was caused by an incorrectly imported `InMemoryCache` from `apollo-cache-inmemory`, because it has been exported by the `@apollo/client` since v3, and the chat example is using v3.2.3.
It's far from perfect, but at least `this.cache.batch` error and the race condition are gone now.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))