### PR TITLE
Fix to override existing tags #2536

### DIFF
--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -419,25 +419,30 @@ func GoTagFieldHook(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Fie
 	return f, nil
 }
 
-func removeDuplicateTags(t string) string {
-	processed := make(map[string]bool)
-	tt := strings.Split(t, " ")
-	returnTags := ""
+func removeDuplicateTags(_tags string) string {
 
-	for _, ti := range tt {
-		kv := strings.Split(ti, ":")
-		if len(kv) == 0 || processed[kv[0]] {
-			continue
+	tags := strings.Split(_tags, " ")
+	uniqueTags := []string{}
+
+	if len(tags) > 0 {
+		tagMap := map[string]string{}
+
+		for _, tag := range tags {
+			tagKV := strings.Split(tag, ":")
+			if len(tagKV) > 0 {
+				tagMap[tagKV[0]] = tag
+			}
 		}
 
-		processed[kv[0]] = true
-		if len(returnTags) > 0 {
-			returnTags += " "
+		for _, tag := range tagMap {
+			uniqueTags = append(uniqueTags, tag)
 		}
-		returnTags += kv[0] + ":" + kv[1]
+		sort.Strings(uniqueTags) // to assure sorting order
+
+		return strings.Join(uniqueTags, " ")
 	}
 
-	return returnTags
+	return _tags
 }
 
 // GoFieldHook applies the goField directive to the generated Field f.

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -83,9 +83,29 @@ func TestModelGeneration(t *testing.T) {
 
 		expectedTags := []string{
 			`anotherTag:"tag" json:"name"`,
-			`yetAnotherTag:"12" json:"enum"`,
-			`yaml:"noVal" repeated:"true" json:"noVal"`,
-			`someTag:"value" repeated:"true" json:"repeated"`,
+			`json:"enum" yetAnotherTag:"12"`,
+			`json:"noVal" repeated:"true" yaml:"noVal"`,
+			`json:"repeated" repeated:"true" someTag:"value"`,
+		}
+
+		for _, tag := range expectedTags {
+			require.True(t, strings.Contains(fileText, tag), tag)
+		}
+	})
+
+	t.Run("tags can be overridden", func(t *testing.T) {
+		file, err := os.ReadFile("./out/generated.go")
+		require.NoError(t, err)
+
+		fileText := string(file)
+
+		expectedTags := []string{
+			`json:"name0" someOtherTag:"someOtherTagValue" database:"GoTagHookDuplicationTestname0"`,
+			`json:"name1" database:"GoTagHookDuplicationTestname1"`,
+			`json:"name2" database:"GoTagHookDuplicationTestname2"`,
+			`json:"name3" database:"GoTagHookDuplicationTestname3"`,
+			`json:"name4" someOtherTag:"someOtherTagValue" database:"GoTagHookDuplicationTestname4"`,
+			`json:"name5" someOtherTag:"someOtherTagValue2" database:"GoTagHookDuplicationTestname5"`,
 		}
 
 		for _, tag := range expectedTags {
@@ -372,28 +392,28 @@ func TestRemoveDuplicate(t *testing.T) {
 			args: args{
 				t: "json:\"name\" json:\"name2\"",
 			},
-			want: "json:\"name\"",
+			want: "json:\"name2\"",
 		},
 		{
 			name: "Duplicate Test with 3",
 			args: args{
 				t: "json:\"name\" json:\"name2\" json:\"name3\"",
 			},
-			want: "json:\"name\"",
+			want: "json:\"name3\"",
 		},
 		{
 			name: "Duplicate Test with 3 and 1 unrelated",
 			args: args{
 				t: "json:\"name\" something:\"name2\" json:\"name3\"",
 			},
-			want: "json:\"name\" something:\"name2\"",
+			want: "json:\"name3\" something:\"name2\"",
 		},
 		{
 			name: "Duplicate Test with 3 and 2 unrelated",
 			args: args{
 				t: "something:\"name1\" json:\"name\" something:\"name2\" json:\"name3\"",
 			},
-			want: "something:\"name1\" json:\"name\"",
+			want: "json:\"name3\" something:\"name2\"",
 		},
 	}
 	for _, tt := range tests {

--- a/plugin/modelgen/out/generated.go
+++ b/plugin/modelgen/out/generated.go
@@ -107,9 +107,18 @@ type CyclicalB struct {
 
 type FieldMutationHook struct {
 	Name     *string       `anotherTag:"tag" json:"name" database:"FieldMutationHookname"`
-	Enum     *ExistingEnum `yetAnotherTag:"12" json:"enum" database:"FieldMutationHookenum"`
-	NoVal    *string       `yaml:"noVal" repeated:"true" json:"noVal" database:"FieldMutationHooknoVal"`
-	Repeated *string       `someTag:"value" repeated:"true" json:"repeated" database:"FieldMutationHookrepeated"`
+	Enum     *ExistingEnum `json:"enum" yetAnotherTag:"12" database:"FieldMutationHookenum"`
+	NoVal    *string       `json:"noVal" repeated:"true" yaml:"noVal" database:"FieldMutationHooknoVal"`
+	Repeated *string       `json:"repeated" repeated:"true" someTag:"value" database:"FieldMutationHookrepeated"`
+}
+
+type GoTagHookDuplicationTest struct {
+	Name0 *string `json:"name0" someOtherTag:"someOtherTagValue" database:"GoTagHookDuplicationTestname0"`
+	Name1 *string `json:"name1" database:"GoTagHookDuplicationTestname1"`
+	Name2 *string `json:"name2" database:"GoTagHookDuplicationTestname2"`
+	Name3 *string `json:"name3" database:"GoTagHookDuplicationTestname3"`
+	Name4 *string `json:"name4" someOtherTag:"someOtherTagValue" database:"GoTagHookDuplicationTestname4"`
+	Name5 *string `json:"name5" someOtherTag:"someOtherTagValue2" database:"GoTagHookDuplicationTestname5"`
 }
 
 type ImplArrayOfA struct {

--- a/plugin/modelgen/out_struct_pointers/generated.go
+++ b/plugin/modelgen/out_struct_pointers/generated.go
@@ -89,9 +89,18 @@ type CyclicalB struct {
 
 type FieldMutationHook struct {
 	Name     *string       `anotherTag:"tag" json:"name" database:"FieldMutationHookname"`
-	Enum     *ExistingEnum `yetAnotherTag:"12" json:"enum" database:"FieldMutationHookenum"`
-	NoVal    *string       `yaml:"noVal" repeated:"true" json:"noVal" database:"FieldMutationHooknoVal"`
-	Repeated *string       `someTag:"value" repeated:"true" json:"repeated" database:"FieldMutationHookrepeated"`
+	Enum     *ExistingEnum `json:"enum" yetAnotherTag:"12" database:"FieldMutationHookenum"`
+	NoVal    *string       `json:"noVal" repeated:"true" yaml:"noVal" database:"FieldMutationHooknoVal"`
+	Repeated *string       `json:"repeated" repeated:"true" someTag:"value" database:"FieldMutationHookrepeated"`
+}
+
+type GoTagHookDuplicationTest struct {
+	Name0 *string `json:"name0" someOtherTag:"someOtherTagValue" database:"GoTagHookDuplicationTestname0"`
+	Name1 *string `json:"name1" database:"GoTagHookDuplicationTestname1"`
+	Name2 *string `json:"name2" database:"GoTagHookDuplicationTestname2"`
+	Name3 *string `json:"name3" database:"GoTagHookDuplicationTestname3"`
+	Name4 *string `json:"name4" someOtherTag:"someOtherTagValue" database:"GoTagHookDuplicationTestname4"`
+	Name5 *string `json:"name5" someOtherTag:"someOtherTagValue2" database:"GoTagHookDuplicationTestname5"`
 }
 
 type ImplArrayOfA struct {

--- a/plugin/modelgen/testdata/schema.graphql
+++ b/plugin/modelgen/testdata/schema.graphql
@@ -69,7 +69,15 @@ type FieldMutationHook {
     enum: ExistingEnum @goTag(key: "yetAnotherTag", value: "12")
     noVal: String @goTag(key: "yaml") @goTag(key : "repeated", value: "true")
     repeated: String @goTag(key: "someTag", value: "value") @goTag(key : "repeated", value: "true")
+}
 
+type GoTagHookDuplicationTest {
+    name0: String @goTag(key: "someOtherTag", value: "someOtherTagValue")
+    name1: String @goTag(key: "json", value: "Name1")
+    name2: String @goTag(key: "json", value: "name2") @goTag(key: "json", value: "Name2")
+    name3: String @goTag(key: "json", value: "name2") @goTag(key: "json", value: "name3") @goTag(key: "json", value: "Name3")
+    name4: String @goTag(key: "json", value: "name2") @goTag(key: "someOtherTag", value: "someOtherTagValue") @goTag(key: "json", value: "Name4")
+    name5: String @goTag(key: "json", value: "name2") @goTag(key: "someOtherTag", value: "someOtherTagValue") @goTag(key: "json", value: "Name4") @goTag(key: "someOtherTag", value: "someOtherTagValue2")
 }
 
 enum ExistingEnum {


### PR DESCRIPTION
- This fix honors user added tags in order they appear and overrides previous tags if any
- tags are now sorted in alphabetical order to have more consistency
- added extra tests post model generation

@StevenACoffman you might want to check this

I have:
 - [Yes] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [Not Required] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
