### PR TITLE
Export default modelgen hooks

### DIFF
--- a/docs/content/recipes/modelgen-hook.md
+++ b/docs/content/recipes/modelgen-hook.md
@@ -2,7 +2,7 @@
 title: "Allowing mutation of generated models before rendering"
 description: How to use a model mutation function to insert a ORM-specific tags onto struct fields.
 linkTitle: "Modelgen hook"
-menu: { main: { parent: 'recipes' } }
+menu: { main: { parent: "recipes" } }
 ---
 
 ## BuildMutateHook
@@ -16,7 +16,7 @@ the generated data structure.
 First of all, we need to create a function that will mutate the generated model.
 Then we can attach the function to the plugin and use it like any other plugin.
 
-``` go
+```go
 import (
 	"fmt"
 	"os"
@@ -64,8 +64,8 @@ This schema:
 
 ```graphql
 type Object {
-    field1: String
-    field2: Int
+	field1: String
+	field2: Int
 }
 ```
 
@@ -84,7 +84,7 @@ For more fine grained control over model generation, a graphql schema aware a Fi
 
 The below recipe uses this feature to add validate tags to the generated model for use with `go-playground/validator` where the validate tags are defined in a constraint directive in the schema.
 
-``` go
+```go
 import (
 	"fmt"
 	"github.com/vektah/gqlparser/v2/ast"
@@ -97,6 +97,11 @@ import (
 
 // Defining mutation function
 func constraintFieldHook(td *ast.Definition, fd *ast.FieldDefinition, f *modelgen.Field) (*modelgen.Field, error) {
+	// Call default hook to proceed standard directives like goField and goTag.
+	// You can omit it, if you don't need.
+	if f, err := modelgen.DefaultFieldMutateHook(td, fd, f); err != nil {
+		return f, err
+	}
 
 	c := fd.Directives.ForName("constraint")
 	if c != nil {
@@ -136,12 +141,12 @@ This schema:
 
 ```graphql
 directive @constraint(
-    format: String
+	format: String
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 input ObjectInput {
-    contactEmail: String @constraint(format: "email")
-    website: String @constraint(format: "uri")
+	contactEmail: String @constraint(format: "email")
+	website: String @constraint(format: "uri")
 }
 ```
 
@@ -155,10 +160,11 @@ type ObjectInput struct {
 ```
 
 If a constraint being used during generation should not be published during introspection, the directive should be listed with `skip_runtime:true` in gqlgen.yml
+
 ```yaml
 directives:
   constraint:
     skip_runtime: true
 ```
 
-The built-in directive `@goTag` is implemented using the FieldMutateHook. See: `plugin/modelgen/models.go` function `GoTagFieldHook`
+The built-in directives `@goField` and `@goTag` is implemented using the FieldMutateHook. See: `plugin/modelgen/models.go` functions `GoFieldHook` and `GoTagFieldHook`

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -17,12 +17,13 @@ import (
 //go:embed models.gotpl
 var modelTemplate string
 
-type BuildMutateHook = func(b *ModelBuild) *ModelBuild
+type (
+	BuildMutateHook = func(b *ModelBuild) *ModelBuild
+	FieldMutateHook = func(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Field, error)
+)
 
-type FieldMutateHook = func(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Field, error)
-
-// defaultFieldMutateHook is the default hook for the Plugin which applies the GoTagFieldHook.
-func defaultFieldMutateHook(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Field, error) {
+// DefaultFieldMutateHook is the default hook for the Plugin which applies the GoFieldHook and GoTagFieldHook.
+func DefaultFieldMutateHook(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Field, error) {
 	var err error
 	f, err = GoFieldHook(td, fd, f)
 	if err != nil {
@@ -31,7 +32,8 @@ func defaultFieldMutateHook(td *ast.Definition, fd *ast.FieldDefinition, f *Fiel
 	return GoTagFieldHook(td, fd, f)
 }
 
-func defaultBuildMutateHook(b *ModelBuild) *ModelBuild {
+// DefaultBuildMutateHook is the default hook for the Plugin which mutate ModelBuild.
+func DefaultBuildMutateHook(b *ModelBuild) *ModelBuild {
 	return b
 }
 
@@ -80,8 +82,8 @@ type EnumValue struct {
 
 func New() plugin.Plugin {
 	return &Plugin{
-		MutateHook: defaultBuildMutateHook,
-		FieldHook:  defaultFieldMutateHook,
+		MutateHook: DefaultBuildMutateHook,
+		FieldHook:  DefaultFieldMutateHook,
 	}
 }
 
@@ -97,7 +99,6 @@ func (m *Plugin) Name() string {
 }
 
 func (m *Plugin) MutateConfig(cfg *config.Config) error {
-
 	b := &ModelBuild{
 		PackageName: cfg.Model.Package,
 	}

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -26,7 +26,7 @@ func TestModelGeneration(t *testing.T) {
 	require.NoError(t, cfg.Init())
 	p := Plugin{
 		MutateHook: mutateHook,
-		FieldHook:  defaultFieldMutateHook,
+		FieldHook:  DefaultFieldMutateHook,
 	}
 	require.NoError(t, p.MutateConfig(cfg))
 	require.NoError(t, goBuild(t, "./out/"))
@@ -279,7 +279,7 @@ func TestModelGenerationStructFieldPointers(t *testing.T) {
 	require.NoError(t, cfg.Init())
 	p := Plugin{
 		MutateHook: mutateHook,
-		FieldHook:  defaultFieldMutateHook,
+		FieldHook:  DefaultFieldMutateHook,
 	}
 	require.NoError(t, p.MutateConfig(cfg))
 


### PR DESCRIPTION
When customizing modelgen plugin with FieldHook for example, then we need to copy whole code of defaultFieldMutateHook to our newly created hook. If we forget to do this, then we loose @goTag and @goField functionality.
With exported code we can simply call it in our custom hook before or after custom code.

I have:
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
