### PR TITLE
POC: Generated model extra fields

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -322,14 +322,21 @@ func (c *Config) injectTypesFromSchema() error {
 }
 
 type TypeMapEntry struct {
-	Model  StringList              `yaml:"model"`
-	Fields map[string]TypeMapField `yaml:"fields,omitempty"`
+	Model       StringList                 `yaml:"model"`
+	Fields      map[string]TypeMapField    `yaml:"fields,omitempty"`
+	ExtraFields map[string]ModelExtraField `yaml:"extraFields,omitempty"`
 }
 
 type TypeMapField struct {
 	Resolver        bool   `yaml:"resolver"`
 	FieldName       string `yaml:"fieldName"`
 	GeneratedMethod string `yaml:"-"`
+}
+
+type ModelExtraField struct {
+	Type         string `yaml:"type"`
+	IsPointer    bool   `yaml:"isPointer"`
+	OverrideTags string `yaml:"overrideTags"`
 }
 
 type StringList []string

--- a/plugin/modelgen/internal/extrafields/types.go
+++ b/plugin/modelgen/internal/extrafields/types.go
@@ -1,0 +1,4 @@
+package extrafields
+
+type Type struct {
+}

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/99designs/gqlgen/graphql"
+	"github.com/99designs/gqlgen/plugin/modelgen/internal/extrafields"
 	"github.com/99designs/gqlgen/plugin/modelgen/out_nullable_input_omittable"
 	"github.com/99designs/gqlgen/plugin/modelgen/out_struct_pointers"
 
@@ -42,6 +43,8 @@ func TestModelGeneration(t *testing.T) {
 	require.True(t, cfg.Models.UserDefined("EnumWithDescription"))
 	require.True(t, cfg.Models.UserDefined("InterfaceWithDescription"))
 	require.True(t, cfg.Models.UserDefined("UnionWithDescription"))
+	require.True(t, cfg.Models.UserDefined("RenameFieldTest"))
+	require.True(t, cfg.Models.UserDefined("ExtraFieldsTest"))
 
 	t.Run("no pointer pointers", func(t *testing.T) {
 		generated, err := os.ReadFile("./out/generated.go")
@@ -278,6 +281,14 @@ func TestModelGeneration(t *testing.T) {
 		require.IsType(t, out.MissingInput{}.NullString, graphql.Omittable[*string]{})
 		require.IsType(t, out.MissingInput{}.NullEnum, graphql.Omittable[*out.MissingEnum]{})
 		require.IsType(t, out.MissingInput{}.NullObject, graphql.Omittable[*out.ExistingInput]{})
+	})
+
+	t.Run("extra fields are present", func(t *testing.T) {
+		var m out.ExtraFieldsTest
+
+		require.IsType(t, m.FieldInt, int64(0))
+		require.IsType(t, m.FieldInternalType, extrafields.Type{})
+		require.IsType(t, m.FieldStringPtr, new(string))
 	})
 }
 

--- a/plugin/modelgen/out/generated.go
+++ b/plugin/modelgen/out/generated.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/99designs/gqlgen/graphql"
+	"github.com/99designs/gqlgen/plugin/modelgen/internal/extrafields"
 )
 
 type A interface {
@@ -105,6 +106,16 @@ type CyclicalB struct {
 	FieldThree *CyclicalA `json:"field_three,omitempty" database:"CyclicalBfield_three"`
 	FieldFour  *CyclicalA `json:"field_four,omitempty" database:"CyclicalBfield_four"`
 	FieldFive  string     `json:"field_five" database:"CyclicalBfield_five"`
+}
+
+type ExtraFieldsTest struct {
+	SchemaField string `json:"SchemaField" database:"ExtraFieldsTestSchemaField"`
+	// User defined extra field
+	FieldInt int64 `json:"field_int_tag" database:"ExtraFieldsTestFieldInt"`
+	// User defined extra field
+	FieldInternalType extrafields.Type `json:"-" database:"ExtraFieldsTestFieldInternalType"`
+	// User defined extra field
+	FieldStringPtr *string `json:"-" database:"ExtraFieldsTestFieldStringPtr"`
 }
 
 type FieldMutationHook struct {

--- a/plugin/modelgen/out_nullable_input_omittable/generated.go
+++ b/plugin/modelgen/out_nullable_input_omittable/generated.go
@@ -107,6 +107,10 @@ type CyclicalB struct {
 	FieldFive  string     `json:"field_five" database:"CyclicalBfield_five"`
 }
 
+type ExtraFieldsTest struct {
+	SchemaField string `json:"SchemaField" database:"ExtraFieldsTestSchemaField"`
+}
+
 type FieldMutationHook struct {
 	Name     *string       `json:"name,omitempty" anotherTag:"tag" database:"FieldMutationHookname"`
 	Enum     *ExistingEnum `json:"enum,omitempty" yetAnotherTag:"12" database:"FieldMutationHookenum"`

--- a/plugin/modelgen/out_struct_pointers/generated.go
+++ b/plugin/modelgen/out_struct_pointers/generated.go
@@ -89,6 +89,10 @@ type CyclicalB struct {
 	FieldFive  string     `json:"field_five" database:"CyclicalBfield_five"`
 }
 
+type ExtraFieldsTest struct {
+	SchemaField string `json:"SchemaField" database:"ExtraFieldsTestSchemaField"`
+}
+
 type FieldMutationHook struct {
 	Name     *string       `json:"name,omitempty" anotherTag:"tag" database:"FieldMutationHookname"`
 	Enum     *ExistingEnum `json:"enum,omitempty" yetAnotherTag:"12" database:"FieldMutationHookenum"`

--- a/plugin/modelgen/testdata/gqlgen.yml
+++ b/plugin/modelgen/testdata/gqlgen.yml
@@ -23,4 +23,13 @@ models:
     fields:
       badName:
         fieldName: GOODnaME
-
+  ExtraFieldsTest:
+    extraFields:
+      FieldInternalType:
+        type: github.com/99designs/gqlgen/plugin/modelgen/internal/extrafields.Type
+      FieldStringPtr:
+        type: "string"
+        isPointer: true
+      FieldInt:
+        type: "int64"
+        overrideTags: 'json:"field_int_tag"'

--- a/plugin/modelgen/testdata/schema.graphql
+++ b/plugin/modelgen/testdata/schema.graphql
@@ -198,3 +198,7 @@ type Xer implements X {
     Id: String! @goField(name: "Id")
     Name: String!
 }
+
+type ExtraFieldsTest {
+  SchemaField: String!
+}


### PR DESCRIPTION
Whenever I was implementing something using gqlgen I was facing the need of several extra fields for intermediate generated go objects in order to pass different data from the parent resolver to the children. Yes, I can define a whole model as a separate object, but it's easier to append one or two extra fields instead.
This PR implements ability to define any extra fields for a generatable models. So they are available to consume by resolver implementations.

TLDR:
the following config
```yaml
models:
  ExtraFieldsTest:
    extraFields:
      FieldInternalType:
        type: github.com/99designs/gqlgen/plugin/modelgen/internal/extrafields.Type
      FieldStringPtr:
        type: "string"
        isPointer: true
      FieldInt:
        type: "int64"
        overrideTags: 'json:"field_int_tag"'
```
 turns out into the following generated model where extra fields are not exposed to the API consumers but only for resolvers.

```go
type ExtraFieldsTest struct {
	SchemaField string `json:"SchemaField" database:"ExtraFieldsTestSchemaField"`
	// User defined extra field
	FieldInt int64 `json:"field_int_tag" database:"ExtraFieldsTestFieldInt"`
	// User defined extra field
	FieldInternalType extrafields.Type `json:"-" database:"ExtraFieldsTestFieldInternalType"`
	// User defined extra field
	FieldStringPtr *string `json:"-" database:"ExtraFieldsTestFieldStringPtr"`
}
```

Any suggestions about config improvements are appreciated.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
