### PR TITLE
feat: make Playground HTML content compatible with UTF-8 charset

### DIFF
--- a/graphql/playground/playground.go
+++ b/graphql/playground/playground.go
@@ -9,6 +9,7 @@ import (
 var page = template.Must(template.New("graphiql").Parse(`<!DOCTYPE html>
 <html>
   <head>
+  	<meta charset="utf-8">
   	<title>{{.title}}</title>
 	<style>
 		body {
@@ -75,7 +76,7 @@ var page = template.Must(template.New("graphiql").Parse(`<!DOCTYPE html>
 // Handler responsible for setting up the playground
 func Handler(title string, endpoint string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add("Content-Type", "text/html")
+		w.Header().Add("Content-Type", "text/html; charset=UTF-8")
 		err := page.Execute(w, map[string]interface{}{
 			"title":                title,
 			"endpoint":             endpoint,

--- a/graphql/playground/playground_test.go
+++ b/graphql/playground/playground_test.go
@@ -35,6 +35,11 @@ func TestHandler_createsAbsoluteURLs(t *testing.T) {
 	if !wantSubURL.Match(b) {
 		t.Errorf("no match for %s in response body", wantSubURL.String())
 	}
+
+	wantMetaCharsetElement := regexp.MustCompile(`<head>\n\s{0,}<meta charset="utf-8">\n\s{0,}.*<title>`) // <meta> element must be in <head> and before <title>
+	if !wantMetaCharsetElement.Match(b) {
+		t.Errorf("no match for %s in response body", wantMetaCharsetElement.String())
+	}
 }
 
 func TestHandler_createsRelativeURLs(t *testing.T) {
@@ -47,6 +52,9 @@ func TestHandler_createsRelativeURLs(t *testing.T) {
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		t.Errorf("res.StatusCode = %d; want %d", res.StatusCode, http.StatusOK)
+	}
+	if res.Header.Get("Content-Type") != "text/html; charset=UTF-8" {
+		t.Errorf("res.Header.Get(\"Content-Type\") = %q; want %q", res.Header.Get("Content-Type"), "text/html; charset=UTF-8")
 	}
 
 	b, err := io.ReadAll(res.Body)


### PR DESCRIPTION
## summary

The current Playground page content and Playground server doesn't compatible with UTF-8 charset. This may result in string corruption and page content unusable if the developers would try to use UTF-8 strings/contents in their schemas or Playground title.

The compatible has been done by:

 - Completing the `Content-Type` header with `text/html; charset=UTF-8`
 - Adding `<meta charset="utf-8">` in `<head>` section and before `<title>` element

In most of the usage scenarios, the Playground would be configured to be deployed behind a gateway or reverse proxy, so I added the UTF-8 support for both `Content-Type` header and template to prevent the mis-configuration of gateway or reverse proxy where it may cause the HTML parser got lost to find out the encoding of the content on the browser side.

### references

 - [`<meta>`: The metadata element - HTML: HyperText Markup Language | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-charset)
 - [Content-Type - HTTP | MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type#directives)
 - [Declaring character encodings in HTML](https://www.w3.org/International/questions/qa-html-encoding-declarations)

Related to: #2354 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content)) (not needed for this PR)