### PR TITLE
fix: issue with extraFields being thrown away

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -305,9 +305,9 @@ func (c *Config) injectTypesFromSchema() error {
 
 					if c.Models[schemaType.Name].Fields == nil {
 						c.Models[schemaType.Name] = TypeMapEntry{
-							Model:        c.Models[schemaType.Name].Model,
-							ExtraFields:  c.Models[schemaType.Name].ExtraFields,
-							Fields:       map[string]TypeMapField{},
+							Model:       c.Models[schemaType.Name].Model,
+							ExtraFields: c.Models[schemaType.Name].ExtraFields,
+							Fields:      map[string]TypeMapField{},
 						}
 					}
 

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -305,8 +305,9 @@ func (c *Config) injectTypesFromSchema() error {
 
 					if c.Models[schemaType.Name].Fields == nil {
 						c.Models[schemaType.Name] = TypeMapEntry{
-							Model:  c.Models[schemaType.Name].Model,
-							Fields: map[string]TypeMapField{},
+							Model:        c.Models[schemaType.Name].Model,
+							ExtraFields:  c.Models[schemaType.Name].ExtraFields,
+							Fields:       map[string]TypeMapField{},
 						}
 					}
 


### PR DESCRIPTION
Currently, I am using `extraFields` but they are discarded when I have a `forceResolver` on that same model/type. This fixes that by carrying through ExtraFields.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
