### PR TITLE
Add support for KeepAlive message in websocket client

### DIFF
--- a/client/websocket.go
+++ b/client/websocket.go
@@ -109,32 +109,37 @@ func (p *Client) WebsocketWithPayload(query string, initPayload map[string]inter
 			return c.Close()
 		},
 		Next: func(response interface{}) error {
-			var op operationMessage
-			err := c.ReadJSON(&op)
-			if err != nil {
-				return err
-			}
-			if op.Type != dataMsg {
-				if op.Type == errorMsg {
-					return fmt.Errorf(string(op.Payload))
-				} else {
-					return fmt.Errorf("expected data message, got %#v", op)
+			for {
+				var op operationMessage
+				err := c.ReadJSON(&op)
+				if err != nil {
+					return err
 				}
-			}
 
-			var respDataRaw Response
-			err = json.Unmarshal(op.Payload, &respDataRaw)
-			if err != nil {
-				return fmt.Errorf("decode: %w", err)
-			}
+				if op.Type != dataMsg {
+					if op.Type == connectionKaMsg {
+						continue
+					} else if op.Type == errorMsg {
+						return fmt.Errorf(string(op.Payload))
+					} else {
+						return fmt.Errorf("expected data message, got %#v", op)
+					}
+				}
 
-			// we want to unpack even if there is an error, so we can see partial responses
-			unpackErr := unpack(respDataRaw.Data, response)
+				var respDataRaw Response
+				err = json.Unmarshal(op.Payload, &respDataRaw)
+				if err != nil {
+					return fmt.Errorf("decode: %w", err)
+				}
 
-			if respDataRaw.Errors != nil {
-				return RawJsonError{respDataRaw.Errors}
+				// we want to unpack even if there is an error, so we can see partial responses
+				unpackErr := unpack(respDataRaw.Data, response)
+
+				if respDataRaw.Errors != nil {
+					return RawJsonError{respDataRaw.Errors}
+				}
+				return unpackErr
 			}
-			return unpackErr
 		},
 	}
 }


### PR DESCRIPTION
Addressing issue #2291 reimplementing commit 670cf22272b490005d46dc2bee1634de1cd06d68 from issue #2209

The default WebSocket client has no support for KeepAlive messages. This is a problem for use cases that take more than 10 seconds (the default keepalive interval).

This PR adds support for KeepAlive messages by ignoring them, so applications don't need to worry about handling KA messages when using the provided WS Client.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
