### PR TITLE
Add Server-Sent Events transport

### DIFF
--- a/_examples/chat/package.json
+++ b/_examples/chat/package.json
@@ -6,17 +6,20 @@
     "@apollo/client": "^3.2.3",
     "apollo-utilities": "^1.0.26",
     "graphql": "^14.0.2",
+    "graphql-sse": "^2.0.0",
     "graphql-tag": "^2.10.0",
     "graphql-ws": "^5.8.1",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
     "react-scripts": "^2.1.1",
     "styled-components": "^5.2.0",
-    "subscriptions-transport-ws": "^0.9.5"
+    "subscriptions-transport-ws": "^0.9.5",
+    "typescript": "^4.9.4"
   },
   "scripts": {
     "start": "react-scripts start",
     "start:graphql-transport-ws": "REACT_APP_WS_PROTOCOL=graphql-transport-ws npm run start",
+    "start:graphql-sse": "REACT_APP_SSE_PROTOCOL=true npm run start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"

--- a/_examples/chat/readme.md
+++ b/_examples/chat/readme.md
@@ -32,3 +32,9 @@ or to run the app with the `graphql-ws` implementation (and the newer `graphql-t
 ```bash
 npm run start:graphql-transport-ws
 ```
+
+or to run the app with the `graphql-sse` implementation do
+
+```bash
+npm run start:graphql-sse
+```

--- a/_examples/chat/server/server.go
+++ b/_examples/chat/server/server.go
@@ -31,6 +31,7 @@ func main() {
 
 	srv := handler.New(chat.NewExecutableSchema(chat.New()))
 
+	srv.AddTransport(transport.SSE{})
 	srv.AddTransport(transport.POST{})
 	srv.AddTransport(transport.Websocket{
 		KeepAlivePingInterval: 10 * time.Second,

--- a/_examples/chat/src/graphql-sse.ts
+++ b/_examples/chat/src/graphql-sse.ts
@@ -1,0 +1,30 @@
+import {
+    ApolloLink,
+    Operation,
+    FetchResult,
+    Observable,
+} from '@apollo/client/core';
+import { print } from 'graphql';
+import { createClient, ClientOptions, Client } from 'graphql-sse';
+
+export class SSELink extends ApolloLink {
+    private client: Client;
+
+    constructor(options: ClientOptions) {
+        super();
+        this.client = createClient(options);
+    }
+
+    public request(operation: Operation): Observable<FetchResult> {
+        return new Observable((sink) => {
+            return this.client.subscribe<FetchResult>(
+                { ...operation, query: print(operation.query) },
+                    {
+                        next: sink.next.bind(sink),
+                        complete: sink.complete.bind(sink),
+                        error: sink.error.bind(sink),
+                    },
+            );
+        });
+    }
+}

--- a/_examples/chat/src/index.js
+++ b/_examples/chat/src/index.js
@@ -11,14 +11,17 @@ import { WebSocketLink as ApolloWebSocketLink} from '@apollo/client/link/ws';
 import { getMainDefinition } from 'apollo-utilities';
 import { App } from './App';
 import { WebSocketLink as GraphQLWSWebSocketLink } from './graphql-ws'
+import { SSELink } from './graphql-sse';
 
-let wsLink;
-if (process.env.REACT_APP_WS_PROTOCOL === 'graphql-transport-ws') {
-    wsLink = new GraphQLWSWebSocketLink({
+let subscriptionLink;
+if (process.env.REACT_APP_SSE_PROTOCOL) {
+  subscriptionLink = new SSELink({ url: 'http://localhost:8085/query' });
+} else if (process.env.REACT_APP_WS_PROTOCOL === 'graphql-transport-ws') {
+    subscriptionLink = new GraphQLWSWebSocketLink({
         url: `ws://localhost:8085/query`
     });
 } else {
-    wsLink = new ApolloWebSocketLink({
+    subscriptionLink = new ApolloWebSocketLink({
         uri: `ws://localhost:8085/query`,
         options: {
             reconnect: true
@@ -36,7 +39,7 @@ const link = split(
         const { kind, operation } = getMainDefinition(query);
         return kind === 'OperationDefinition' && operation === 'subscription';
     },
-    wsLink,
+    subscriptionLink,
     httpLink,
 );
 

--- a/_examples/chat/tsconfig.json
+++ b/_examples/chat/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "preserve"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/graphql/handler/transport/sse.go
+++ b/graphql/handler/transport/sse.go
@@ -1,0 +1,108 @@
+package transport
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+	"io"
+	"log"
+	"mime"
+	"net/http"
+	"strings"
+)
+
+type SSE struct{}
+
+var _ graphql.Transport = SSE{}
+
+func (t SSE) Supports(r *http.Request) bool {
+	if !strings.Contains(r.Header.Get("Accept"), "text/event-stream") {
+		return false
+	}
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return false
+	}
+	return r.Method == http.MethodPost && mediaType == "application/json"
+}
+
+func (t SSE) Do(w http.ResponseWriter, r *http.Request, exec graphql.GraphExecutor) {
+	ctx := r.Context()
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		SendErrorf(w, http.StatusInternalServerError, "streaming unsupported")
+		return
+	}
+	defer flusher.Flush()
+
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Content-Type", "application/json")
+
+	params := &graphql.RawParams{}
+	start := graphql.Now()
+	params.Headers = r.Header
+	params.ReadTime = graphql.TraceTiming{
+		Start: start,
+		End:   graphql.Now(),
+	}
+
+	bodyString, err := getRequestBody(r)
+	if err != nil {
+		gqlErr := gqlerror.Errorf("could not get json request body: %+v", err)
+		resp := exec.DispatchError(ctx, gqlerror.List{gqlErr})
+		log.Printf("could not get json request body: %+v", err.Error())
+		writeJson(w, resp)
+		return
+	}
+
+	bodyReader := io.NopCloser(strings.NewReader(bodyString))
+	if err = jsonDecode(bodyReader, &params); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		gqlErr := gqlerror.Errorf(
+			"json request body could not be decoded: %+v body:%s",
+			err,
+			bodyString,
+		)
+		resp := exec.DispatchError(ctx, gqlerror.List{gqlErr})
+		log.Printf("decoding error: %+v body:%s", err.Error(), bodyString)
+		writeJson(w, resp)
+		return
+	}
+
+	rc, OpErr := exec.CreateOperationContext(ctx, params)
+	if OpErr != nil {
+		w.WriteHeader(statusFor(OpErr))
+		resp := exec.DispatchError(graphql.WithOperationContext(ctx, rc), OpErr)
+		writeJson(w, resp)
+		return
+	}
+
+	ctx = graphql.WithOperationContext(ctx, rc)
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	fmt.Fprint(w, ":\n\n")
+	flusher.Flush()
+
+	responses, ctx := exec.DispatchOperation(ctx, rc)
+
+	for {
+		response := responses(ctx)
+		if response == nil {
+			break
+		}
+		writeJsonWithSSE(w, response)
+		flusher.Flush()
+	}
+
+	fmt.Fprint(w, "event: complete\n\n")
+}
+
+func writeJsonWithSSE(w io.Writer, response *graphql.Response) {
+	b, err := json.Marshal(response)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Fprintf(w, "event: next\ndata: %s\n\n", b)
+}

--- a/graphql/handler/transport/sse.go
+++ b/graphql/handler/transport/sse.go
@@ -3,13 +3,15 @@ package transport
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/99designs/gqlgen/graphql"
-	"github.com/vektah/gqlparser/v2/gqlerror"
 	"io"
 	"log"
 	"mime"
 	"net/http"
 	"strings"
+
+	"github.com/vektah/gqlparser/v2/gqlerror"
+
+	"github.com/99designs/gqlgen/graphql"
 )
 
 type SSE struct{}

--- a/graphql/handler/transport/sse_test.go
+++ b/graphql/handler/transport/sse_test.go
@@ -2,15 +2,18 @@ package transport_test
 
 import (
 	"bufio"
-	"github.com/99designs/gqlgen/graphql/handler/testserver"
-	"github.com/99designs/gqlgen/graphql/handler/transport"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/99designs/gqlgen/graphql/handler/testserver"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 )
 
 func TestSSE(t *testing.T) {
@@ -88,8 +91,10 @@ func TestSSE(t *testing.T) {
 
 		var Client = &http.Client{}
 		req, err := createHTTPRequest(srv.URL, `{"query":"subscription { name }"}`)
+		require.NoError(t, err, "Create request threw error -> %s", err)
 		res, err := Client.Do(req)
-		assert.NoError(t, err, "Request threw error -> %s", err)
+		require.NoError(t, err, "Request threw error -> %s", err)
+		defer res.Body.Close()
 		assert.Equal(t, 200, res.StatusCode, "Request return wrong status -> %s", res.Status)
 		assert.Equal(t, "keep-alive", res.Header.Get("Connection"))
 		assert.Equal(t, "text/event-stream", res.Header.Get("Content-Type"))

--- a/graphql/handler/transport/sse_test.go
+++ b/graphql/handler/transport/sse_test.go
@@ -1,0 +1,129 @@
+package transport_test
+
+import (
+	"bufio"
+	"github.com/99designs/gqlgen/graphql/handler/testserver"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestSSE(t *testing.T) {
+	initialize := func(sse transport.SSE) *testserver.TestServer {
+		h := testserver.New()
+		h.AddTransport(sse)
+		return h
+	}
+
+	initializeWithServer := func(sse transport.SSE) (*testserver.TestServer, *httptest.Server) {
+		h := initialize(sse)
+		return h, httptest.NewServer(h)
+	}
+
+	createHTTPTestRequest := func(query string) *http.Request {
+		req := httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader(query))
+		req.Header.Set("Accept", "text/event-stream")
+		req.Header.Set("content-type", "application/json; charset=utf-8")
+		return req
+	}
+
+	createHTTPRequest := func(url string, query string) (*http.Request, error) {
+		req, err := http.NewRequest("POST", url, strings.NewReader(query))
+		assert.NoError(t, err, "Request threw error -> %s", err)
+		req.Header.Set("Accept", "text/event-stream")
+		req.Header.Set("content-type", "application/json; charset=utf-8")
+		return req, err
+	}
+
+	readLine := func(br *bufio.Reader) string {
+		bs, err := br.ReadString('\n')
+		if err != nil {
+			t.Fatal(err)
+		}
+		return bs
+	}
+
+	t.Run("stream failure", func(t *testing.T) {
+		h := initialize(transport.SSE{})
+		req := httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader(`{"query":"subscription { name }"}`))
+		req.Header.Set("content-type", "application/json; charset=utf-8")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		assert.Equal(t, 400, w.Code, "Request return wrong status -> %s", w.Code)
+		assert.Equal(t, `{"errors":[{"message":"transport not supported"}],"data":null}`, w.Body.String())
+	})
+
+	t.Run("decode failure", func(t *testing.T) {
+		h := initialize(transport.SSE{})
+		req := createHTTPTestRequest("notjson")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		assert.Equal(t, 400, w.Code, "Request return wrong status -> %s", w.Code)
+		assert.Equal(t, `{"errors":[{"message":"json request body could not be decoded: invalid character 'o' in literal null (expecting 'u') body:notjson"}],"data":null}`, w.Body.String())
+	})
+
+	t.Run("parse failure", func(t *testing.T) {
+		h := initialize(transport.SSE{})
+		req := createHTTPTestRequest(`{"query":"subscription {{ name }"}`)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		assert.Equal(t, 422, w.Code, "Request return wrong status -> %s", w.Code)
+	})
+
+	t.Run("subscribe", func(t *testing.T) {
+		handler, srv := initializeWithServer(transport.SSE{})
+		defer srv.Close()
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			handler.SendNextSubscriptionMessage()
+		}()
+
+		var Client = &http.Client{}
+		req, err := createHTTPRequest(srv.URL, `{"query":"subscription { name }"}`)
+		res, err := Client.Do(req)
+		assert.NoError(t, err, "Request threw error -> %s", err)
+		assert.Equal(t, 200, res.StatusCode, "Request return wrong status -> %s", res.Status)
+		assert.Equal(t, "keep-alive", res.Header.Get("Connection"))
+		assert.Equal(t, "text/event-stream", res.Header.Get("Content-Type"))
+
+		br := bufio.NewReader(res.Body)
+
+		assert.Equal(t, ":\n", readLine(br))
+		assert.Equal(t, "\n", readLine(br))
+		assert.Equal(t, "event: next\n", readLine(br))
+		assert.Equal(t, "data: {\"data\":{\"name\":\"test\"}}\n", readLine(br))
+		assert.Equal(t, "\n", readLine(br))
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			handler.SendNextSubscriptionMessage()
+		}()
+
+		assert.Equal(t, "event: next\n", readLine(br))
+		assert.Equal(t, "data: {\"data\":{\"name\":\"test\"}}\n", readLine(br))
+		assert.Equal(t, "\n", readLine(br))
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			handler.SendCompleteSubscriptionMessage()
+		}()
+
+		assert.Equal(t, "event: complete\n", readLine(br))
+		assert.Equal(t, "\n", readLine(br))
+
+		_, err = br.ReadByte()
+		assert.Equal(t, err, io.EOF)
+
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
Inspired by the feature request [#329](https://github.com/99designs/gqlgen/issues/329) and several [articles](https://hackernoon.com/graphql-subscriptions-using-ssefetch-over-websockets) about GraphQL subscriptions via Server-Sent Events, I started to implement an SSE transport that follows this [protocol specification](https://github.com/enisdenjo/graphql-sse/blob/master/PROTOCOL.md) and is compatible with the [graphql-sse](https://github.com/enisdenjo/graphql-sse) library at the _distinct connections mode_.
The result is this PR. Besides tests and documentation, I added an SSE option to the chat example as well. Please try it.

Remarks: I didn't want to change the `Supports(r *http.Request)` functions of the present transports to add a filter that rejects all `text/event-stream` requests, instead the order in which the transport  `Supports(r *http.Request)` are called is essential. This can of course be solved the other way around if desired.

Many thanks to the developers of gqlgen for this great library!