### PR TITLE
POST transport: missing return and unnecessary logs

### DIFF
--- a/graphql/handler/transport/http_post.go
+++ b/graphql/handler/transport/http_post.go
@@ -3,7 +3,6 @@ package transport
 import (
 	"fmt"
 	"io"
-	"log"
 	"mime"
 	"net/http"
 	"strings"
@@ -58,7 +57,6 @@ func (h POST) Do(w http.ResponseWriter, r *http.Request, exec graphql.GraphExecu
 	if err != nil {
 		gqlErr := gqlerror.Errorf("could not get json request body: %+v", err)
 		resp := exec.DispatchError(ctx, gqlerror.List{gqlErr})
-		log.Printf("could not get json request body: %+v", err.Error())
 		writeJson(w, resp)
 		return
 	}
@@ -72,7 +70,6 @@ func (h POST) Do(w http.ResponseWriter, r *http.Request, exec graphql.GraphExecu
 			bodyString,
 		)
 		resp := exec.DispatchError(ctx, gqlerror.List{gqlErr})
-		log.Printf("decoding error: %+v body:%s", err.Error(), bodyString)
 		writeJson(w, resp)
 		return
 	}

--- a/graphql/handler/transport/http_post.go
+++ b/graphql/handler/transport/http_post.go
@@ -60,6 +60,7 @@ func (h POST) Do(w http.ResponseWriter, r *http.Request, exec graphql.GraphExecu
 		resp := exec.DispatchError(ctx, gqlerror.List{gqlErr})
 		log.Printf("could not get json request body: %+v", err.Error())
 		writeJson(w, resp)
+		return
 	}
 
 	bodyReader := io.NopCloser(strings.NewReader(bodyString))


### PR DESCRIPTION
The HTTP POST transport was missing a return in the first error case.

I also removed the two `log.Printf` calls which seem to have been left there unintentionally.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
