### PR TITLE
Use exact capitalization from field names overridden in config

### DIFF
--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -48,9 +48,12 @@ type Object struct {
 
 type Field struct {
 	Description string
-	Name        string
-	Type        types.Type
-	Tag         string
+	// Name is the field's name as it appears in the schema
+	Name string
+	// GoName is the field's name as it appears in the generated Go code
+	GoName string
+	Type   types.Type
+	Tag    string
 }
 
 type Enum struct {
@@ -178,7 +181,7 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 					}
 				}
 
-				name := field.Name
+				name := templates.ToGo(field.Name)
 				if nameOveride := cfg.Models[schemaType.Name].Fields[field.Name].FieldName; nameOveride != "" {
 					name = nameOveride
 				}
@@ -192,7 +195,8 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 				}
 
 				f := &Field{
-					Name:        name,
+					Name:        field.Name,
+					GoName:      name,
 					Type:        typ,
 					Description: field.Description,
 					Tag:         `json:"` + field.Name + `"`,

--- a/plugin/modelgen/models.gotpl
+++ b/plugin/modelgen/models.gotpl
@@ -29,7 +29,7 @@
 			{{- with .Description }}
 				{{.|prefixLines "// "}}
 			{{- end}}
-			{{ $field.Name|go }} {{$field.Type | ref}} `{{$field.Tag}}`
+			{{ $field.GoName }} {{$field.Type | ref}} `{{$field.Tag}}`
 		{{- end }}
 	}
 

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -236,6 +236,10 @@ func TestModelGeneration(t *testing.T) {
 		require.Nil(t, out.Recursive{}.FieldThree)
 		require.NotNil(t, out.Recursive{}.FieldFour)
 	})
+
+	t.Run("overridden struct field names use same capitalization as config", func(t *testing.T) {
+		require.NotNil(t, out.RenameFieldTest{}.GOODnaME)
+	})
 }
 
 func TestModelGenerationStructFieldPointers(t *testing.T) {

--- a/plugin/modelgen/out/generated.go
+++ b/plugin/modelgen/out/generated.go
@@ -131,6 +131,11 @@ type Recursive struct {
 	FieldFour  string     `json:"FieldFour" database:"RecursiveFieldFour"`
 }
 
+type RenameFieldTest struct {
+	GOODnaME   string `json:"badName" database:"RenameFieldTestbadName"`
+	OtherField string `json:"otherField" database:"RenameFieldTestotherField"`
+}
+
 // TypeWithDescription is a type with a description
 type TypeWithDescription struct {
 	Name *string `json:"name" database:"TypeWithDescriptionname"`

--- a/plugin/modelgen/out_struct_pointers/generated.go
+++ b/plugin/modelgen/out_struct_pointers/generated.go
@@ -131,6 +131,11 @@ type Recursive struct {
 	FieldFour  string     `json:"FieldFour" database:"RecursiveFieldFour"`
 }
 
+type RenameFieldTest struct {
+	BadName    string `json:"badName" database:"RenameFieldTestbadName"`
+	OtherField string `json:"otherField" database:"RenameFieldTestotherField"`
+}
+
 // TypeWithDescription is a type with a description
 type TypeWithDescription struct {
 	Name *string `json:"name" database:"TypeWithDescriptionname"`

--- a/plugin/modelgen/testdata/gqlgen.yml
+++ b/plugin/modelgen/testdata/gqlgen.yml
@@ -19,4 +19,8 @@ models:
     model: github.com/99designs/gqlgen/plugin/modelgen/out.ExistingUnion
   ExistingType:
     model: github.com/99designs/gqlgen/plugin/modelgen/out.ExistingType
+  RenameFieldTest:
+    fields:
+      badName:
+        fieldName: GOODnaME
 

--- a/plugin/modelgen/testdata/schema.graphql
+++ b/plugin/modelgen/testdata/schema.graphql
@@ -164,3 +164,8 @@ type Recursive {
     FieldThree: Recursive!
     FieldFour: String!
 }
+
+type RenameFieldTest {
+    badName: String!
+    otherField: String!
+}


### PR DESCRIPTION
Closes #1447 

Behavior prior to this PR: given the following schema and gqlgen config:

Schema:
```graphql
type RenameFieldTest {
    badName: String!
    otherField: String!
}
```

gqlgen.yml:
```yml
models:
  RenameFieldTest:
    fields:
      badName:
        fieldName: GOODnaME
```

gqlgen generates the following Go struct:

```go
type RenameFieldTest struct {
	GOODnaMe   string `json:"badName"`  // <----- field name should be GOODnaME, but e is lowercase
	OtherField string `json:"otherField"`
}
```

Behavior after this PR (modelgen strictly adheres to field names overridden in the config): 

```go
type RenameFieldTest struct {
	GOODnaME   string `json:"badName"` // <----- the 'e' is now correctly capitalized
	OtherField string `json:"otherField"`
```

Field names that are not overridden in the config will be exactly the same as before this PR, so users will only see different behavior if they had an overridden name that happened to fall into one of these funny capitalization edge cases.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] ~~Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))~~ (not necessary)
