### PR TITLE
Enable Subscription Resolver to return websocket error message

### DIFF
--- a/_examples/chat/chat_test.go
+++ b/_examples/chat/chat_test.go
@@ -2,13 +2,14 @@ package chat
 
 import (
 	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"runtime"
-	"sync"
-	"testing"
 )
 
 func TestChatSubscriptions(t *testing.T) {

--- a/graphql/handler/apollofederatedtracingv1/generated/apollo_trace.pb.go
+++ b/graphql/handler/apollofederatedtracingv1/generated/apollo_trace.pb.go
@@ -7,11 +7,12 @@
 package generated
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -350,6 +350,7 @@ func (c *wsConnection) subscribe(start time.Time, msg *message) {
 	c.mu.Unlock()
 
 	go func() {
+		ctx = withSubscriptionErrorContext(ctx)
 		defer func() {
 			if r := recover(); r != nil {
 				err := rc.Recover(ctx, r)
@@ -362,7 +363,11 @@ func (c *wsConnection) subscribe(start time.Time, msg *message) {
 				}
 				c.sendError(msg.id, gqlerr)
 			}
-			c.complete(msg.id)
+			if errs := getSubscriptionError(ctx); len(errs) != 0 {
+				c.sendError(msg.id, errs...)
+			} else {
+				c.complete(msg.id)
+			}
 			c.mu.Lock()
 			delete(c.active, msg.id)
 			c.mu.Unlock()

--- a/graphql/handler/transport/websocket_resolver_error.go
+++ b/graphql/handler/transport/websocket_resolver_error.go
@@ -20,33 +20,35 @@ type subscriptionError struct {
 
 // AddSubscriptionError is used to let websocket return an error message after subscription resolver returns a channel.
 // for example:
-// func (r *subscriptionResolver) Method(ctx context.Context) (<-chan *model.Message, error) {
-//	ch := make(chan *model.Message)
-//	go func() {
-//      defer func() {
-//			close(ch)
-//      }
-//		// some kind of block processing (e.g.: gRPC client streaming)
-//		stream, err := gRPCClientStreamRequest(ctx)
-//		if err != nil {
-//			   transport.AddSubscriptionError(ctx, err)
-//             return // must return and close channel so websocket can send error back
-//      }
-//		for {
-//			m, err := stream.Recv()
-//			if err == io.EOF {
-//				return
-//			}
-//			if err != nil {
-//			   transport.AddSubscriptionError(ctx, err)
-//             return // must return and close channel so websocket can send error back
-//			}
-//			ch <- m
-//		}
-//	}()
 //
-//	return ch, nil
-//}
+//	func (r *subscriptionResolver) Method(ctx context.Context) (<-chan *model.Message, error) {
+//		ch := make(chan *model.Message)
+//		go func() {
+//	     defer func() {
+//				close(ch)
+//	     }
+//			// some kind of block processing (e.g.: gRPC client streaming)
+//			stream, err := gRPCClientStreamRequest(ctx)
+//			if err != nil {
+//				   transport.AddSubscriptionError(ctx, err)
+//	            return // must return and close channel so websocket can send error back
+//	     }
+//			for {
+//				m, err := stream.Recv()
+//				if err == io.EOF {
+//					return
+//				}
+//				if err != nil {
+//				   transport.AddSubscriptionError(ctx, err)
+//	            return // must return and close channel so websocket can send error back
+//				}
+//				ch <- m
+//			}
+//		}()
+//
+//		return ch, nil
+//	}
+//
 // see https://github.com/99designs/gqlgen/pull/2506 for more details
 func AddSubscriptionError(ctx context.Context, err *gqlerror.Error) {
 	subscriptionErrStruct := getSubscriptionErrorStruct(ctx)

--- a/graphql/handler/transport/websocket_resolver_error.go
+++ b/graphql/handler/transport/websocket_resolver_error.go
@@ -1,0 +1,65 @@
+package transport
+
+import (
+	"context"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+)
+
+// A private key for context that only this package can access. This is important
+// to prevent collisions between different context uses
+var wsSubscriptionErrorCtxKey = &wsSubscriptionErrorContextKey{"subscription-error"}
+
+type wsSubscriptionErrorContextKey struct {
+	name string
+}
+
+type subscriptionError struct {
+	errs []*gqlerror.Error
+}
+
+// AddSubscriptionError is used to let websocket return an error message after subscription resolver returns a channel.
+// for example:
+//func (r *subscriptionResolver) Method(ctx context.Context) (<-chan *model.Message, error) {
+//	ch := make(chan *model.Message)
+//	go func() {
+//      defer func() {
+//			close(ch)
+//      }
+//		// some kind of block processing (e.g.: gRPC client streaming)
+//		stream, err := gRPCClientStreamRequest(ctx)
+//		if err != nil {
+//			   transport.AddSubscriptionError(ctx, err)
+//             return // must return and close channel so websocket can send error back
+//      }
+//		for {
+//			m, err := stream.Recv()
+//			if err == io.EOF {
+//				return
+//			}
+//			if err != nil {
+//			   transport.AddSubscriptionError(ctx, err)
+//             return // must return and close channel so websocket can send error back
+//			}
+//			ch <- m
+//		}
+//	}()
+//
+//	return ch, nil
+//}
+func AddSubscriptionError(ctx context.Context, err *gqlerror.Error) {
+	subscriptionErrStruct := getSubscriptionErrorStruct(ctx)
+	subscriptionErrStruct.errs = append(subscriptionErrStruct.errs, err)
+}
+
+func withSubscriptionErrorContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, wsSubscriptionErrorCtxKey, &subscriptionError{})
+}
+
+func getSubscriptionErrorStruct(ctx context.Context) *subscriptionError {
+	v, _ := ctx.Value(wsSubscriptionErrorCtxKey).(*subscriptionError)
+	return v
+}
+
+func getSubscriptionError(ctx context.Context) []*gqlerror.Error {
+	return getSubscriptionErrorStruct(ctx).errs
+}

--- a/graphql/handler/transport/websocket_resolver_error.go
+++ b/graphql/handler/transport/websocket_resolver_error.go
@@ -46,6 +46,7 @@ type subscriptionError struct {
 //
 //	return ch, nil
 //}
+// see https://github.com/99designs/gqlgen/pull/2506 for more details
 func AddSubscriptionError(ctx context.Context, err *gqlerror.Error) {
 	subscriptionErrStruct := getSubscriptionErrorStruct(ctx)
 	subscriptionErrStruct.errs = append(subscriptionErrStruct.errs, err)

--- a/graphql/handler/transport/websocket_resolver_error.go
+++ b/graphql/handler/transport/websocket_resolver_error.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"context"
+
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
@@ -19,7 +20,7 @@ type subscriptionError struct {
 
 // AddSubscriptionError is used to let websocket return an error message after subscription resolver returns a channel.
 // for example:
-//func (r *subscriptionResolver) Method(ctx context.Context) (<-chan *model.Message, error) {
+// func (r *subscriptionResolver) Method(ctx context.Context) (<-chan *model.Message, error) {
 //	ch := make(chan *model.Message)
 //	go func() {
 //      defer func() {

--- a/plugin/federation/testdata/entityresolver/generated/errors.go
+++ b/plugin/federation/testdata/entityresolver/generated/errors.go
@@ -3,7 +3,6 @@ package generated
 import "errors"
 
 // Errors defined for retained code that we want to stick around between generations.
-//
 var (
 	ErrResolvingHelloWithErrorsByName         = errors.New("error resolving HelloWithErrorsByName")
 	ErrEmptyKeyResolvingHelloWithErrorsByName = errors.New("error (empty key) resolving HelloWithErrorsByName")

--- a/plugin/resolvergen/testdata/return_values/return_values_test.go
+++ b/plugin/resolvergen/testdata/return_values/return_values_test.go
@@ -1,9 +1,10 @@
 package return_values
 
 import (
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 //go:generate rm -f resolvers.go


### PR DESCRIPTION
Solve issue https://github.com/99designs/gqlgen/issues/1118

Currently there is no way of returning an error to client, after subscription resolver returns channel.
This is inconvenient because some clients have build-in retry on error message, and that is not going to work with gqlgen servers.

Ideally the subscriotion resolver should return an error channel as well, but this is going to be a breaking change.
Instead we can propagate error with context similar to `graphql.AddError`. This way the change would have no impact to existing users, and users can choose to opt into this behavior.

Tested on my local with resolver code:
```
func (r *SubscriptionResolver) Method(ctx context.Context, input models.Input) (<-chan *models.Response, error) {
	outputChan := make(chan *models.Response)

	streamClient, err := r.StreamClient.GetStream(ctx,toProto(input))
	if err != nil {
		return nil, mperror.Wrap(err, "fail to make grpc calls")
	}

	go func() {
		defer close(outputChan)
		for {
			outputProto, err :=  r.StreamClient.Recv()
			if err == io.EOF {
				return
			}

			if err != nil {
				transport.AddSubscriptionError(ctx, gqlerror.Errorf(err.Error()))
				return
			}

			outputModel := toModel(outputProto)

			select {
			case <-ctx.Done():
				return
			case outputChan <- outputModel:
				continue
			}
		}
	}()

	return outputChan, nil
}

![Screen Shot 2023-01-12 at 11 35 45 AM](https://user-images.githubusercontent.com/10200233/212168867-1024138f-a58a-4a56-8bd2-66ca2a02a13d.png)

According to the [spec](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#error), there should be no more message after error message, and this change adheres to the spec



I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
