### PR TITLE
New dictgen plugin for issue #2473

### DIFF
--- a/plugin/dictgen/dictgen.go
+++ b/plugin/dictgen/dictgen.go
@@ -1,0 +1,134 @@
+package dictgen
+
+import (
+	_ "embed"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"github.com/99designs/gqlgen/codegen"
+	"github.com/99designs/gqlgen/codegen/config"
+	"github.com/99designs/gqlgen/codegen/templates"
+	"github.com/99designs/gqlgen/plugin"
+)
+
+//go:embed roots.gotpl
+var rootsTemplate string
+
+//go:embed objects.gotpl
+var objectsTemplate string
+
+func New() plugin.Plugin {
+	return &Plugin{}
+}
+
+const (
+	QueryPkgName        = "gqlquery"
+	MutationPkgName     = "gqlmutation"
+	SubscriptionPkgName = "gqlsubscription"
+	ObjectPkgName       = "gqlobject"
+)
+
+type Plugin struct{}
+
+var _ plugin.CodeGenerator = (*Plugin)(nil)
+
+func (m *Plugin) Name() string {
+	return "dictgen"
+}
+
+func (m *Plugin) GenerateCode(data *codegen.Data) error {
+	if err := generateRoots(data); err != nil {
+		return err
+	}
+
+	if err := generateObjects(data); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func generateRoots(data *codegen.Data) error {
+	roots := map[string]*codegen.Object{
+		QueryPkgName:        data.QueryRoot,
+		MutationPkgName:     data.MutationRoot,
+		SubscriptionPkgName: data.SubscriptionRoot,
+	}
+
+	for packageName, rootObject := range roots {
+		filePath := removeAndGetDictFilepath(packageName, data)
+
+		if rootObject == nil || len(rootObject.Fields) == 0 {
+			continue
+		}
+
+		if err := templates.Render(templates.Options{
+			PackageName: packageName,
+			Filename:    filePath,
+			Data:        rootObject,
+			Funcs: template.FuncMap{
+				"goName": templates.ToGoModelName,
+			},
+			GeneratedHeader: true,
+			Template:        rootsTemplate,
+			Packages:        data.Config.Packages,
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func generateObjects(data *codegen.Data) error {
+	allObjects := codegen.Objects{}
+	allObjects = append(allObjects, data.Objects...)
+	allObjects = append(allObjects, data.Inputs...)
+
+	objects := codegen.Objects{}
+	for _, o := range allObjects {
+		if o == data.QueryRoot || o == data.MutationRoot || o == data.SubscriptionRoot {
+			continue
+		}
+
+		if o.IsReserved() {
+			continue
+		}
+
+		objects = append(objects, o)
+	}
+
+	filePath := removeAndGetDictFilepath(ObjectPkgName, data)
+
+	if len(objects) != 0 {
+		if err := templates.Render(templates.Options{
+			PackageName: ObjectPkgName,
+			Filename:    filePath,
+			Data:        objects,
+			Funcs: template.FuncMap{
+				"goName": templates.ToGoModelName,
+			},
+			GeneratedHeader: true,
+			Template:        objectsTemplate,
+			Packages:        data.Config.Packages,
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func removeAndGetDictFilepath(packageName string, data *codegen.Data) string {
+	filePath := filepath.Join(packageName, "names.go")
+	if data.Config.Exec.Layout == config.ExecLayoutFollowSchema {
+		filePath = filepath.Join(data.Config.Exec.DirName, filePath)
+	} else {
+		filePath = filepath.Join(filepath.Dir(data.Config.Exec.Filename), filePath)
+	}
+
+	_ = os.RemoveAll(filepath.Dir(filePath))
+
+	return filePath
+}

--- a/plugin/dictgen/objects.gotpl
+++ b/plugin/dictgen/objects.gotpl
@@ -1,0 +1,37 @@
+{{ $objects := . }}
+
+const (
+	{{- range $object := $objects }}
+        {{ goName $object.Name }} = "{{ $object.Name }}"
+	{{- end }}
+)
+
+{{- range $object := $objects }}
+    {{- if .Fields }}
+        {{ $goObjectName := goName $object.Name }}
+        // GraphQL schema field names for {{ $goObjectName }}.
+        type fieldsOf{{ $goObjectName }} struct {
+            {{- range $field := .Fields }}
+                // GraphQL schema field name for {{ $object.Name }}: {{ $field.Name }}
+                {{ $field.GoFieldName }} string
+            {{- end }}
+        }
+
+        {{ $helperName := print $goObjectName "Fields" }}
+        // {{ $helperName }} returns GraphQL schema field names for {{ $object.Name }}.
+        func {{ $helperName }}() fieldsOf{{ $goObjectName }} {
+            return fieldsOf{{ $goObjectName }}{
+                {{- range $field := .Fields }}
+                    {{ $field.GoFieldName }}: "{{ $field.Name }}",
+                {{- end }}
+            }
+        }
+
+        type {{ $goObjectName }}Helpers struct {}
+
+        // F returns structure with GraphQL schema field names.
+        func (t *{{ $goObjectName }}Helpers) F() fieldsOf{{ $goObjectName }} {
+            return {{ $helperName }}()
+        }
+    {{ end }}
+{{- end }}

--- a/plugin/dictgen/roots.gotpl
+++ b/plugin/dictgen/roots.gotpl
@@ -1,0 +1,32 @@
+{{ $object := . }}
+
+const (
+	{{- range $field := $object.Fields }}
+		{{- if $field.IsResolver }}
+			{{ $field.GoFieldName }} = "{{ $field.Name }}"
+		{{- end }}
+	{{- end }}
+)
+
+{{- range $field := $object.Fields }}
+	{{- if $field.IsResolver }}
+		{{- if $field.Args }}
+			type argsOf{{ $field.GoFieldName }} struct {
+				{{- range $arg := $field.Args }}
+					// GraphQL schema argument name for {{ $field.Name }}: {{ $arg.Name }}
+					{{ goName $arg.VarName }} string
+				{{- end }}
+			}
+
+			{{ $helperName := print $field.GoFieldName "Args" }}
+			// {{ $helperName }} returns GraphQL schema argument names for {{ $object.Name }}: {{ $field.Name }}.
+			func {{ $helperName }}() argsOf{{ $field.GoFieldName }} {
+				return argsOf{{ $field.GoFieldName }}{
+					{{- range $arg := $field.Args }}
+						{{ goName $arg.VarName }}: "{{ $arg.Name }}",
+					{{- end }}
+				}
+			}
+		{{ end }}
+	{{- end }}
+{{- end }}


### PR DESCRIPTION
Full idea described in issue #2473

Maybe this plugin can be enabled by default?
Or maybe configuration file needs extend for options to enable plugin AND probably add some configuration.

Usefull usecase of this plugin in cooperation with modelgen, simple example:

```go
func CreateMutateHook(cfg *config.Config) modelgen.BuildMutateHook {
	return func(b *modelgen.ModelBuild) *modelgen.ModelBuild {
		gqlobjectPackage := types.NewPackage(cfg.Exec.ImportPath()+"/"+dictgen.ObjectPkgName, "")

		for i, m := range b.Models {
			fields := []*modelgen.Field{}
			fields = append(fields, &modelgen.Field{
				Type: types.NewNamed(
					types.NewTypeName(0, gqlobjectPackage, m.Name+"Helpers", nil),
					nil,
					nil,
				),
			})
			fields = append(fields, m.Fields...)
			b.Models[i].Fields = fields
		}

		return b
	}
}

.........

api.ReplacePlugin(&modelgen.Plugin{
	MutateHook: hooks.CreateMutateHook(cfg),
})
```

Hook embed "helpers" structure to any model that generated by modelgen. As a result we have access to all field names directly from initialized structure in resolvers. For example:

```go
func (r *mutationResolver) PersonCreate(ctx context.Context, data models.PersonData) (bool, error) {
    data.F().LastName // "lastName" string from graphql schema.
}

```