### PR TITLE
pin nancy because latest tag lookup is failing

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,3 +18,5 @@ jobs:
           go-version: ${{ matrix.go }}
       - run: go mod download && go list -json -deps all > go.list
       - uses: sonatype-nexus-community/nancy-github-action@main
+        with:
+          nancyVersion: "v1.0.42"


### PR DESCRIPTION
The `latest` lookup for nancy is very flaky, causing a number of failures that I need to retry manually.

Signed-off-by: Steve Coffman <steve@khanacademy.org>
