### PR TITLE
#2298: fix gqlgen extracting module name from comment line

### DIFF
--- a/internal/code/imports.go
+++ b/internal/code/imports.go
@@ -1,6 +1,8 @@
 package code
 
 import (
+	"bufio"
+	"fmt"
 	"go/build"
 	"go/parser"
 	"go/token"
@@ -74,7 +76,7 @@ func goModuleRoot(dir string) (string, bool) {
 		}
 
 		if content, err := os.ReadFile(filepath.Join(modDir, "go.mod")); err == nil {
-			moduleName := string(modregex.FindSubmatch(content)[1])
+			moduleName := extractModuleName(content)
 			result = goModuleSearchResult{
 				path:       moduleName,
 				goModPath:  modDir,
@@ -124,6 +126,27 @@ func goModuleRoot(dir string) (string, bool) {
 		return "", false
 	}
 	return res.path, true
+}
+
+func extractModuleName(content []byte) string {
+	for {
+		advance, tkn, err := bufio.ScanLines(content, false)
+		if err != nil {
+			panic(fmt.Errorf("error parsing mod file: %w", err))
+		}
+		if advance == 0 {
+			break
+		}
+		s := strings.Trim(string(tkn), " \t")
+		if len(s) != 0 && !strings.HasPrefix(s, "//") {
+			break
+		}
+		if advance <= len(content) {
+			content = content[advance:]
+		}
+	}
+	moduleName := string(modregex.FindSubmatch(content)[1])
+	return moduleName
 }
 
 // ImportPathForDir takes a path and returns a golang import path for the package

--- a/internal/code/imports_test.go
+++ b/internal/code/imports_test.go
@@ -10,10 +10,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestExtractModuleName(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	modDir := filepath.Join(wd, "..", "..", "testdata")
+	content, err := os.ReadFile(filepath.Join(modDir, "gomod-with-leading-comments.mod"))
+	require.NoError(t, err)
+	assert.Equal(t, "github.com/99designs/gqlgen", extractModuleName(content))
+}
+
 func TestImportPathForDir(t *testing.T) {
 	wd, err := os.Getwd()
 
 	require.NoError(t, err)
+
+	assert.Equal(t, "github.com/99designs/gqlgen/internal/code", ImportPathForDir(wd))
 
 	assert.Equal(t, "github.com/99designs/gqlgen/internal/code", ImportPathForDir(wd))
 	assert.Equal(t, "github.com/99designs/gqlgen/api", ImportPathForDir(filepath.Join(wd, "..", "..", "api")))

--- a/testdata/gomod-with-leading-comments.mod
+++ b/testdata/gomod-with-leading-comments.mod
@@ -1,0 +1,7 @@
+// main module of gqlgen
+
+   // and another module to test stripping of comment lines
+
+module github.com/99designs/gqlgen // replace it for new project
+
+go 1.16


### PR DESCRIPTION
Per this discussion:
https://github.com/99designs/gqlgen/issues/2298

This is fixed. Parser now ignores leading comments and empty lines.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))


