### PR TITLE
Leverage (*Imports).LookupType when generating interface field getters

### DIFF
--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -229,7 +229,7 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 			return ""
 		}
 
-		getter := fmt.Sprintf("func (this %s) Get%s() %s { return ", templates.ToGo(model.Name), field.GoName, field.Type.String())
+		getter := fmt.Sprintf("func (this %s) Get%s() %s { return ", templates.ToGo(model.Name), field.GoName, templates.CurrentImports.LookupType(field.Type))
 		_, interfaceFieldTypeIsPointer := field.Type.(*types.Pointer)
 		var structFieldTypeIsPointer bool
 		for _, f := range model.Fields {


### PR DESCRIPTION
After #2314 was merged, I tried using it as a go module from a different repository, and realized that import paths were being added to the type names. `templates` already has a helper function for this, so I just used that
