### PR TITLE
fix enum capitalization

### DIFF
--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -519,6 +519,17 @@ func wordWalker(str string, f func(*wordInfo)) {
 		matchCommonInitial := false
 		upperWord := strings.ToUpper(word)
 		if commonInitialisms[upperWord] {
+			// If the uppercase word (string(runes[w:i]) is "ID" or "IP"
+			// AND
+			// the word is the first two characters of the str
+			// AND
+			// that is not the end of the word
+			// AND
+			// the length of the string is greater than 3
+			// AND
+			// the third rune is an uppercase one
+			// THEN
+			// do NOT count this as an initialism.
 			switch upperWord {
 			case "ID", "IP":
 				if word == str[:2] && !eow && len(str) > 3 && unicode.IsUpper(runes[3]) {

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -517,7 +517,14 @@ func wordWalker(str string, f func(*wordInfo)) {
 		}
 
 		matchCommonInitial := false
-		if commonInitialisms[strings.ToUpper(word)] {
+		upperWord := strings.ToUpper(word)
+		if commonInitialisms[upperWord] {
+			switch upperWord {
+			case "ID", "IP":
+				if word == str[:2] && !eow && len(str) > 3 && unicode.IsUpper(runes[3]) {
+					continue
+				}
+			}
 			hasCommonInitial = true
 			matchCommonInitial = true
 		}

--- a/codegen/templates/templates_test.go
+++ b/codegen/templates/templates_test.go
@@ -44,6 +44,15 @@ func TestToGo(t *testing.T) {
 	require.Equal(t, "RelatedUrls", ToGo("RelatedUrls"))
 	require.Equal(t, "ITicket", ToGo("ITicket"))
 	require.Equal(t, "FooTicket", ToGo("fooTicket"))
+
+	require.Equal(t, "Idle", ToGo("IDLE"))
+	require.Equal(t, "Idle", ToGo("Idle"))
+	require.Equal(t, "Idle", ToGo("idle"))
+	require.Equal(t, "Identities", ToGo("IDENTITIES"))
+	require.Equal(t, "Identities", ToGo("Identities"))
+	require.Equal(t, "Identities", ToGo("identities"))
+	require.Equal(t, "Iphone", ToGo("IPHONE"))
+	require.Equal(t, "IPhone", ToGo("iPHONE"))
 }
 
 func TestToGoPrivate(t *testing.T) {
@@ -73,6 +82,15 @@ func TestToGoPrivate(t *testing.T) {
 	require.Equal(t, "id", ToGoPrivate("id"))
 	require.Equal(t, "", ToGoPrivate(""))
 	require.Equal(t, "_", ToGoPrivate("_"))
+
+	require.Equal(t, "idle", ToGoPrivate("IDLE"))
+	require.Equal(t, "idle", ToGoPrivate("Idle"))
+	require.Equal(t, "idle", ToGoPrivate("idle"))
+	require.Equal(t, "identities", ToGoPrivate("IDENTITIES"))
+	require.Equal(t, "identities", ToGoPrivate("Identities"))
+	require.Equal(t, "identities", ToGoPrivate("identities"))
+	require.Equal(t, "iphone", ToGoPrivate("IPHONE"))
+	require.Equal(t, "iPhone", ToGoPrivate("iPHONE"))
 }
 
 func TestToGoModelName(t *testing.T) {


### PR DESCRIPTION
First of all, sorry for my bad english.

In my case, I want to use `IDLE` and it should be `Idle`. But the generated output shows me `IDLe`.
And I found similar issue #2469. So I try to satisfy both.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
