### PR TITLE
Fix uint32 unmarshal

### DIFF
--- a/graphql/uint.go
+++ b/graphql/uint.go
@@ -60,7 +60,7 @@ func MarshalUint32(i uint32) Marshaler {
 func UnmarshalUint32(v interface{}) (uint32, error) {
 	switch v := v.(type) {
 	case string:
-		iv, err := strconv.ParseInt(v, 10, 32)
+		iv, err := strconv.ParseUint(v, 10, 32)
 		if err != nil {
 			return 0, err
 		}

--- a/graphql/uint_test.go
+++ b/graphql/uint_test.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,7 @@ func mustUnmarshalUint(v interface{}) uint {
 func TestUint32(t *testing.T) {
 	t.Run("marshal", func(t *testing.T) {
 		assert.Equal(t, "123", m2s(MarshalUint32(123)))
+		assert.Equal(t, "4294967295", m2s(MarshalUint32(math.MaxUint32)))
 	})
 
 	t.Run("unmarshal", func(t *testing.T) {
@@ -38,6 +40,7 @@ func TestUint32(t *testing.T) {
 		assert.Equal(t, uint32(123), mustUnmarshalUint32(int64(123)))
 		assert.Equal(t, uint32(123), mustUnmarshalUint32(json.Number("123")))
 		assert.Equal(t, uint32(123), mustUnmarshalUint32("123"))
+		assert.Equal(t, uint32(4294967295), mustUnmarshalUint32("4294967295"))
 	})
 }
 


### PR DESCRIPTION
The string unmarshal for uint32 used ParseInt instead of ParseUint, which would parse the wrong range of valid numbers.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
