### PR TITLE
missed a closing parenthesis in documentation

### DIFF
--- a/docs/content/reference/errors.md
+++ b/docs/content/reference/errors.md
@@ -164,7 +164,7 @@ returned from here will also go through the error presenter.
 
 You change this when creating the server:
 ```go
-server := handler.NewDefaultServer(MakeExecutableSchema(resolvers)
+server := handler.NewDefaultServer(MakeExecutableSchema(resolvers))
 server.SetRecoverFunc(func(ctx context.Context, err interface{}) error {
     // notify bug tracker...
 


### PR DESCRIPTION
Spotted a typo in sample code for documentation.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
