### PR TITLE
Check if go.mod exists while init

### DIFF
--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -23,6 +23,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
 	github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546 // indirect
-	golang.org/x/text v0.3.7
+	golang.org/x/text v0.3.8
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67 // indirect
 )

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -133,8 +133,9 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
+golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190515012406-7d7faa4812bd/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/stretchr/testify v1.7.1
 	github.com/urfave/cli/v2 v2.8.1
 	github.com/vektah/gqlparser/v2 v2.5.1
-	golang.org/x/text v0.3.8
+	golang.org/x/text v0.3.7
 	golang.org/x/tools v0.1.12
 	google.golang.org/protobuf v1.28.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/stretchr/testify v1.7.1
 	github.com/urfave/cli/v2 v2.8.1
 	github.com/vektah/gqlparser/v2 v2.5.1
-	golang.org/x/text v0.3.7
+	golang.org/x/text v0.3.8
 	golang.org/x/tools v0.1.12
 	google.golang.org/protobuf v1.28.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,9 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
+golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=

--- a/go.sum
+++ b/go.sum
@@ -81,11 +81,8 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
-golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
-golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
-golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
-golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,11 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
+golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
+golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
+golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=

--- a/main.go
+++ b/main.go
@@ -12,12 +12,13 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/99designs/gqlgen/api"
 	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/internal/code"
 	"github.com/99designs/gqlgen/plugin/servergen"
-	"github.com/urfave/cli/v2"
 )
 
 //go:embed init-templates/schema.graphqls
@@ -39,6 +40,28 @@ func fileExists(filename string) bool {
 	return !errors.Is(err, fs.ErrNotExist)
 }
 
+// see Go source code:
+// https://github.com/golang/go/blob/f57ebed35132d02e5cf016f324853217fb545e91/src/cmd/go/internal/modload/init.go#L1283
+func findModuleRoot(dir string) (roots string) {
+	if dir == "" {
+		panic("dir not set")
+	}
+	dir = filepath.Clean(dir)
+
+	// Look for enclosing go.mod.
+	for {
+		if fi, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil && !fi.IsDir() {
+			return dir
+		}
+		d := filepath.Dir(dir)
+		if d == dir { // the parent of the root is itself, so we can go no further
+			break
+		}
+		dir = d
+	}
+	return ""
+}
+
 func initFile(filename, contents string) error {
 	if err := os.MkdirAll(filepath.Dir(filename), 0o755); err != nil {
 		return fmt.Errorf("unable to create directory for file '%s': %w\n", filename, err)
@@ -56,20 +79,35 @@ var initCmd = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.BoolFlag{Name: "verbose, v", Usage: "show logs"},
 		&cli.StringFlag{Name: "config, c", Usage: "the config filename", Value: "gqlgen.yml"},
-		&cli.StringFlag{Name: "server", Usage: "where to write the server stub to", Value: "server.go"},
-		&cli.StringFlag{Name: "schema", Usage: "where to write the schema stub to", Value: "graph/schema.graphqls"},
+		&cli.StringFlag{
+			Name:  "server",
+			Usage: "where to write the server stub to",
+			Value: "server.go",
+		},
+		&cli.StringFlag{
+			Name:  "schema",
+			Usage: "where to write the schema stub to",
+			Value: "graph/schema.graphqls",
+		},
 	},
 	Action: func(ctx *cli.Context) error {
 		configFilename := ctx.String("config")
 		serverFilename := ctx.String("server")
 		schemaFilename := ctx.String("schema")
 
-		pkgName := code.ImportPathForDir(".")
-		if pkgName == "" {
-			return fmt.Errorf("unable to determine import path for current directory, you probably need to run 'go mod init' first")
+		cwd, err := os.Getwd()
+		if err != nil {
+			log.Println(err)
+			return fmt.Errorf("unable to determine current directory:%w", err)
 		}
-
-		if !fileExists("go.mod") {
+		pkgName := code.ImportPathForDir(cwd)
+		if pkgName == "" {
+			return fmt.Errorf(
+				"unable to determine import path for current directory, you probably need to run 'go mod init' first",
+			)
+		}
+		modRoot := findModuleRoot(cwd)
+		if modRoot == "" {
 			return fmt.Errorf("go.mod is missing. Please, do 'go mod init' first\n")
 		}
 
@@ -79,7 +117,7 @@ var initCmd = &cli.Command{
 				return fmt.Errorf("%s already exists", filename)
 			}
 		}
-		_, err := config.LoadConfigFromDefaultLocations()
+		_, err = config.LoadConfigFromDefaultLocations()
 		if err == nil {
 			return fmt.Errorf("gqlgen.yml already exists in a parent directory\n")
 		}

--- a/main.go
+++ b/main.go
@@ -69,10 +69,10 @@ var initCmd = &cli.Command{
 			return fmt.Errorf("unable to determine import path for current directory, you probably need to run 'go mod init' first")
 		}
 
-		// 
 		if !fileExists("go.mod") {
-			return fmt.Errorf("go.mod is missing! Please, do `go mod init your-project` first\n")
+			return fmt.Errorf("go.mod is missing. Please, do 'go mod init' first\n")
 		}
+		
 		// check schema and config don't already exist
 		for _, filename := range []string{configFilename, schemaFilename, serverFilename} {
 			if fileExists(filename) {

--- a/main.go
+++ b/main.go
@@ -69,6 +69,10 @@ var initCmd = &cli.Command{
 			return fmt.Errorf("unable to determine import path for current directory, you probably need to run 'go mod init' first")
 		}
 
+		// 
+		if !fileExists("go.mod") {
+			return fmt.Errorf("go.mod is missing! Please, do `go mod init your-project` first\n")
+		}
 		// check schema and config don't already exist
 		for _, filename := range []string{configFilename, schemaFilename, serverFilename} {
 			if fileExists(filename) {

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ var initCmd = &cli.Command{
 		if !fileExists("go.mod") {
 			return fmt.Errorf("go.mod is missing. Please, do 'go mod init' first\n")
 		}
-		
+
 		// check schema and config don't already exist
 		for _, filename := range []string{configFilename, schemaFilename, serverFilename} {
 			if fileExists(filename) {


### PR DESCRIPTION
If for something reason we miss go.mod and then run "go run github.com/99designs/gqlgen init" we get cascade errors like:

```
projects/source/go/test/typeparam/issue51836.dir imports
        ./aa: "./aa" is relative, but relative import paths are not supported in module mode
tidy failed: go mod tidy failed: exit status 

```

This simple check prevent this


