### PR TITLE
replace encoding/json with goccy/go-json

### DIFF
--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -17,6 +17,7 @@ require (
 )
 
 require (
+	github.com/goccy/go-json v0.9.11 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/opentracing/basictracer-go v1.1.0 // indirect

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -17,13 +17,12 @@ require (
 )
 
 require (
-	github.com/goccy/go-json v0.9.11 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/opentracing/basictracer-go v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
 	github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546 // indirect
-	golang.org/x/text v0.3.7
+	golang.org/x/text v0.4.0
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67 // indirect
 )

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -135,8 +135,9 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
+golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190515012406-7d7faa4812bd/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -16,6 +16,8 @@ github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm
 github.com/gin-gonic/gin v1.5.0/go.mod h1:Nd6IXA8m5kNZdNEHMBd93KT+mdY3+bewLgRvmCsR2Do=
 github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3ygWanZIBtBW0W2TM=
 github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEKwgtJRd2xk99HeFyHw3yid4rvQIY=
+github.com/goccy/go-json v0.9.11 h1:/pAaQDLHEoCq/5FFmSKBswWmK6H0e8g4159Kc/X/nqk=
+github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=

--- a/api/testdata/default/graph/schema.graphqls
+++ b/api/testdata/default/graph/schema.graphqls
@@ -14,6 +14,9 @@ type User {
   name: String!
 }
 
+"""
+Description!
+"""
 type Query {
   todos: [Todo!]!
 }

--- a/client/client.go
+++ b/client/client.go
@@ -4,12 +4,13 @@ package client
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/mitchellh/mapstructure"
 )

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2,12 +2,13 @@ package client_test
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
 	"testing"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/99designs/gqlgen/client"
 	"github.com/stretchr/testify/require"

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,6 +1,6 @@
 package client
 
-import "encoding/json"
+import json "github.com/goccy/go-json"
 
 // RawJsonError is a json formatted error from a GraphQL server.
 type RawJsonError struct {

--- a/client/websocket.go
+++ b/client/websocket.go
@@ -1,12 +1,13 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http/httptest"
 	"reflect"
 	"strings"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/gorilla/websocket"
 )

--- a/client/withfilesoption.go
+++ b/client/withfilesoption.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -10,6 +9,8 @@ import (
 	"net/textproto"
 	"os"
 	"strings"
+
+	json "github.com/goccy/go-json"
 )
 
 type fileFormDataMap struct {

--- a/codegen/testserver/followschema/mutation_with_custom_scalar.go
+++ b/codegen/testserver/followschema/mutation_with_custom_scalar.go
@@ -1,10 +1,11 @@
 package followschema
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"regexp"
+
+	json "github.com/goccy/go-json"
 )
 
 var re = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")

--- a/codegen/testserver/singlefile/mutation_with_custom_scalar.go
+++ b/codegen/testserver/singlefile/mutation_with_custom_scalar.go
@@ -1,10 +1,11 @@
 package singlefile
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"regexp"
+
+	json "github.com/goccy/go-json"
 )
 
 var re = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/stretchr/testify v1.7.1
 	github.com/urfave/cli/v2 v2.8.1
 	github.com/vektah/gqlparser/v2 v2.5.1
-	golang.org/x/text v0.3.7
+	golang.org/x/text v0.4.0
 	golang.org/x/tools v0.1.12
 	google.golang.org/protobuf v1.28.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -20,4 +20,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require github.com/agnivade/levenshtein v1.1.1 // indirect
+require (
+	github.com/agnivade/levenshtein v1.1.1 // indirect
+	github.com/goccy/go-json v0.9.11
+)

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,9 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
+golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
+github.com/goccy/go-json v0.9.11 h1:/pAaQDLHEoCq/5FFmSKBswWmK6H0e8g4159Kc/X/nqk=
+github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/graphql/any.go
+++ b/graphql/any.go
@@ -1,8 +1,9 @@
 package graphql
 
 import (
-	"encoding/json"
 	"io"
+
+	json "github.com/goccy/go-json"
 )
 
 func MarshalAny(v interface{}) Marshaler {

--- a/graphql/coercion.go
+++ b/graphql/coercion.go
@@ -1,7 +1,7 @@
 package graphql
 
 import (
-	"encoding/json"
+	json "github.com/goccy/go-json"
 )
 
 // CoerceList applies coercion from a single value to a list.

--- a/graphql/coercion_test.go
+++ b/graphql/coercion_test.go
@@ -1,8 +1,9 @@
 package graphql
 
 import (
-	"encoding/json"
 	"testing"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/graphql/executor/testexecutor/testexecutor.go
+++ b/graphql/executor/testexecutor/testexecutor.go
@@ -3,10 +3,11 @@ package testexecutor
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"time"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/executor"

--- a/graphql/float.go
+++ b/graphql/float.go
@@ -2,11 +2,12 @@ package graphql
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"math"
 	"strconv"
+
+	json "github.com/goccy/go-json"
 )
 
 func MarshalFloat(f float64) Marshaler {

--- a/graphql/handler/apollofederatedtracingv1/tracing_test.go
+++ b/graphql/handler/apollofederatedtracingv1/tracing_test.go
@@ -3,13 +3,14 @@ package apollofederatedtracingv1_test
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler/apollofederatedtracingv1"

--- a/graphql/handler/apollotracing/tracer_test.go
+++ b/graphql/handler/apollotracing/tracer_test.go
@@ -1,12 +1,13 @@
 package apollotracing_test
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler/apollotracing"

--- a/graphql/handler/debug/tracer.go
+++ b/graphql/handler/debug/tracer.go
@@ -2,11 +2,12 @@ package debug
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+
+	json "github.com/goccy/go-json"
 
 	. "github.com/logrusorgru/aurora/v3"
 	"github.com/mattn/go-colorable"

--- a/graphql/handler/server.go
+++ b/graphql/handler/server.go
@@ -2,10 +2,11 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/executor"

--- a/graphql/handler/transport/error.go
+++ b/graphql/handler/transport/error.go
@@ -1,9 +1,10 @@
 package transport
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/vektah/gqlparser/v2/gqlerror"

--- a/graphql/handler/transport/http_form.go
+++ b/graphql/handler/transport/http_form.go
@@ -1,11 +1,12 @@
 package transport
 
 import (
-	"encoding/json"
 	"io"
 	"mime"
 	"net/http"
 	"os"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/99designs/gqlgen/graphql"
 )

--- a/graphql/handler/transport/http_get.go
+++ b/graphql/handler/transport/http_get.go
@@ -1,11 +1,12 @@
 package transport
 
 import (
-	"encoding/json"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/errcode"

--- a/graphql/handler/transport/http_post_test.go
+++ b/graphql/handler/transport/http_post_test.go
@@ -26,7 +26,7 @@ func TestPOST(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", "notjson")
 		assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
 		assert.Equal(t, resp.Header().Get("Content-Type"), "application/json")
-		assert.Equal(t, `{"errors":[{"message":"json body could not be decoded: invalid character 'o' in literal null (expecting 'u')"}],"data":null}`, resp.Body.String())
+		assert.Equal(t, `{"errors":[{"message":"json body could not be decoded: json: invalid character o as null"}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("parse failure", func(t *testing.T) {

--- a/graphql/handler/transport/util.go
+++ b/graphql/handler/transport/util.go
@@ -1,9 +1,10 @@
 package transport
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/vektah/gqlparser/v2/gqlerror"

--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -3,7 +3,6 @@ package transport
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -11,6 +10,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/errcode"

--- a/graphql/handler/transport/websocket_graphql_transport_ws.go
+++ b/graphql/handler/transport/websocket_graphql_transport_ws.go
@@ -1,8 +1,9 @@
 package transport
 
 import (
-	"encoding/json"
 	"fmt"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/gorilla/websocket"
 )

--- a/graphql/handler/transport/websocket_graphqlws.go
+++ b/graphql/handler/transport/websocket_graphqlws.go
@@ -1,8 +1,9 @@
 package transport
 
 import (
-	"encoding/json"
 	"fmt"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/gorilla/websocket"
 )

--- a/graphql/handler/transport/websocket_subprotocol.go
+++ b/graphql/handler/transport/websocket_subprotocol.go
@@ -1,8 +1,9 @@
 package transport
 
 import (
-	"encoding/json"
 	"errors"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/gorilla/websocket"
 )

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -2,13 +2,14 @@ package transport_test
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql"

--- a/graphql/id.go
+++ b/graphql/id.go
@@ -1,10 +1,11 @@
 package graphql
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
+
+	json "github.com/goccy/go-json"
 )
 
 func MarshalID(s string) Marshaler {

--- a/graphql/int.go
+++ b/graphql/int.go
@@ -1,10 +1,11 @@
 package graphql
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
+
+	json "github.com/goccy/go-json"
 )
 
 func MarshalInt(i int) Marshaler {

--- a/graphql/int_test.go
+++ b/graphql/int_test.go
@@ -1,8 +1,9 @@
 package graphql
 
 import (
-	"encoding/json"
 	"testing"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/graphql/map.go
+++ b/graphql/map.go
@@ -1,9 +1,10 @@
 package graphql
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
+
+	json "github.com/goccy/go-json"
 )
 
 func MarshalMap(val map[string]interface{}) Marshaler {

--- a/graphql/response.go
+++ b/graphql/response.go
@@ -2,8 +2,9 @@ package graphql
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )

--- a/graphql/string.go
+++ b/graphql/string.go
@@ -1,10 +1,11 @@
 package graphql
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
+
+	json "github.com/goccy/go-json"
 )
 
 const encodeHex = "0123456789ABCDEF"

--- a/graphql/string_test.go
+++ b/graphql/string_test.go
@@ -1,8 +1,9 @@
 package graphql
 
 import (
-	"encoding/json"
 	"testing"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/graphql/uint.go
+++ b/graphql/uint.go
@@ -1,10 +1,11 @@
 package graphql
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
+
+	json "github.com/goccy/go-json"
 )
 
 func MarshalUint(i uint) Marshaler {

--- a/graphql/uint_test.go
+++ b/graphql/uint_test.go
@@ -1,8 +1,9 @@
 package graphql
 
 import (
-	"encoding/json"
 	"testing"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/plugin/federation/federation_entityresolver_test.go
+++ b/plugin/federation/federation_entityresolver_test.go
@@ -2,10 +2,11 @@
 package federation
 
 import (
-	"encoding/json"
 	"strconv"
 	"strings"
 	"testing"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"

--- a/plugin/resolvergen/testdata/filetemplate/out/schema.custom.go
+++ b/plugin/resolvergen/testdata/filetemplate/out/schema.custom.go
@@ -35,9 +35,9 @@ type resolverCustomResolverType struct{ *CustomResolverType }
 // !!! WARNING !!!
 // The code below was going to be deleted when updating resolvers. It has been copied here so you have
 // one last chance to move it out of harms way if you want. There are two reasons this happens:
-//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//     it when you're done.
-//   - You have helper methods in this file. Move them out to keep these resolver files clean.
+//  - When renaming or deleting a resolver the old code will be put in here. You can safely delete
+//    it when you're done.
+//  - You have helper methods in this file. Move them out to keep these resolver files clean.
 func AUserHelperFunction() {
 	// AUserHelperFunction implementation
 }

--- a/plugin/resolvergen/testdata/followschema/out/schema.resolvers.go
+++ b/plugin/resolvergen/testdata/followschema/out/schema.resolvers.go
@@ -35,9 +35,9 @@ type resolverCustomResolverType struct{ *CustomResolverType }
 // !!! WARNING !!!
 // The code below was going to be deleted when updating resolvers. It has been copied here so you have
 // one last chance to move it out of harms way if you want. There are two reasons this happens:
-//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//     it when you're done.
-//   - You have helper methods in this file. Move them out to keep these resolver files clean.
+//  - When renaming or deleting a resolver the old code will be put in here. You can safely delete
+//    it when you're done.
+//  - You have helper methods in this file. Move them out to keep these resolver files clean.
 func AUserHelperFunction() {
 	// AUserHelperFunction implementation
 }


### PR DESCRIPTION
goccy/go-json is a more performant version of encoding/json.
Using it seems to improve the amount of memory allocated and ns/op. 
I used the benchmark in _examples/starwars to compare the performance:

encoding/json version:
```
BenchmarkSimpleQueryNoArgs-12              48986             23931 ns/op            8237 B/op        146 allocs/op
```

goccy/go-json version:
```
BenchmarkSimpleQueryNoArgs-12              53048             21194 ns/op            7824 B/op        141 allocs/op
```
 On average i observed about a 5% improvement
