### PR TITLE
RemoveDuplicateTags func introduced to fix #2514

### DIFF
--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -415,7 +415,38 @@ func GoTagFieldHook(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Fie
 		f.Tag = f.Tag + " " + strings.Join(args, " ")
 	}
 
+	f.Tag = removeDuplicateTags(f.Tag)
+
 	return f, nil
+}
+
+// removeDuplicateTags removes duplicate tags
+func removeDuplicateTags(t string) string {
+
+	tt := strings.Split(t, " ")
+
+	if len(tt) > 0 {
+		tagMap := map[string]string{}
+		returnTags := ""
+
+		for _, ti := range tt {
+			kv := strings.Split(ti, ":")
+			if len(kv) > 0 {
+				tagMap[kv[0]] = kv[1]
+			}
+		}
+
+		for k, v := range tagMap {
+			if len(returnTags) > 0 {
+				returnTags += " "
+			}
+			returnTags += k + ":" + v
+		}
+		return returnTags
+
+	}
+
+	return t
 }
 
 // GoFieldHook applies the goField directive to the generated Field f.

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -350,3 +350,57 @@ func goBuild(t *testing.T, path string) error {
 
 	return nil
 }
+
+func TestRemoveDuplicate(t *testing.T) {
+	type args struct {
+		t string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Duplicate Test with 1",
+			args: args{
+				t: "json:\"name\"",
+			},
+			want: "json:\"name\"",
+		},
+		{
+			name: "Duplicate Test with 2",
+			args: args{
+				t: "json:\"name\" json:\"name2\"",
+			},
+			want: "json:\"name2\"",
+		},
+		{
+			name: "Duplicate Test with 3",
+			args: args{
+				t: "json:\"name\" json:\"name2\" json:\"name3\"",
+			},
+			want: "json:\"name3\"",
+		},
+		{
+			name: "Duplicate Test with 3 and 1 unrelated",
+			args: args{
+				t: "json:\"name\" something:\"name2\" json:\"name3\"",
+			},
+			want: "json:\"name3\" something:\"name2\"",
+		},
+		{
+			name: "Duplicate Test with 3 and 2 unrelated",
+			args: args{
+				t: "something:\"name1\" json:\"name\" something:\"name2\" json:\"name3\"",
+			},
+			want: "something:\"name2\" json:\"name3\"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := removeDuplicateTags(tt.args.t); got != tt.want {
+				t.Errorf("removeDuplicate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/plugin/modelgen/out_struct_pointers/generated.go
+++ b/plugin/modelgen/out_struct_pointers/generated.go
@@ -89,8 +89,8 @@ type CyclicalB struct {
 
 type FieldMutationHook struct {
 	Name     *string       `json:"name" anotherTag:"tag" database:"FieldMutationHookname"`
-	Enum     *ExistingEnum `json:"enum" yetAnotherTag:"12" database:"FieldMutationHookenum"`
-	NoVal    *string       `json:"noVal" yaml:"noVal" repeated:"true" database:"FieldMutationHooknoVal"`
+	Enum     *ExistingEnum `yetAnotherTag:"12" json:"enum" database:"FieldMutationHookenum"`
+	NoVal    *string       `repeated:"true" json:"noVal" yaml:"noVal" database:"FieldMutationHooknoVal"`
 	Repeated *string       `json:"repeated" someTag:"value" repeated:"true" database:"FieldMutationHookrepeated"`
 }
 


### PR DESCRIPTION
As described in #2514, and without this PR, `GoTagFieldHook` just appends new tags, so `@goTag` will not override an existing tag.

Ideally it should override existing tag, since the sole purpose of the `@goTag` directive is to give control to user.

In this PR, the `removeDuplicateTags` helper func is introduced to fix #2514

I have:
 - [✓] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [Not Required] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
