### PR TITLE
fix similar basic kind bytes edge case

### DIFF
--- a/internal/code/compare.go
+++ b/internal/code/compare.go
@@ -165,6 +165,9 @@ func CompatibleTypes(expected types.Type, actual types.Type) error {
 }
 
 func similarBasicKind(kind types.BasicKind) types.BasicKind {
+	if kind == types.Byte {
+		return kind
+	}
 	switch kind {
 	case types.Int8, types.Int16:
 		return types.Int64

--- a/internal/code/compare_test.go
+++ b/internal/code/compare_test.go
@@ -63,6 +63,25 @@ func TestCompatibleTypes(t *testing.T) {
 	}
 }
 
+func TestSimilarBasicKind(t *testing.T) {
+	valid := []struct {
+		name     string
+		expected types.BasicKind
+		actual   types.BasicKind
+	}{
+		{name: "string=string", expected: types.String, actual: types.String},
+		{name: "int8=int", expected: types.Int64, actual: types.Int8},
+		{name: "byte=byte", expected: types.Byte, actual: types.Byte},
+	}
+
+	for _, tc := range valid {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, similarBasicKind(tc.actual))
+
+		})
+	}
+}
+
 func parseTypeStr(t *testing.T, s string) types.Type {
 	t.Helper()
 


### PR DESCRIPTION
Found and issue from v0.17.24+ with binding bytes type

Fixes #2524

Describe your PR and link to any relevant issues. 

I currently went for a quick fix / show as draft for what the issue is as describe in #2524. 
Another solution is to add a check in the compare to check for simple kind before going for the similar. This approach is cleaner as I less liked adding the if bytes return check in the function. Added a test to show the failure.

```go
if actualBasic.Kind() != expected.Kind() &&  similarBasicKind(actualBasic.Kind()) != expected.Kind() {
		return fmt.Errorf("basic kind differs, %s != %s", expected.Name(), actualBasic.Name())
	}
```

@mstephano if you can weigh in, as you wrote the original fix, which is great! so we don't miss any edge case.

I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [X] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
