### PR TITLE
consider goField directive for getters generation

### DIFF
--- a/codegen/testserver/followschema/models-gen.go
+++ b/codegen/testserver/followschema/models-gen.go
@@ -220,7 +220,7 @@ type ValidInput struct {
 	Underscore  string `json:"_"`
 }
 
-//  These things are all valid, but without care generate invalid go code
+// These things are all valid, but without care generate invalid go code
 type ValidType struct {
 	DifferentCase      string `json:"differentCase"`
 	DifferentCaseOld   string `json:"different_case"`

--- a/codegen/testserver/singlefile/models-gen.go
+++ b/codegen/testserver/singlefile/models-gen.go
@@ -220,7 +220,7 @@ type ValidInput struct {
 	Underscore  string `json:"_"`
 }
 
-//  These things are all valid, but without care generate invalid go code
+// These things are all valid, but without care generate invalid go code
 type ValidType struct {
 	DifferentCase      string `json:"differentCase"`
 	DifferentCaseOld   string `json:"different_case"`

--- a/graphql/executable_schema_mock.go
+++ b/graphql/executable_schema_mock.go
@@ -15,25 +15,25 @@ var _ ExecutableSchema = &ExecutableSchemaMock{}
 
 // ExecutableSchemaMock is a mock implementation of ExecutableSchema.
 //
-// 	func TestSomethingThatUsesExecutableSchema(t *testing.T) {
+//	func TestSomethingThatUsesExecutableSchema(t *testing.T) {
 //
-// 		// make and configure a mocked ExecutableSchema
-// 		mockedExecutableSchema := &ExecutableSchemaMock{
-// 			ComplexityFunc: func(typeName string, fieldName string, childComplexity int, args map[string]interface{}) (int, bool) {
-// 				panic("mock out the Complexity method")
-// 			},
-// 			ExecFunc: func(ctx context.Context) ResponseHandler {
-// 				panic("mock out the Exec method")
-// 			},
-// 			SchemaFunc: func() *ast.Schema {
-// 				panic("mock out the Schema method")
-// 			},
-// 		}
+//		// make and configure a mocked ExecutableSchema
+//		mockedExecutableSchema := &ExecutableSchemaMock{
+//			ComplexityFunc: func(typeName string, fieldName string, childComplexity int, args map[string]interface{}) (int, bool) {
+//				panic("mock out the Complexity method")
+//			},
+//			ExecFunc: func(ctx context.Context) ResponseHandler {
+//				panic("mock out the Exec method")
+//			},
+//			SchemaFunc: func() *ast.Schema {
+//				panic("mock out the Schema method")
+//			},
+//		}
 //
-// 		// use mockedExecutableSchema in code that requires ExecutableSchema
-// 		// and then make assertions.
+//		// use mockedExecutableSchema in code that requires ExecutableSchema
+//		// and then make assertions.
 //
-// 	}
+//	}
 type ExecutableSchemaMock struct {
 	// ComplexityFunc mocks the Complexity method.
 	ComplexityFunc func(typeName string, fieldName string, childComplexity int, args map[string]interface{}) (int, bool)
@@ -95,7 +95,8 @@ func (mock *ExecutableSchemaMock) Complexity(typeName string, fieldName string, 
 
 // ComplexityCalls gets all the calls that were made to Complexity.
 // Check the length with:
-//     len(mockedExecutableSchema.ComplexityCalls())
+//
+//	len(mockedExecutableSchema.ComplexityCalls())
 func (mock *ExecutableSchemaMock) ComplexityCalls() []struct {
 	TypeName        string
 	FieldName       string
@@ -132,7 +133,8 @@ func (mock *ExecutableSchemaMock) Exec(ctx context.Context) ResponseHandler {
 
 // ExecCalls gets all the calls that were made to Exec.
 // Check the length with:
-//     len(mockedExecutableSchema.ExecCalls())
+//
+//	len(mockedExecutableSchema.ExecCalls())
 func (mock *ExecutableSchemaMock) ExecCalls() []struct {
 	Ctx context.Context
 } {
@@ -160,7 +162,8 @@ func (mock *ExecutableSchemaMock) Schema() *ast.Schema {
 
 // SchemaCalls gets all the calls that were made to Schema.
 // Check the length with:
-//     len(mockedExecutableSchema.SchemaCalls())
+//
+//	len(mockedExecutableSchema.SchemaCalls())
 func (mock *ExecutableSchemaMock) SchemaCalls() []struct {
 } {
 	var calls []struct {

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -23,6 +23,11 @@ type FieldMutateHook = func(td *ast.Definition, fd *ast.FieldDefinition, f *Fiel
 
 // defaultFieldMutateHook is the default hook for the Plugin which applies the GoTagFieldHook.
 func defaultFieldMutateHook(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Field, error) {
+	var err error
+	f, err = GoFieldHook(td, fd, f)
+	if err != nil {
+		return f, err
+	}
 	return GoTagFieldHook(td, fd, f)
 }
 
@@ -409,6 +414,20 @@ func GoTagFieldHook(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Fie
 		f.Tag = f.Tag + " " + strings.Join(args, " ")
 	}
 
+	return f, nil
+}
+
+// GoFieldHook applies the goField directive to the generated Field f.
+func GoFieldHook(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Field, error) {
+	args := make([]string, 0)
+	_ = args
+	for _, goField := range fd.Directives.ForNames("goField") {
+		if arg := goField.Arguments.ForName("name"); arg != nil {
+			if k, err := arg.Value.Value(nil); err == nil {
+				f.GoName = k.(string)
+			}
+		}
+	}
 	return f, nil
 }
 

--- a/plugin/modelgen/out/generated.go
+++ b/plugin/modelgen/out/generated.go
@@ -65,6 +65,11 @@ type UnionWithDescription interface {
 	IsUnionWithDescription()
 }
 
+type X interface {
+	IsX()
+	GetId() string
+}
+
 type CDImplemented struct {
 	A string  `json:"a" database:"CDImplementeda"`
 	B int     `json:"b" database:"CDImplementedb"`
@@ -201,6 +206,14 @@ type TypeWithDescription struct {
 }
 
 func (TypeWithDescription) IsUnionWithDescription() {}
+
+type Xer struct {
+	Id   string `json:"Id" database:"XerId"`
+	Name string `json:"Name" database:"XerName"`
+}
+
+func (Xer) IsX()               {}
+func (this Xer) GetId() string { return this.Id }
 
 type FooBarr struct {
 	Name string `json:"name" database:"_Foo_Barrname"`

--- a/plugin/modelgen/testdata/schema.graphql
+++ b/plugin/modelgen/testdata/schema.graphql
@@ -3,6 +3,11 @@ directive @goTag(
     value: String
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
+directive @goField(
+	forceResolver: Boolean
+	name: String
+) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION | INTERFACE
+
 type Query {
     thisShoudlntGetGenerated: Boolean
 }
@@ -178,4 +183,13 @@ interface ArrayOfA {
 type ImplArrayOfA implements ArrayOfA {
     trickyField: [CDImplemented!]!
     trickyFieldPointer: [CDImplemented]
+}
+
+interface X {
+    Id: String! @goField(name: "Id")
+}
+
+type Xer implements X {
+    Id: String! @goField(name: "Id")
+    Name: String!
 }


### PR DESCRIPTION
Fixes #2439

When you have an interface and override generated models fields name with goField directive. This PR makes it so getters generated by gqlgen will access field values using the field that was specified in the `goField` directive.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
