### PR TITLE
Add on-close handler for websockets.

### DIFF
--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -24,6 +24,7 @@ type (
 		InitFunc              WebsocketInitFunc
 		InitTimeout           time.Duration
 		ErrorFunc             WebsocketErrorFunc
+		CloseFunc             WebsocketCloseFunc
 		KeepAlivePingInterval time.Duration
 		PingPongInterval      time.Duration
 
@@ -45,6 +46,9 @@ type (
 
 	WebsocketInitFunc  func(ctx context.Context, initPayload InitPayload) (context.Context, error)
 	WebsocketErrorFunc func(ctx context.Context, err error)
+
+	// Callback called when websocket is closed.
+	WebsocketCloseFunc func(ctx context.Context, closeCode int)
 )
 
 var errReadTimeout = errors.New("read timeout")
@@ -433,4 +437,5 @@ func (c *wsConnection) close(closeCode int, message string) {
 	}
 	c.mu.Unlock()
 	_ = c.conn.Close()
+	c.CloseFunc(c.ctx, closeCode)
 }

--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -437,5 +437,8 @@ func (c *wsConnection) close(closeCode int, message string) {
 	}
 	c.mu.Unlock()
 	_ = c.conn.Close()
-	c.CloseFunc(c.ctx, closeCode)
+
+	if c.CloseFunc != nil {
+		c.CloseFunc(c.ctx, closeCode)
+	}
 }


### PR DESCRIPTION
## Summary
When a websocket is closed, it'd be beneficial to have an on-close handler that can be registered to execute teardown logic. This approach is better than spinning up a goroutine and blocking on `ctx.Done()` (in cases where that's the only other option).

See issue: #2604 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
