### PR TITLE
Avoid GraphQL to Go Naming Collision with "ToGoModelName" func

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,3 +48,4 @@ jobs:
           # skip cache because of flaky behaviors
           skip-build-cache: true
           skip-pkg-cache: true
+          args: '--timeout 5m'

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -311,7 +311,7 @@ func buildGoModelNameKey(parts []string) string {
 	return strings.Join(parts, sep)
 }
 
-func goModelName(toGoFunc func(string) string, parts []string) string {
+func goModelName(primaryToGoFunc func(string) string, parts []string) string {
 	modelNamesMu.Lock()
 	defer modelNamesMu.Unlock()
 
@@ -330,8 +330,16 @@ func goModelName(toGoFunc func(string) string, parts []string) string {
 
 		applyToGoFunc = func(parts []string) string {
 			var out string
-			for _, p := range parts {
-				out = fmt.Sprintf("%s%s", out, toGoFunc(p))
+			switch len(parts) {
+			case 0:
+				return ""
+			case 1:
+				return primaryToGoFunc(parts[0])
+			default:
+				out = primaryToGoFunc(parts[0])
+			}
+			for _, p := range parts[1:] {
+				out = fmt.Sprintf("%s%s", out, ToGo(p))
 			}
 			return out
 		}

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -353,8 +353,6 @@ func ToGoModelName(parts ...string) string {
 	}
 
 	// attempt first pass
-
-	// test first pass
 	if goName := applyToGo(parts); !nameExists(goName) {
 		modelNames[goNameKey] = goName
 		return goName

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -338,7 +338,7 @@ func ToGoModelName(parts ...string) string {
 		applyValidGoName = func(parts []string) string {
 			var out string
 			for _, p := range parts {
-				out = fmt.Sprintf("%s%s", out, ValidGoName(p))
+				out = fmt.Sprintf("%s%s", out, replaceInvalidCharacters(p))
 			}
 			return out
 		}
@@ -399,8 +399,8 @@ var (
 	goNameRe = regexp.MustCompile("[^a-zA-Z0-9_]")
 )
 
-func ValidGoName(in string) string {
-	return goNameRe.ReplaceAllString(in, "_")
+func replaceInvalidCharacters(in string) string {
+	return goNameRe.ReplaceAllLiteralString(in, "_")
 }
 
 func ToGo(name string) string {

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -418,7 +418,9 @@ func replaceInvalidCharacters(in string) string {
 func wordWalkerFunc(private bool, nameRunes *[]rune) func(*wordInfo) {
 	return func(info *wordInfo) {
 		word := info.Word
-		if private && info.WordOffset == 0 {
+
+		switch {
+		case private && info.WordOffset == 0:
 			if strings.ToUpper(word) == word || strings.ToLower(word) == word {
 				// ID → id, CAMEL → camel
 				word = strings.ToLower(info.Word)
@@ -426,15 +428,16 @@ func wordWalkerFunc(private bool, nameRunes *[]rune) func(*wordInfo) {
 				// ITicket → iTicket
 				word = LcFirst(info.Word)
 			}
-		} else if info.MatchCommonInitial {
+
+		case info.MatchCommonInitial:
 			word = strings.ToUpper(word)
-		} else if !info.HasCommonInitial {
-			if strings.ToUpper(word) == word || strings.ToLower(word) == word {
-				// FOO or foo → Foo
-				// FOo → FOo
-				word = UcFirst(strings.ToLower(word))
-			}
+
+		case !info.HasCommonInitial && strings.ToUpper(word) == word || strings.ToLower(word) == word:
+			// FOO or foo → Foo
+			// FOo → FOo
+			word = UcFirst(strings.ToLower(word))
 		}
+
 		*nameRunes = append(*nameRunes, []rune(word)...)
 	}
 }

--- a/codegen/templates/templates_test.go
+++ b/codegen/templates/templates_test.go
@@ -137,7 +137,7 @@ func TestToGoModelName(t *testing.T) {
 
 func Test_wordWalker(t *testing.T) {
 	helper := func(str string) []*wordInfo {
-		var resultList []*wordInfo
+		resultList := make([]*wordInfo, 0)
 		wordWalker(str, func(info *wordInfo) {
 			resultList = append(resultList, info)
 		})
@@ -162,7 +162,7 @@ func Test_wordWalker(t *testing.T) {
 	require.Equal(t, []*wordInfo{{Word: "A"}}, helper("A"))
 	require.Equal(t, []*wordInfo{{Word: "ID", HasCommonInitial: true, MatchCommonInitial: true}}, helper("ID"))
 	require.Equal(t, []*wordInfo{{Word: "id", HasCommonInitial: true, MatchCommonInitial: true}}, helper("id"))
-	require.Equal(t, []*wordInfo{}, helper(""))
+	require.Equal(t, make([]*wordInfo, 0), helper(""))
 
 	require.Equal(t, []*wordInfo{{Word: "Related"}, {Word: "Urls"}}, helper("RelatedUrls"))
 	require.Equal(t, []*wordInfo{{Word: "ITicket"}}, helper("ITicket"))

--- a/codegen/templates/templates_test.go
+++ b/codegen/templates/templates_test.go
@@ -196,7 +196,7 @@ func TestToGoPrivateModelName(t *testing.T) {
 }
 
 func Test_wordWalker(t *testing.T) {
-	helper := func(str string) []*wordInfo {
+	makeInput := func(str string) []*wordInfo {
 		resultList := make([]*wordInfo, 0)
 		wordWalker(str, func(info *wordInfo) {
 			resultList = append(resultList, info)
@@ -204,28 +204,95 @@ func Test_wordWalker(t *testing.T) {
 		return resultList
 	}
 
-	require.Equal(t, []*wordInfo{{Word: "TO"}, {Word: "CAMEL"}}, helper("TO_CAMEL"))
-	require.Equal(t, []*wordInfo{{Word: "to"}, {Word: "camel"}}, helper("to_camel"))
-	require.Equal(t, []*wordInfo{{Word: "to"}, {Word: "Camel"}}, helper("toCamel"))
-	require.Equal(t, []*wordInfo{{Word: "To"}, {Word: "Camel"}}, helper("ToCamel"))
-	require.Equal(t, []*wordInfo{{Word: "to"}, {Word: "camel"}}, helper("to-camel"))
+	type aTest struct {
+		expected []*wordInfo
+		input    []*wordInfo
+	}
 
-	require.Equal(t, []*wordInfo{{Word: "Related"}, {Word: "URLs", HasCommonInitial: true}}, helper("RelatedURLs"))
-	require.Equal(t, []*wordInfo{{Word: "Image"}, {Word: "IDs", HasCommonInitial: true}}, helper("ImageIDs"))
-	require.Equal(t, []*wordInfo{{Word: "Foo"}, {Word: "ID", HasCommonInitial: true, MatchCommonInitial: true}}, helper("FooID"))
-	require.Equal(t, []*wordInfo{{Word: "ID", HasCommonInitial: true, MatchCommonInitial: true}, {Word: "Foo"}}, helper("IDFoo"))
-	require.Equal(t, []*wordInfo{{Word: "Foo"}, {Word: "ASCII", HasCommonInitial: true, MatchCommonInitial: true}}, helper("FooASCII"))
-	require.Equal(t, []*wordInfo{{Word: "ASCII", HasCommonInitial: true, MatchCommonInitial: true}, {Word: "Foo"}}, helper("ASCIIFoo"))
-	require.Equal(t, []*wordInfo{{Word: "Foo"}, {Word: "UTF8", HasCommonInitial: true, MatchCommonInitial: true}}, helper("FooUTF8"))
-	require.Equal(t, []*wordInfo{{Word: "UTF8", HasCommonInitial: true, MatchCommonInitial: true}, {Word: "Foo"}}, helper("UTF8Foo"))
+	theTests := []aTest{
+		{
+			input:    makeInput("TO_CAMEL"),
+			expected: []*wordInfo{{Word: "TO"}, {WordOffset: 1, Word: "CAMEL"}},
+		},
+		{
+			input:    makeInput("to_camel"),
+			expected: []*wordInfo{{Word: "to"}, {WordOffset: 1, Word: "camel"}},
+		},
+		{
+			input:    makeInput("toCamel"),
+			expected: []*wordInfo{{Word: "to"}, {WordOffset: 1, Word: "Camel"}},
+		},
+		{
+			input:    makeInput("ToCamel"),
+			expected: []*wordInfo{{Word: "To"}, {WordOffset: 1, Word: "Camel"}},
+		},
+		{
+			input:    makeInput("to-camel"),
+			expected: []*wordInfo{{Word: "to"}, {WordOffset: 1, Word: "camel"}},
+		},
+		{
+			input:    makeInput("RelatedURLs"),
+			expected: []*wordInfo{{Word: "Related"}, {WordOffset: 1, Word: "URLs", HasCommonInitial: true}},
+		},
+		{
+			input:    makeInput("ImageIDs"),
+			expected: []*wordInfo{{Word: "Image"}, {WordOffset: 1, Word: "IDs", HasCommonInitial: true}},
+		},
+		{
+			input:    makeInput("FooID"),
+			expected: []*wordInfo{{Word: "Foo"}, {WordOffset: 1, Word: "ID", HasCommonInitial: true, MatchCommonInitial: true}},
+		},
+		{
+			input:    makeInput("IDFoo"),
+			expected: []*wordInfo{{Word: "ID", HasCommonInitial: true, MatchCommonInitial: true}, {WordOffset: 1, Word: "Foo"}},
+		},
+		{
+			input:    makeInput("FooASCII"),
+			expected: []*wordInfo{{Word: "Foo"}, {WordOffset: 1, Word: "ASCII", HasCommonInitial: true, MatchCommonInitial: true}},
+		},
+		{
+			input:    makeInput("ASCIIFoo"),
+			expected: []*wordInfo{{Word: "ASCII", HasCommonInitial: true, MatchCommonInitial: true}, {WordOffset: 1, Word: "Foo"}},
+		},
+		{
+			input:    makeInput("FooUTF8"),
+			expected: []*wordInfo{{Word: "Foo"}, {WordOffset: 1, Word: "UTF8", HasCommonInitial: true, MatchCommonInitial: true}},
+		},
+		{
+			input:    makeInput("UTF8Foo"),
+			expected: []*wordInfo{{Word: "UTF8", HasCommonInitial: true, MatchCommonInitial: true}, {WordOffset: 1, Word: "Foo"}},
+		},
+		{
+			input:    makeInput("A"),
+			expected: []*wordInfo{{Word: "A"}},
+		},
+		{
+			input:    makeInput("ID"),
+			expected: []*wordInfo{{Word: "ID", HasCommonInitial: true, MatchCommonInitial: true}},
+		},
+		{
+			input:    makeInput("id"),
+			expected: []*wordInfo{{Word: "id", HasCommonInitial: true, MatchCommonInitial: true}},
+		},
+		{
+			input:    makeInput(""),
+			expected: make([]*wordInfo, 0),
+		},
+		{
+			input:    makeInput("RelatedUrls"),
+			expected: []*wordInfo{{Word: "Related"}, {WordOffset: 1, Word: "Urls"}},
+		},
+		{
+			input:    makeInput("ITicket"),
+			expected: []*wordInfo{{Word: "ITicket"}},
+		},
+	}
 
-	require.Equal(t, []*wordInfo{{Word: "A"}}, helper("A"))
-	require.Equal(t, []*wordInfo{{Word: "ID", HasCommonInitial: true, MatchCommonInitial: true}}, helper("ID"))
-	require.Equal(t, []*wordInfo{{Word: "id", HasCommonInitial: true, MatchCommonInitial: true}}, helper("id"))
-	require.Equal(t, make([]*wordInfo, 0), helper(""))
-
-	require.Equal(t, []*wordInfo{{Word: "Related"}, {Word: "Urls"}}, helper("RelatedUrls"))
-	require.Equal(t, []*wordInfo{{Word: "ITicket"}}, helper("ITicket"))
+	for i, at := range theTests {
+		t.Run(fmt.Sprintf("wordWalker-%d", i), func(t *testing.T) {
+			require.Equal(t, at.input, at.expected)
+		})
+	}
 }
 
 func TestCenter(t *testing.T) {

--- a/codegen/templates/templates_test.go
+++ b/codegen/templates/templates_test.go
@@ -135,6 +135,66 @@ func TestToGoModelName(t *testing.T) {
 	}
 }
 
+func TestToGoPrivateModelName(t *testing.T) {
+	type aTest struct {
+		input    [][]string
+		expected []string
+	}
+
+	theTests := []aTest{
+		{
+			input:    [][]string{{"MyValue"}},
+			expected: []string{"myValue"},
+		},
+		{
+			input:    [][]string{{"MyValue"}, {"myValue"}},
+			expected: []string{"myValue", "myValue0"},
+		},
+		{
+			input:    [][]string{{"MyValue"}, {"YourValue"}},
+			expected: []string{"myValue", "yourValue"},
+		},
+		{
+			input:    [][]string{{"MyEnumName", "Value"}},
+			expected: []string{"myEnumNameValue"},
+		},
+		{
+			input:    [][]string{{"MyEnumName", "Value"}, {"MyEnumName", "value"}},
+			expected: []string{"myEnumNameValue", "myEnumNamevalue"},
+		},
+		{
+			input:    [][]string{{"MyEnumName", "value"}, {"MyEnumName", "Value"}},
+			expected: []string{"myEnumNameValue", "myEnumNameValue0"},
+		},
+		{
+			input:    [][]string{{"MyEnumName", "Value"}, {"MyEnumName", "value"}, {"MyEnumName", "vALue"}, {"MyEnumName", "VALue"}},
+			expected: []string{"myEnumNameValue", "myEnumNamevalue", "myEnumNameVALue", "myEnumNameVALue0"},
+		},
+		{
+			input:    [][]string{{"MyEnumName", "TitleValue"}, {"MyEnumName", "title_value"}, {"MyEnumName", "title_Value"}, {"MyEnumName", "Title_Value"}},
+			expected: []string{"myEnumNameTitleValue", "myEnumNametitle_value", "myEnumNametitle_Value", "myEnumNameTitle_Value"},
+		},
+		{
+			input:    [][]string{{"MyEnumName", "TitleValue", "OtherValue"}},
+			expected: []string{"myEnumNameTitleValueOtherValue"},
+		},
+		{
+			input:    [][]string{{"MyEnumName", "TitleValue", "OtherValue"}, {"MyEnumName", "title_value", "OtherValue"}},
+			expected: []string{"myEnumNameTitleValueOtherValue", "myEnumNametitle_valueOtherValue"},
+		},
+	}
+
+	for ti, at := range theTests {
+		resetModelNames()
+		t.Run(fmt.Sprintf("modelname-%d", ti), func(t *testing.T) {
+			at := at
+			for i, n := range at.input {
+				require.Equal(t, at.expected[i], ToGoPrivateModelName(n...))
+			}
+		})
+	}
+}
+
 func Test_wordWalker(t *testing.T) {
 	helper := func(str string) []*wordInfo {
 		resultList := make([]*wordInfo, 0)

--- a/codegen/templates/templates_test.go
+++ b/codegen/templates/templates_test.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"embed"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -74,9 +75,69 @@ func TestToGoPrivate(t *testing.T) {
 	require.Equal(t, "_", ToGoPrivate("_"))
 }
 
+func TestToGoModelName(t *testing.T) {
+	type aTest struct {
+		input    [][]string
+		expected []string
+	}
+
+	theTests := []aTest{
+		{
+			input:    [][]string{{"MyValue"}},
+			expected: []string{"MyValue"},
+		},
+		{
+			input:    [][]string{{"MyValue"}, {"myValue"}},
+			expected: []string{"MyValue", "MyValue0"},
+		},
+		{
+			input:    [][]string{{"MyValue"}, {"YourValue"}},
+			expected: []string{"MyValue", "YourValue"},
+		},
+		{
+			input:    [][]string{{"MyEnumName", "Value"}},
+			expected: []string{"MyEnumNameValue"},
+		},
+		{
+			input:    [][]string{{"MyEnumName", "Value"}, {"MyEnumName", "value"}},
+			expected: []string{"MyEnumNameValue", "MyEnumNamevalue"},
+		},
+		{
+			input:    [][]string{{"MyEnumName", "value"}, {"MyEnumName", "Value"}},
+			expected: []string{"MyEnumNameValue", "MyEnumNameValue0"},
+		},
+		{
+			input:    [][]string{{"MyEnumName", "Value"}, {"MyEnumName", "value"}, {"MyEnumName", "vALue"}, {"MyEnumName", "VALue"}},
+			expected: []string{"MyEnumNameValue", "MyEnumNamevalue", "MyEnumNameVALue", "MyEnumNameVALue0"},
+		},
+		{
+			input:    [][]string{{"MyEnumName", "TitleValue"}, {"MyEnumName", "title_value"}, {"MyEnumName", "title_Value"}, {"MyEnumName", "Title_Value"}},
+			expected: []string{"MyEnumNameTitleValue", "MyEnumNametitle_value", "MyEnumNametitle_Value", "MyEnumNameTitle_Value"},
+		},
+		{
+			input:    [][]string{{"MyEnumName", "TitleValue", "OtherValue"}},
+			expected: []string{"MyEnumNameTitleValueOtherValue"},
+		},
+		{
+			input:    [][]string{{"MyEnumName", "TitleValue", "OtherValue"}, {"MyEnumName", "title_value", "OtherValue"}},
+			expected: []string{"MyEnumNameTitleValueOtherValue", "MyEnumNametitle_valueOtherValue"},
+		},
+	}
+
+	for ti, at := range theTests {
+		resetModelNames()
+		t.Run(fmt.Sprintf("modelname-%d", ti), func(t *testing.T) {
+			at := at
+			for i, n := range at.input {
+				require.Equal(t, at.expected[i], ToGoModelName(n...))
+			}
+		})
+	}
+}
+
 func Test_wordWalker(t *testing.T) {
 	helper := func(str string) []*wordInfo {
-		resultList := []*wordInfo{}
+		var resultList []*wordInfo
 		wordWalker(str, func(info *wordInfo) {
 			resultList = append(resultList, info)
 		})

--- a/docs/content/reference/name-collision.md
+++ b/docs/content/reference/name-collision.md
@@ -1,0 +1,188 @@
+---
+title: Handling type naming collisions
+description: Examples of logic used to avoid type name collision
+linkTitle: Name Collision
+menu: { main: { parent: 'reference', weight: 10 }}
+---
+
+While most generated Golang types must have unique names by virtue of being based on their GraphQL `type` counterpart,
+which themselves must be unique, there are a few edge scenarios where conflicts can occur.  This document describes
+how those collisions are handled.
+
+## Enum Constants
+
+Enum type generation is a prime example of where naming collisions can occur, as we build the const names per value
+as a composite of the Enum name and each individual value.
+
+### Example Problem
+
+Currently, enum types are transposed as such:
+
+```graphql
+enum MyEnum {
+  value1
+  value2
+  value3
+  value4
+}
+```
+
+Which will result in the following Golang:
+
+```go
+type MyEnum string
+
+const (
+	MyEnumValue1 MyEnum = "value1"
+	MyEnumValue2 MyEnum = "value2"
+	MyEnumValue3 MyEnum = "value3"
+	MyEnumValue4 MyEnum = "value4"
+)
+```
+
+However, those above enum values are just strings.  What if you encounter a scenario where the following is
+necessary:
+
+```graphql
+enum MyEnum {
+  value1
+  value2
+  value3
+  value4
+	Value4
+	Value_4
+}
+```
+
+The `Value4` and `Value_4` enum values cannot be directly transposed into the same "pretty" naming convention as their
+resulting constant names would conflict with the name for `value4`, as so:
+
+```go
+type MyEnum string
+
+const (
+	MyEnumValue1 MyEnum = "value1"
+	MyEnumValue2 MyEnum = "value2"
+	MyEnumValue3 MyEnum = "value3"
+	MyEnumValue4 MyEnum = "value4"
+	MyEnumValue4 MyEnum = "Value4"
+	MyEnumValue4 MyEnum = "Value_4"
+)
+```
+
+Which immediately leads to compilation errors as we now have three constants with the same name, but different values.
+
+### Resolution
+
+1. Store each name generated as part of a run for later comparison
+2. Try pretty approach first.  Use if no conflicts
+3. If non-composite name, append integer to end of name, starting at 0 and going to `math.MaxInt`
+4. If composite name, in reverse order, the pieces of the name have a less opinionated converter applied
+5. If all else fails, append integer to end of name, starting at 0 and going to `math.MaxInt`
+
+The first step to produce a name that does not conflict with an existing name succeeds.
+
+## Examples
+
+### Example A
+GraphQL:
+```graphql
+enum MyEnum {
+  Value
+  value
+  TitleValue
+  title_value
+}
+```
+Go:
+```go
+type MyEnum string
+
+const (
+  MyEnumValue MyEnum = "Value"
+  MyEnumvalue MyEnum = "value"
+  MyEnumTitleValue MyEnum = "TitleValue"
+  MyEnumtitle_value MyEnum = "title_value"
+)
+```
+
+### Example B
+GraphQL:
+```graphql
+enum MyEnum {
+	TitleValue
+	title_value
+	title_Value
+	Title_Value
+}
+```
+Go:
+```go
+type MyEnum string
+const (
+	MyEnumTitleValue MyEnum = "TitleValue"
+	MyEnumtitle_value MyEnum = "title_value"
+	MyEnumtitle_Value MyEnum = "title_Value"
+	MyEnumTitle_Value MyEnum = "Title_Value"
+)
+```
+
+### Example C
+GraphQL:
+```graphql
+enum MyEnum {
+	value
+	Value
+}
+```
+Go:
+```go
+type MyEnum string
+const (
+	MyEnumValue = "value"
+	MyEnumValue0 = "Value"
+)
+```
+
+## Warning
+
+Name collision resolution is handled per-name, as they come in.  If you change the order of an enum, you could very
+well end up with the same constant resolving to a different value.
+
+Lets mutate [Example C](#example-c):
+
+### Example C - State A
+GraphQL:
+```graphql
+enum MyEnum {
+	value
+	Value
+}
+```
+Go:
+```go
+type MyEnum string
+const (
+	MyEnumValue = "value"
+	MyEnumValue0 = "Value"
+)
+```
+
+### Example C - State B
+GraphQL:
+```graphql
+enum MyEnum {
+	Value
+	value
+}
+```
+Go:
+```go
+type MyEnum string
+const (
+	MyEnumValue = "Value"
+	MyEnumValue0 = "value"
+)
+```
+
+Notice how the constant names are the same, but the value that each applies to has changed.

--- a/docs/content/reference/name-collision.md
+++ b/docs/content/reference/name-collision.md
@@ -75,7 +75,10 @@ Which immediately leads to compilation errors as we now have three constants wit
 ### Resolution
 
 1. Store each name generated as part of a run for later comparison
-2. Try pretty approach first.  Use if no conflicts
+2. Try to coerce name into `CapitalCase`.  Use if no conflicts.
+	- This process attempts to break apart identifiers into "words", identified by separating on capital letters,
+    underscores, hyphens, and spaces.
+  - Each "word" is capitalized and appended to previous word.
 3. If non-composite name, append integer to end of name, starting at 0 and going to `math.MaxInt`
 4. If composite name, in reverse order, the pieces of the name have a less opinionated converter applied
 5. If all else fails, append integer to end of name, starting at 0 and going to `math.MaxInt`

--- a/plugin/modelgen/models.gotpl
+++ b/plugin/modelgen/models.gotpl
@@ -14,11 +14,11 @@
 
 {{- range $model := .Interfaces }}
 	{{ with .Description }} {{.|prefixLines "// "}} {{ end }}
-	type {{.Name|go }} interface {
+	type {{ goModelName .Name }} interface {
 		{{- range $impl := .Implements }}
-			Is{{ $impl|go }}()
+			Is{{ goModelName $impl }}()
 		{{- end }}
-		Is{{.Name|go }}()
+		Is{{ goModelName .Name }}()
 		{{- range $field := .Fields }}
 			{{- with .Description }}
 				{{.|prefixLines "// "}}
@@ -30,7 +30,7 @@
 
 {{ range $model := .Models }}
 	{{with .Description }} {{.|prefixLines "// "}} {{end}}
-	type {{ .Name|go }} struct {
+	type {{ goModelName .Name }} struct {
 		{{- range $field := .Fields }}
 			{{- with .Description }}
 				{{.|prefixLines "// "}}
@@ -40,7 +40,7 @@
 	}
 
 	{{ range .Implements }}
-		func ({{ $model.Name|go }}) Is{{ .|go }}() {}
+		func ({{ goModelName $model.Name }}) Is{{ goModelName . }}() {}
 		{{- with getInterfaceByName . }}
 			{{- range .Fields }}
 				{{- with .Description }}
@@ -54,48 +54,48 @@
 
 {{ range $enum := .Enums }}
 	{{ with .Description }} {{.|prefixLines "// "}} {{end}}
-	type {{.Name|go }} string
+	type {{ goModelName .Name }} string
 	const (
 	{{- range $value := .Values}}
 		{{- with .Description}}
 			{{.|prefixLines "// "}}
 		{{- end}}
-		{{ $enum.Name|go }}{{ .Name|go }} {{$enum.Name|go }} = {{.Name|quote}}
+		{{ goModelName $enum.Name .Name }} {{ goModelName $enum.Name }} = {{ .Name|quote }}
 	{{- end }}
 	)
 
-	var All{{.Name|go }} = []{{ .Name|go }}{
+	var All{{ goModelName .Name }} = []{{ goModelName .Name }}{
 	{{- range $value := .Values}}
-		{{$enum.Name|go }}{{ .Name|go }},
+		{{ goModelName $enum.Name .Name }},
 	{{- end }}
 	}
 
-	func (e {{.Name|go }}) IsValid() bool {
+	func (e {{ goModelName .Name }}) IsValid() bool {
 		switch e {
-		case {{ range $index, $element := .Values}}{{if $index}},{{end}}{{ $enum.Name|go }}{{ $element.Name|go }}{{end}}:
+		case {{ range $index, $element := .Values}}{{if $index}},{{end}}{{ goModelName $enum.Name $element.Name }}{{end}}:
 			return true
 		}
 		return false
 	}
 
-	func (e {{.Name|go }}) String() string {
+	func (e {{ goModelName .Name }}) String() string {
 		return string(e)
 	}
 
-	func (e *{{.Name|go }}) UnmarshalGQL(v interface{}) error {
+	func (e *{{ goModelName .Name }}) UnmarshalGQL(v interface{}) error {
 		str, ok := v.(string)
 		if !ok {
 			return fmt.Errorf("enums must be strings")
 		}
 
-		*e = {{ .Name|go }}(str)
+		*e = {{ goModelName .Name }}(str)
 		if !e.IsValid() {
 			return fmt.Errorf("%s is not a valid {{ .Name }}", str)
 		}
 		return nil
 	}
 
-	func (e {{.Name|go }}) MarshalGQL(w io.Writer) {
+	func (e {{ goModelName .Name }}) MarshalGQL(w io.Writer) {
 		fmt.Fprint(w, strconv.Quote(e.String()))
 	}
 


### PR DESCRIPTION
This is a first pass attempt at addressing #2321.  There are some edge cases, as described in the documentation, but I believe it to be about the best possible until the generator is altered to take a high-level look at every single possile generated name before templating even starts, and handles resolution there.

I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [X] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
