### PR TITLE
Update graphiql to 2.0.7

### DIFF
--- a/graphql/playground/playground.go
+++ b/graphql/playground/playground.go
@@ -82,9 +82,9 @@ func Handler(title string, endpoint string) http.HandlerFunc {
 			"endpoint":             endpoint,
 			"endpointIsAbsolute":   endpointHasScheme(endpoint),
 			"subscriptionEndpoint": getSubscriptionEndpoint(endpoint),
-			"version":              "2.0.1",
-			"cssSRI":               "sha256-hYUgpHapGug0ucdB5kG0zSipubcQOJcGjclIZke2rl8=",
-			"jsSRI":                "sha256-jMXGO5+Y4OhcHPSR34jpzpzlz4OZTlxcvaDXSWmUMRo=",
+			"version":              "2.0.7",
+			"cssSRI":               "sha256-gQryfbGYeYFxnJYnfPStPYFt0+uv8RP8Dm++eh00G9c=",
+			"jsSRI":                "sha256-qQ6pw7LwTLC+GfzN+cJsYXfVWRKH9O5o7+5H96gTJhQ=",
 			"reactSRI":             "sha256-Ipu/TQ50iCCVZBUsZyNJfxrDk0E2yhaEIz0vqI+kFG8=",
 			"reactDOMSRI":          "sha256-nbMykgB6tsOFJ7OdVmPpdqMFVk4ZsqWocT6issAPUF0=",
 		})


### PR DESCRIPTION
Updated Graphiql to version 2.0.7

<img width="1440" alt="Screenshot 2022-09-15 at 17 32 14" src="https://user-images.githubusercontent.com/4588963/190445622-0dc1f6be-3882-4808-8ed4-2d39a227aff1.png">

I tested it with the examples in the repo and everything seems to be working
The new version of the graphiql allows to send the headers as websocket init_connection payload as you can see in the screenshot