### PR TITLE
graphql.Error is not deprecated anymore

### DIFF
--- a/graphql/context_operation.go
+++ b/graphql/context_operation.go
@@ -107,8 +107,8 @@ func (c *OperationContext) Errorf(ctx context.Context, format string, args ...in
 	AddErrorf(ctx, format, args...)
 }
 
-// Error sends an error to the client, passing it through the formatter.
-// Deprecated: use graphql.AddError(ctx, err) instead
+// Error add error or multiple errors (if underlaying type is gqlerror.List) into the stack.
+// Then it will be sends to the client, passing it through the formatter.
 func (c *OperationContext) Error(ctx context.Context, err error) {
 	if errList, ok := err.(gqlerror.List); ok {
 		for _, e := range errList {


### PR DESCRIPTION
graphql.Error functionality changed, but graphql.Errorf is still deprecated.