### PR TITLE
Update diagram in documentation

### DIFF
--- a/graphql/handler.go
+++ b/graphql/handler.go
@@ -42,14 +42,14 @@ type (
 	// Its important to understand the lifecycle of a graphql request and the terminology we use in gqlgen
 	// before working with these
 	//
-	// +--- REQUEST   POST /graphql --------------------------------------------+
-	// | +- OPERATION query OpName { viewer { name } } -----------------------+ |
-	// | |  RESPONSE  { "data": { "viewer": { "name": "bob" } } }             | |
-	// | +- OPERATION subscription OpName2 { chat { message } } --------------+ |
-	// | |  RESPONSE  { "data": { "chat": { "message": "hello" } } }          | |
-	// | |  RESPONSE  { "data": { "chat": { "message": "byee" } } }           | |
-	// | +--------------------------------------------------------------------+ |
-	// +------------------------------------------------------------------------+
+	//  +--- REQUEST   POST /graphql --------------------------------------------+
+	//  | +- OPERATION query OpName { viewer { name } } -----------------------+ |
+	//  | |  RESPONSE  { "data": { "viewer": { "name": "bob" } } }             | |
+	//  | +- OPERATION subscription OpName2 { chat { message } } --------------+ |
+	//  | |  RESPONSE  { "data": { "chat": { "message": "hello" } } }          | |
+	//  | |  RESPONSE  { "data": { "chat": { "message": "byee" } } }           | |
+	//  | +--------------------------------------------------------------------+ |
+	//  +------------------------------------------------------------------------+
 	HandlerExtension interface {
 		// ExtensionName should be a CamelCase string version of the extension which may be shown in stats and logging.
 		ExtensionName() string


### PR DESCRIPTION
The diagram wasn't rendering properly in Go docs, which was a shame because it's a great diagram. This PR fixes that by indenting it another space.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

Before and after:
![Screenshot 2022-09-16 at 15-58-28 graphql - Go Documentation Server](https://user-images.githubusercontent.com/2402010/190828403-42a749ad-d737-4e9c-98ad-43c2cbe131ec.png)

![Screenshot 2022-09-16 at 15-58-49 graphql - Go Documentation Server](https://user-images.githubusercontent.com/2402010/190828412-a474acd8-609c-43c2-a496-a5342b3be826.png)

