### PR TITLE
Use the go:embed API to lookup templates

### DIFF
--- a/_examples/embedding/subdir/gendir/generated.go
+++ b/_examples/embedding/subdir/gendir/generated.go
@@ -178,7 +178,7 @@ var sources = []*ast.Source{
 	{Name: "../federation/directives.graphql", Input: `
 	scalar _Any
 	scalar _FieldSet
-	
+
 	directive @external on FIELD_DEFINITION
 	directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 	directive @provides(fields: _FieldSet!) on FIELD_DEFINITION

--- a/_examples/embedding/subdir/root_.generated.go
+++ b/_examples/embedding/subdir/root_.generated.go
@@ -172,7 +172,7 @@ var sources = []*ast.Source{
 	{Name: "federation/directives.graphql", Input: `
 	scalar _Any
 	scalar _FieldSet
-	
+
 	directive @external on FIELD_DEFINITION
 	directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 	directive @provides(fields: _FieldSet!) on FIELD_DEFINITION

--- a/_examples/federation/accounts/graph/generated/generated.go
+++ b/_examples/federation/accounts/graph/generated/generated.go
@@ -266,7 +266,7 @@ type User @key(fields: "id") {
 	{Name: "../../federation/directives.graphql", Input: `
 	scalar _Any
 	scalar _FieldSet
-	
+
 	directive @external on FIELD_DEFINITION
 	directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 	directive @provides(fields: _FieldSet!) on FIELD_DEFINITION

--- a/_examples/federation/products/graph/generated/generated.go
+++ b/_examples/federation/products/graph/generated/generated.go
@@ -294,7 +294,7 @@ type Product @key(fields: "manufacturer { id } id") @key(fields: "upc") {
 	{Name: "../../federation/directives.graphql", Input: `
 	scalar _Any
 	scalar _FieldSet
-	
+
 	directive @external on FIELD_DEFINITION
 	directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 	directive @provides(fields: _FieldSet!) on FIELD_DEFINITION

--- a/_examples/federation/reviews/graph/generated/generated.go
+++ b/_examples/federation/reviews/graph/generated/generated.go
@@ -326,7 +326,7 @@ extend type Product @key(fields: " manufacturer{  id} id") {
 	{Name: "../../federation/directives.graphql", Input: `
 	scalar _Any
 	scalar _FieldSet
-	
+
 	directive @external on FIELD_DEFINITION
 	directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 	directive @provides(fields: _FieldSet!) on FIELD_DEFINITION

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -15,7 +15,7 @@ import (
 )
 
 //go:embed *.gotpl
-var CodegenTemplates embed.FS
+var codegenTemplates embed.FS
 
 func GenerateCode(data *Data) error {
 	if !data.Config.Exec.IsDefined() {
@@ -40,7 +40,7 @@ func generateSingleFile(data *Data) error {
 		RegionTags:      true,
 		GeneratedHeader: true,
 		Packages:        data.Config.Packages,
-		TemplateFS:      CodegenTemplates,
+		TemplateFS:      codegenTemplates,
 	})
 }
 
@@ -87,6 +87,7 @@ func generatePerSchema(data *Data) error {
 			RegionTags:      true,
 			GeneratedHeader: true,
 			Packages:        data.Config.Packages,
+			TemplateFS:      codegenTemplates,
 		})
 		if err != nil {
 			return err
@@ -150,6 +151,7 @@ func generateRootFile(data *Data) error {
 		RegionTags:      false,
 		GeneratedHeader: true,
 		Packages:        data.Config.Packages,
+		TemplateFS:      codegenTemplates,
 	})
 }
 

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -1,6 +1,7 @@
 package codegen
 
 import (
+	"embed"
 	"errors"
 	"fmt"
 	"os"
@@ -12,6 +13,9 @@ import (
 	"github.com/99designs/gqlgen/codegen/templates"
 	"github.com/vektah/gqlparser/v2/ast"
 )
+
+//go:embed *.gotpl
+var CodegenTemplates embed.FS
 
 func GenerateCode(data *Data) error {
 	if !data.Config.Exec.IsDefined() {
@@ -36,6 +40,7 @@ func generateSingleFile(data *Data) error {
 		RegionTags:      true,
 		GeneratedHeader: true,
 		Packages:        data.Config.Packages,
+		TemplateFS:      CodegenTemplates,
 	})
 }
 

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -79,7 +79,7 @@ func Render(cfg Options) error {
 		return err
 	}
 
-	var allTemplates []string
+	roots := make([]string, 0, len(t.Templates()))
 	for _, template := range t.Templates() {
 		// templates that end with _.gotpl are special files we don't want to include
 		if strings.HasSuffix(template.Name(), "_.gotpl") ||
@@ -88,23 +88,23 @@ func Render(cfg Options) error {
 			continue
 		}
 
-		allTemplates = append(allTemplates, template.Name())
+		roots = append(roots, template.Name())
 	}
 
 	// then execute all the important looking ones in order, adding them to the same file
-	sort.Slice(allTemplates, func(i, j int) bool {
+	sort.Slice(roots, func(i, j int) bool {
 		// important files go first
-		if strings.HasSuffix(allTemplates[i], "!.gotpl") {
+		if strings.HasSuffix(roots[i], "!.gotpl") {
 			return true
 		}
-		if strings.HasSuffix(allTemplates[j], "!.gotpl") {
+		if strings.HasSuffix(roots[j], "!.gotpl") {
 			return false
 		}
-		return allTemplates[i] < allTemplates[j]
+		return roots[i] < roots[j]
 	})
 
 	var buf bytes.Buffer
-	for _, root := range allTemplates {
+	for _, root := range roots {
 		if cfg.RegionTags {
 			buf.WriteString("\n// region    " + center(70, "*", " "+root+" ") + "\n")
 		}

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -82,7 +82,9 @@ func Render(cfg Options) error {
 	var allTemplates []string
 	for _, template := range t.Templates() {
 		// templates that end with _.gotpl are special files we don't want to include
-		if strings.HasSuffix(template.Name(), "_.gotpl") {
+		if strings.HasSuffix(template.Name(), "_.gotpl") ||
+			// filter out templates added with {{ template xxx }} syntax inside the template file
+			!strings.HasSuffix(template.Name(), ".gotpl") {
 			continue
 		}
 

--- a/codegen/templates/templates_test.go
+++ b/codegen/templates/templates_test.go
@@ -127,6 +127,7 @@ func TestTemplateOverride(t *testing.T) {
 }
 
 func TestRenderFS(t *testing.T) {
+
 	tempDir := t.TempDir()
 
 	outDir := filepath.Join(tempDir, "output")
@@ -144,6 +145,10 @@ func TestRenderFS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	contents, _ := os.ReadFile(f.Name())
-	assert.Equal(t, "package \n\nimport (\n)\nthis is my test package\n", string(contents))
+	expectedString := "package \n\nimport (\n)\nthis is my test package"
+	actualContents, _ := os.ReadFile(f.Name())
+	actualContentsStr := string(actualContents)
+
+	// don't look at last character since it's \n on Linux and \r\n on Windows
+	assert.Equal(t, expectedString, actualContentsStr[:len(expectedString)])
 }

--- a/codegen/templates/templates_test.go
+++ b/codegen/templates/templates_test.go
@@ -1,13 +1,19 @@
 package templates
 
 import (
+	"embed"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/99designs/gqlgen/internal/code"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+//go:embed *.gotpl
+var templateFS embed.FS
 
 func TestToGo(t *testing.T) {
 	require.Equal(t, "ToCamel", ToGo("TO_CAMEL"))
@@ -118,4 +124,26 @@ func TestTemplateOverride(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestRenderFS(t *testing.T) {
+	tempDir := t.TempDir()
+
+	outDir := filepath.Join(tempDir, "output")
+
+	_ = os.Mkdir(outDir, 0o755)
+
+	f, err := os.CreateTemp(outDir, "gqlgen.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	defer os.RemoveAll(f.Name())
+	err = Render(Options{TemplateFS: templateFS, Filename: f.Name(), Packages: &code.Packages{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	contents, _ := os.ReadFile(f.Name())
+	assert.Equal(t, "package \n\nimport (\n)\nthis is my test package\n", string(contents))
 }

--- a/codegen/templates/test.gotpl
+++ b/codegen/templates/test.gotpl
@@ -1,0 +1,1 @@
+this is my test package

--- a/codegen/templates/test_.gotpl
+++ b/codegen/templates/test_.gotpl
@@ -1,0 +1,1 @@
+this will not be included

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -1,6 +1,7 @@
 package federation
 
 import (
+	"embed"
 	"fmt"
 	"sort"
 	"strings"
@@ -13,6 +14,9 @@ import (
 	"github.com/99designs/gqlgen/plugin"
 	"github.com/99designs/gqlgen/plugin/federation/fieldset"
 )
+
+//go:embed *.gotpl
+var codegenTemplates embed.FS
 
 type federation struct {
 	Entities []*Entity
@@ -85,7 +89,7 @@ func (f *federation) InjectSourceEarly() *ast.Source {
 	input := `
 	scalar _Any
 	scalar _FieldSet
-	
+
 	directive @external on FIELD_DEFINITION
 	directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 	directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
@@ -274,6 +278,7 @@ func (f *federation) GenerateCode(data *codegen.Data) error {
 		Data:            f,
 		GeneratedHeader: true,
 		Packages:        data.Config.Packages,
+		TemplateFS:      codegenTemplates,
 	})
 }
 

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -1,7 +1,7 @@
 package federation
 
 import (
-	"embed"
+	_ "embed"
 	"fmt"
 	"sort"
 	"strings"
@@ -15,8 +15,8 @@ import (
 	"github.com/99designs/gqlgen/plugin/federation/fieldset"
 )
 
-//go:embed *.gotpl
-var codegenTemplates embed.FS
+//go:embed federation.gotpl
+var federationTemplate string
 
 type federation struct {
 	Entities []*Entity
@@ -278,7 +278,7 @@ func (f *federation) GenerateCode(data *codegen.Data) error {
 		Data:            f,
 		GeneratedHeader: true,
 		Packages:        data.Config.Packages,
-		TemplateFS:      codegenTemplates,
+		Template:        federationTemplate,
 	})
 }
 

--- a/plugin/federation/testdata/entityresolver/generated/exec.go
+++ b/plugin/federation/testdata/entityresolver/generated/exec.go
@@ -764,7 +764,7 @@ type MultiHelloMultipleRequires @key(fields: "name") @entityResolver(multi: true
 	{Name: "../../../federation/directives.graphql", Input: `
 	scalar _Any
 	scalar _FieldSet
-	
+
 	directive @external on FIELD_DEFINITION
 	directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 	directive @provides(fields: _FieldSet!) on FIELD_DEFINITION

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -1,6 +1,7 @@
 package modelgen
 
 import (
+	"embed"
 	"fmt"
 	"go/types"
 	"sort"
@@ -11,6 +12,9 @@ import (
 	"github.com/99designs/gqlgen/plugin"
 	"github.com/vektah/gqlparser/v2/ast"
 )
+
+//go:embed *.gotpl
+var codegenTemplates embed.FS
 
 type BuildMutateHook = func(b *ModelBuild) *ModelBuild
 
@@ -269,6 +273,7 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 		Data:            b,
 		GeneratedHeader: true,
 		Packages:        cfg.Packages,
+		TemplateFS:      codegenTemplates,
 	})
 	if err != nil {
 		return err

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -1,7 +1,7 @@
 package modelgen
 
 import (
-	"embed"
+	_ "embed"
 	"fmt"
 	"go/types"
 	"sort"
@@ -13,8 +13,8 @@ import (
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
-//go:embed *.gotpl
-var codegenTemplates embed.FS
+//go:embed models.gotpl
+var modelTemplate string
 
 type BuildMutateHook = func(b *ModelBuild) *ModelBuild
 
@@ -273,7 +273,7 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 		Data:            b,
 		GeneratedHeader: true,
 		Packages:        cfg.Packages,
-		TemplateFS:      codegenTemplates,
+		Template:        modelTemplate,
 	})
 	if err != nil {
 		return err

--- a/plugin/resolvergen/resolver.go
+++ b/plugin/resolvergen/resolver.go
@@ -1,6 +1,7 @@
 package resolvergen
 
 import (
+	"embed"
 	"errors"
 	"io/fs"
 	"os"
@@ -13,6 +14,9 @@ import (
 	"github.com/99designs/gqlgen/internal/rewrite"
 	"github.com/99designs/gqlgen/plugin"
 )
+
+//go:embed *.gotpl
+var codegenTemplates embed.FS
 
 func New() plugin.Plugin {
 	return &Plugin{}
@@ -76,6 +80,7 @@ func (m *Plugin) generateSingleFile(data *codegen.Data) error {
 		Filename:    data.Config.Resolver.Filename,
 		Data:        resolverBuild,
 		Packages:    data.Config.Packages,
+		TemplateFS:  codegenTemplates,
 	})
 }
 
@@ -140,9 +145,10 @@ func (m *Plugin) generatePerSchema(data *codegen.Data) error {
 			FileNotice: `
 				// This file will be automatically regenerated based on the schema, any resolver implementations
 				// will be copied through when generating and any unknown code will be moved to the end.`,
-			Filename: filename,
-			Data:     resolverBuild,
-			Packages: data.Config.Packages,
+			Filename:   filename,
+			Data:       resolverBuild,
+			Packages:   data.Config.Packages,
+			TemplateFS: codegenTemplates,
 		})
 		if err != nil {
 			return err

--- a/plugin/resolvergen/resolver.go
+++ b/plugin/resolvergen/resolver.go
@@ -1,7 +1,7 @@
 package resolvergen
 
 import (
-	"embed"
+	_ "embed"
 	"errors"
 	"io/fs"
 	"os"
@@ -15,8 +15,8 @@ import (
 	"github.com/99designs/gqlgen/plugin"
 )
 
-//go:embed *.gotpl
-var codegenTemplates embed.FS
+//go:embed resolver.gotpl
+var resolverTemplate string
 
 func New() plugin.Plugin {
 	return &Plugin{}
@@ -80,7 +80,7 @@ func (m *Plugin) generateSingleFile(data *codegen.Data) error {
 		Filename:    data.Config.Resolver.Filename,
 		Data:        resolverBuild,
 		Packages:    data.Config.Packages,
-		TemplateFS:  codegenTemplates,
+		Template:    resolverTemplate,
 	})
 }
 
@@ -145,10 +145,10 @@ func (m *Plugin) generatePerSchema(data *codegen.Data) error {
 			FileNotice: `
 				// This file will be automatically regenerated based on the schema, any resolver implementations
 				// will be copied through when generating and any unknown code will be moved to the end.`,
-			Filename:   filename,
-			Data:       resolverBuild,
-			Packages:   data.Config.Packages,
-			TemplateFS: codegenTemplates,
+			Filename: filename,
+			Data:     resolverBuild,
+			Packages: data.Config.Packages,
+			Template: resolverTemplate,
 		})
 		if err != nil {
 			return err

--- a/plugin/servergen/server.go
+++ b/plugin/servergen/server.go
@@ -1,7 +1,7 @@
 package servergen
 
 import (
-	"embed"
+	_ "embed"
 	"errors"
 	"io/fs"
 	"log"
@@ -12,8 +12,8 @@ import (
 	"github.com/99designs/gqlgen/plugin"
 )
 
-//go:embed *.gotpl
-var codegenTemplates embed.FS
+//go:embed server.gotpl
+var serverTemplate string
 
 func New(filename string) plugin.Plugin {
 	return &Plugin{filename}
@@ -41,7 +41,7 @@ func (m *Plugin) GenerateCode(data *codegen.Data) error {
 			Filename:    m.filename,
 			Data:        serverBuild,
 			Packages:    data.Config.Packages,
-			TemplateFS:  codegenTemplates,
+			Template:    serverTemplate,
 		})
 	}
 

--- a/plugin/servergen/server.go
+++ b/plugin/servergen/server.go
@@ -1,6 +1,7 @@
 package servergen
 
 import (
+	"embed"
 	"errors"
 	"io/fs"
 	"log"
@@ -10,6 +11,9 @@ import (
 	"github.com/99designs/gqlgen/codegen/templates"
 	"github.com/99designs/gqlgen/plugin"
 )
+
+//go:embed *.gotpl
+var codegenTemplates embed.FS
 
 func New(filename string) plugin.Plugin {
 	return &Plugin{filename}
@@ -37,6 +41,7 @@ func (m *Plugin) GenerateCode(data *codegen.Data) error {
 			Filename:    m.filename,
 			Data:        serverBuild,
 			Packages:    data.Config.Packages,
+			TemplateFS:  codegenTemplates,
 		})
 	}
 

--- a/plugin/stubgen/stubs.go
+++ b/plugin/stubgen/stubs.go
@@ -1,6 +1,7 @@
 package stubgen
 
 import (
+	"embed"
 	"path/filepath"
 	"syscall"
 
@@ -11,6 +12,9 @@ import (
 	"github.com/99designs/gqlgen/codegen/templates"
 	"github.com/99designs/gqlgen/plugin"
 )
+
+//go:embed *.gotpl
+var codegenTemplates embed.FS
 
 func New(filename string, typename string) plugin.Plugin {
 	return &Plugin{filename: filename, typeName: typename}
@@ -51,6 +55,7 @@ func (m *Plugin) GenerateCode(data *codegen.Data) error {
 		},
 		GeneratedHeader: true,
 		Packages:        data.Config.Packages,
+		TemplateFS:      codegenTemplates,
 	})
 }
 

--- a/plugin/stubgen/stubs.go
+++ b/plugin/stubgen/stubs.go
@@ -1,7 +1,7 @@
 package stubgen
 
 import (
-	"embed"
+	_ "embed"
 	"path/filepath"
 	"syscall"
 
@@ -13,8 +13,8 @@ import (
 	"github.com/99designs/gqlgen/plugin"
 )
 
-//go:embed *.gotpl
-var codegenTemplates embed.FS
+//go:embed stubs.gotpl
+var stubsTemplate string
 
 func New(filename string, typename string) plugin.Plugin {
 	return &Plugin{filename: filename, typeName: typename}
@@ -55,7 +55,7 @@ func (m *Plugin) GenerateCode(data *codegen.Data) error {
 		},
 		GeneratedHeader: true,
 		Packages:        data.Config.Packages,
-		TemplateFS:      codegenTemplates,
+		Template:        stubsTemplate,
 	})
 }
 


### PR DESCRIPTION
Add a new template config option `TemplateFS`. If this is passed we will use it as the source to lookup files as opposed to trying to read the file system directly.

Fixes #2260 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))