### PR TITLE
Add json.Number support to UnmarshalString

### DIFF
--- a/graphql/string.go
+++ b/graphql/string.go
@@ -56,6 +56,8 @@ func UnmarshalString(v interface{}) (string, error) {
 		return strconv.FormatInt(v, 10), nil
 	case float64:
 		return fmt.Sprintf("%f", v), nil
+	case json.Number:
+		return string(v), nil
 	case bool:
 		if v {
 			return "true", nil

--- a/graphql/string.go
+++ b/graphql/string.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -55,7 +56,7 @@ func UnmarshalString(v interface{}) (string, error) {
 	case int64:
 		return strconv.FormatInt(v, 10), nil
 	case float64:
-		return fmt.Sprintf("%f", v), nil
+		return strconv.FormatFloat(v, 'f', -1, 64), nil
 	case json.Number:
 		return string(v), nil
 	case bool:

--- a/graphql/string_test.go
+++ b/graphql/string_test.go
@@ -1,27 +1,42 @@
 package graphql
 
 import (
-	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestString(t *testing.T) {
-	assert.Equal(t, `"hello"`, doStrMarshal("hello"))
-	assert.Equal(t, `"he\tllo"`, doStrMarshal("he\tllo"))
-	assert.Equal(t, `"he\tllo"`, doStrMarshal("he	llo"))
-	assert.Equal(t, `"he\nllo"`, doStrMarshal("he\nllo"))
-	assert.Equal(t, `"he\r\nllo"`, doStrMarshal("he\r\nllo"))
-	assert.Equal(t, `"he\\llo"`, doStrMarshal(`he\llo`))
-	assert.Equal(t, `"quotes\"nested\"in\"quotes\""`, doStrMarshal(`quotes"nested"in"quotes"`))
-	assert.Equal(t, `"\u0000"`, doStrMarshal("\u0000"))
-	assert.Equal(t, `"\u0000"`, doStrMarshal("\u0000"))
-	assert.Equal(t, "\"\U000fe4ed\"", doStrMarshal("\U000fe4ed"))
+	t.Run("marshal", func(t *testing.T) {
+		assert.Equal(t, `"hello"`, m2s(MarshalString("hello")))
+		assert.Equal(t, `"he\tllo"`, m2s(MarshalString("he\tllo")))
+		assert.Equal(t, `"he\tllo"`, m2s(MarshalString("he	llo")))
+		assert.Equal(t, `"he\nllo"`, m2s(MarshalString("he\nllo")))
+		assert.Equal(t, `"he\r\nllo"`, m2s(MarshalString("he\r\nllo")))
+		assert.Equal(t, `"he\\llo"`, m2s(MarshalString(`he\llo`)))
+		assert.Equal(t, `"quotes\"nested\"in\"quotes\""`, m2s(MarshalString(`quotes"nested"in"quotes"`)))
+		assert.Equal(t, `"\u0000"`, m2s(MarshalString("\u0000")))
+		assert.Equal(t, `"\u0000"`, m2s(MarshalString("\u0000")))
+		assert.Equal(t, "\"\U000fe4ed\"", m2s(MarshalString("\U000fe4ed")))
+	})
+
+	t.Run("unmarshal", func(t *testing.T) {
+		assert.Equal(t, "123", mustUnmarshalString("123"))
+		assert.Equal(t, "123", mustUnmarshalString(123))
+		assert.Equal(t, "123", mustUnmarshalString(int64(123)))
+		assert.Equal(t, "123.000000", mustUnmarshalString(float64(123)))
+		assert.Equal(t, "123", mustUnmarshalString(json.Number("123")))
+		assert.Equal(t, "true", mustUnmarshalString(true))
+		assert.Equal(t, "false", mustUnmarshalString(false))
+		assert.Equal(t, "null", mustUnmarshalString(nil))
+	})
 }
 
-func doStrMarshal(s string) string {
-	var buf bytes.Buffer
-	MarshalString(s).MarshalGQL(&buf)
-	return buf.String()
+func mustUnmarshalString(v interface{}) string {
+	res, err := UnmarshalString(v)
+	if err != nil {
+		panic(err)
+	}
+	return res
 }

--- a/graphql/string_test.go
+++ b/graphql/string_test.go
@@ -25,7 +25,7 @@ func TestString(t *testing.T) {
 		assert.Equal(t, "123", mustUnmarshalString("123"))
 		assert.Equal(t, "123", mustUnmarshalString(123))
 		assert.Equal(t, "123", mustUnmarshalString(int64(123)))
-		assert.Equal(t, "123.000000", mustUnmarshalString(float64(123)))
+		assert.Equal(t, "123", mustUnmarshalString(float64(123)))
 		assert.Equal(t, "123", mustUnmarshalString(json.Number("123")))
 		assert.Equal(t, "true", mustUnmarshalString(true))
 		assert.Equal(t, "false", mustUnmarshalString(false))


### PR DESCRIPTION
`UnmarshalString` currently supports most basic types (`string`, `int`, `float64`, ...), but not `json.Number`, which is used when decoding float values from JSON.

This PR:
* Adds `json.Number` support to `UnmarshalString`
* Implements `graphql.UnmarshalString` tests which were missing
* Changes the behaviour of `graphql.UnmarshalString` with `float64` inputs to output a string with the smallest number of digits necessary (`graphql.UnmarshalString(float64(123))` will output `"123"` instead of `"123.000000"`)

The last change while not strictly necessary seemed to make more sense when I was writing the tests. I made it in a separate commit so it can be easily discarded.

I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [X] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
