### PR TITLE
fix #2524 basic alias Byte was not binded properly

### DIFF
--- a/_examples/scalars/.gqlgen.yml
+++ b/_examples/scalars/.gqlgen.yml
@@ -22,3 +22,7 @@ models:
     model: "github.com/99designs/gqlgen/codegen/testserver/singlefile.Bytes"
   Runes:
     model: "github.com/99designs/gqlgen/_examples/scalars/model.Runes"
+  DefinedTypeBytes:
+    model: "github.com/99designs/gqlgen/_examples/scalars/external.Bytes"
+  DefinedTypeRunes:
+    model: "github.com/99designs/gqlgen/_examples/scalars/external.Runes"

--- a/_examples/scalars/.gqlgen.yml
+++ b/_examples/scalars/.gqlgen.yml
@@ -18,3 +18,7 @@ models:
     model: github.com/99designs/gqlgen/_examples/scalars/model.Banned
   DarkMode:
     model: github.com/99designs/gqlgen/_examples/scalars/model.Preferences
+  Bytes:
+    model: "github.com/99designs/gqlgen/codegen/testserver/singlefile.Bytes"
+  Runes:
+    model: "github.com/99designs/gqlgen/_examples/scalars/model.Runes"

--- a/_examples/scalars/external/model.go
+++ b/_examples/scalars/external/model.go
@@ -3,7 +3,7 @@ package external
 type (
 	ObjectID     int
 	Manufacturer string // remote named string
-	Count        uint32 // remote named uint32
+	Count        uint8  // remote named uint8
 )
 
 const (

--- a/_examples/scalars/external/model.go
+++ b/_examples/scalars/external/model.go
@@ -1,9 +1,18 @@
 package external
 
+import (
+	"fmt"
+	"io"
+
+	"github.com/99designs/gqlgen/graphql"
+)
+
 type (
-	ObjectID     int
-	Manufacturer string // remote named string
-	Count        uint8  // remote named uint8
+	ObjectID      int
+	Manufacturer  string // remote named string
+	Count         uint8  // remote named uint8
+	ExternalBytes []byte
+	ExternalRunes []rune
 )
 
 const (
@@ -11,3 +20,41 @@ const (
 	ManufacturerHonda  Manufacturer = "HONDA"
 	ManufacturerToyota Manufacturer = "TOYOTA"
 )
+
+func MarshalBytes(b ExternalBytes) graphql.Marshaler {
+	return graphql.WriterFunc(func(w io.Writer) {
+		_, _ = fmt.Fprintf(w, "%q", string(b))
+	})
+}
+
+func UnmarshalBytes(v interface{}) (ExternalBytes, error) {
+	switch v := v.(type) {
+	case string:
+		return ExternalBytes(v), nil
+	case *string:
+		return ExternalBytes(*v), nil
+	case ExternalBytes:
+		return v, nil
+	default:
+		return nil, fmt.Errorf("%T is not ExternalBytes", v)
+	}
+}
+
+func MarshalRunes(r ExternalRunes) graphql.Marshaler {
+	return graphql.WriterFunc(func(w io.Writer) {
+		_, _ = fmt.Fprintf(w, "%q", string(r))
+	})
+}
+
+func UnmarshalRunes(v interface{}) (ExternalRunes, error) {
+	switch v := v.(type) {
+	case string:
+		return ExternalRunes(v), nil
+	case *string:
+		return ExternalRunes(*v), nil
+	case ExternalRunes:
+		return v, nil
+	default:
+		return nil, fmt.Errorf("%T is not ExternalRunes", v)
+	}
+}

--- a/_examples/scalars/generated.go
+++ b/_examples/scalars/generated.go
@@ -74,6 +74,8 @@ type ComplexityRoot struct {
 		Name              func(childComplexity int) int
 		PrimitiveResolver func(childComplexity int) int
 		PtrPrefs          func(childComplexity int) int
+		RemoteBytes       func(childComplexity int) int
+		RemoteRunes       func(childComplexity int) int
 		SomeBytes         func(childComplexity int) int
 		SomeOtherBytes    func(childComplexity int) int
 		SomeRunes         func(childComplexity int) int
@@ -255,6 +257,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.User.PtrPrefs(childComplexity), true
+
+	case "User.remoteBytes":
+		if e.complexity.User.RemoteBytes == nil {
+			break
+		}
+
+		return e.complexity.User.RemoteBytes(childComplexity), true
+
+	case "User.remoteRunes":
+		if e.complexity.User.RemoteRunes == nil {
+			break
+		}
+
+		return e.complexity.User.RemoteRunes(childComplexity), true
 
 	case "User.someBytes":
 		if e.complexity.User.SomeBytes == nil {
@@ -638,6 +654,10 @@ func (ec *executionContext) fieldContext_Query_user(ctx context.Context, field g
 				return ec.fieldContext_User_someOtherBytes(ctx, field)
 			case "someRunes":
 				return ec.fieldContext_User_someRunes(ctx, field)
+			case "remoteBytes":
+				return ec.fieldContext_User_remoteBytes(ctx, field)
+			case "remoteRunes":
+				return ec.fieldContext_User_remoteRunes(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -734,6 +754,10 @@ func (ec *executionContext) fieldContext_Query_search(ctx context.Context, field
 				return ec.fieldContext_User_someOtherBytes(ctx, field)
 			case "someRunes":
 				return ec.fieldContext_User_someRunes(ctx, field)
+			case "remoteBytes":
+				return ec.fieldContext_User_remoteBytes(ctx, field)
+			case "remoteRunes":
+				return ec.fieldContext_User_remoteRunes(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -830,6 +854,10 @@ func (ec *executionContext) fieldContext_Query_userByTier(ctx context.Context, f
 				return ec.fieldContext_User_someOtherBytes(ctx, field)
 			case "someRunes":
 				return ec.fieldContext_User_someRunes(ctx, field)
+			case "remoteBytes":
+				return ec.fieldContext_User_remoteBytes(ctx, field)
+			case "remoteRunes":
+				return ec.fieldContext_User_remoteRunes(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1838,6 +1866,94 @@ func (ec *executionContext) fieldContext_User_someRunes(ctx context.Context, fie
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Runes does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _User_remoteBytes(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_User_remoteBytes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RemoteBytes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(external.ExternalBytes)
+	fc.Result = res
+	return ec.marshalNDefinedTypeBytes2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋexternalᚐExternalBytes(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_User_remoteBytes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type DefinedTypeBytes does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _User_remoteRunes(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_User_remoteRunes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RemoteRunes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(external.ExternalRunes)
+	fc.Result = res
+	return ec.marshalNDefinedTypeRunes2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋexternalᚐExternalRunes(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_User_remoteRunes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type DefinedTypeRunes does not have child fields")
 		},
 	}
 	return fc, nil
@@ -3956,6 +4072,20 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
+		case "remoteBytes":
+
+			out.Values[i] = ec._User_remoteBytes(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "remoteRunes":
+
+			out.Values[i] = ec._User_remoteRunes(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -4359,6 +4489,48 @@ func (ec *executionContext) marshalNDarkMode2ᚖgithubᚗcomᚋ99designsᚋgqlge
 		return graphql.Null
 	}
 	res := model.MarshalPreferences(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNDefinedTypeBytes2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋexternalᚐExternalBytes(ctx context.Context, v interface{}) (external.ExternalBytes, error) {
+	res, err := external.UnmarshalBytes(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNDefinedTypeBytes2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋexternalᚐExternalBytes(ctx context.Context, sel ast.SelectionSet, v external.ExternalBytes) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	res := external.MarshalBytes(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNDefinedTypeRunes2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋexternalᚐExternalRunes(ctx context.Context, v interface{}) (external.ExternalRunes, error) {
+	res, err := external.UnmarshalRunes(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNDefinedTypeRunes2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋexternalᚐExternalRunes(ctx context.Context, sel ast.SelectionSet, v external.ExternalRunes) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	res := external.MarshalRunes(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")

--- a/_examples/scalars/generated.go
+++ b/_examples/scalars/generated.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/99designs/gqlgen/_examples/scalars/external"
 	"github.com/99designs/gqlgen/_examples/scalars/model"
+	"github.com/99designs/gqlgen/codegen/testserver/singlefile"
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/introspection"
 	gqlparser "github.com/vektah/gqlparser/v2"
@@ -73,6 +74,9 @@ type ComplexityRoot struct {
 		Name              func(childComplexity int) int
 		PrimitiveResolver func(childComplexity int) int
 		PtrPrefs          func(childComplexity int) int
+		SomeBytes         func(childComplexity int) int
+		SomeOtherBytes    func(childComplexity int) int
+		SomeRunes         func(childComplexity int) int
 		Tier              func(childComplexity int) int
 		ValPrefs          func(childComplexity int) int
 		Weddings          func(childComplexity int) int
@@ -251,6 +255,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.User.PtrPrefs(childComplexity), true
+
+	case "User.someBytes":
+		if e.complexity.User.SomeBytes == nil {
+			break
+		}
+
+		return e.complexity.User.SomeBytes(childComplexity), true
+
+	case "User.someOtherBytes":
+		if e.complexity.User.SomeOtherBytes == nil {
+			break
+		}
+
+		return e.complexity.User.SomeOtherBytes(childComplexity), true
+
+	case "User.someRunes":
+		if e.complexity.User.SomeRunes == nil {
+			break
+		}
+
+		return e.complexity.User.SomeRunes(childComplexity), true
 
 	case "User.tier":
 		if e.complexity.User.Tier == nil {
@@ -607,6 +632,12 @@ func (ec *executionContext) fieldContext_Query_user(ctx context.Context, field g
 				return ec.fieldContext_User_cars(ctx, field)
 			case "weddings":
 				return ec.fieldContext_User_weddings(ctx, field)
+			case "someBytes":
+				return ec.fieldContext_User_someBytes(ctx, field)
+			case "someOtherBytes":
+				return ec.fieldContext_User_someOtherBytes(ctx, field)
+			case "someRunes":
+				return ec.fieldContext_User_someRunes(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -697,6 +728,12 @@ func (ec *executionContext) fieldContext_Query_search(ctx context.Context, field
 				return ec.fieldContext_User_cars(ctx, field)
 			case "weddings":
 				return ec.fieldContext_User_weddings(ctx, field)
+			case "someBytes":
+				return ec.fieldContext_User_someBytes(ctx, field)
+			case "someOtherBytes":
+				return ec.fieldContext_User_someOtherBytes(ctx, field)
+			case "someRunes":
+				return ec.fieldContext_User_someRunes(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -787,6 +824,12 @@ func (ec *executionContext) fieldContext_Query_userByTier(ctx context.Context, f
 				return ec.fieldContext_User_cars(ctx, field)
 			case "weddings":
 				return ec.fieldContext_User_weddings(ctx, field)
+			case "someBytes":
+				return ec.fieldContext_User_someBytes(ctx, field)
+			case "someOtherBytes":
+				return ec.fieldContext_User_someOtherBytes(ctx, field)
+			case "someRunes":
+				return ec.fieldContext_User_someRunes(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1663,6 +1706,138 @@ func (ec *executionContext) fieldContext_User_weddings(ctx context.Context, fiel
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _User_someBytes(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_User_someBytes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SomeBytes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNBytes2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_User_someBytes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Bytes does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _User_someOtherBytes(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_User_someOtherBytes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SomeOtherBytes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNBytes2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_User_someOtherBytes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Bytes does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _User_someRunes(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_User_someRunes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SomeRunes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]rune)
+	fc.Result = res
+	return ec.marshalNRunes2ᚕrune(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_User_someRunes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Runes does not have child fields")
 		},
 	}
 	return fc, nil
@@ -3760,6 +3935,27 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
+		case "someBytes":
+
+			out.Values[i] = ec._User_someBytes(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "someOtherBytes":
+
+			out.Values[i] = ec._User_someOtherBytes(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "someRunes":
+
+			out.Values[i] = ec._User_someRunes(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -4129,6 +4325,27 @@ func (ec *executionContext) marshalNBoolean2githubᚗcomᚋ99designsᚋgqlgenᚋ
 	return res
 }
 
+func (ec *executionContext) unmarshalNBytes2ᚕbyte(ctx context.Context, v interface{}) ([]byte, error) {
+	res, err := singlefile.UnmarshalBytes(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNBytes2ᚕbyte(ctx context.Context, sel ast.SelectionSet, v []byte) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	res := singlefile.MarshalBytes(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
 func (ec *executionContext) unmarshalNDarkMode2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐPrefs(ctx context.Context, v interface{}) (*model.Prefs, error) {
 	res, err := model.UnmarshalPreferences(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -4234,6 +4451,27 @@ func (ec *executionContext) marshalNPoint2ᚖgithubᚗcomᚋ99designsᚋgqlgen�
 		return graphql.Null
 	}
 	return v
+}
+
+func (ec *executionContext) unmarshalNRunes2ᚕrune(ctx context.Context, v interface{}) ([]rune, error) {
+	res, err := model.UnmarshalRunes(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNRunes2ᚕrune(ctx context.Context, sel ast.SelectionSet, v []rune) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	res := model.MarshalRunes(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
 }
 
 func (ec *executionContext) unmarshalNString2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋexternalᚐManufacturer(ctx context.Context, v interface{}) (external.Manufacturer, error) {

--- a/_examples/scalars/model/model.go
+++ b/_examples/scalars/model/model.go
@@ -59,6 +59,8 @@ type User struct {
 	SomeBytes       []byte
 	SomeOtherBytes  []byte
 	SomeRunes       []rune
+	RemoteBytes     external.ExternalBytes
+	RemoteRunes     external.ExternalRunes
 }
 
 // Point is serialized as a simple array, eg [1, 2]

--- a/_examples/scalars/model/model.go
+++ b/_examples/scalars/model/model.go
@@ -56,6 +56,9 @@ type User struct {
 	Children        uint
 	Cars            external.Count
 	Weddings        Sum
+	SomeBytes       []byte
+	SomeOtherBytes  []byte
+	SomeRunes       []rune
 }
 
 // Point is serialized as a simple array, eg [1, 2]
@@ -203,4 +206,23 @@ func UnmarshalPreferences(v interface{}) (*Prefs, error) {
 		return nil, err
 	}
 	return &Prefs{DarkMode: tmp}, nil
+}
+
+func MarshalRunes(r []rune) graphql.Marshaler {
+	return graphql.WriterFunc(func(w io.Writer) {
+		_, _ = fmt.Fprintf(w, "%q", string(r))
+	})
+}
+
+func UnmarshalRunes(v interface{}) ([]rune, error) {
+	switch v := v.(type) {
+	case string:
+		return []rune(v), nil
+	case *string:
+		return []rune(*v), nil
+	case []rune:
+		return v, nil
+	default:
+		return nil, fmt.Errorf("%T is not []rune", v)
+	}
 }

--- a/_examples/scalars/resolvers.go
+++ b/_examples/scalars/resolvers.go
@@ -43,6 +43,8 @@ func (r *queryResolver) User(ctx context.Context, id external.ObjectID) (*model.
 		SomeBytes:       []byte("abcdef"),
 		SomeOtherBytes:  []byte{97, 98, 99, 100, 101, 102},
 		SomeRunes:       []rune{'H', 'e', 'l', 'l', 'o', ' ', '世', '界'},
+		RemoteBytes:     external.ExternalBytes("fedcba"),
+		RemoteRunes:     external.ExternalRunes{'界', '世', ' ', 'H', 'e', 'l', 'l', 'o'},
 	}, nil
 }
 

--- a/_examples/scalars/resolvers.go
+++ b/_examples/scalars/resolvers.go
@@ -40,6 +40,9 @@ func (r *queryResolver) User(ctx context.Context, id external.ObjectID) (*model.
 		Children:        3,
 		Cars:            5,
 		Weddings:        2,
+		SomeBytes:       []byte("abcdef"),
+		SomeOtherBytes:  []byte{97, 98, 99, 100, 101, 102},
+		SomeRunes:       []rune{'H', 'e', 'l', 'l', 'o', ' ', '世', '界'},
 	}, nil
 }
 

--- a/_examples/scalars/scalar_test.go
+++ b/_examples/scalars/scalar_test.go
@@ -25,6 +25,9 @@ type RawUser struct {
 	Children          int
 	Cars              int
 	Weddings          int
+	SomeBytes         string
+	SomeOtherBytes    string
+	SomeRunes         string
 }
 
 func TestScalars(t *testing.T) {
@@ -88,6 +91,16 @@ func TestScalars(t *testing.T) {
 		require.Equal(t, 3, resp.User.Children)
 		require.Equal(t, 5, resp.User.Cars)
 		require.Equal(t, 2, resp.User.Weddings)
+	})
+
+	t.Run("basic alias byte and rune", func(t *testing.T) {
+		var resp struct{ User RawUser }
+
+		err := c.Post(`{ user(id:"=1=") { someBytes someOtherBytes someRunes } }`, &resp)
+		require.NoError(t, err)
+		require.Equal(t, "abcdef", resp.User.SomeBytes)
+		require.Equal(t, "abcdef", resp.User.SomeOtherBytes)
+		require.Equal(t, "Hello 世界", resp.User.SomeRunes)
 	})
 
 	t.Run("custom error messages", func(t *testing.T) {

--- a/_examples/scalars/scalar_test.go
+++ b/_examples/scalars/scalar_test.go
@@ -28,6 +28,8 @@ type RawUser struct {
 	SomeBytes         string
 	SomeOtherBytes    string
 	SomeRunes         string
+	RemoteBytes       string
+	RemoteRunes       string
 }
 
 func TestScalars(t *testing.T) {
@@ -93,14 +95,16 @@ func TestScalars(t *testing.T) {
 		require.Equal(t, 2, resp.User.Weddings)
 	})
 
-	t.Run("basic alias byte and rune", func(t *testing.T) {
+	t.Run("basic aliases byte and rune", func(t *testing.T) {
 		var resp struct{ User RawUser }
 
-		err := c.Post(`{ user(id:"=1=") { someBytes someOtherBytes someRunes } }`, &resp)
+		err := c.Post(`{ user(id:"=1=") { someBytes someOtherBytes someRunes remoteBytes remoteRunes } }`, &resp)
 		require.NoError(t, err)
 		require.Equal(t, "abcdef", resp.User.SomeBytes)
 		require.Equal(t, "abcdef", resp.User.SomeOtherBytes)
 		require.Equal(t, "Hello 世界", resp.User.SomeRunes)
+		require.Equal(t, "fedcba", resp.User.RemoteBytes)
+		require.Equal(t, "界世 Hello", resp.User.RemoteRunes)
 	})
 
 	t.Run("custom error messages", func(t *testing.T) {

--- a/_examples/scalars/schema.graphql
+++ b/_examples/scalars/schema.graphql
@@ -25,6 +25,8 @@ type User {
     someBytes: Bytes!
     someOtherBytes: Bytes!
     someRunes: Runes!
+    remoteBytes: DefinedTypeBytes!
+    remoteRunes: DefinedTypeRunes!
 }
 
 type Address {
@@ -50,3 +52,5 @@ scalar Banned
 scalar DarkMode
 scalar Bytes
 scalar Runes
+scalar DefinedTypeBytes
+scalar DefinedTypeRunes

--- a/_examples/scalars/schema.graphql
+++ b/_examples/scalars/schema.graphql
@@ -22,6 +22,9 @@ type User {
     children: Int!
     cars: Int!
     weddings: Int!
+    someBytes: Bytes!
+    someOtherBytes: Bytes!
+    someRunes: Runes!
 }
 
 type Address {
@@ -45,3 +48,5 @@ scalar Timestamp
 scalar Point
 scalar Banned
 scalar DarkMode
+scalar Bytes
+scalar Runes

--- a/integration/testomitempty.graphql
+++ b/integration/testomitempty.graphql
@@ -22,7 +22,7 @@ type DefinedTypeFromBasics {
     # for example, value of 5.76 comes out as 5.760000228881836, anyone knows how to fix this?
     newFloat32: Float32!
 
-    # uint64 need a scalar because it is bigger than int64
+    # uint64 needs a scalar because it is bigger than int64
     newUint64: Uint64!
 }
 

--- a/internal/code/compare.go
+++ b/internal/code/compare.go
@@ -168,7 +168,7 @@ func similarBasicKind(kind types.BasicKind) types.BasicKind {
 	switch kind {
 	case types.Int8, types.Int16:
 		return types.Int64
-	case types.Uint, types.Uint8, types.Uint16, types.Uint32: // exclude Uint64: it still needs scalar with custom marshalling/unmarshalling because it is bigger then int64
+	case types.Uint, types.Uint8, types.Uint16, types.Uint32: // exclude Uint64: it still needs scalar with custom marshalling/unmarshalling because it is bigger than int64
 		return types.Int64
 	default:
 		return kind

--- a/internal/code/compare.go
+++ b/internal/code/compare.go
@@ -40,7 +40,7 @@ func CompatibleTypes(expected types.Type, actual types.Type) error {
 
 	case *types.Basic:
 		if actualBasic, ok := actual.(*types.Basic); ok {
-			if similarBasicKind(actualBasic.Kind()) != expected.Kind() {
+			if actualBasic.Kind() != expected.Kind() && similarBasicKind(actualBasic.Kind()) != expected.Kind() {
 				return fmt.Errorf("basic kind differs, %s != %s", expected.Name(), actualBasic.Name())
 			}
 


### PR DESCRIPTION
Issue from v0.17.24+ with binding bytes type

Fixes #2524 for basic [alias](https://github.com/golang/go/blob/a11b8e37652ff60302b4a4a55a8a43db6a066ecf/src/go/types/basic.go#L45) `Byte` (proposition from @roneli). Also added tests to make sure binding works properly for:
- basic alias `Rune`
- defined type for []byte
- defined type for []rune

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
