### PR TITLE
prepend goTag directive on struct tags and omit overridden duplicate struct tags per  #2514

### DIFF
--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -388,8 +388,9 @@ func (m *Plugin) generateFields(cfg *config.Config, schemaType *ast.Definition) 
 	return fields, nil
 }
 
-// GoTagFieldHook prepend the goTag directive to the generated Field f. When applying the Tag to the field, the field
-// name is used when no value argument is present.
+// GoTagFieldHook prepends the goTag directive to the generated Field f.
+// When applying the Tag to the field, the field
+// name is used if no value argument is present.
 func GoTagFieldHook(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Field, error) {
 	args := make([]string, 0)
 	for _, goTag := range fd.Directives.ForNames("goTag") {
@@ -412,15 +413,12 @@ func GoTagFieldHook(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Fie
 	}
 
 	if len(args) > 0 {
-		f.Tag = strings.Join(args, " ") + " " + f.Tag
+		f.Tag = removeDuplicateTags(strings.Join(args, " ") + " " + f.Tag)
 	}
-
-	f.Tag = removeDuplicateTags(f.Tag)
 
 	return f, nil
 }
 
-// removeDuplicateTags removes duplicate tags
 func removeDuplicateTags(t string) string {
 	processed := make(map[string]bool)
 	tt := strings.Split(t, " ")
@@ -434,9 +432,9 @@ func removeDuplicateTags(t string) string {
 
 		processed[kv[0]] = true
 		if len(returnTags) > 0 {
-			returnTags = returnTags + " "
+			returnTags += " "
 		}
-		returnTags = returnTags + kv[0] + ":" + kv[1]
+		returnTags += kv[0] + ":" + kv[1]
 	}
 
 	return returnTags

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -388,7 +388,7 @@ func (m *Plugin) generateFields(cfg *config.Config, schemaType *ast.Definition) 
 	return fields, nil
 }
 
-// GoTagFieldHook applies the goTag directive to the generated Field f. When applying the Tag to the field, the field
+// GoTagFieldHook prepend the goTag directive to the generated Field f. When applying the Tag to the field, the field
 // name is used when no value argument is present.
 func GoTagFieldHook(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Field, error) {
 	args := make([]string, 0)
@@ -412,7 +412,7 @@ func GoTagFieldHook(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Fie
 	}
 
 	if len(args) > 0 {
-		f.Tag = f.Tag + " " + strings.Join(args, " ")
+		f.Tag = strings.Join(args, " ") + " " + f.Tag
 	}
 
 	f.Tag = removeDuplicateTags(f.Tag)
@@ -422,31 +422,24 @@ func GoTagFieldHook(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Fie
 
 // removeDuplicateTags removes duplicate tags
 func removeDuplicateTags(t string) string {
-
+	processed := make(map[string]bool)
 	tt := strings.Split(t, " ")
+	returnTags := ""
 
-	if len(tt) > 0 {
-		tagMap := map[string]string{}
-		returnTags := ""
-
-		for _, ti := range tt {
-			kv := strings.Split(ti, ":")
-			if len(kv) > 0 {
-				tagMap[kv[0]] = kv[1]
-			}
+	for _, ti := range tt {
+		kv := strings.Split(ti, ":")
+		if len(kv) == 0 || processed[kv[0]] {
+			continue
 		}
 
-		for k, v := range tagMap {
-			if len(returnTags) > 0 {
-				returnTags += " "
-			}
-			returnTags += k + ":" + v
+		processed[kv[0]] = true
+		if len(returnTags) > 0 {
+			returnTags = returnTags + " "
 		}
-		return returnTags
-
+		returnTags = returnTags + kv[0] + ":" + kv[1]
 	}
 
-	return t
+	return returnTags
 }
 
 // GoFieldHook applies the goField directive to the generated Field f.

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -415,7 +415,38 @@ func GoTagFieldHook(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Fie
 		f.Tag = f.Tag + " " + strings.Join(args, " ")
 	}
 
+	f.Tag = removeDuplicateTags(f.Tag)
+
 	return f, nil
+}
+
+// removeDuplicateTags removes duplicate tags
+func removeDuplicateTags(t string) string {
+
+	tt := strings.Split(t, " ")
+
+	if len(tt) > 0 {
+		tagMap := map[string]string{}
+		returnTags := ""
+
+		for _, ti := range tt {
+			kv := strings.Split(ti, ":")
+			if len(kv) > 0 {
+				tagMap[kv[0]] = kv[1]
+			}
+		}
+
+		for k, v := range tagMap {
+			if len(returnTags) > 0 {
+				returnTags += " "
+			}
+			returnTags += k + ":" + v
+		}
+		return returnTags
+
+	}
+
+	return t
 }
 
 // GoFieldHook applies the goField directive to the generated Field f.

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -372,28 +372,28 @@ func TestRemoveDuplicate(t *testing.T) {
 			args: args{
 				t: "json:\"name\" json:\"name2\"",
 			},
-			want: "json:\"name2\"",
+			want: "json:\"name\"",
 		},
 		{
 			name: "Duplicate Test with 3",
 			args: args{
 				t: "json:\"name\" json:\"name2\" json:\"name3\"",
 			},
-			want: "json:\"name3\"",
+			want: "json:\"name\"",
 		},
 		{
 			name: "Duplicate Test with 3 and 1 unrelated",
 			args: args{
 				t: "json:\"name\" something:\"name2\" json:\"name3\"",
 			},
-			want: "json:\"name3\" something:\"name2\"",
+			want: "json:\"name\" something:\"name2\"",
 		},
 		{
 			name: "Duplicate Test with 3 and 2 unrelated",
 			args: args{
 				t: "something:\"name1\" json:\"name\" something:\"name2\" json:\"name3\"",
 			},
-			want: "something:\"name2\" json:\"name3\"",
+			want: "something:\"name1\" json:\"name\"",
 		},
 	}
 	for _, tt := range tests {

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -350,3 +350,57 @@ func goBuild(t *testing.T, path string) error {
 
 	return nil
 }
+
+func TestRemoveDuplicate(t *testing.T) {
+	type args struct {
+		t string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Duplicate Test with 1",
+			args: args{
+				t: "json:\"name\"",
+			},
+			want: "json:\"name\"",
+		},
+		{
+			name: "Duplicate Test with 2",
+			args: args{
+				t: "json:\"name\" json:\"name2\"",
+			},
+			want: "json:\"name2\"",
+		},
+		{
+			name: "Duplicate Test with 3",
+			args: args{
+				t: "json:\"name\" json:\"name2\" json:\"name3\"",
+			},
+			want: "json:\"name3\"",
+		},
+		{
+			name: "Duplicate Test with 3 and 1 unrelated",
+			args: args{
+				t: "json:\"name\" something:\"name2\" json:\"name3\"",
+			},
+			want: "json:\"name3\" something:\"name2\"",
+		},
+		{
+			name: "Duplicate Test with 3 and 2 unrelated",
+			args: args{
+				t: "something:\"name1\" json:\"name\" something:\"name2\" json:\"name3\"",
+			},
+			want: "something:\"name2\" json:\"name3\"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := removeDuplicateTags(tt.args.t); got != tt.want {
+				t.Errorf("removeDuplicate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -82,14 +82,14 @@ func TestModelGeneration(t *testing.T) {
 		fileText := string(file)
 
 		expectedTags := []string{
-			`json:"name" anotherTag:"tag"`,
-			`json:"enum" yetAnotherTag:"12"`,
-			`json:"noVal" yaml:"noVal"`,
-			`json:"repeated" someTag:"value" repeated:"true"`,
+			`anotherTag:"tag" json:"name"`,
+			`yetAnotherTag:"12" json:"enum"`,
+			`yaml:"noVal" repeated:"true" json:"noVal"`,
+			`someTag:"value" repeated:"true" json:"repeated"`,
 		}
 
 		for _, tag := range expectedTags {
-			require.True(t, strings.Contains(fileText, tag))
+			require.True(t, strings.Contains(fileText, tag), tag)
 		}
 	})
 

--- a/plugin/modelgen/out/generated.go
+++ b/plugin/modelgen/out/generated.go
@@ -106,10 +106,10 @@ type CyclicalB struct {
 }
 
 type FieldMutationHook struct {
-	Name     *string       `json:"name" anotherTag:"tag" database:"FieldMutationHookname"`
-	Enum     *ExistingEnum `json:"enum" yetAnotherTag:"12" database:"FieldMutationHookenum"`
-	NoVal    *string       `json:"noVal" yaml:"noVal" repeated:"true" database:"FieldMutationHooknoVal"`
-	Repeated *string       `json:"repeated" someTag:"value" repeated:"true" database:"FieldMutationHookrepeated"`
+	Name     *string       `anotherTag:"tag" json:"name" database:"FieldMutationHookname"`
+	Enum     *ExistingEnum `yetAnotherTag:"12" json:"enum" database:"FieldMutationHookenum"`
+	NoVal    *string       `yaml:"noVal" repeated:"true" json:"noVal" database:"FieldMutationHooknoVal"`
+	Repeated *string       `someTag:"value" repeated:"true" json:"repeated" database:"FieldMutationHookrepeated"`
 }
 
 type ImplArrayOfA struct {

--- a/plugin/modelgen/out_struct_pointers/generated.go
+++ b/plugin/modelgen/out_struct_pointers/generated.go
@@ -89,8 +89,8 @@ type CyclicalB struct {
 
 type FieldMutationHook struct {
 	Name     *string       `json:"name" anotherTag:"tag" database:"FieldMutationHookname"`
-	Enum     *ExistingEnum `json:"enum" yetAnotherTag:"12" database:"FieldMutationHookenum"`
-	NoVal    *string       `json:"noVal" yaml:"noVal" repeated:"true" database:"FieldMutationHooknoVal"`
+	Enum     *ExistingEnum `yetAnotherTag:"12" json:"enum" database:"FieldMutationHookenum"`
+	NoVal    *string       `repeated:"true" json:"noVal" yaml:"noVal" database:"FieldMutationHooknoVal"`
 	Repeated *string       `json:"repeated" someTag:"value" repeated:"true" database:"FieldMutationHookrepeated"`
 }
 

--- a/plugin/modelgen/out_struct_pointers/generated.go
+++ b/plugin/modelgen/out_struct_pointers/generated.go
@@ -88,10 +88,10 @@ type CyclicalB struct {
 }
 
 type FieldMutationHook struct {
-	Name     *string       `json:"name" anotherTag:"tag" database:"FieldMutationHookname"`
+	Name     *string       `anotherTag:"tag" json:"name" database:"FieldMutationHookname"`
 	Enum     *ExistingEnum `yetAnotherTag:"12" json:"enum" database:"FieldMutationHookenum"`
-	NoVal    *string       `repeated:"true" json:"noVal" yaml:"noVal" database:"FieldMutationHooknoVal"`
-	Repeated *string       `json:"repeated" someTag:"value" repeated:"true" database:"FieldMutationHookrepeated"`
+	NoVal    *string       `yaml:"noVal" repeated:"true" json:"noVal" database:"FieldMutationHooknoVal"`
+	Repeated *string       `someTag:"value" repeated:"true" json:"repeated" database:"FieldMutationHookrepeated"`
 }
 
 type ImplArrayOfA struct {


### PR DESCRIPTION
As described in #2514, and without this PR, `GoTagFieldHook` just appends new tags, so `@goTag` will not override an existing tag.

Ideally it should override existing tag, since the sole purpose of the `@goTag` directive is to give control to user.

In this PR, the `removeDuplicateTags` helper func is introduced to fix #2514

This PR was originally authored by @valllabh in #2531 but I have adjusted it slightly.

I have:
 - [✓] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [Not Required] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))