### PR TITLE
Removes user property in order to utilize newly created resolver

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -252,7 +252,6 @@ func (r *mutationResolver) CreateTodo(ctx context.Context, input model.NewTodo) 
 	todo := &model.Todo{
 		Text:   input.Text,
 		ID:     fmt.Sprintf("T%d", rand.Int()),
-		User:   &model.User{ID: input.UserID, Name: "user " + input.UserID},
 		UserID: input.UserID,
 	}
 	r.todos = append(r.todos, todo)


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 
simply put, the user property was duplicated, such that it was not clear why the new - auto resolving - resolver was relevant. removing the user line, clears up the confusion

I have:
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
