### PR TITLE
feat: support ApolloSandbox playground

### DIFF
--- a/graphql/playground/apollo_sandbox_playground.go
+++ b/graphql/playground/apollo_sandbox_playground.go
@@ -35,6 +35,10 @@ var apolloSandboxPage = template.Must(template.New("ApolloSandbox").Parse(`<!doc
     target: '#embedded-sandbox',
     initialEndpoint: url,
 		persistExplorerState: true,
+		initialState: {
+			includeCookies: true,
+			pollForSchemaUpdates: false,
+		}
   });
   </script>
 </body>

--- a/graphql/playground/apollo_sandbox_playground.go
+++ b/graphql/playground/apollo_sandbox_playground.go
@@ -1,0 +1,57 @@
+package playground
+
+import (
+	"html/template"
+	"net/http"
+)
+
+var apolloSandboxPage = template.Must(template.New("ApolloSandbox").Parse(`<!doctype html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>{{.title}}</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="icon" href="https://embeddable-sandbox.cdn.apollographql.com/_latest/public/assets/favicon-dark.png">
+	<style>
+	body {
+		margin: 0;
+		overflow: hidden;
+	}
+</style>
+</head>
+
+<body>
+  <div style="width: 100vw; height: 100vh;" id='embedded-sandbox'></div>
+  <!-- NOTE: New version available at https://embeddable-sandbox.cdn.apollographql.com/ -->
+  <script rel="preload" as="script" crossorigin="anonymous" integrity="{{.mainSRI}}" type="text/javascript" src="https://embeddable-sandbox.cdn.apollographql.com/58165cf7452dbad480c7cb85e7acba085b3bac1d/embeddable-sandbox.umd.production.min.js"></script>
+  <script>
+{{- if .endpointIsAbsolute}}
+	const url = {{.endpoint}};
+{{- else}}
+	const url = location.protocol + '//' + location.host + {{.endpoint}};
+{{- end}}
+  new window.EmbeddedSandbox({
+    target: '#embedded-sandbox',
+    initialEndpoint: url,
+		persistExplorerState: true,
+  });
+  </script>
+</body>
+
+</html>`))
+
+// ApolloSandboxHandler responsible for setting up the altair playground
+func ApolloSandboxHandler(title, endpoint string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		err := apolloSandboxPage.Execute(w, map[string]interface{}{
+			"title":              title,
+			"endpoint":           endpoint,
+			"endpointIsAbsolute": endpointHasScheme(endpoint),
+			"mainSRI":            "sha256-/E4VNgAWFmbNLyXACSYoqsDAj68jC1sCMSQ0cDjf4YM=",
+		})
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/graphql/playground/apollo_sandbox_playground.go
+++ b/graphql/playground/apollo_sandbox_playground.go
@@ -31,6 +31,7 @@ var apolloSandboxPage = template.Must(template.New("ApolloSandbox").Parse(`<!doc
 {{- else}}
 	const url = location.protocol + '//' + location.host + {{.endpoint}};
 {{- end}}
+	<!-- See https://www.apollographql.com/docs/graphos/explorer/sandbox/#options -->
   new window.EmbeddedSandbox({
     target: '#embedded-sandbox',
     initialEndpoint: url,


### PR DESCRIPTION
I would like to add ApolloSandbox to the Playground options, similar to  #2437

[Apollo Sandbox: an open GraphQL IDE for local development - Apollo GraphQL Blog](https://www.apollographql.com/blog/announcement/platform/apollo-sandbox-an-open-graphql-ide-for-local-development/#1-one-click-query-building-in-explorer)

ApolloSandbox includes developer-friendly features such as useful browsing of schema documentation, easy building queries, and sharing of queries in specific cases for debug.
 
#### new ApolloSandboxHandler

```go
http.Handle("/", playground.ApolloSandboxHandler("GraphQL playground", "/query"))
```

