### PR TITLE
Generate federation entity resolvers for interfaces with @key fields defined

### DIFF
--- a/plugin/federation/federation_test.go
+++ b/plugin/federation/federation_test.go
@@ -87,12 +87,21 @@ func TestNoEntities(t *testing.T) {
 	require.Len(t, f.Entities, 0)
 }
 
+func TestUnusedInterfaceKeyDirective(t *testing.T) {
+	f, cfg := load(t, "testdata/interfaces/unused_key.yml")
+
+	err := f.MutateConfig(cfg)
+	require.NoError(t, err)
+	require.Len(t, f.Entities, 0)
+}
+
 func TestInterfaceKeyDirective(t *testing.T) {
 	f, cfg := load(t, "testdata/interfaces/key.yml")
 
 	err := f.MutateConfig(cfg)
 	require.NoError(t, err)
-	require.Len(t, f.Entities, 0)
+	require.Len(t, cfg.Schema.Types["_Entity"].Types, 1)
+	require.Len(t, f.Entities, 2)
 }
 
 func TestInterfaceExtendsDirective(t *testing.T) {

--- a/plugin/federation/testdata/interfaces/key.graphqls
+++ b/plugin/federation/testdata/interfaces/key.graphqls
@@ -2,3 +2,8 @@ extend interface Hello @key(fields: "name") {
     name: String!
     secondary: String!
 }
+
+type World implements Hello @key(fields: "name") {
+    name: String!
+    secondary: String!
+}

--- a/plugin/federation/testdata/interfaces/unused_key.graphqls
+++ b/plugin/federation/testdata/interfaces/unused_key.graphqls
@@ -1,0 +1,4 @@
+extend interface Hello @key(fields: "name") {
+    name: String!
+    secondary: String!
+}

--- a/plugin/federation/testdata/interfaces/unused_key.yml
+++ b/plugin/federation/testdata/interfaces/unused_key.yml
@@ -1,0 +1,6 @@
+schema:
+  - "testdata/interfaces/unused_key.graphqls"
+exec:
+  filename: testdata/interfaces/generated/exec.go
+federation:
+  filename: testdata/interfaces/generated/federation.go


### PR DESCRIPTION
When using interfaces and interfaceObjects as described by the Apollo spec you have to be able to resolve the interface types as described [here](https://www.apollographql.com/docs/federation/federated-types/interfaces/#interface-reference-resolver). 

This updates the generation to allow `@key` fields on interfaces and generates the resulting functions needed to handling resolving the entities. 

I left the existing test but changed it to be an unused interface, and then created a new test with an interface that is used to verify it works. I've also validated this works with the federated gateway to properly handle resolving interface return types coming from a different subgraph.

The only thing I'm not sure about is around line 223. I'm using an object that implements the interface to get the field types. This seemed easier to maintain long term as it seemed like I would need to fork to code and have one path for an interface and one path for an object since there isn't an object for the interface. Open to ideas to improve this though.

Not sure if any docs specifically for this are desired, the use of `@key` fields is documented already and it follows the same pattern.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
