### PR TITLE
Add omit_getters config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ first model in this list is used as the default type and it will always be used 
 
 There isn't any way around this, gqlgen has no way to know what you want in a given context.
 
+### Why do my interfaces have getters? Can I disable these?
+These were added in v0.17.14 to allow accessing common interface fields without casting to a concrete type.
+However, certain fields, like Relay-style Connections, cannot be implemented with simple getters.
+
+If you'd prefer to not have getters generated in your interfaces, you can add the following in your `gqlgen.yml`:
+```yaml
+# gqlgen.yml
+omit_getters: true
+```
+
 ## Other Resources
 
 - [Christopher Biscardi @ Gophercon UK 2018](https://youtu.be/FdURVezcdcw)

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	StructTag                     string                     `yaml:"struct_tag,omitempty"`
 	Directives                    map[string]DirectiveConfig `yaml:"directives,omitempty"`
 	OmitSliceElementPointers      bool                       `yaml:"omit_slice_element_pointers,omitempty"`
+	OmitGetters                   bool                       `yaml:"omit_getters,omitempty"`
 	StructFieldsAlwaysPointers    bool                       `yaml:"struct_fields_always_pointers,omitempty"`
 	ResolversAlwaysReturnPointers bool                       `yaml:"resolvers_always_return_pointers,omitempty"`
 	SkipValidation                bool                       `yaml:"skip_validation,omitempty"`

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -103,9 +103,13 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 		}
 		switch schemaType.Kind {
 		case ast.Interface, ast.Union:
-			fields, err := m.generateFields(cfg, schemaType)
-			if err != nil {
-				return err
+			var fields []*Field
+			var err error
+			if !cfg.OmitGetters {
+				fields, err = m.generateFields(cfg, schemaType)
+				if err != nil {
+					return err
+				}
 			}
 
 			it := &Interface{

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -312,6 +312,12 @@ func TestModelGenerationStructFieldPointers(t *testing.T) {
 		require.Nil(t, out_struct_pointers.Recursive{}.FieldThree)
 		require.NotNil(t, out_struct_pointers.Recursive{}.FieldFour)
 	})
+
+	t.Run("no getters", func(t *testing.T) {
+		generated, err := os.ReadFile("./out_struct_pointers/generated.go")
+		require.NoError(t, err)
+		require.NotContains(t, string(generated), "func (this")
+	})
 }
 
 func mutateHook(b *ModelBuild) *ModelBuild {

--- a/plugin/modelgen/out_struct_pointers/generated.go
+++ b/plugin/modelgen/out_struct_pointers/generated.go
@@ -10,50 +10,38 @@ import (
 
 type A interface {
 	IsA()
-	GetA() string
 }
 
 type ArrayOfA interface {
 	IsArrayOfA()
-	GetTrickyField() []A
-	GetTrickyFieldPointer() []A
 }
 
 type B interface {
 	IsB()
-	GetB() int
 }
 
 type C interface {
 	IsA()
 	IsC()
-	GetA() string
-	GetC() bool
 }
 
 type D interface {
 	IsA()
 	IsB()
 	IsD()
-	GetA() string
-	GetB() int
-	GetD() *string
 }
 
 type FooBarer interface {
 	IsFooBarer()
-	GetName() string
 }
 
 // InterfaceWithDescription is an interface with a description
 type InterfaceWithDescription interface {
 	IsInterfaceWithDescription()
-	GetName() *string
 }
 
 type MissingInterface interface {
 	IsMissingInterface()
-	GetName() *string
 }
 
 type MissingUnion interface {
@@ -72,16 +60,11 @@ type CDImplemented struct {
 	D *string `json:"d" database:"CDImplementedd"`
 }
 
-func (CDImplemented) IsC()              {}
-func (this CDImplemented) GetA() string { return this.A }
-func (this CDImplemented) GetC() bool   { return this.C }
+func (CDImplemented) IsC() {}
 
 func (CDImplemented) IsA() {}
 
 func (CDImplemented) IsD() {}
-
-func (this CDImplemented) GetB() int     { return this.B }
-func (this CDImplemented) GetD() *string { return this.D }
 
 func (CDImplemented) IsB() {}
 
@@ -113,26 +96,6 @@ type ImplArrayOfA struct {
 }
 
 func (ImplArrayOfA) IsArrayOfA() {}
-func (this ImplArrayOfA) GetTrickyField() []A {
-	if this.TrickyField == nil {
-		return nil
-	}
-	interfaceSlice := make([]A, 0, len(this.TrickyField))
-	for _, concrete := range this.TrickyField {
-		interfaceSlice = append(interfaceSlice, concrete)
-	}
-	return interfaceSlice
-}
-func (this ImplArrayOfA) GetTrickyFieldPointer() []A {
-	if this.TrickyFieldPointer == nil {
-		return nil
-	}
-	interfaceSlice := make([]A, 0, len(this.TrickyFieldPointer))
-	for _, concrete := range this.TrickyFieldPointer {
-		interfaceSlice = append(interfaceSlice, concrete)
-	}
-	return interfaceSlice
-}
 
 type MissingInput struct {
 	Name *string      `json:"name" database:"MissingInputname"`
@@ -147,8 +110,7 @@ type MissingTypeNotNull struct {
 	Missing2 MissingTypeNullable `json:"missing2" database:"MissingTypeNotNullmissing2"`
 }
 
-func (MissingTypeNotNull) IsMissingInterface()   {}
-func (this MissingTypeNotNull) GetName() *string { return &this.Name }
+func (MissingTypeNotNull) IsMissingInterface() {}
 
 func (MissingTypeNotNull) IsExistingInterface() {}
 
@@ -164,8 +126,7 @@ type MissingTypeNullable struct {
 	Missing2 *MissingTypeNotNull `json:"missing2" database:"MissingTypeNullablemissing2"`
 }
 
-func (MissingTypeNullable) IsMissingInterface()   {}
-func (this MissingTypeNullable) GetName() *string { return this.Name }
+func (MissingTypeNullable) IsMissingInterface() {}
 
 func (MissingTypeNullable) IsExistingInterface() {}
 
@@ -206,8 +167,7 @@ type FooBarr struct {
 	Name string `json:"name" database:"_Foo_Barrname"`
 }
 
-func (FooBarr) IsFooBarer()          {}
-func (this FooBarr) GetName() string { return this.Name }
+func (FooBarr) IsFooBarer() {}
 
 // EnumWithDescription is an enum with a description
 type EnumWithDescription string

--- a/plugin/modelgen/testdata/gqlgen_struct_field_pointers.yml
+++ b/plugin/modelgen/testdata/gqlgen_struct_field_pointers.yml
@@ -7,6 +7,7 @@ model:
   filename: out_struct_pointers/generated.go
 
 struct_fields_always_pointers: false
+omit_getters: true
 
 models:
   ExistingModel:


### PR DESCRIPTION
As discussed in #2331 with @StevenACoffman and @MichaelMure , adding a config option to disable getter generation for interface types
