### PR TITLE
fix #2465 remote model with omitempty

### DIFF
--- a/codegen/util.go
+++ b/codegen/util.go
@@ -41,6 +41,7 @@ func findGoInterface(def types.Type) (*types.Interface, error) {
 
 func equalFieldName(source, target string) bool {
 	source = strings.ReplaceAll(source, "_", "")
+	source = strings.ReplaceAll(source, ",omitempty", "")
 	target = strings.ReplaceAll(target, "_", "")
 	return strings.EqualFold(source, target)
 }

--- a/integration/gqlgen.yml
+++ b/integration/gqlgen.yml
@@ -1,6 +1,7 @@
 schema:
   - "schema.graphql"
   - "user.graphql"
+  - "testomitempty.graphql"
 
 exec:
   filename: generated.go
@@ -9,6 +10,11 @@ model:
 resolver:
   filename: resolver.go
   type: Resolver
+
+struct_tag: json
+
+autobind:
+  - "github.com/99designs/gqlgen/integration/testomitempty"
 
 models:
   Element:

--- a/integration/schema-expected.graphql
+++ b/integration/schema-expected.graphql
@@ -46,6 +46,10 @@ type Query {
   viewer: Viewer
 }
 
+type RemoteModelWithOmitempty {
+  newDesc: String
+}
+
 type User {
   likes: [String!]!
   name: String!

--- a/integration/testomitempty.graphql
+++ b/integration/testomitempty.graphql
@@ -1,0 +1,3 @@
+type RemoteModelWithOmitempty {
+    newDesc: String
+}

--- a/integration/testomitempty/testmodel.go
+++ b/integration/testomitempty/testmodel.go
@@ -1,0 +1,5 @@
+package testomitempty
+
+type RemoteModelWithOmitempty struct {
+	Description string `json:"newDesc,omitempty"`
+}


### PR DESCRIPTION
Fixes #2465 

Running `go generate` creates unnecessary resolvers when:
1. using a remote model that has a `json` tag with `omitempty`, and the value of json is different than the attribute name
2. the remote package is in `autobind` in `gqlgen.yml` file, and also `struct_tag: json` is used
3. these new resolvers need to be implemented but my expected result is to be able to use my model right away

The reason I am having this error is because I am adding `gqlgen` to an existing repo with many models. I want these models to stay in the files they are right now, not having them "duplicated" under /graph/model.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
 
 Here is a video demonstrating my integration test:

https://user-images.githubusercontent.com/18444266/207514324-cc2cb0f2-6699-42f9-b364-4df109739a16.mov


