### PR TITLE
Fix 2546: Federation 2 Relax external for object

### DIFF
--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -89,8 +89,6 @@ func (f *federation) InjectSourceEarly() *ast.Source {
 	input := `
 	scalar _Any
 	scalar _FieldSet
-
-	directive @external on FIELD_DEFINITION
 	directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 	directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 	directive @extends on OBJECT | INTERFACE
@@ -99,10 +97,12 @@ func (f *federation) InjectSourceEarly() *ast.Source {
 	if f.Version == 1 {
 		input += `
 	directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
+	directive @external on FIELD_DEFINITION
 `
 	} else if f.Version == 2 {
 		input += `
 	directive @key(fields: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+	directive @external on FIELD_DEFINITION | OBJECT
 	directive @link(import: [String!], url: String!) repeatable on SCHEMA
 	directive @shareable on OBJECT | FIELD_DEFINITION
 	directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION


### PR DESCRIPTION
Fixes #2546

`@external` was originally (Federation v1) only applicable on `FIELD_DEFINITION`.
Federation v2 relaxed directive definition to also allow applying it on `OBJECT` (which has the same effect as making all the object fields as `@external`).

The specs for v2 indicate that it is allowed on objects: https://www.apollographql.com/docs/federation/subgraph-spec/. `directive @external on FIELD_DEFINITION | OBJECT` A dig through the source of gqlgen resulted in this: https://github.com/99designs/gqlgen/blob/db1e3b81e71adcbad5143cf4b91fb402bb7ceba6/plugin/federation/federation.go#L93

Signed-off-by: Steve Coffman <steve@khanacademy.org>
