### PR TITLE
fix #2485 Defined type from a basic type should not need scalar

### DIFF
--- a/_examples/scalars/external/model.go
+++ b/_examples/scalars/external/model.go
@@ -1,3 +1,12 @@
 package external
 
-type ObjectID int
+type (
+	ObjectID     int
+	Manufacturer string // remote named string
+)
+
+const (
+	ManufacturerTesla  Manufacturer = "TESLA"
+	ManufacturerHonda  Manufacturer = "HONDA"
+	ManufacturerToyota Manufacturer = "TOYOTA"
+)

--- a/_examples/scalars/generated.go
+++ b/_examples/scalars/generated.go
@@ -60,10 +60,13 @@ type ComplexityRoot struct {
 
 	User struct {
 		Address           func(childComplexity int) int
+		CarManufacturer   func(childComplexity int) int
 		Created           func(childComplexity int) int
 		CustomResolver    func(childComplexity int) int
 		ID                func(childComplexity int) int
 		IsBanned          func(childComplexity int) int
+		IsLoginBanned     func(childComplexity int) int
+		IsQueryBanned     func(childComplexity int) int
 		Modified          func(childComplexity int) int
 		Name              func(childComplexity int) int
 		PrimitiveResolver func(childComplexity int) int
@@ -155,6 +158,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.User.Address(childComplexity), true
 
+	case "User.carManufacturer":
+		if e.complexity.User.CarManufacturer == nil {
+			break
+		}
+
+		return e.complexity.User.CarManufacturer(childComplexity), true
+
 	case "User.created":
 		if e.complexity.User.Created == nil {
 			break
@@ -182,6 +192,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.User.IsBanned(childComplexity), true
+
+	case "User.isLoginBanned":
+		if e.complexity.User.IsLoginBanned == nil {
+			break
+		}
+
+		return e.complexity.User.IsLoginBanned(childComplexity), true
+
+	case "User.isQueryBanned":
+		if e.complexity.User.IsQueryBanned == nil {
+			break
+		}
+
+		return e.complexity.User.IsQueryBanned(childComplexity), true
 
 	case "User.modified":
 		if e.complexity.User.Modified == nil {
@@ -539,6 +563,10 @@ func (ec *executionContext) fieldContext_Query_user(ctx context.Context, field g
 				return ec.fieldContext_User_ptrPrefs(ctx, field)
 			case "isBanned":
 				return ec.fieldContext_User_isBanned(ctx, field)
+			case "isLoginBanned":
+				return ec.fieldContext_User_isLoginBanned(ctx, field)
+			case "isQueryBanned":
+				return ec.fieldContext_User_isQueryBanned(ctx, field)
 			case "primitiveResolver":
 				return ec.fieldContext_User_primitiveResolver(ctx, field)
 			case "customResolver":
@@ -547,6 +575,8 @@ func (ec *executionContext) fieldContext_Query_user(ctx context.Context, field g
 				return ec.fieldContext_User_address(ctx, field)
 			case "tier":
 				return ec.fieldContext_User_tier(ctx, field)
+			case "carManufacturer":
+				return ec.fieldContext_User_carManufacturer(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -617,6 +647,10 @@ func (ec *executionContext) fieldContext_Query_search(ctx context.Context, field
 				return ec.fieldContext_User_ptrPrefs(ctx, field)
 			case "isBanned":
 				return ec.fieldContext_User_isBanned(ctx, field)
+			case "isLoginBanned":
+				return ec.fieldContext_User_isLoginBanned(ctx, field)
+			case "isQueryBanned":
+				return ec.fieldContext_User_isQueryBanned(ctx, field)
 			case "primitiveResolver":
 				return ec.fieldContext_User_primitiveResolver(ctx, field)
 			case "customResolver":
@@ -625,6 +659,8 @@ func (ec *executionContext) fieldContext_Query_search(ctx context.Context, field
 				return ec.fieldContext_User_address(ctx, field)
 			case "tier":
 				return ec.fieldContext_User_tier(ctx, field)
+			case "carManufacturer":
+				return ec.fieldContext_User_carManufacturer(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -695,6 +731,10 @@ func (ec *executionContext) fieldContext_Query_userByTier(ctx context.Context, f
 				return ec.fieldContext_User_ptrPrefs(ctx, field)
 			case "isBanned":
 				return ec.fieldContext_User_isBanned(ctx, field)
+			case "isLoginBanned":
+				return ec.fieldContext_User_isLoginBanned(ctx, field)
+			case "isQueryBanned":
+				return ec.fieldContext_User_isQueryBanned(ctx, field)
 			case "primitiveResolver":
 				return ec.fieldContext_User_primitiveResolver(ctx, field)
 			case "customResolver":
@@ -703,6 +743,8 @@ func (ec *executionContext) fieldContext_Query_userByTier(ctx context.Context, f
 				return ec.fieldContext_User_address(ctx, field)
 			case "tier":
 				return ec.fieldContext_User_tier(ctx, field)
+			case "carManufacturer":
+				return ec.fieldContext_User_carManufacturer(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1144,6 +1186,94 @@ func (ec *executionContext) fieldContext_User_isBanned(ctx context.Context, fiel
 	return fc, nil
 }
 
+func (ec *executionContext) _User_isLoginBanned(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_User_isLoginBanned(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IsLoginBanned, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.LoginBanned)
+	fc.Result = res
+	return ec.marshalNBoolean2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐLoginBanned(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_User_isLoginBanned(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _User_isQueryBanned(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_User_isQueryBanned(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IsQueryBanned, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_User_isQueryBanned(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _User_primitiveResolver(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_User_primitiveResolver(ctx, field)
 	if err != nil {
@@ -1315,6 +1445,50 @@ func (ec *executionContext) fieldContext_User_tier(ctx context.Context, field gr
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Tier does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _User_carManufacturer(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_User_carManufacturer(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CarManufacturer, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(external.Manufacturer)
+	fc.Result = res
+	return ec.marshalNString2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋexternalᚐManufacturer(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_User_carManufacturer(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -3322,6 +3496,20 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
+		case "isLoginBanned":
+
+			out.Values[i] = ec._User_isLoginBanned(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "isQueryBanned":
+
+			out.Values[i] = ec._User_isQueryBanned(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "primitiveResolver":
 			field := field
 
@@ -3370,6 +3558,13 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 
 			out.Values[i] = ec._User_tier(ctx, field, obj)
 
+		case "carManufacturer":
+
+			out.Values[i] = ec._User_carManufacturer(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -3724,6 +3919,21 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 	return res
 }
 
+func (ec *executionContext) unmarshalNBoolean2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐLoginBanned(ctx context.Context, v interface{}) (model.LoginBanned, error) {
+	res, err := graphql.UnmarshalBoolean(v)
+	return model.LoginBanned(res), graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNBoolean2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐLoginBanned(ctx context.Context, sel ast.SelectionSet, v model.LoginBanned) graphql.Marshaler {
+	res := graphql.MarshalBoolean(bool(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
 func (ec *executionContext) unmarshalNDarkMode2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐPrefs(ctx context.Context, v interface{}) (*model.Prefs, error) {
 	res, err := model.UnmarshalPreferences(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -3784,6 +3994,21 @@ func (ec *executionContext) marshalNPoint2ᚖgithubᚗcomᚋ99designsᚋgqlgen�
 		return graphql.Null
 	}
 	return v
+}
+
+func (ec *executionContext) unmarshalNString2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋexternalᚐManufacturer(ctx context.Context, v interface{}) (external.Manufacturer, error) {
+	res, err := graphql.UnmarshalString(v)
+	return external.Manufacturer(res), graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNString2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋexternalᚐManufacturer(ctx context.Context, sel ast.SelectionSet, v external.Manufacturer) graphql.Marshaler {
+	res := graphql.MarshalString(string(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v interface{}) (string, error) {

--- a/_examples/scalars/model/model.go
+++ b/_examples/scalars/model/model.go
@@ -12,7 +12,11 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 )
 
-type Banned bool
+type (
+	Banned      bool
+	LoginBanned bool
+	QueryBanned = bool
+)
 
 func (b Banned) MarshalGQL(w io.Writer) {
 	if b {
@@ -36,15 +40,18 @@ func (b *Banned) UnmarshalGQL(v interface{}) error {
 }
 
 type User struct {
-	ID       external.ObjectID
-	Name     string
-	Created  time.Time  // direct binding to builtin types with external Marshal/Unmarshal methods
-	Modified *time.Time // direct binding to builtin types with external Marshal/Unmarshal methods
-	ValPrefs Prefs      // external un/marshal that act on pointers
-	PtrPrefs *Prefs
-	IsBanned Banned
-	Address  Address
-	Tier     Tier
+	ID              external.ObjectID
+	Name            string
+	Created         time.Time  // direct binding to builtin types with external Marshal/Unmarshal methods
+	Modified        *time.Time // direct binding to builtin types with external Marshal/Unmarshal methods
+	ValPrefs        Prefs      // external un/marshal that act on pointers
+	PtrPrefs        *Prefs
+	IsBanned        Banned
+	IsLoginBanned   LoginBanned
+	IsQueryBanned   QueryBanned
+	Address         Address
+	Tier            Tier
+	CarManufacturer external.Manufacturer
 }
 
 // Point is serialized as a simple array, eg [1, 2]

--- a/_examples/scalars/resolvers.go
+++ b/_examples/scalars/resolvers.go
@@ -29,11 +29,14 @@ func (r *queryResolver) UserByTier(ctx context.Context, tier model.Tier, darkMod
 
 func (r *queryResolver) User(ctx context.Context, id external.ObjectID) (*model.User, error) {
 	return &model.User{
-		ID:      id,
-		Name:    fmt.Sprintf("Test User %d", id),
-		Created: time.Now(),
-		Address: model.Address{ID: 1, Location: &model.Point{X: 1, Y: 2}},
-		Tier:    model.TierC,
+		ID:              id,
+		Name:            fmt.Sprintf("Test User %d", id),
+		Created:         time.Now(),
+		Address:         model.Address{ID: 1, Location: &model.Point{X: 1, Y: 2}},
+		Tier:            model.TierC,
+		CarManufacturer: external.ManufacturerTesla,
+		IsLoginBanned:   true,
+		IsQueryBanned:   true,
 	}, nil
 }
 
@@ -50,18 +53,20 @@ func (r *queryResolver) Search(ctx context.Context, input *model.SearchArgs) ([]
 
 	return []*model.User{
 		{
-			ID:      1,
-			Name:    "Test User 1",
-			Created: created,
-			Address: model.Address{ID: 2, Location: &location},
-			Tier:    model.TierA,
+			ID:              1,
+			Name:            "Test User 1",
+			Created:         created,
+			Address:         model.Address{ID: 2, Location: &location},
+			Tier:            model.TierA,
+			CarManufacturer: external.ManufacturerHonda,
 		},
 		{
-			ID:      2,
-			Name:    "Test User 2",
-			Created: created,
-			Address: model.Address{ID: 1, Location: &location},
-			Tier:    model.TierC,
+			ID:              2,
+			Name:            "Test User 2",
+			Created:         created,
+			Address:         model.Address{ID: 1, Location: &location},
+			Tier:            model.TierC,
+			CarManufacturer: external.ManufacturerToyota,
 		},
 	}, nil
 }

--- a/_examples/scalars/scalar_test.go
+++ b/_examples/scalars/scalar_test.go
@@ -18,6 +18,10 @@ type RawUser struct {
 	PrimitiveResolver string
 	CustomResolver    string
 	Tier              string
+	CarManufacturer   string
+	IsBanned          bool
+	IsLoginBanned     bool
+	IsQueryBanned     bool
 }
 
 func TestScalars(t *testing.T) {
@@ -53,6 +57,24 @@ func TestScalars(t *testing.T) {
 		err := c.Post(`{ search {  address { location }  } }`, &resp)
 		require.NoError(t, err)
 		require.Equal(t, "37,144", resp.Search[0].Address.Location)
+	})
+
+	t.Run("remote named string", func(t *testing.T) {
+		var resp struct{ User RawUser }
+
+		err := c.Post(`{ user(id:"=1=") { carManufacturer } }`, &resp)
+		require.NoError(t, err)
+		require.Equal(t, "TESLA", resp.User.CarManufacturer)
+	})
+
+	t.Run("alias declaration and type definition", func(t *testing.T) {
+		var resp struct{ User RawUser }
+
+		err := c.Post(`{ user(id:"=1=") { isBanned isLoginBanned isQueryBanned } }`, &resp)
+		require.NoError(t, err)
+		require.Equal(t, false, resp.User.IsBanned)
+		require.Equal(t, true, resp.User.IsLoginBanned)
+		require.Equal(t, true, resp.User.IsQueryBanned)
 	})
 
 	t.Run("custom error messages", func(t *testing.T) {

--- a/_examples/scalars/schema.graphql
+++ b/_examples/scalars/schema.graphql
@@ -1,6 +1,6 @@
 type Query {
     user(id: ID!): User
-    search(input: SearchArgs = {location: "37,144", isBanned: false}): [User!]!
+    search(input: SearchArgs = { location: "37,144", isBanned: false }): [User!]!
     userByTier(tier: Tier!, darkMode: DarkMode!): [User!]!
 }
 
@@ -12,10 +12,13 @@ type User {
     valPrefs: DarkMode
     ptrPrefs: DarkMode
     isBanned: Banned!
+    isLoginBanned: Boolean!
+    isQueryBanned: Boolean!
     primitiveResolver: String!
     customResolver: Point!
     address: Address
     tier: Tier
+    carManufacturer: String!
 }
 
 type Address {

--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -252,6 +252,15 @@ func (t *TypeReference) IsStruct() bool {
 	return isStruct
 }
 
+func (t *TypeReference) IsUnderlyingBasic() bool {
+	_, isUnderlyingBasic := t.GO.Underlying().(*types.Basic)
+	return isUnderlyingBasic
+}
+
+func (t *TypeReference) IsScalarID() bool {
+	return t.Definition.Kind == ast.Scalar && t.Marshaler.Name() == "MarshalID"
+}
+
 func (t *TypeReference) IsScalar() bool {
 	return t.Definition.Kind == ast.Scalar
 }

--- a/codegen/type.gotpl
+++ b/codegen/type.gotpl
@@ -56,6 +56,8 @@
 						return *res, graphql.ErrorOnPath(ctx, err)
 					{{- else if and (not $type.IsTargetNilable) $type.IsNilable }}
 						return &res, graphql.ErrorOnPath(ctx, err)
+					{{- else if and $type.IsNamed $type.Definition.BuiltIn (not $type.IsScalarID) }}
+						return {{ $type.GO | ref }}(res), graphql.ErrorOnPath(ctx, err)
 					{{- else}}
 						return res, graphql.ErrorOnPath(ctx, err)
 					{{- end }}
@@ -172,7 +174,11 @@
 					{{- else if and (not $type.IsTargetNilable) $type.IsNilable }}
 						{{- $v = "*v" }}
 					{{- end }}
-					res := {{ $type.Marshaler | call }}({{- if $type.CastType }}{{ $type.CastType | ref }}({{ $v }}){{else}}{{ $v }}{{- end }})
+					{{- if and $type.IsNamed $type.Definition.BuiltIn (not $type.IsScalarID) }}
+						res := {{ $type.Marshaler | call }}({{- if and $type.GO.Underlying $type.IsUnderlyingBasic }}{{ $type.GO.Underlying | ref }}({{ $v }}){{else}}{{ $v }}{{- end }})
+					{{- else }}
+						res := {{ $type.Marshaler | call }}({{- if $type.CastType }}{{ $type.CastType | ref }}({{ $v }}){{else}}{{ $v }}{{- end }})
+					{{- end }}
 					{{- if $type.GQL.NonNull }}
 						if res == graphql.Null {
 							if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {

--- a/integration/generated.go
+++ b/integration/generated.go
@@ -49,7 +49,7 @@ type DirectiveRoot struct {
 }
 
 type ComplexityRoot struct {
-	DummyUserWithRemoteNamedBasics struct {
+	DefinedTypeFromBasics struct {
 		NewBool    func(childComplexity int) int
 		NewFloat64 func(childComplexity int) int
 		NewID      func(childComplexity int) int
@@ -123,61 +123,61 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 	_ = ec
 	switch typeName + "." + field {
 
-	case "DummyUserWithRemoteNamedBasics.newBool":
-		if e.complexity.DummyUserWithRemoteNamedBasics.NewBool == nil {
+	case "DefinedTypeFromBasics.newBool":
+		if e.complexity.DefinedTypeFromBasics.NewBool == nil {
 			break
 		}
 
-		return e.complexity.DummyUserWithRemoteNamedBasics.NewBool(childComplexity), true
+		return e.complexity.DefinedTypeFromBasics.NewBool(childComplexity), true
 
-	case "DummyUserWithRemoteNamedBasics.newFloat64":
-		if e.complexity.DummyUserWithRemoteNamedBasics.NewFloat64 == nil {
+	case "DefinedTypeFromBasics.newFloat64":
+		if e.complexity.DefinedTypeFromBasics.NewFloat64 == nil {
 			break
 		}
 
-		return e.complexity.DummyUserWithRemoteNamedBasics.NewFloat64(childComplexity), true
+		return e.complexity.DefinedTypeFromBasics.NewFloat64(childComplexity), true
 
-	case "DummyUserWithRemoteNamedBasics.newID":
-		if e.complexity.DummyUserWithRemoteNamedBasics.NewID == nil {
+	case "DefinedTypeFromBasics.newID":
+		if e.complexity.DefinedTypeFromBasics.NewID == nil {
 			break
 		}
 
-		return e.complexity.DummyUserWithRemoteNamedBasics.NewID(childComplexity), true
+		return e.complexity.DefinedTypeFromBasics.NewID(childComplexity), true
 
-	case "DummyUserWithRemoteNamedBasics.newInt":
-		if e.complexity.DummyUserWithRemoteNamedBasics.NewInt == nil {
+	case "DefinedTypeFromBasics.newInt":
+		if e.complexity.DefinedTypeFromBasics.NewInt == nil {
 			break
 		}
 
-		return e.complexity.DummyUserWithRemoteNamedBasics.NewInt(childComplexity), true
+		return e.complexity.DefinedTypeFromBasics.NewInt(childComplexity), true
 
-	case "DummyUserWithRemoteNamedBasics.newInt32":
-		if e.complexity.DummyUserWithRemoteNamedBasics.NewInt32 == nil {
+	case "DefinedTypeFromBasics.newInt32":
+		if e.complexity.DefinedTypeFromBasics.NewInt32 == nil {
 			break
 		}
 
-		return e.complexity.DummyUserWithRemoteNamedBasics.NewInt32(childComplexity), true
+		return e.complexity.DefinedTypeFromBasics.NewInt32(childComplexity), true
 
-	case "DummyUserWithRemoteNamedBasics.newInt64":
-		if e.complexity.DummyUserWithRemoteNamedBasics.NewInt64 == nil {
+	case "DefinedTypeFromBasics.newInt64":
+		if e.complexity.DefinedTypeFromBasics.NewInt64 == nil {
 			break
 		}
 
-		return e.complexity.DummyUserWithRemoteNamedBasics.NewInt64(childComplexity), true
+		return e.complexity.DefinedTypeFromBasics.NewInt64(childComplexity), true
 
-	case "DummyUserWithRemoteNamedBasics.newString":
-		if e.complexity.DummyUserWithRemoteNamedBasics.NewString == nil {
+	case "DefinedTypeFromBasics.newString":
+		if e.complexity.DefinedTypeFromBasics.NewString == nil {
 			break
 		}
 
-		return e.complexity.DummyUserWithRemoteNamedBasics.NewString(childComplexity), true
+		return e.complexity.DefinedTypeFromBasics.NewString(childComplexity), true
 
-	case "DummyUserWithRemoteNamedBasics.newUint":
-		if e.complexity.DummyUserWithRemoteNamedBasics.NewUint == nil {
+	case "DefinedTypeFromBasics.newUint":
+		if e.complexity.DefinedTypeFromBasics.NewUint == nil {
 			break
 		}
 
-		return e.complexity.DummyUserWithRemoteNamedBasics.NewUint(childComplexity), true
+		return e.complexity.DefinedTypeFromBasics.NewUint(childComplexity), true
 
 	case "Element.child":
 		if e.complexity.Element.Child == nil {
@@ -501,8 +501,8 @@ func (ec *executionContext) field___Type_fields_args(ctx context.Context, rawArg
 
 // region    **************************** field.gotpl *****************************
 
-func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newString(ctx context.Context, field graphql.CollectedField, obj *remote_api.DummyUserWithRemoteNamedBasics) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_DummyUserWithRemoteNamedBasics_newString(ctx, field)
+func (ec *executionContext) _DefinedTypeFromBasics_newString(ctx context.Context, field graphql.CollectedField, obj *remote_api.DefinedTypeFromBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DefinedTypeFromBasics_newString(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -532,9 +532,9 @@ func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newString(ctx contex
 	return ec.marshalNString2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedString(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newString(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newString(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "DummyUserWithRemoteNamedBasics",
+		Object:     "DefinedTypeFromBasics",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -545,8 +545,8 @@ func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newStrin
 	return fc, nil
 }
 
-func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newInt(ctx context.Context, field graphql.CollectedField, obj *remote_api.DummyUserWithRemoteNamedBasics) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_DummyUserWithRemoteNamedBasics_newInt(ctx, field)
+func (ec *executionContext) _DefinedTypeFromBasics_newInt(ctx context.Context, field graphql.CollectedField, obj *remote_api.DefinedTypeFromBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DefinedTypeFromBasics_newInt(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -576,9 +576,9 @@ func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newInt(ctx context.C
 	return ec.marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newInt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newInt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "DummyUserWithRemoteNamedBasics",
+		Object:     "DefinedTypeFromBasics",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -589,8 +589,8 @@ func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newInt(c
 	return fc, nil
 }
 
-func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newInt32(ctx context.Context, field graphql.CollectedField, obj *remote_api.DummyUserWithRemoteNamedBasics) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_DummyUserWithRemoteNamedBasics_newInt32(ctx, field)
+func (ec *executionContext) _DefinedTypeFromBasics_newInt32(ctx context.Context, field graphql.CollectedField, obj *remote_api.DefinedTypeFromBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DefinedTypeFromBasics_newInt32(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -620,9 +620,9 @@ func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newInt32(ctx context
 	return ec.marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt32(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newInt32(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newInt32(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "DummyUserWithRemoteNamedBasics",
+		Object:     "DefinedTypeFromBasics",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -633,8 +633,8 @@ func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newInt32
 	return fc, nil
 }
 
-func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newInt64(ctx context.Context, field graphql.CollectedField, obj *remote_api.DummyUserWithRemoteNamedBasics) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_DummyUserWithRemoteNamedBasics_newInt64(ctx, field)
+func (ec *executionContext) _DefinedTypeFromBasics_newInt64(ctx context.Context, field graphql.CollectedField, obj *remote_api.DefinedTypeFromBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DefinedTypeFromBasics_newInt64(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -664,9 +664,9 @@ func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newInt64(ctx context
 	return ec.marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt64(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newInt64(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newInt64(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "DummyUserWithRemoteNamedBasics",
+		Object:     "DefinedTypeFromBasics",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -677,8 +677,8 @@ func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newInt64
 	return fc, nil
 }
 
-func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newBool(ctx context.Context, field graphql.CollectedField, obj *remote_api.DummyUserWithRemoteNamedBasics) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_DummyUserWithRemoteNamedBasics_newBool(ctx, field)
+func (ec *executionContext) _DefinedTypeFromBasics_newBool(ctx context.Context, field graphql.CollectedField, obj *remote_api.DefinedTypeFromBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DefinedTypeFromBasics_newBool(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -708,9 +708,9 @@ func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newBool(ctx context.
 	return ec.marshalNBoolean2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedBool(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newBool(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newBool(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "DummyUserWithRemoteNamedBasics",
+		Object:     "DefinedTypeFromBasics",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -721,8 +721,8 @@ func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newBool(
 	return fc, nil
 }
 
-func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newFloat64(ctx context.Context, field graphql.CollectedField, obj *remote_api.DummyUserWithRemoteNamedBasics) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_DummyUserWithRemoteNamedBasics_newFloat64(ctx, field)
+func (ec *executionContext) _DefinedTypeFromBasics_newFloat64(ctx context.Context, field graphql.CollectedField, obj *remote_api.DefinedTypeFromBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DefinedTypeFromBasics_newFloat64(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -752,9 +752,9 @@ func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newFloat64(ctx conte
 	return ec.marshalNFloat2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedFloat64(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newFloat64(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newFloat64(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "DummyUserWithRemoteNamedBasics",
+		Object:     "DefinedTypeFromBasics",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -765,8 +765,8 @@ func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newFloat
 	return fc, nil
 }
 
-func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newID(ctx context.Context, field graphql.CollectedField, obj *remote_api.DummyUserWithRemoteNamedBasics) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_DummyUserWithRemoteNamedBasics_newID(ctx, field)
+func (ec *executionContext) _DefinedTypeFromBasics_newID(ctx context.Context, field graphql.CollectedField, obj *remote_api.DefinedTypeFromBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DefinedTypeFromBasics_newID(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -796,9 +796,9 @@ func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newID(ctx context.Co
 	return ec.marshalNID2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedID(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "DummyUserWithRemoteNamedBasics",
+		Object:     "DefinedTypeFromBasics",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -809,8 +809,8 @@ func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newID(ct
 	return fc, nil
 }
 
-func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newUint(ctx context.Context, field graphql.CollectedField, obj *remote_api.DummyUserWithRemoteNamedBasics) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_DummyUserWithRemoteNamedBasics_newUint(ctx, field)
+func (ec *executionContext) _DefinedTypeFromBasics_newUint(ctx context.Context, field graphql.CollectedField, obj *remote_api.DefinedTypeFromBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DefinedTypeFromBasics_newUint(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -840,9 +840,9 @@ func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newUint(ctx context.
 	return ec.marshalNUint2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newUint(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newUint(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "DummyUserWithRemoteNamedBasics",
+		Object:     "DefinedTypeFromBasics",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -3528,68 +3528,68 @@ func (ec *executionContext) unmarshalInputListCoercion(ctx context.Context, obj 
 
 // region    **************************** object.gotpl ****************************
 
-var dummyUserWithRemoteNamedBasicsImplementors = []string{"DummyUserWithRemoteNamedBasics"}
+var definedTypeFromBasicsImplementors = []string{"DefinedTypeFromBasics"}
 
-func (ec *executionContext) _DummyUserWithRemoteNamedBasics(ctx context.Context, sel ast.SelectionSet, obj *remote_api.DummyUserWithRemoteNamedBasics) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, dummyUserWithRemoteNamedBasicsImplementors)
+func (ec *executionContext) _DefinedTypeFromBasics(ctx context.Context, sel ast.SelectionSet, obj *remote_api.DefinedTypeFromBasics) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, definedTypeFromBasicsImplementors)
 	out := graphql.NewFieldSet(fields)
 	var invalids uint32
 	for i, field := range fields {
 		switch field.Name {
 		case "__typename":
-			out.Values[i] = graphql.MarshalString("DummyUserWithRemoteNamedBasics")
+			out.Values[i] = graphql.MarshalString("DefinedTypeFromBasics")
 		case "newString":
 
-			out.Values[i] = ec._DummyUserWithRemoteNamedBasics_newString(ctx, field, obj)
+			out.Values[i] = ec._DefinedTypeFromBasics_newString(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
 		case "newInt":
 
-			out.Values[i] = ec._DummyUserWithRemoteNamedBasics_newInt(ctx, field, obj)
+			out.Values[i] = ec._DefinedTypeFromBasics_newInt(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
 		case "newInt32":
 
-			out.Values[i] = ec._DummyUserWithRemoteNamedBasics_newInt32(ctx, field, obj)
+			out.Values[i] = ec._DefinedTypeFromBasics_newInt32(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
 		case "newInt64":
 
-			out.Values[i] = ec._DummyUserWithRemoteNamedBasics_newInt64(ctx, field, obj)
+			out.Values[i] = ec._DefinedTypeFromBasics_newInt64(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
 		case "newBool":
 
-			out.Values[i] = ec._DummyUserWithRemoteNamedBasics_newBool(ctx, field, obj)
+			out.Values[i] = ec._DefinedTypeFromBasics_newBool(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
 		case "newFloat64":
 
-			out.Values[i] = ec._DummyUserWithRemoteNamedBasics_newFloat64(ctx, field, obj)
+			out.Values[i] = ec._DefinedTypeFromBasics_newFloat64(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
 		case "newID":
 
-			out.Values[i] = ec._DummyUserWithRemoteNamedBasics_newID(ctx, field, obj)
+			out.Values[i] = ec._DefinedTypeFromBasics_newID(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
 		case "newUint":
 
-			out.Values[i] = ec._DummyUserWithRemoteNamedBasics_newUint(ctx, field, obj)
+			out.Values[i] = ec._DefinedTypeFromBasics_newUint(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++

--- a/integration/generated.go
+++ b/integration/generated.go
@@ -49,6 +49,17 @@ type DirectiveRoot struct {
 }
 
 type ComplexityRoot struct {
+	DummyUserWithRemoteNamedBasics struct {
+		NewBool    func(childComplexity int) int
+		NewFloat64 func(childComplexity int) int
+		NewID      func(childComplexity int) int
+		NewInt     func(childComplexity int) int
+		NewInt32   func(childComplexity int) int
+		NewInt64   func(childComplexity int) int
+		NewString  func(childComplexity int) int
+		NewUint    func(childComplexity int) int
+	}
+
 	Element struct {
 		Child      func(childComplexity int) int
 		Error      func(childComplexity int) int
@@ -111,6 +122,62 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 	ec := executionContext{nil, e}
 	_ = ec
 	switch typeName + "." + field {
+
+	case "DummyUserWithRemoteNamedBasics.newBool":
+		if e.complexity.DummyUserWithRemoteNamedBasics.NewBool == nil {
+			break
+		}
+
+		return e.complexity.DummyUserWithRemoteNamedBasics.NewBool(childComplexity), true
+
+	case "DummyUserWithRemoteNamedBasics.newFloat64":
+		if e.complexity.DummyUserWithRemoteNamedBasics.NewFloat64 == nil {
+			break
+		}
+
+		return e.complexity.DummyUserWithRemoteNamedBasics.NewFloat64(childComplexity), true
+
+	case "DummyUserWithRemoteNamedBasics.newID":
+		if e.complexity.DummyUserWithRemoteNamedBasics.NewID == nil {
+			break
+		}
+
+		return e.complexity.DummyUserWithRemoteNamedBasics.NewID(childComplexity), true
+
+	case "DummyUserWithRemoteNamedBasics.newInt":
+		if e.complexity.DummyUserWithRemoteNamedBasics.NewInt == nil {
+			break
+		}
+
+		return e.complexity.DummyUserWithRemoteNamedBasics.NewInt(childComplexity), true
+
+	case "DummyUserWithRemoteNamedBasics.newInt32":
+		if e.complexity.DummyUserWithRemoteNamedBasics.NewInt32 == nil {
+			break
+		}
+
+		return e.complexity.DummyUserWithRemoteNamedBasics.NewInt32(childComplexity), true
+
+	case "DummyUserWithRemoteNamedBasics.newInt64":
+		if e.complexity.DummyUserWithRemoteNamedBasics.NewInt64 == nil {
+			break
+		}
+
+		return e.complexity.DummyUserWithRemoteNamedBasics.NewInt64(childComplexity), true
+
+	case "DummyUserWithRemoteNamedBasics.newString":
+		if e.complexity.DummyUserWithRemoteNamedBasics.NewString == nil {
+			break
+		}
+
+		return e.complexity.DummyUserWithRemoteNamedBasics.NewString(childComplexity), true
+
+	case "DummyUserWithRemoteNamedBasics.newUint":
+		if e.complexity.DummyUserWithRemoteNamedBasics.NewUint == nil {
+			break
+		}
+
+		return e.complexity.DummyUserWithRemoteNamedBasics.NewUint(childComplexity), true
 
 	case "Element.child":
 		if e.complexity.Element.Child == nil {
@@ -433,6 +500,358 @@ func (ec *executionContext) field___Type_fields_args(ctx context.Context, rawArg
 // endregion ************************** directives.gotpl **************************
 
 // region    **************************** field.gotpl *****************************
+
+func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newString(ctx context.Context, field graphql.CollectedField, obj *remote_api.DummyUserWithRemoteNamedBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DummyUserWithRemoteNamedBasics_newString(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NewString, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(testomitempty.NamedString)
+	fc.Result = res
+	return ec.marshalNString2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedString(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newString(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DummyUserWithRemoteNamedBasics",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newInt(ctx context.Context, field graphql.CollectedField, obj *remote_api.DummyUserWithRemoteNamedBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DummyUserWithRemoteNamedBasics_newInt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NewInt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(testomitempty.NamedInt)
+	fc.Result = res
+	return ec.marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newInt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DummyUserWithRemoteNamedBasics",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newInt32(ctx context.Context, field graphql.CollectedField, obj *remote_api.DummyUserWithRemoteNamedBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DummyUserWithRemoteNamedBasics_newInt32(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NewInt32, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(testomitempty.NamedInt32)
+	fc.Result = res
+	return ec.marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt32(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newInt32(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DummyUserWithRemoteNamedBasics",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newInt64(ctx context.Context, field graphql.CollectedField, obj *remote_api.DummyUserWithRemoteNamedBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DummyUserWithRemoteNamedBasics_newInt64(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NewInt64, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(testomitempty.NamedInt64)
+	fc.Result = res
+	return ec.marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newInt64(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DummyUserWithRemoteNamedBasics",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newBool(ctx context.Context, field graphql.CollectedField, obj *remote_api.DummyUserWithRemoteNamedBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DummyUserWithRemoteNamedBasics_newBool(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NewBool, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(testomitempty.NamedBool)
+	fc.Result = res
+	return ec.marshalNBoolean2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedBool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newBool(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DummyUserWithRemoteNamedBasics",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newFloat64(ctx context.Context, field graphql.CollectedField, obj *remote_api.DummyUserWithRemoteNamedBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DummyUserWithRemoteNamedBasics_newFloat64(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NewFloat64, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(testomitempty.NamedFloat64)
+	fc.Result = res
+	return ec.marshalNFloat2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedFloat64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newFloat64(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DummyUserWithRemoteNamedBasics",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newID(ctx context.Context, field graphql.CollectedField, obj *remote_api.DummyUserWithRemoteNamedBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DummyUserWithRemoteNamedBasics_newID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NewID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(testomitempty.NamedID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DummyUserWithRemoteNamedBasics",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DummyUserWithRemoteNamedBasics_newUint(ctx context.Context, field graphql.CollectedField, obj *remote_api.DummyUserWithRemoteNamedBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DummyUserWithRemoteNamedBasics_newUint(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NewUint, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(testomitempty.NamedUint)
+	fc.Result = res
+	return ec.marshalNUint2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DummyUserWithRemoteNamedBasics_newUint(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DummyUserWithRemoteNamedBasics",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Uint does not have child fields")
+		},
+	}
+	return fc, nil
+}
 
 func (ec *executionContext) _Element_child(ctx context.Context, field graphql.CollectedField, obj *models.Element) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Element_child(ctx, field)
@@ -3109,6 +3528,83 @@ func (ec *executionContext) unmarshalInputListCoercion(ctx context.Context, obj 
 
 // region    **************************** object.gotpl ****************************
 
+var dummyUserWithRemoteNamedBasicsImplementors = []string{"DummyUserWithRemoteNamedBasics"}
+
+func (ec *executionContext) _DummyUserWithRemoteNamedBasics(ctx context.Context, sel ast.SelectionSet, obj *remote_api.DummyUserWithRemoteNamedBasics) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, dummyUserWithRemoteNamedBasicsImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DummyUserWithRemoteNamedBasics")
+		case "newString":
+
+			out.Values[i] = ec._DummyUserWithRemoteNamedBasics_newString(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "newInt":
+
+			out.Values[i] = ec._DummyUserWithRemoteNamedBasics_newInt(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "newInt32":
+
+			out.Values[i] = ec._DummyUserWithRemoteNamedBasics_newInt32(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "newInt64":
+
+			out.Values[i] = ec._DummyUserWithRemoteNamedBasics_newInt64(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "newBool":
+
+			out.Values[i] = ec._DummyUserWithRemoteNamedBasics_newBool(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "newFloat64":
+
+			out.Values[i] = ec._DummyUserWithRemoteNamedBasics_newFloat64(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "newID":
+
+			out.Values[i] = ec._DummyUserWithRemoteNamedBasics_newID(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "newUint":
+
+			out.Values[i] = ec._DummyUserWithRemoteNamedBasics_newUint(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var elementImplementors = []string{"Element"}
 
 func (ec *executionContext) _Element(ctx context.Context, sel ast.SelectionSet, obj *models.Element) graphql.Marshaler {
@@ -3796,6 +4292,21 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 	return res
 }
 
+func (ec *executionContext) unmarshalNBoolean2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedBool(ctx context.Context, v interface{}) (testomitempty.NamedBool, error) {
+	res, err := graphql.UnmarshalBoolean(v)
+	return testomitempty.NamedBool(res), graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNBoolean2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedBool(ctx context.Context, sel ast.SelectionSet, v testomitempty.NamedBool) graphql.Marshaler {
+	res := graphql.MarshalBoolean(bool(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
 func (ec *executionContext) unmarshalNDateFilter2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋmodelsᚑgoᚐDateFilter(ctx context.Context, v interface{}) (models.DateFilter, error) {
 	res, err := ec.unmarshalInputDateFilter(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -3813,6 +4324,81 @@ func (ec *executionContext) marshalNElement2ᚖgithubᚗcomᚋ99designsᚋgqlgen
 		return graphql.Null
 	}
 	return ec._Element(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNFloat2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedFloat64(ctx context.Context, v interface{}) (testomitempty.NamedFloat64, error) {
+	res, err := graphql.UnmarshalFloatContext(ctx, v)
+	return testomitempty.NamedFloat64(res), graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNFloat2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedFloat64(ctx context.Context, sel ast.SelectionSet, v testomitempty.NamedFloat64) graphql.Marshaler {
+	res := graphql.MarshalFloatContext(float64(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return graphql.WrapContextMarshaler(ctx, res)
+}
+
+func (ec *executionContext) unmarshalNID2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedID(ctx context.Context, v interface{}) (testomitempty.NamedID, error) {
+	res, err := remote_api.UnmarshalID(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNID2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedID(ctx context.Context, sel ast.SelectionSet, v testomitempty.NamedID) graphql.Marshaler {
+	res := remote_api.MarshalID(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt(ctx context.Context, v interface{}) (testomitempty.NamedInt, error) {
+	res, err := graphql.UnmarshalInt(v)
+	return testomitempty.NamedInt(res), graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt(ctx context.Context, sel ast.SelectionSet, v testomitempty.NamedInt) graphql.Marshaler {
+	res := graphql.MarshalInt(int(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt32(ctx context.Context, v interface{}) (testomitempty.NamedInt32, error) {
+	res, err := graphql.UnmarshalInt32(v)
+	return testomitempty.NamedInt32(res), graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt32(ctx context.Context, sel ast.SelectionSet, v testomitempty.NamedInt32) graphql.Marshaler {
+	res := graphql.MarshalInt32(int32(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt64(ctx context.Context, v interface{}) (testomitempty.NamedInt64, error) {
+	res, err := graphql.UnmarshalInt64(v)
+	return testomitempty.NamedInt64(res), graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt64(ctx context.Context, sel ast.SelectionSet, v testomitempty.NamedInt64) graphql.Marshaler {
+	res := graphql.MarshalInt64(int64(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
 }
 
 func (ec *executionContext) unmarshalNInt2int(ctx context.Context, v interface{}) (int, error) {
@@ -3833,6 +4419,21 @@ func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.Selecti
 func (ec *executionContext) unmarshalNListCoercion2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋmodelsᚑgoᚐListCoercion(ctx context.Context, v interface{}) (*models.ListCoercion, error) {
 	res, err := ec.unmarshalInputListCoercion(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNString2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedString(ctx context.Context, v interface{}) (testomitempty.NamedString, error) {
+	res, err := graphql.UnmarshalString(v)
+	return testomitempty.NamedString(res), graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNString2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedString(ctx context.Context, sel ast.SelectionSet, v testomitempty.NamedString) graphql.Marshaler {
+	res := graphql.MarshalString(string(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v interface{}) (string, error) {
@@ -3880,6 +4481,21 @@ func (ec *executionContext) marshalNString2ᚕstringᚄ(ctx context.Context, sel
 	}
 
 	return ret
+}
+
+func (ec *executionContext) unmarshalNUint2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint(ctx context.Context, v interface{}) (testomitempty.NamedUint, error) {
+	res, err := remote_api.UnmarshalUint(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUint2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint(ctx context.Context, sel ast.SelectionSet, v testomitempty.NamedUint) graphql.Marshaler {
+	res := remote_api.MarshalUint(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {

--- a/integration/gqlgen.yml
+++ b/integration/gqlgen.yml
@@ -15,6 +15,7 @@ struct_tag: json
 
 autobind:
   - "github.com/99designs/gqlgen/integration/testomitempty"
+  - "github.com/99designs/gqlgen/integration/remote_api"
 
 models:
   Element:
@@ -26,3 +27,7 @@ models:
     fields:
       likes:
         resolver: true
+  Uint:
+    model: github.com/99designs/gqlgen/integration/remote_api.Uint
+  ID:
+    model: github.com/99designs/gqlgen/integration/remote_api.ID

--- a/integration/remote_api/user.go
+++ b/integration/remote_api/user.go
@@ -14,7 +14,7 @@ type User struct {
 	Likes []string
 }
 
-type DummyUserWithRemoteNamedBasics struct {
+type DefinedTypeFromBasics struct {
 	NewString  testomitempty.NamedString  `json:"newString"`
 	NewInt     testomitempty.NamedInt     `json:"newInt"`
 	NewInt8    testomitempty.NamedInt8    `json:"newInt8"`

--- a/integration/remote_api/user.go
+++ b/integration/remote_api/user.go
@@ -1,6 +1,67 @@
 package remote_api
 
+import (
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/99designs/gqlgen/integration/testomitempty"
+)
+
 type User struct {
 	Name  string
 	Likes []string
+}
+
+type DummyUserWithRemoteNamedBasics struct {
+	NewString  testomitempty.NamedString  `json:"newString"`
+	NewInt     testomitempty.NamedInt     `json:"newInt"`
+	NewInt8    testomitempty.NamedInt8    `json:"newInt8"`
+	NewInt16   testomitempty.NamedInt16   `json:"newInt16"`
+	NewInt32   testomitempty.NamedInt32   `json:"newInt32"`
+	NewInt64   testomitempty.NamedInt64   `json:"newInt64"`
+	NewBool    testomitempty.NamedBool    `json:"newBool"`
+	NewFloat32 testomitempty.NamedFloat32 `json:"newFloat32"`
+	NewFloat64 testomitempty.NamedFloat64 `json:"newFloat64"`
+	NewUint    testomitempty.NamedUint    `json:"newUint"`
+	NewUint8   testomitempty.NamedUint8   `json:"newUint8"`
+	NewUint16  testomitempty.NamedUint16  `json:"newUint16"`
+	NewUint32  testomitempty.NamedUint32  `json:"newUint32"`
+	NewUint64  testomitempty.NamedUint64  `json:"newUint64"`
+	NewID      testomitempty.NamedID      `json:"newID"`
+}
+
+// Lets redefine the base Uint type to use an id from an external library
+func MarshalUint(id testomitempty.NamedUint) graphql.Marshaler {
+	return graphql.WriterFunc(func(w io.Writer) {
+		io.WriteString(w, strconv.Quote(fmt.Sprintf("=%d=", id)))
+	})
+}
+
+// And the same for the unmarshaler
+func UnmarshalUint(v interface{}) (testomitempty.NamedUint, error) {
+	str, ok := v.(string)
+	if !ok {
+		return 0, fmt.Errorf("ids must be strings")
+	}
+	i, err := strconv.Atoi(str[1 : len(str)-1])
+	return testomitempty.NamedUint(i), err
+}
+
+// Lets redefine the base ID type to use an id from an external library
+func MarshalID(id testomitempty.NamedID) graphql.Marshaler {
+	return graphql.WriterFunc(func(w io.Writer) {
+		io.WriteString(w, strconv.Quote(fmt.Sprintf("=%d=", id)))
+	})
+}
+
+// And the same for the unmarshaler
+func UnmarshalID(v interface{}) (testomitempty.NamedID, error) {
+	str, ok := v.(string)
+	if !ok {
+		return 0, fmt.Errorf("ids must be strings")
+	}
+	i, err := strconv.Atoi(str[1 : len(str)-1])
+	return testomitempty.NamedID(i), err
 }

--- a/integration/schema-expected.graphql
+++ b/integration/schema-expected.graphql
@@ -16,7 +16,7 @@ input DateFilter {
   value: String!
 }
 
-type DummyUserWithRemoteNamedBasics {
+type DefinedTypeFromBasics {
   newBool: Boolean!
   newFloat64: Float!
   newID: ID!

--- a/integration/schema-expected.graphql
+++ b/integration/schema-expected.graphql
@@ -16,6 +16,17 @@ input DateFilter {
   value: String!
 }
 
+type DummyUserWithRemoteNamedBasics {
+  newBool: Boolean!
+  newFloat64: Float!
+  newID: ID!
+  newInt: Int!
+  newInt32: Int!
+  newInt64: Int!
+  newString: String!
+  newUint: Uint!
+}
+
 type Element {
   child: Element!
   error: Boolean!
@@ -49,6 +60,8 @@ type Query {
 type RemoteModelWithOmitempty {
   newDesc: String
 }
+
+scalar Uint
 
 type User {
   likes: [String!]!

--- a/integration/testomitempty.graphql
+++ b/integration/testomitempty.graphql
@@ -2,7 +2,7 @@ type RemoteModelWithOmitempty {
     newDesc: String
 }
 
-type DummyUserWithRemoteNamedBasics {
+type DefinedTypeFromBasics {
     newString: String!
     newInt: Int!
     newInt32: Int!

--- a/integration/testomitempty.graphql
+++ b/integration/testomitempty.graphql
@@ -1,3 +1,25 @@
 type RemoteModelWithOmitempty {
     newDesc: String
 }
+
+type DummyUserWithRemoteNamedBasics {
+    newString: String!
+    newInt: Int!
+    newInt32: Int!
+    newInt64: Int!
+    newBool: Boolean!
+    newFloat64: Float!
+    newID: ID!
+
+    ### BELOW ARE NOT SUPPORTED AS BASIC - MUST CREATE SCALAR WITH MARSHALFUNC AND UNMARSHARLFUNC ###
+    #newInt8: Int!
+    #newInt16: Int!
+    #newFloat32: Float!
+    newUint: Uint! # scalar created for uint
+    #newUint8: Int!
+    #newUint16: Int!
+    #newUint32: Int!
+    #newUint64: Int!
+}
+
+scalar Uint

--- a/integration/testomitempty/testmodel.go
+++ b/integration/testomitempty/testmodel.go
@@ -1,5 +1,23 @@
 package testomitempty
 
+type (
+	NamedString  string
+	NamedInt     int
+	NamedInt8    int8
+	NamedInt16   int16
+	NamedInt32   int32
+	NamedInt64   int64
+	NamedBool    bool
+	NamedFloat32 float32
+	NamedFloat64 float64
+	NamedUint    uint
+	NamedUint8   uint8
+	NamedUint16  uint16
+	NamedUint32  uint32
+	NamedUint64  uint64
+	NamedID      int
+)
+
 type RemoteModelWithOmitempty struct {
 	Description string `json:"newDesc,omitempty"`
 }

--- a/internal/code/compare.go
+++ b/internal/code/compare.go
@@ -39,12 +39,19 @@ func CompatibleTypes(expected types.Type, actual types.Type) error {
 		}
 
 	case *types.Basic:
-		if actual, ok := actual.(*types.Basic); ok {
-			if actual.Kind() != expected.Kind() {
-				return fmt.Errorf("basic kind differs, %s != %s", expected.Name(), actual.Name())
+		if actualBasic, ok := actual.(*types.Basic); ok {
+			if actualBasic.Kind() != expected.Kind() {
+				return fmt.Errorf("basic kind differs, %s != %s", expected.Name(), actualBasic.Name())
 			}
 
 			return nil
+		} else if actual, ok := actual.(*types.Named); ok {
+			if underlyingBasic, ok := actual.Underlying().(*types.Basic); ok {
+				if underlyingBasic.Kind() != expected.Kind() {
+					return fmt.Errorf("basic kind differs with underlying, %s != %s", expected.Name(), underlyingBasic.Name())
+				}
+				return nil
+			}
 		}
 
 	case *types.Struct:

--- a/internal/code/compare.go
+++ b/internal/code/compare.go
@@ -47,10 +47,7 @@ func CompatibleTypes(expected types.Type, actual types.Type) error {
 			return nil
 		} else if actual, ok := actual.(*types.Named); ok {
 			if underlyingBasic, ok := actual.Underlying().(*types.Basic); ok {
-				if underlyingBasic.Kind() != expected.Kind() {
-					return fmt.Errorf("basic kind differs with underlying, %s != %s", expected.Name(), underlyingBasic.Name())
-				}
-				return nil
+				return CompatibleTypes(expected, underlyingBasic)
 			}
 		}
 


### PR DESCRIPTION
### Fixes #2485 : Defined type from a basic type should not require a scalar

Before this PR, running `go generate` when using a defined type from a basic type (string, int, boolean, float) that are then used in go struct will display an error message saying `<type> is incompatible with <named_type>`. We would then need to create a `scalar` with its related `MarshalFunc` and `UnmarshalFunc` to remove the error message. This will lead to many copy-pastes of the same MarshalFunc and UnmarshalFunc with only the type being changed.

After this PR gqlgen will support the following cases (see Go spec: https://go.dev/ref/spec#Type_declarations):
- GraphQL scalar with custom marshalling/unmarshalling
- a type definition from a basic type **without** a custom scalar and `MarshalFunc` and `UnmarshalFunc`
- an alias declaration **without** a custom scalar and `MarshalFunc` and `UnmarshalFunc`

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
