### PR TITLE
fix #2485 for some types requiring a scalar

### DIFF
--- a/_examples/scalars/external/model.go
+++ b/_examples/scalars/external/model.go
@@ -3,6 +3,7 @@ package external
 type (
 	ObjectID     int
 	Manufacturer string // remote named string
+	Count        uint32 // remote named uint32
 )
 
 const (

--- a/_examples/scalars/generated.go
+++ b/_examples/scalars/generated.go
@@ -61,6 +61,8 @@ type ComplexityRoot struct {
 	User struct {
 		Address           func(childComplexity int) int
 		CarManufacturer   func(childComplexity int) int
+		Cars              func(childComplexity int) int
+		Children          func(childComplexity int) int
 		Created           func(childComplexity int) int
 		CustomResolver    func(childComplexity int) int
 		ID                func(childComplexity int) int
@@ -73,6 +75,7 @@ type ComplexityRoot struct {
 		PtrPrefs          func(childComplexity int) int
 		Tier              func(childComplexity int) int
 		ValPrefs          func(childComplexity int) int
+		Weddings          func(childComplexity int) int
 	}
 }
 
@@ -165,6 +168,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.User.CarManufacturer(childComplexity), true
 
+	case "User.cars":
+		if e.complexity.User.Cars == nil {
+			break
+		}
+
+		return e.complexity.User.Cars(childComplexity), true
+
+	case "User.children":
+		if e.complexity.User.Children == nil {
+			break
+		}
+
+		return e.complexity.User.Children(childComplexity), true
+
 	case "User.created":
 		if e.complexity.User.Created == nil {
 			break
@@ -248,6 +265,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.User.ValPrefs(childComplexity), true
+
+	case "User.weddings":
+		if e.complexity.User.Weddings == nil {
+			break
+		}
+
+		return e.complexity.User.Weddings(childComplexity), true
 
 	}
 	return 0, false
@@ -577,6 +601,12 @@ func (ec *executionContext) fieldContext_Query_user(ctx context.Context, field g
 				return ec.fieldContext_User_tier(ctx, field)
 			case "carManufacturer":
 				return ec.fieldContext_User_carManufacturer(ctx, field)
+			case "children":
+				return ec.fieldContext_User_children(ctx, field)
+			case "cars":
+				return ec.fieldContext_User_cars(ctx, field)
+			case "weddings":
+				return ec.fieldContext_User_weddings(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -661,6 +691,12 @@ func (ec *executionContext) fieldContext_Query_search(ctx context.Context, field
 				return ec.fieldContext_User_tier(ctx, field)
 			case "carManufacturer":
 				return ec.fieldContext_User_carManufacturer(ctx, field)
+			case "children":
+				return ec.fieldContext_User_children(ctx, field)
+			case "cars":
+				return ec.fieldContext_User_cars(ctx, field)
+			case "weddings":
+				return ec.fieldContext_User_weddings(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -745,6 +781,12 @@ func (ec *executionContext) fieldContext_Query_userByTier(ctx context.Context, f
 				return ec.fieldContext_User_tier(ctx, field)
 			case "carManufacturer":
 				return ec.fieldContext_User_carManufacturer(ctx, field)
+			case "children":
+				return ec.fieldContext_User_children(ctx, field)
+			case "cars":
+				return ec.fieldContext_User_cars(ctx, field)
+			case "weddings":
+				return ec.fieldContext_User_weddings(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1489,6 +1531,138 @@ func (ec *executionContext) fieldContext_User_carManufacturer(ctx context.Contex
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _User_children(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_User_children(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Children, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(uint)
+	fc.Result = res
+	return ec.marshalNInt2uint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_User_children(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _User_cars(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_User_cars(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Cars, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(external.Count)
+	fc.Result = res
+	return ec.marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋexternalᚐCount(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_User_cars(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _User_weddings(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_User_weddings(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Weddings, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.Sum)
+	fc.Result = res
+	return ec.marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐSum(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_User_weddings(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -3565,6 +3739,27 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
+		case "children":
+
+			out.Values[i] = ec._User_children(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "cars":
+
+			out.Values[i] = ec._User_cars(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "weddings":
+
+			out.Values[i] = ec._User_weddings(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -3962,6 +4157,51 @@ func (ec *executionContext) unmarshalNID2githubᚗcomᚋ99designsᚋgqlgenᚋ_ex
 
 func (ec *executionContext) marshalNID2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋexternalᚐObjectID(ctx context.Context, sel ast.SelectionSet, v external.ObjectID) graphql.Marshaler {
 	res := model.MarshalID(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋexternalᚐCount(ctx context.Context, v interface{}) (external.Count, error) {
+	res, err := graphql.UnmarshalInt64(v)
+	return external.Count(res), graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋexternalᚐCount(ctx context.Context, sel ast.SelectionSet, v external.Count) graphql.Marshaler {
+	res := graphql.MarshalInt64(int64(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐSum(ctx context.Context, v interface{}) (model.Sum, error) {
+	res, err := graphql.UnmarshalInt64(v)
+	return model.Sum(res), graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐSum(ctx context.Context, sel ast.SelectionSet, v model.Sum) graphql.Marshaler {
+	res := graphql.MarshalInt64(int64(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNInt2uint(ctx context.Context, v interface{}) (uint, error) {
+	res, err := graphql.UnmarshalInt64(v)
+	return uint(res), graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInt2uint(ctx context.Context, sel ast.SelectionSet, v uint) graphql.Marshaler {
+	res := graphql.MarshalInt64(int64(v))
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")

--- a/_examples/scalars/model/model.go
+++ b/_examples/scalars/model/model.go
@@ -16,6 +16,7 @@ type (
 	Banned      bool
 	LoginBanned bool
 	QueryBanned = bool
+	Sum         uint16 // local named uint16
 )
 
 func (b Banned) MarshalGQL(w io.Writer) {
@@ -52,6 +53,9 @@ type User struct {
 	Address         Address
 	Tier            Tier
 	CarManufacturer external.Manufacturer
+	Children        uint
+	Cars            external.Count
+	Weddings        Sum
 }
 
 // Point is serialized as a simple array, eg [1, 2]

--- a/_examples/scalars/resolvers.go
+++ b/_examples/scalars/resolvers.go
@@ -37,6 +37,9 @@ func (r *queryResolver) User(ctx context.Context, id external.ObjectID) (*model.
 		CarManufacturer: external.ManufacturerTesla,
 		IsLoginBanned:   true,
 		IsQueryBanned:   true,
+		Children:        3,
+		Cars:            5,
+		Weddings:        2,
 	}, nil
 }
 

--- a/_examples/scalars/scalar_test.go
+++ b/_examples/scalars/scalar_test.go
@@ -22,6 +22,9 @@ type RawUser struct {
 	IsBanned          bool
 	IsLoginBanned     bool
 	IsQueryBanned     bool
+	Children          int
+	Cars              int
+	Weddings          int
 }
 
 func TestScalars(t *testing.T) {
@@ -75,6 +78,16 @@ func TestScalars(t *testing.T) {
 		require.Equal(t, false, resp.User.IsBanned)
 		require.Equal(t, true, resp.User.IsLoginBanned)
 		require.Equal(t, true, resp.User.IsQueryBanned)
+	})
+
+	t.Run("unusual basic", func(t *testing.T) {
+		var resp struct{ User RawUser }
+
+		err := c.Post(`{ user(id:"=1=") { children cars weddings } }`, &resp)
+		require.NoError(t, err)
+		require.Equal(t, 3, resp.User.Children)
+		require.Equal(t, 5, resp.User.Cars)
+		require.Equal(t, 2, resp.User.Weddings)
 	})
 
 	t.Run("custom error messages", func(t *testing.T) {

--- a/_examples/scalars/schema.graphql
+++ b/_examples/scalars/schema.graphql
@@ -19,6 +19,9 @@ type User {
     address: Address
     tier: Tier
     carManufacturer: String!
+    children: Int!
+    cars: Int!
+    weddings: Int!
 }
 
 type Address {

--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -257,6 +257,30 @@ func (t *TypeReference) IsUnderlyingBasic() bool {
 	return isUnderlyingBasic
 }
 
+func (t *TypeReference) IsUnusualBasic() bool {
+	if basic, isBasic := t.GO.(*types.Basic); isBasic {
+		switch basic.Kind() {
+		case types.Int8, types.Int16, types.Uint, types.Uint8, types.Uint16, types.Uint32:
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+func (t *TypeReference) IsUnderlyingUnusualBasic() bool {
+	if basic, isUnderlyingBasic := t.GO.Underlying().(*types.Basic); isUnderlyingBasic {
+		switch basic.Kind() {
+		case types.Int8, types.Int16, types.Uint, types.Uint8, types.Uint16, types.Uint32:
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
 func (t *TypeReference) IsScalarID() bool {
 	return t.Definition.Kind == ast.Scalar && t.Marshaler.Name() == "MarshalID"
 }

--- a/codegen/type.gotpl
+++ b/codegen/type.gotpl
@@ -56,6 +56,8 @@
 						return *res, graphql.ErrorOnPath(ctx, err)
 					{{- else if and (not $type.IsTargetNilable) $type.IsNilable }}
 						return &res, graphql.ErrorOnPath(ctx, err)
+					{{- else if or $type.IsUnusualBasic $type.IsUnderlyingUnusualBasic }}
+						return {{ $type.GO | ref }}(res), graphql.ErrorOnPath(ctx, err)
 					{{- else if and $type.IsNamed $type.Definition.BuiltIn (not $type.IsScalarID) }}
 						return {{ $type.GO | ref }}(res), graphql.ErrorOnPath(ctx, err)
 					{{- else}}
@@ -174,7 +176,9 @@
 					{{- else if and (not $type.IsTargetNilable) $type.IsNilable }}
 						{{- $v = "*v" }}
 					{{- end }}
-					{{- if and $type.IsNamed $type.Definition.BuiltIn (not $type.IsScalarID) }}
+					{{- if or $type.IsUnusualBasic $type.IsUnderlyingUnusualBasic }}
+						res := {{ $type.Marshaler | call }}({{ $type.Target | ref }}({{ $v }}))
+					{{- else if and $type.IsNamed $type.Definition.BuiltIn (not $type.IsScalarID) }}
 						res := {{ $type.Marshaler | call }}({{- if and $type.GO.Underlying $type.IsUnderlyingBasic }}{{ $type.GO.Underlying | ref }}({{ $v }}){{else}}{{ $v }}{{- end }})
 					{{- else }}
 						res := {{ $type.Marshaler | call }}({{- if $type.CastType }}{{ $type.CastType | ref }}({{ $v }}){{else}}{{ $v }}{{- end }})

--- a/integration/generated.go
+++ b/integration/generated.go
@@ -51,13 +51,20 @@ type DirectiveRoot struct {
 type ComplexityRoot struct {
 	DefinedTypeFromBasics struct {
 		NewBool    func(childComplexity int) int
+		NewFloat32 func(childComplexity int) int
 		NewFloat64 func(childComplexity int) int
 		NewID      func(childComplexity int) int
 		NewInt     func(childComplexity int) int
+		NewInt16   func(childComplexity int) int
 		NewInt32   func(childComplexity int) int
 		NewInt64   func(childComplexity int) int
+		NewInt8    func(childComplexity int) int
 		NewString  func(childComplexity int) int
 		NewUint    func(childComplexity int) int
+		NewUint16  func(childComplexity int) int
+		NewUint32  func(childComplexity int) int
+		NewUint64  func(childComplexity int) int
+		NewUint8   func(childComplexity int) int
 	}
 
 	Element struct {
@@ -130,6 +137,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.DefinedTypeFromBasics.NewBool(childComplexity), true
 
+	case "DefinedTypeFromBasics.newFloat32":
+		if e.complexity.DefinedTypeFromBasics.NewFloat32 == nil {
+			break
+		}
+
+		return e.complexity.DefinedTypeFromBasics.NewFloat32(childComplexity), true
+
 	case "DefinedTypeFromBasics.newFloat64":
 		if e.complexity.DefinedTypeFromBasics.NewFloat64 == nil {
 			break
@@ -151,6 +165,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.DefinedTypeFromBasics.NewInt(childComplexity), true
 
+	case "DefinedTypeFromBasics.newInt16":
+		if e.complexity.DefinedTypeFromBasics.NewInt16 == nil {
+			break
+		}
+
+		return e.complexity.DefinedTypeFromBasics.NewInt16(childComplexity), true
+
 	case "DefinedTypeFromBasics.newInt32":
 		if e.complexity.DefinedTypeFromBasics.NewInt32 == nil {
 			break
@@ -165,6 +186,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.DefinedTypeFromBasics.NewInt64(childComplexity), true
 
+	case "DefinedTypeFromBasics.newInt8":
+		if e.complexity.DefinedTypeFromBasics.NewInt8 == nil {
+			break
+		}
+
+		return e.complexity.DefinedTypeFromBasics.NewInt8(childComplexity), true
+
 	case "DefinedTypeFromBasics.newString":
 		if e.complexity.DefinedTypeFromBasics.NewString == nil {
 			break
@@ -178,6 +206,34 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.DefinedTypeFromBasics.NewUint(childComplexity), true
+
+	case "DefinedTypeFromBasics.newUint16":
+		if e.complexity.DefinedTypeFromBasics.NewUint16 == nil {
+			break
+		}
+
+		return e.complexity.DefinedTypeFromBasics.NewUint16(childComplexity), true
+
+	case "DefinedTypeFromBasics.newUint32":
+		if e.complexity.DefinedTypeFromBasics.NewUint32 == nil {
+			break
+		}
+
+		return e.complexity.DefinedTypeFromBasics.NewUint32(childComplexity), true
+
+	case "DefinedTypeFromBasics.newUint64":
+		if e.complexity.DefinedTypeFromBasics.NewUint64 == nil {
+			break
+		}
+
+		return e.complexity.DefinedTypeFromBasics.NewUint64(childComplexity), true
+
+	case "DefinedTypeFromBasics.newUint8":
+		if e.complexity.DefinedTypeFromBasics.NewUint8 == nil {
+			break
+		}
+
+		return e.complexity.DefinedTypeFromBasics.NewUint8(childComplexity), true
 
 	case "Element.child":
 		if e.complexity.Element.Child == nil {
@@ -589,6 +645,94 @@ func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newInt(ctx contex
 	return fc, nil
 }
 
+func (ec *executionContext) _DefinedTypeFromBasics_newInt8(ctx context.Context, field graphql.CollectedField, obj *remote_api.DefinedTypeFromBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DefinedTypeFromBasics_newInt8(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NewInt8, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(testomitempty.NamedInt8)
+	fc.Result = res
+	return ec.marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt8(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newInt8(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DefinedTypeFromBasics",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DefinedTypeFromBasics_newInt16(ctx context.Context, field graphql.CollectedField, obj *remote_api.DefinedTypeFromBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DefinedTypeFromBasics_newInt16(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NewInt16, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(testomitempty.NamedInt16)
+	fc.Result = res
+	return ec.marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt16(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newInt16(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DefinedTypeFromBasics",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _DefinedTypeFromBasics_newInt32(ctx context.Context, field graphql.CollectedField, obj *remote_api.DefinedTypeFromBasics) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_DefinedTypeFromBasics_newInt32(ctx, field)
 	if err != nil {
@@ -765,6 +909,182 @@ func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newFloat64(ctx co
 	return fc, nil
 }
 
+func (ec *executionContext) _DefinedTypeFromBasics_newUint(ctx context.Context, field graphql.CollectedField, obj *remote_api.DefinedTypeFromBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DefinedTypeFromBasics_newUint(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NewUint, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(testomitempty.NamedUint)
+	fc.Result = res
+	return ec.marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newUint(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DefinedTypeFromBasics",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DefinedTypeFromBasics_newUint8(ctx context.Context, field graphql.CollectedField, obj *remote_api.DefinedTypeFromBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DefinedTypeFromBasics_newUint8(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NewUint8, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(testomitempty.NamedUint8)
+	fc.Result = res
+	return ec.marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint8(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newUint8(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DefinedTypeFromBasics",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DefinedTypeFromBasics_newUint16(ctx context.Context, field graphql.CollectedField, obj *remote_api.DefinedTypeFromBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DefinedTypeFromBasics_newUint16(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NewUint16, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(testomitempty.NamedUint16)
+	fc.Result = res
+	return ec.marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint16(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newUint16(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DefinedTypeFromBasics",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DefinedTypeFromBasics_newUint32(ctx context.Context, field graphql.CollectedField, obj *remote_api.DefinedTypeFromBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DefinedTypeFromBasics_newUint32(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NewUint32, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(testomitempty.NamedUint32)
+	fc.Result = res
+	return ec.marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint32(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newUint32(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DefinedTypeFromBasics",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _DefinedTypeFromBasics_newID(ctx context.Context, field graphql.CollectedField, obj *remote_api.DefinedTypeFromBasics) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_DefinedTypeFromBasics_newID(ctx, field)
 	if err != nil {
@@ -809,8 +1129,8 @@ func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newID(ctx context
 	return fc, nil
 }
 
-func (ec *executionContext) _DefinedTypeFromBasics_newUint(ctx context.Context, field graphql.CollectedField, obj *remote_api.DefinedTypeFromBasics) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_DefinedTypeFromBasics_newUint(ctx, field)
+func (ec *executionContext) _DefinedTypeFromBasics_newFloat32(ctx context.Context, field graphql.CollectedField, obj *remote_api.DefinedTypeFromBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DefinedTypeFromBasics_newFloat32(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -823,7 +1143,7 @@ func (ec *executionContext) _DefinedTypeFromBasics_newUint(ctx context.Context, 
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.NewUint, nil
+		return obj.NewFloat32, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -835,19 +1155,63 @@ func (ec *executionContext) _DefinedTypeFromBasics_newUint(ctx context.Context, 
 		}
 		return graphql.Null
 	}
-	res := resTmp.(testomitempty.NamedUint)
+	res := resTmp.(testomitempty.NamedFloat32)
 	fc.Result = res
-	return ec.marshalNUint2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint(ctx, field.Selections, res)
+	return ec.marshalNFloat322githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedFloat32(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newUint(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newFloat32(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "DefinedTypeFromBasics",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Uint does not have child fields")
+			return nil, errors.New("field of type Float32 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DefinedTypeFromBasics_newUint64(ctx context.Context, field graphql.CollectedField, obj *remote_api.DefinedTypeFromBasics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DefinedTypeFromBasics_newUint64(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NewUint64, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(testomitempty.NamedUint64)
+	fc.Result = res
+	return ec.marshalNUint642githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DefinedTypeFromBasics_newUint64(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DefinedTypeFromBasics",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Uint64 does not have child fields")
 		},
 	}
 	return fc, nil
@@ -3552,6 +3916,20 @@ func (ec *executionContext) _DefinedTypeFromBasics(ctx context.Context, sel ast.
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "newInt8":
+
+			out.Values[i] = ec._DefinedTypeFromBasics_newInt8(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "newInt16":
+
+			out.Values[i] = ec._DefinedTypeFromBasics_newInt16(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "newInt32":
 
 			out.Values[i] = ec._DefinedTypeFromBasics_newInt32(ctx, field, obj)
@@ -3580,6 +3958,34 @@ func (ec *executionContext) _DefinedTypeFromBasics(ctx context.Context, sel ast.
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "newUint":
+
+			out.Values[i] = ec._DefinedTypeFromBasics_newUint(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "newUint8":
+
+			out.Values[i] = ec._DefinedTypeFromBasics_newUint8(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "newUint16":
+
+			out.Values[i] = ec._DefinedTypeFromBasics_newUint16(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "newUint32":
+
+			out.Values[i] = ec._DefinedTypeFromBasics_newUint32(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "newID":
 
 			out.Values[i] = ec._DefinedTypeFromBasics_newID(ctx, field, obj)
@@ -3587,9 +3993,16 @@ func (ec *executionContext) _DefinedTypeFromBasics(ctx context.Context, sel ast.
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "newUint":
+		case "newFloat32":
 
-			out.Values[i] = ec._DefinedTypeFromBasics_newUint(ctx, field, obj)
+			out.Values[i] = ec._DefinedTypeFromBasics_newFloat32(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "newUint64":
+
+			out.Values[i] = ec._DefinedTypeFromBasics_newUint64(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
@@ -4341,6 +4754,21 @@ func (ec *executionContext) marshalNFloat2githubᚗcomᚋ99designsᚋgqlgenᚋin
 	return graphql.WrapContextMarshaler(ctx, res)
 }
 
+func (ec *executionContext) unmarshalNFloat322githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedFloat32(ctx context.Context, v interface{}) (testomitempty.NamedFloat32, error) {
+	res, err := remote_api.UnmarshalFloat32(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNFloat322githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedFloat32(ctx context.Context, sel ast.SelectionSet, v testomitempty.NamedFloat32) graphql.Marshaler {
+	res := remote_api.MarshalFloat32(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
 func (ec *executionContext) unmarshalNID2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedID(ctx context.Context, v interface{}) (testomitempty.NamedID, error) {
 	res, err := remote_api.UnmarshalID(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -4371,6 +4799,21 @@ func (ec *executionContext) marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋinte
 	return res
 }
 
+func (ec *executionContext) unmarshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt16(ctx context.Context, v interface{}) (testomitempty.NamedInt16, error) {
+	res, err := graphql.UnmarshalInt64(v)
+	return testomitempty.NamedInt16(res), graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt16(ctx context.Context, sel ast.SelectionSet, v testomitempty.NamedInt16) graphql.Marshaler {
+	res := graphql.MarshalInt64(int64(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
 func (ec *executionContext) unmarshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt32(ctx context.Context, v interface{}) (testomitempty.NamedInt32, error) {
 	res, err := graphql.UnmarshalInt32(v)
 	return testomitempty.NamedInt32(res), graphql.ErrorOnPath(ctx, err)
@@ -4392,6 +4835,81 @@ func (ec *executionContext) unmarshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋin
 }
 
 func (ec *executionContext) marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt64(ctx context.Context, sel ast.SelectionSet, v testomitempty.NamedInt64) graphql.Marshaler {
+	res := graphql.MarshalInt64(int64(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt8(ctx context.Context, v interface{}) (testomitempty.NamedInt8, error) {
+	res, err := graphql.UnmarshalInt64(v)
+	return testomitempty.NamedInt8(res), graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedInt8(ctx context.Context, sel ast.SelectionSet, v testomitempty.NamedInt8) graphql.Marshaler {
+	res := graphql.MarshalInt64(int64(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint(ctx context.Context, v interface{}) (testomitempty.NamedUint, error) {
+	res, err := graphql.UnmarshalInt64(v)
+	return testomitempty.NamedUint(res), graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint(ctx context.Context, sel ast.SelectionSet, v testomitempty.NamedUint) graphql.Marshaler {
+	res := graphql.MarshalInt64(int64(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint16(ctx context.Context, v interface{}) (testomitempty.NamedUint16, error) {
+	res, err := graphql.UnmarshalInt64(v)
+	return testomitempty.NamedUint16(res), graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint16(ctx context.Context, sel ast.SelectionSet, v testomitempty.NamedUint16) graphql.Marshaler {
+	res := graphql.MarshalInt64(int64(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint32(ctx context.Context, v interface{}) (testomitempty.NamedUint32, error) {
+	res, err := graphql.UnmarshalInt64(v)
+	return testomitempty.NamedUint32(res), graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint32(ctx context.Context, sel ast.SelectionSet, v testomitempty.NamedUint32) graphql.Marshaler {
+	res := graphql.MarshalInt64(int64(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint8(ctx context.Context, v interface{}) (testomitempty.NamedUint8, error) {
+	res, err := graphql.UnmarshalInt64(v)
+	return testomitempty.NamedUint8(res), graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInt2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint8(ctx context.Context, sel ast.SelectionSet, v testomitempty.NamedUint8) graphql.Marshaler {
 	res := graphql.MarshalInt64(int64(v))
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -4483,13 +5001,13 @@ func (ec *executionContext) marshalNString2ᚕstringᚄ(ctx context.Context, sel
 	return ret
 }
 
-func (ec *executionContext) unmarshalNUint2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint(ctx context.Context, v interface{}) (testomitempty.NamedUint, error) {
-	res, err := remote_api.UnmarshalUint(v)
+func (ec *executionContext) unmarshalNUint642githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint64(ctx context.Context, v interface{}) (testomitempty.NamedUint64, error) {
+	res, err := remote_api.UnmarshalUint64(v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalNUint2githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint(ctx context.Context, sel ast.SelectionSet, v testomitempty.NamedUint) graphql.Marshaler {
-	res := remote_api.MarshalUint(v)
+func (ec *executionContext) marshalNUint642githubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋtestomitemptyᚐNamedUint64(ctx context.Context, sel ast.SelectionSet, v testomitempty.NamedUint64) graphql.Marshaler {
+	res := remote_api.MarshalUint64(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")

--- a/integration/gqlgen.yml
+++ b/integration/gqlgen.yml
@@ -27,7 +27,9 @@ models:
     fields:
       likes:
         resolver: true
-  Uint:
-    model: github.com/99designs/gqlgen/integration/remote_api.Uint
+  Float32:
+    model: github.com/99designs/gqlgen/integration/remote_api.Float32
+  Uint64:
+    model: github.com/99designs/gqlgen/integration/remote_api.Uint64
   ID:
     model: github.com/99designs/gqlgen/integration/remote_api.ID

--- a/integration/remote_api/user.go
+++ b/integration/remote_api/user.go
@@ -32,21 +32,38 @@ type DefinedTypeFromBasics struct {
 	NewID      testomitempty.NamedID      `json:"newID"`
 }
 
-// Lets redefine the base Uint type to use an id from an external library
-func MarshalUint(id testomitempty.NamedUint) graphql.Marshaler {
+// Lets redefine the base Float32 type
+func MarshalFloat32(id testomitempty.NamedFloat32) graphql.Marshaler {
+	return graphql.WriterFunc(func(w io.Writer) {
+		io.WriteString(w, strconv.Quote(fmt.Sprintf("=%v=", id)))
+	})
+}
+
+// And the same for the unmarshaler
+func UnmarshalFloat32(v interface{}) (testomitempty.NamedFloat32, error) {
+	str, ok := v.(string)
+	if !ok {
+		return 0, fmt.Errorf("float32 must be Float32")
+	}
+	i, err := strconv.Atoi(str[1 : len(str)-1])
+	return testomitempty.NamedFloat32(i), err
+}
+
+// Lets redefine the base Uint64 type
+func MarshalUint64(id testomitempty.NamedUint64) graphql.Marshaler {
 	return graphql.WriterFunc(func(w io.Writer) {
 		io.WriteString(w, strconv.Quote(fmt.Sprintf("=%d=", id)))
 	})
 }
 
 // And the same for the unmarshaler
-func UnmarshalUint(v interface{}) (testomitempty.NamedUint, error) {
+func UnmarshalUint64(v interface{}) (testomitempty.NamedUint64, error) {
 	str, ok := v.(string)
 	if !ok {
-		return 0, fmt.Errorf("ids must be strings")
+		return 0, fmt.Errorf("uint64 must be Uint64")
 	}
 	i, err := strconv.Atoi(str[1 : len(str)-1])
-	return testomitempty.NamedUint(i), err
+	return testomitempty.NamedUint64(i), err
 }
 
 // Lets redefine the base ID type to use an id from an external library

--- a/integration/schema-expected.graphql
+++ b/integration/schema-expected.graphql
@@ -18,13 +18,20 @@ input DateFilter {
 
 type DefinedTypeFromBasics {
   newBool: Boolean!
+  newFloat32: Float32!
   newFloat64: Float!
   newID: ID!
   newInt: Int!
+  newInt8: Int!
+  newInt16: Int!
   newInt32: Int!
   newInt64: Int!
   newString: String!
-  newUint: Uint!
+  newUint: Int!
+  newUint8: Int!
+  newUint16: Int!
+  newUint32: Int!
+  newUint64: Uint64!
 }
 
 type Element {
@@ -37,6 +44,8 @@ enum ErrorType {
   CUSTOM
   NORMAL
 }
+
+scalar Float32
 
 input ListCoercion {
   enumVal: [ErrorType]
@@ -61,7 +70,7 @@ type RemoteModelWithOmitempty {
   newDesc: String
 }
 
-scalar Uint
+scalar Uint64
 
 type User {
   likes: [String!]!

--- a/integration/testomitempty.graphql
+++ b/integration/testomitempty.graphql
@@ -5,21 +5,26 @@ type RemoteModelWithOmitempty {
 type DefinedTypeFromBasics {
     newString: String!
     newInt: Int!
+    newInt8: Int!
+    newInt16: Int!
     newInt32: Int!
     newInt64: Int!
     newBool: Boolean!
     newFloat64: Float!
+    newUint: Int!
+    newUint8: Int!
+    newUint16: Int!
+    newUint32: Int!
     newID: ID!
 
     ### BELOW ARE NOT SUPPORTED AS BASIC - MUST CREATE SCALAR WITH MARSHALFUNC AND UNMARSHARLFUNC ###
-    #newInt8: Int!
-    #newInt16: Int!
-    #newFloat32: Float!
-    newUint: Uint! # scalar created for uint
-    #newUint8: Int!
-    #newUint16: Int!
-    #newUint32: Int!
-    #newUint64: Int!
+    # float32 needs a scalar because precision changes by converting to float64 and back to float32 while marshalling/unmarshalling
+    # for example, value of 5.76 comes out as 5.760000228881836, anyone knows how to fix this?
+    newFloat32: Float32!
+
+    # uint64 need a scalar because it is bigger than int64
+    newUint64: Uint64!
 }
 
-scalar Uint
+scalar Float32
+scalar Uint64

--- a/internal/code/compare.go
+++ b/internal/code/compare.go
@@ -40,7 +40,7 @@ func CompatibleTypes(expected types.Type, actual types.Type) error {
 
 	case *types.Basic:
 		if actualBasic, ok := actual.(*types.Basic); ok {
-			if actualBasic.Kind() != expected.Kind() {
+			if similarBasicKind(actualBasic.Kind()) != expected.Kind() {
 				return fmt.Errorf("basic kind differs, %s != %s", expected.Name(), actualBasic.Name())
 			}
 
@@ -162,4 +162,15 @@ func CompatibleTypes(expected types.Type, actual types.Type) error {
 	}
 
 	return fmt.Errorf("type mismatch %T != %T", expected, actual)
+}
+
+func similarBasicKind(kind types.BasicKind) types.BasicKind {
+	switch kind {
+	case types.Int8, types.Int16:
+		return types.Int64
+	case types.Uint, types.Uint8, types.Uint16, types.Uint32: // exclude Uint64: it still needs scalar with custom marshalling/unmarshalling because it is bigger then int64
+		return types.Int64
+	default:
+		return kind
+	}
 }


### PR DESCRIPTION
Following PR # [2486](https://github.com/99designs/gqlgen/pull/2486), some types require a scalar to work properly. This PR fixes some of them except `float32` and `uint64`. The reasons are as follow:

- float32: the precision changed when marshalling/unmarshalling from float64 back to float32. As an example, value of 5.76 comes out as 5.760000228881836. Anyone knows how to fix this? You can see this [branch](https://github.com/mstephano/gqlgen/tree/fix/float32) for an example, or precisely this [commit](https://github.com/mstephano/gqlgen/commit/9ee30a5d9897a82b3a9db7fb752504530e05613d).
- uint64: it is bigger than int64

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
