### PR TITLE
support named interface to Field.CallArgs

### DIFF
--- a/codegen/field.go
+++ b/codegen/field.go
@@ -562,7 +562,7 @@ func (f *Field) CallArgs() string {
 	for _, arg := range f.Args {
 		tmp := "fc.Args[" + strconv.Quote(arg.Name) + "].(" + templates.CurrentImports.LookupType(arg.TypeReference.GO) + ")"
 
-		if types.IsInterface(arg.TypeReference.GO) {
+		if iface, ok := arg.TypeReference.GO.(*types.Interface); ok && iface.Empty() {
 			tmp = fmt.Sprintf(`
 				func () interface{} {
 					if fc.Args["%s"] == nil {

--- a/codegen/field_test.go
+++ b/codegen/field_test.go
@@ -123,7 +123,7 @@ func TestField_CallArgs(t *testing.T) {
 		Expected string
 	}{
 		{
-			Name: "Field with method that has context, and two args (string, interface)",
+			Name: "Field with method that has context, and three args (string, interface, named interface)",
 			Field: Field{
 				MethodHasContext: true,
 				Args: []*FieldArgument{
@@ -132,12 +132,24 @@ func TestField_CallArgs(t *testing.T) {
 							Name: "test",
 						},
 						TypeReference: &config.TypeReference{
-							GO: &types.Interface{},
+							GO: (&types.Interface{}).Complete(),
 						},
 					},
 					{
 						ArgumentDefinition: &ast2.ArgumentDefinition{
 							Name: "test2",
+						},
+						TypeReference: &config.TypeReference{
+							GO: types.NewNamed(
+								types.NewTypeName(token.NoPos, nil, "TestInterface", nil),
+								(&types.Interface{}).Complete(),
+								nil,
+							),
+						},
+					},
+					{
+						ArgumentDefinition: &ast2.ArgumentDefinition{
+							Name: "test3",
 						},
 						TypeReference: &config.TypeReference{
 							GO: types.Typ[types.String],
@@ -151,7 +163,7 @@ func TestField_CallArgs(t *testing.T) {
 						return nil
 					}
 					return fc.Args["test"].(interface{})
-				}(), fc.Args["test2"].(string)`,
+				}(), fc.Args["test2"].(TestInterface), fc.Args["test3"].(string)`,
 		},
 		{
 			Name: "Resolver field that isn't root object with single int argument",


### PR DESCRIPTION
`types.IsInterface` returns true when passed value's underlying type is interface.
its too much in this situation.
so, if argument type is something like `type ID interface { isID() }`, `types.IsInterface` returns true. it will generate unexpected code.

I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [X] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
