### PR TITLE
feat: removeDuplicateTags() validates tags and panic with meaningful …

### DIFF
--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -434,6 +434,11 @@ func removeDuplicateTags(t string) string {
 	// iterate backwards through tags so appended goTag directives are prioritized
 	for i := len(tt) - 1; i >= 0; i-- {
 		ti := tt[i]
+		// check if ti contains ":", and not contains any empty space. if not, tag is in wrong format
+		if !strings.Contains(ti, ":") || strings.Contains(ti, " ") {
+			panic(fmt.Errorf("wrong format of tags: %s. goTag directive should be in format: @goTag(key: \"something\", value:\"value1,value2,etc\"), no empty space is allowed", t))
+		}
+
 		kv := strings.Split(ti, ":")
 		if len(kv) == 0 || processed[kv[0]] {
 			continue

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -356,9 +356,10 @@ func TestRemoveDuplicate(t *testing.T) {
 		t string
 	}
 	tests := []struct {
-		name string
-		args args
-		want string
+		name      string
+		args      args
+		want      string
+		wantPanic bool
 	}{
 		{
 			name: "Duplicate Test with 1",
@@ -395,11 +396,23 @@ func TestRemoveDuplicate(t *testing.T) {
 			},
 			want: "something:\"name2\" json:\"name3\"",
 		},
+		{
+			name: "Test value with empty space",
+			args: args{
+				t: "json:\"name, name2\"",
+			},
+			want:      "json:\"name, name2\"",
+			wantPanic: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := removeDuplicateTags(tt.args.t); got != tt.want {
-				t.Errorf("removeDuplicate() = %v, want %v", got, tt.want)
+			if tt.wantPanic {
+				assert.Panics(t, func() { removeDuplicateTags(tt.args.t) }, "The code did not panic")
+			} else {
+				if got := removeDuplicateTags(tt.args.t); got != tt.want {
+					t.Errorf("removeDuplicate() = %v, want %v", got, tt.want)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
if schema defines a bad goTag, example: 
```
type AObject {
    id: ObjectID! @goTag(key: "bson", value: "_id, omitempty")
}
```
The value contains an empty space. This will break removeDuplicateTags function and panic which vague error message which makes it hard to debug.

My PR check goTag format and panic with  meaningful message which help debug a lot.

Before:
![image](https://user-images.githubusercontent.com/45360805/228243279-af7a6ce0-e272-40c0-97e9-d4c4f998eb88.png)
After:
![image](https://user-images.githubusercontent.com/45360805/228243382-c0eb5d75-aa47-46c5-afc2-a32274939067.png)

Test result:
<img width="628" alt="image" src="https://user-images.githubusercontent.com/45360805/228245129-efeab0eb-a3f1-45da-891e-a33c20399b6a.png">


I have:
 - [✅] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [❌ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
