### PR TITLE
remove extra call to packages.Load fix #2505

### DIFF
--- a/internal/code/packages.go
+++ b/internal/code/packages.go
@@ -38,15 +38,6 @@ func (p *Packages) ReloadAll(importPaths ...string) []*packages.Package {
 	return p.LoadAll(importPaths...)
 }
 
-func (p *Packages) checkModuleLoaded(pkgs []*packages.Package) bool {
-	for i := range pkgs {
-		if pkgs[i] == nil || pkgs[i].Module == nil {
-			return false
-		}
-	}
-	return true
-}
-
 // LoadAll will call packages.Load and return the package data for the given packages,
 // but if the package already have been loaded it will return cached values instead.
 func (p *Packages) LoadAll(importPaths ...string) []*packages.Package {
@@ -65,13 +56,6 @@ func (p *Packages) LoadAll(importPaths ...string) []*packages.Package {
 	if len(missing) > 0 {
 		p.numLoadCalls++
 		pkgs, err := packages.Load(&packages.Config{Mode: mode}, missing...)
-
-		// Sometimes packages.Load not loaded the module info. Call it again to reload it.
-		if !p.checkModuleLoaded(pkgs) {
-			fmt.Println("reloading module info")
-			pkgs, err = packages.Load(&packages.Config{Mode: mode}, missing...)
-		}
-
 		if err != nil {
 			p.loadErrors = append(p.loadErrors, err)
 		}


### PR DESCRIPTION
This removes a slow and seemingly unnecessary call to packages.Load

I don't know how to test this because it's not clear what it's solving and how to reproduce the issue. In our codebase nothing bad happens, it just runs faster.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [N/A] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
