### PR TITLE
Respect options in WebsocketOnce

### DIFF
--- a/client/websocket.go
+++ b/client/websocket.go
@@ -45,7 +45,7 @@ func (p *Client) Websocket(query string, options ...Option) *Subscription {
 
 // Grab a single response from a websocket based query
 func (p *Client) WebsocketOnce(query string, resp interface{}, options ...Option) error {
-	sock := p.Websocket(query)
+	sock := p.Websocket(query, options...)
 	defer sock.Close()
 	return sock.Next(&resp)
 }


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

`WebsocketOnce` for some reason don't pass down the options.

Since is a small change to a package that is used for testing (I use it for testing as well), I have not added tests.
