### PR TITLE
Replace deprecated ioutil pkg with os & io

### DIFF
--- a/_examples/embedding/subdir/resolvers.go
+++ b/_examples/embedding/subdir/resolvers.go
@@ -4,7 +4,7 @@
 package subdir
 
 import (
-	context "context"
+	"context"
 
 	"github.com/99designs/gqlgen/_examples/embedding/subdir/gendir"
 )

--- a/_examples/fileupload/fileupload_test.go
+++ b/_examples/fileupload/fileupload_test.go
@@ -4,7 +4,6 @@ package fileupload
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http/httptest"
 	"os"
 	"testing"
@@ -23,12 +22,12 @@ func TestFileUpload(t *testing.T) {
 	defer srv.Close()
 	gql := gqlclient.New(srv.Config.Handler, gqlclient.Path("/graphql"))
 
-	aTxtFile, _ := ioutil.TempFile(os.TempDir(), "a.txt")
+	aTxtFile, _ := os.CreateTemp(os.TempDir(), "a.txt")
 	defer os.Remove(aTxtFile.Name())
 	aTxtFile.WriteString(`test`)
 
-	a1TxtFile, _ := ioutil.TempFile(os.TempDir(), "a.txt")
-	b1TxtFile, _ := ioutil.TempFile(os.TempDir(), "b.txt")
+	a1TxtFile, _ := os.CreateTemp(os.TempDir(), "a.txt")
+	b1TxtFile, _ := os.CreateTemp(os.TempDir(), "b.txt")
 	defer os.Remove(a1TxtFile.Name())
 	defer os.Remove(b1TxtFile.Name())
 	a1TxtFile.WriteString(`test1`)
@@ -38,7 +37,7 @@ func TestFileUpload(t *testing.T) {
 		resolver.MutationResolver.SingleUpload = func(ctx context.Context, file graphql.Upload) (*model.File, error) {
 			require.NotNil(t, file)
 			require.NotNil(t, file.File)
-			content, err := ioutil.ReadAll(file.File)
+			content, err := io.ReadAll(file.File)
 			require.Nil(t, err)
 			require.Equal(t, string(content), "test")
 
@@ -75,7 +74,7 @@ func TestFileUpload(t *testing.T) {
 			require.Equal(t, req.ID, 1)
 			require.NotNil(t, req.File)
 			require.NotNil(t, req.File.File)
-			content, err := ioutil.ReadAll(req.File.File)
+			content, err := io.ReadAll(req.File.File)
 			require.Nil(t, err)
 			require.Equal(t, string(content), "test")
 
@@ -114,7 +113,7 @@ func TestFileUpload(t *testing.T) {
 			var resp []*model.File
 			for i := range files {
 				require.NotNil(t, files[i].File)
-				content, err := ioutil.ReadAll(files[i].File)
+				content, err := io.ReadAll(files[i].File)
 				require.Nil(t, err)
 				contents = append(contents, string(content))
 				resp = append(resp, &model.File{
@@ -164,7 +163,7 @@ func TestFileUpload(t *testing.T) {
 			for i := range req {
 				require.NotNil(t, req[i].File)
 				require.NotNil(t, req[i].File.File)
-				content, err := ioutil.ReadAll(req[i].File.File)
+				content, err := io.ReadAll(req[i].File.File)
 				require.Nil(t, err)
 				ids = append(ids, req[i].ID)
 				contents = append(contents, string(content))

--- a/_examples/fileupload/server/server.go
+++ b/_examples/fileupload/server/server.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 
@@ -41,7 +41,7 @@ func getResolver() *fileupload.Stub {
 	resolver := &fileupload.Stub{}
 
 	resolver.MutationResolver.SingleUpload = func(ctx context.Context, file graphql.Upload) (*model.File, error) {
-		content, err := ioutil.ReadAll(file.File)
+		content, err := io.ReadAll(file.File)
 		if err != nil {
 			return nil, err
 		}
@@ -52,7 +52,7 @@ func getResolver() *fileupload.Stub {
 		}, nil
 	}
 	resolver.MutationResolver.SingleUploadWithPayload = func(ctx context.Context, req model.UploadFile) (*model.File, error) {
-		content, err := ioutil.ReadAll(req.File.File)
+		content, err := io.ReadAll(req.File.File)
 		if err != nil {
 			return nil, err
 		}
@@ -68,7 +68,7 @@ func getResolver() *fileupload.Stub {
 		}
 		var resp []*model.File
 		for i := range files {
-			content, err := ioutil.ReadAll(files[i].File)
+			content, err := io.ReadAll(files[i].File)
 			if err != nil {
 				return []*model.File{}, err
 			}
@@ -86,7 +86,7 @@ func getResolver() *fileupload.Stub {
 		}
 		var resp []*model.File
 		for i := range req {
-			content, err := ioutil.ReadAll(req[i].File.File)
+			content, err := io.ReadAll(req[i].File.File)
 			if err != nil {
 				return []*model.File{}, err
 			}

--- a/_examples/scalars/resolvers.go
+++ b/_examples/scalars/resolvers.go
@@ -3,9 +3,9 @@
 package scalars
 
 import (
-	context "context"
+	"context"
 	"fmt"
-	time "time"
+	"time"
 
 	"github.com/99designs/gqlgen/_examples/scalars/external"
 	"github.com/99designs/gqlgen/_examples/scalars/model"

--- a/client/client.go
+++ b/client/client.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -130,7 +130,7 @@ func (p *Client) newRequest(query string, options ...Option) (*http.Request, err
 		if err != nil {
 			return nil, fmt.Errorf("encode: %w", err)
 		}
-		bd.HTTP.Body = ioutil.NopCloser(bytes.NewBuffer(requestBody))
+		bd.HTTP.Body = io.NopCloser(bytes.NewBuffer(requestBody))
 	default:
 		panic("unsupported encoding " + bd.HTTP.Header.Get("Content-Type"))
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -3,7 +3,7 @@ package client_test
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
@@ -15,7 +15,7 @@ import (
 
 func TestClient(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			panic(err)
 		}
@@ -44,7 +44,7 @@ func TestClient(t *testing.T) {
 
 func TestClientMultipartFormData(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.Contains(t, string(bodyBytes), `Content-Disposition: form-data; name="operations"`)
 		require.Contains(t, string(bodyBytes), `{"query":"mutation ($input: Input!) {}","variables":{"file":{}}`)
@@ -74,7 +74,7 @@ func TestClientMultipartFormData(t *testing.T) {
 			ff.Write([]byte("Hello World"))
 			bodyWriter.Close()
 
-			bd.HTTP.Body = ioutil.NopCloser(bodyBuf)
+			bd.HTTP.Body = io.NopCloser(bodyBuf)
 			bd.HTTP.Header.Set("Content-Type", bodyWriter.FormDataContentType())
 		},
 	)
@@ -145,7 +145,7 @@ func TestAddCookie(t *testing.T) {
 
 func TestAddExtensions(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			panic(err)
 		}

--- a/client/websocket.go
+++ b/client/websocket.go
@@ -3,7 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http/httptest"
 	"strings"
 
@@ -56,7 +56,7 @@ func (p *Client) WebsocketWithPayload(query string, initPayload map[string]inter
 		return errorSubscription(fmt.Errorf("request: %w", err))
 	}
 
-	requestBody, err := ioutil.ReadAll(r.Body)
+	requestBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		return errorSubscription(fmt.Errorf("parse body: %w", err))
 	}

--- a/client/withfilesoption.go
+++ b/client/withfilesoption.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
@@ -50,7 +50,7 @@ func WithFiles() Option {
 		bodyBuf := &bytes.Buffer{}
 		bodyWriter := multipart.NewWriter(bodyBuf)
 
-		//-b7955bd2e1d17b67ac157b9e9ddb6238888caefc6f3541920a1debad284d
+		// -b7955bd2e1d17b67ac157b9e9ddb6238888caefc6f3541920a1debad284d
 		// Content-Disposition: form-data; name="operations"
 		//
 		// {"query":"mutation ($input: Input!) {}","variables":{"input":{"file":{}}}
@@ -108,14 +108,14 @@ func WithFiles() Option {
 		for i, fileData := range filesGroup {
 			h := make(textproto.MIMEHeader)
 			h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%d"; filename="%s"`, i, fileData[0].file.Name()))
-			b, _ := ioutil.ReadFile(fileData[0].file.Name())
+			b, _ := os.ReadFile(fileData[0].file.Name())
 			h.Set("Content-Type", http.DetectContentType(b))
 			ff, _ := bodyWriter.CreatePart(h)
 			ff.Write(b)
 		}
 		bodyWriter.Close()
 
-		bd.HTTP.Body = ioutil.NopCloser(bodyBuf)
+		bd.HTTP.Body = io.NopCloser(bodyBuf)
 		bd.HTTP.Header.Set("Content-Type", bodyWriter.FormDataContentType())
 	}
 }

--- a/client/withfilesoption_test.go
+++ b/client/withfilesoption_test.go
@@ -2,7 +2,6 @@ package client_test
 
 import (
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -16,9 +15,9 @@ import (
 )
 
 func TestWithFiles(t *testing.T) {
-	tempFile1, _ := ioutil.TempFile(os.TempDir(), "tempFile1")
-	tempFile2, _ := ioutil.TempFile(os.TempDir(), "tempFile2")
-	tempFile3, _ := ioutil.TempFile(os.TempDir(), "tempFile3")
+	tempFile1, _ := os.CreateTemp(os.TempDir(), "tempFile1")
+	tempFile2, _ := os.CreateTemp(os.TempDir(), "tempFile2")
+	tempFile3, _ := os.CreateTemp(os.TempDir(), "tempFile3")
 	defer os.Remove(tempFile1.Name())
 	defer os.Remove(tempFile2.Name())
 	defer os.Remove(tempFile3.Name())
@@ -40,7 +39,7 @@ func TestWithFiles(t *testing.T) {
 				}
 				require.NoError(t, err)
 
-				slurp, err := ioutil.ReadAll(p)
+				slurp, err := io.ReadAll(p)
 				require.NoError(t, err)
 
 				contentDisposition := p.Header.Get("Content-Disposition")
@@ -82,7 +81,7 @@ func TestWithFiles(t *testing.T) {
 				}
 				require.NoError(t, err)
 
-				slurp, err := ioutil.ReadAll(p)
+				slurp, err := io.ReadAll(p)
 				require.NoError(t, err)
 
 				contentDisposition := p.Header.Get("Content-Disposition")
@@ -135,7 +134,7 @@ func TestWithFiles(t *testing.T) {
 				}
 				require.NoError(t, err)
 
-				slurp, err := ioutil.ReadAll(p)
+				slurp, err := io.ReadAll(p)
 				require.NoError(t, err)
 
 				contentDisposition := p.Header.Get("Content-Disposition")
@@ -194,7 +193,7 @@ func TestWithFiles(t *testing.T) {
 				}
 				require.NoError(t, err)
 
-				slurp, err := ioutil.ReadAll(p)
+				slurp, err := io.ReadAll(p)
 				require.NoError(t, err)
 
 				contentDisposition := p.Header.Get("Content-Disposition")

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -61,7 +60,7 @@ func LoadDefaultConfig() (*Config, error) {
 		filename = filepath.ToSlash(filename)
 		var err error
 		var schemaRaw []byte
-		schemaRaw, err = ioutil.ReadFile(filename)
+		schemaRaw, err = os.ReadFile(filename)
 		if err != nil {
 			return nil, fmt.Errorf("unable to open schema: %w", err)
 		}
@@ -98,7 +97,7 @@ var path2regex = strings.NewReplacer(
 func LoadConfig(filename string) (*Config, error) {
 	config := DefaultConfig()
 
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read config: %w", err)
 	}
@@ -177,7 +176,7 @@ func CompleteConfig(config *Config) error {
 		filename = filepath.ToSlash(filename)
 		var err error
 		var schemaRaw []byte
-		schemaRaw, err = ioutil.ReadFile(filename)
+		schemaRaw, err = os.ReadFile(filename)
 		if err != nil {
 			return fmt.Errorf("unable to open schema: %w", err)
 		}

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -3,7 +3,7 @@ package codegen
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -131,7 +131,7 @@ func generateRootFile(data *Data) error {
 	_, thisFile, _, _ := runtime.Caller(0)
 	rootDir := filepath.Dir(thisFile)
 	templatePath := filepath.Join(rootDir, "root_.gotpl")
-	templateBytes, err := ioutil.ReadFile(templatePath)
+	templateBytes, err := os.ReadFile(templatePath)
 	if err != nil {
 		return err
 	}

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"go/types"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -95,7 +94,7 @@ func Render(cfg Options) error {
 			if strings.HasSuffix(info.Name(), "_.gotpl") {
 				return nil
 			}
-			b, err := ioutil.ReadFile(path)
+			b, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}
@@ -576,7 +575,7 @@ func resolveName(name string, skip int) string {
 func render(filename string, tpldata interface{}) (*bytes.Buffer, error) {
 	t := template.New("").Funcs(Funcs())
 
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -602,7 +601,7 @@ func write(filename string, b []byte, packages *code.Packages) error {
 		formatted = b
 	}
 
-	err = ioutil.WriteFile(filename, formatted, 0o644)
+	err = os.WriteFile(filename, formatted, 0o644)
 	if err != nil {
 		return fmt.Errorf("failed to write %s: %w", filename, err)
 	}

--- a/codegen/templates/templates_test.go
+++ b/codegen/templates/templates_test.go
@@ -1,7 +1,6 @@
 package templates
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -109,7 +108,7 @@ func TestCenter(t *testing.T) {
 }
 
 func TestTemplateOverride(t *testing.T) {
-	f, err := ioutil.TempFile("", "gqlgen")
+	f, err := os.CreateTemp("", "gqlgen")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/codegen/testserver/generated_test.go
+++ b/codegen/testserver/generated_test.go
@@ -5,7 +5,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,7 +35,7 @@ func loadPackage(name string, fset *token.FileSet) *ast.Package {
 	if err != nil {
 		panic(err)
 	}
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		panic(err)
 	}

--- a/docs/content/reference/plugins.md
+++ b/docs/content/reference/plugins.md
@@ -18,7 +18,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"time"

--- a/graphql/handler/transport/http_form.go
+++ b/graphql/handler/transport/http_form.go
@@ -3,7 +3,6 @@ package transport
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"os"
@@ -124,7 +123,7 @@ func (f MultipartForm) Do(w http.ResponseWriter, r *http.Request, exec graphql.G
 
 		var upload graphql.Upload
 		if r.ContentLength < f.maxMemory() {
-			fileBytes, err := ioutil.ReadAll(part)
+			fileBytes, err := io.ReadAll(part)
 			if err != nil {
 				w.WriteHeader(http.StatusUnprocessableEntity)
 				writeJsonErrorf(w, "failed to read file for key %s", key)
@@ -145,7 +144,7 @@ func (f MultipartForm) Do(w http.ResponseWriter, r *http.Request, exec graphql.G
 				}
 			}
 		} else {
-			tmpFile, err := ioutil.TempFile(os.TempDir(), "gqlgen-")
+			tmpFile, err := os.CreateTemp(os.TempDir(), "gqlgen-")
 			if err != nil {
 				w.WriteHeader(http.StatusUnprocessableEntity)
 				writeJsonErrorf(w, "failed to create temp file for key %s", key)

--- a/graphql/handler/transport/http_form_test.go
+++ b/graphql/handler/transport/http_form_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -210,7 +210,7 @@ func TestFileUpload(t *testing.T) {
 		req := &http.Request{
 			Method: "POST",
 			Header: http.Header{"Content-Type": {`multipart/form-data; boundary="foo123"`}},
-			Body:   ioutil.NopCloser(new(bytes.Buffer)),
+			Body:   io.NopCloser(new(bytes.Buffer)),
 		}
 		resp := httptest.NewRecorder()
 		h.ServeHTTP(resp, req)

--- a/internal/code/imports.go
+++ b/internal/code/imports.go
@@ -4,7 +4,7 @@ import (
 	"go/build"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -26,7 +26,7 @@ func NameForDir(dir string) string {
 	if err != nil {
 		return SanitizePackageName(filepath.Base(dir))
 	}
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return SanitizePackageName(filepath.Base(dir))
 	}
@@ -73,7 +73,7 @@ func goModuleRoot(dir string) (string, bool) {
 			break
 		}
 
-		if content, err := ioutil.ReadFile(filepath.Join(modDir, "go.mod")); err == nil {
+		if content, err := os.ReadFile(filepath.Join(modDir, "go.mod")); err == nil {
 			moduleName := string(modregex.FindSubmatch(content)[1])
 			result = goModuleSearchResult{
 				path:       moduleName,

--- a/internal/imports/prune_test.go
+++ b/internal/imports/prune_test.go
@@ -1,7 +1,7 @@
 package imports
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -18,7 +18,7 @@ func TestPrune(t *testing.T) {
 }
 
 func mustReadFile(filename string) []byte {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/rewrite/rewriter.go
+++ b/internal/rewrite/rewriter.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -56,7 +56,7 @@ func (r *Rewriter) getSource(start, end token.Pos) string {
 
 func (r *Rewriter) getFile(filename string) string {
 	if _, ok := r.files[filename]; !ok {
-		b, err := ioutil.ReadFile(filename)
+		b, err := os.ReadFile(filename)
 		if err != nil {
 			panic(fmt.Errorf("unable to load file, already exists: %w", err))
 		}

--- a/main.go
+++ b/main.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -43,7 +43,7 @@ func initFile(filename, contents string) error {
 	if err := os.MkdirAll(filepath.Dir(filename), 0o755); err != nil {
 		return fmt.Errorf("unable to create directory for file '%s': %w\n", filename, err)
 	}
-	if err := ioutil.WriteFile(filename, []byte(contents), 0o644); err != nil {
+	if err := os.WriteFile(filename, []byte(contents), 0o644); err != nil {
 		return fmt.Errorf("unable to write file '%s': %w\n", filename, err)
 	}
 
@@ -171,7 +171,7 @@ func main() {
 		if context.Bool("verbose") {
 			log.SetFlags(0)
 		} else {
-			log.SetOutput(ioutil.Discard)
+			log.SetOutput(io.Discard)
 		}
 		return nil
 	}

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -4,7 +4,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -39,7 +39,7 @@ func TestModelGeneration(t *testing.T) {
 	require.True(t, cfg.Models.UserDefined("UnionWithDescription"))
 
 	t.Run("no pointer pointers", func(t *testing.T) {
-		generated, err := ioutil.ReadFile("./out/generated.go")
+		generated, err := os.ReadFile("./out/generated.go")
 		require.NoError(t, err)
 		require.NotContains(t, string(generated), "**")
 	})
@@ -55,7 +55,7 @@ func TestModelGeneration(t *testing.T) {
 	})
 
 	t.Run("tags are applied", func(t *testing.T) {
-		file, err := ioutil.ReadFile("./out/generated.go")
+		file, err := os.ReadFile("./out/generated.go")
 		require.NoError(t, err)
 
 		fileText := string(file)
@@ -73,7 +73,7 @@ func TestModelGeneration(t *testing.T) {
 	})
 
 	t.Run("field hooks are applied", func(t *testing.T) {
-		file, err := ioutil.ReadFile("./out/generated.go")
+		file, err := os.ReadFile("./out/generated.go")
 		require.NoError(t, err)
 
 		fileText := string(file)
@@ -253,7 +253,7 @@ func TestModelGenerationStructFieldPointers(t *testing.T) {
 	require.NoError(t, p.MutateConfig(cfg))
 
 	t.Run("no pointer pointers", func(t *testing.T) {
-		generated, err := ioutil.ReadFile("./out_struct_pointers/generated.go")
+		generated, err := os.ReadFile("./out_struct_pointers/generated.go")
 		require.NoError(t, err)
 		require.NotContains(t, string(generated), "**")
 	})

--- a/plugin/resolvergen/resolver_test.go
+++ b/plugin/resolvergen/resolver_test.go
@@ -2,7 +2,7 @@ package resolvergen
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"syscall"
 	"testing"
 
@@ -33,7 +33,7 @@ func TestLayoutSingleFile(t *testing.T) {
 func TestLayoutFollowSchema(t *testing.T) {
 	testFollowSchemaPersistence(t, "testdata/followschema")
 
-	b, err := ioutil.ReadFile("testdata/followschema/out/schema.resolvers.go")
+	b, err := os.ReadFile("testdata/followschema/out/schema.resolvers.go")
 	require.NoError(t, err)
 	source := string(b)
 
@@ -45,7 +45,7 @@ func TestLayoutFollowSchema(t *testing.T) {
 func TestLayoutFollowSchemaWithCustomFilename(t *testing.T) {
 	testFollowSchemaPersistence(t, "testdata/filetemplate")
 
-	b, err := ioutil.ReadFile("testdata/filetemplate/out/schema.custom.go")
+	b, err := os.ReadFile("testdata/filetemplate/out/schema.custom.go")
 	require.NoError(t, err)
 	source := string(b)
 

--- a/testdata/gqlgen.go
+++ b/testdata/gqlgen.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"time"
@@ -19,7 +19,7 @@ func main() {
 	cfgPath := flag.String("config", "", "path to config file (use default if omitted)")
 	flag.Parse()
 
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 
 	start := graphql.Now()
 


### PR DESCRIPTION
As of Go 1.16, the same functionality of `ioutil` pkg is now provided by package `io` or
package `os`, and those implementations should be preferred in new code.

So replacing all usage of `ioutil` pkg with `io` & `os`.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

If this PR is acceptable, I intend to raise similar PRs to https://github.com/vektah/gqlparser & https://github.com/vektah/dataloaden