### PR TITLE
Add omit_complexity config option for issue #2502

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Directives                    map[string]DirectiveConfig `yaml:"directives,omitempty"`
 	OmitSliceElementPointers      bool                       `yaml:"omit_slice_element_pointers,omitempty"`
 	OmitGetters                   bool                       `yaml:"omit_getters,omitempty"`
+	OmitComplexity                bool                       `yaml:"omit_complexity,omitempty"`
 	StructFieldsAlwaysPointers    bool                       `yaml:"struct_fields_always_pointers,omitempty"`
 	ReturnPointersInUmarshalInput bool                       `yaml:"return_pointers_in_unmarshalinput,omitempty"`
 	ResolversAlwaysReturnPointers bool                       `yaml:"resolvers_always_return_pointers,omitempty"`

--- a/codegen/generated!.gotpl
+++ b/codegen/generated!.gotpl
@@ -51,6 +51,7 @@
 	}
 
 	type ComplexityRoot struct {
+	{{- if not .Config.OmitComplexity }}
 	{{ range $object := .Objects }}
 		{{ if not $object.IsReserved -}}
 			{{ ucFirst $object.Name }} struct {
@@ -63,6 +64,7 @@
 			}
 		{{- end }}
 	{{ end }}
+	{{- end }}
 	}
 {{ end }}
 
@@ -104,6 +106,7 @@
 	func (e *executableSchema) Complexity(typeName, field string, childComplexity int, rawArgs map[string]interface{}) (int, bool) {
 		ec := executionContext{nil, e}
 		_ = ec
+		{{ if not .Config.OmitComplexity -}}
 		switch typeName + "." + field {
 		{{ range $object := .Objects }}
 			{{ if not $object.IsReserved }}
@@ -130,6 +133,7 @@
 			{{ end }}
 		{{ end }}
 		}
+		{{- end }}
 		return 0, false
 	}
 

--- a/codegen/root_.gotpl
+++ b/codegen/root_.gotpl
@@ -49,6 +49,7 @@ type DirectiveRoot struct {
 }
 
 type ComplexityRoot struct {
+{{- if not .Config.OmitComplexity }}
 {{ range $object := .Objects }}
 	{{ if not $object.IsReserved -}}
 		{{ ucFirst $object.Name }} struct {
@@ -61,6 +62,7 @@ type ComplexityRoot struct {
 		}
 	{{- end }}
 {{ end }}
+{{- end }}
 }
 
 type executableSchema struct {
@@ -76,6 +78,7 @@ func (e *executableSchema) Schema() *ast.Schema {
 func (e *executableSchema) Complexity(typeName, field string, childComplexity int, rawArgs map[string]interface{}) (int, bool) {
 	ec := executionContext{nil, e}
 	_ = ec
+	{{ if not .Config.OmitComplexity }}
 	switch typeName + "." + field {
 	{{ range $object := .Objects }}
 		{{ if not $object.IsReserved }}
@@ -102,6 +105,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		{{ end }}
 	{{ end }}
 	}
+	{{- end }}
 	return 0, false
 }
 

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -44,6 +44,9 @@ resolver:
 # Optional: turn on to use []Thing instead of []*Thing
 # omit_slice_element_pointers: false
 
+# Optional: turn on to skip generation of ComplexityRoot struct content and Complexity function
+# omit_complexity: false
+
 # Optional: turn off to make struct-type struct fields not use pointers
 # e.g. type Thing struct { FieldA OtherThing } instead of { FieldA *OtherThing }
 # struct_fields_always_pointers: true


### PR DESCRIPTION
Full description in issue #2502 

Introduced a new config flag `omit_complexity`, which when set to `true` will skip the generation of the body of the following:
```
type ComplexityRoot struct {
  // empty struct
}
```

```
func (e *executableSchema) Complexity(typeName, field string, childComplexity int, rawArgs map[string]interface{}) (int, bool) {
  ec := executionContext{nil, e}
  _ = ec

  // switch statement is not generated

  return 0, false
}
```

Fixes the following compiler issue when GraphQL schema is too large: 
`<autogenerated>:1: internal compiler error: NewBulk too big: nbit=13244 count=1469951 nword=414 size=608559714`
