### PR TITLE
WIP: Refactor federation requires to populate on entity via a function

### DIFF
--- a/_examples/federation/reviews/graph/federation.go
+++ b/_examples/federation/reviews/graph/federation.go
@@ -121,13 +121,9 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 					return fmt.Errorf(`resolving Entity "User": %w`, err)
 				}
 
-				entity.Host.ID, err = ec.unmarshalNString2string(ctx, rep["host"].(map[string]interface{})["id"])
+				err = ec.PopulateUserRequires(ctx, entity, rep)
 				if err != nil {
-					return err
-				}
-				entity.Email, err = ec.unmarshalNString2string(ctx, rep["email"])
-				if err != nil {
-					return err
+					return fmt.Errorf(`populating requires for Entity "User": %w`, err)
 				}
 				list[idx[i]] = entity
 				return nil

--- a/_examples/federation/reviews/graph/federation.requires.go
+++ b/_examples/federation/reviews/graph/federation.requires.go
@@ -1,0 +1,13 @@
+package graph
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/99designs/gqlgen/_examples/federation/reviews/graph/model"
+)
+
+// PopulateUserRequires is the requires populator for the User entity.
+func (ec *executionContext) PopulateUserRequires(ctx context.Context, entity *model.User, reps map[string]interface{}) error {
+	panic(fmt.Errorf("not implemented: PopulateUserRequires"))
+}

--- a/plugin/federation/entity.go
+++ b/plugin/federation/entity.go
@@ -2,6 +2,7 @@ package federation
 
 import (
 	"go/types"
+	"strings"
 
 	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/99designs/gqlgen/codegen/templates"
@@ -17,6 +18,7 @@ type Entity struct {
 	Resolvers []*EntityResolver
 	Requires  []*Requires
 	Multi     bool
+	Type      types.Type
 }
 
 type EntityResolver struct {
@@ -114,4 +116,10 @@ func (e *Entity) keyFields() []string {
 		keyFields[i] = field[0]
 	}
 	return keyFields
+}
+
+// GetTypeInfo - get the imported package & type name combo.  package.TypeName
+func (e Entity) GetTypeInfo() string {
+	typeParts := strings.Split(e.Type.String(), "/")
+	return typeParts[len(typeParts)-1]
 }

--- a/plugin/federation/federation.gotpl
+++ b/plugin/federation/federation.gotpl
@@ -103,10 +103,10 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 						if err != nil {
 							return fmt.Errorf(`resolving Entity "{{$entity.Def.Name}}": %w`, err)
 						}
-						{{ range $entity.Requires }}
-							entity.{{.Field.JoinGo `.`}}, err = ec.{{.Type.UnmarshalFunc}}(ctx, rep["{{.Field.Join `"].(map[string]interface{})["`}}"])
+						{{ if $entity.Requires }}
+							err = ec.Populate{{$entity.Def.Name}}Requires(ctx, entity, rep)
 							if err != nil {
-								return err
+								return fmt.Errorf(`populating requires for Entity "{{$entity.Def.Name}}": %w`, err)
 							}
 						{{- end }}
 						list[idx[i]] = entity

--- a/plugin/federation/requires.gotpl
+++ b/plugin/federation/requires.gotpl
@@ -1,0 +1,20 @@
+{{ range .ExistingImports }}
+{{ if ne .Alias "" }}
+{{ reserveImport .ImportPath .Alias }}
+{{ else }}
+{{ reserveImport .ImportPath }}
+{{ end }}
+{{ end }}
+
+{{ range .Populators -}}
+{{ if .Comment -}}
+// {{.Comment}}
+{{- else -}}
+// {{.FuncName}} is the requires populator for the {{.Entity.Def.Name}} entity.
+{{- end }}
+func (ec *executionContext) {{.FuncName}}(ctx context.Context, entity *{{.Entity.GetTypeInfo}}, reps map[string]interface{}) error {
+	{{.Implementation}}
+}
+{{ end }}
+
+{{ .OriginalSource }}

--- a/plugin/federation/testdata/entityresolver/generated/federation.go
+++ b/plugin/federation/testdata/entityresolver/generated/federation.go
@@ -172,13 +172,9 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 					return fmt.Errorf(`resolving Entity "PlanetMultipleRequires": %w`, err)
 				}
 
-				entity.Diameter, err = ec.unmarshalNInt2int(ctx, rep["diameter"])
+				err = ec.PopulatePlanetMultipleRequiresRequires(ctx, entity, rep)
 				if err != nil {
-					return err
-				}
-				entity.Density, err = ec.unmarshalNInt2int(ctx, rep["density"])
-				if err != nil {
-					return err
+					return fmt.Errorf(`populating requires for Entity "PlanetMultipleRequires": %w`, err)
 				}
 				list[idx[i]] = entity
 				return nil
@@ -200,9 +196,9 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 					return fmt.Errorf(`resolving Entity "PlanetRequires": %w`, err)
 				}
 
-				entity.Diameter, err = ec.unmarshalNInt2int(ctx, rep["diameter"])
+				err = ec.PopulatePlanetRequiresRequires(ctx, entity, rep)
 				if err != nil {
-					return err
+					return fmt.Errorf(`populating requires for Entity "PlanetRequires": %w`, err)
 				}
 				list[idx[i]] = entity
 				return nil
@@ -224,9 +220,9 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 					return fmt.Errorf(`resolving Entity "PlanetRequiresNested": %w`, err)
 				}
 
-				entity.World.Foo, err = ec.unmarshalNString2string(ctx, rep["world"].(map[string]interface{})["foo"])
+				err = ec.PopulatePlanetRequiresNestedRequires(ctx, entity, rep)
 				if err != nil {
-					return err
+					return fmt.Errorf(`populating requires for Entity "PlanetRequiresNested": %w`, err)
 				}
 				list[idx[i]] = entity
 				return nil

--- a/plugin/federation/testdata/entityresolver/generated/federation.requires.go
+++ b/plugin/federation/testdata/entityresolver/generated/federation.requires.go
@@ -1,0 +1,38 @@
+package generated
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/99designs/gqlgen/plugin/federation/testdata/entityresolver/generated/model"
+)
+
+// PopulateMultiHelloMultipleRequiresRequires is the requires populator for the MultiHelloMultipleRequires entity.
+func (ec *executionContext) PopulateMultiHelloMultipleRequiresRequires(ctx context.Context, entity *model.MultiHelloMultipleRequires, reps map[string]interface{}) error {
+	panic(fmt.Errorf("not implemented: PopulateMultiHelloMultipleRequiresRequires"))
+}
+
+// PopulateMultiHelloRequiresRequires is the requires populator for the MultiHelloRequires entity.
+func (ec *executionContext) PopulateMultiHelloRequiresRequires(ctx context.Context, entity *model.MultiHelloRequires, reps map[string]interface{}) error {
+	panic(fmt.Errorf("not implemented: PopulateMultiHelloRequiresRequires"))
+}
+
+// PopulateMultiPlanetRequiresNestedRequires is the requires populator for the MultiPlanetRequiresNested entity.
+func (ec *executionContext) PopulateMultiPlanetRequiresNestedRequires(ctx context.Context, entity *model.MultiPlanetRequiresNested, reps map[string]interface{}) error {
+	panic(fmt.Errorf("not implemented: PopulateMultiPlanetRequiresNestedRequires"))
+}
+
+// PopulatePlanetMultipleRequiresRequires is the requires populator for the PlanetMultipleRequires entity.
+func (ec *executionContext) PopulatePlanetMultipleRequiresRequires(ctx context.Context, entity *model.PlanetMultipleRequires, reps map[string]interface{}) error {
+	panic(fmt.Errorf("not implemented: PopulatePlanetMultipleRequiresRequires"))
+}
+
+// PopulatePlanetRequiresRequires is the requires populator for the PlanetRequires entity.
+func (ec *executionContext) PopulatePlanetRequiresRequires(ctx context.Context, entity *model.PlanetRequires, reps map[string]interface{}) error {
+	panic(fmt.Errorf("not implemented: PopulatePlanetRequiresRequires"))
+}
+
+// PopulatePlanetRequiresNestedRequires is the requires populator for the PlanetRequiresNested entity.
+func (ec *executionContext) PopulatePlanetRequiresNestedRequires(ctx context.Context, entity *model.PlanetRequiresNested, reps map[string]interface{}) error {
+	panic(fmt.Errorf("not implemented: PopulatePlanetRequiresNestedRequires"))
+}


### PR DESCRIPTION
The PR is WIP as I'd like to elicit feedback before regenerating the tests, etc.

This PR addresses several issues:

- https://github.com/99designs/gqlgen/issues/2559
- https://github.com/99designs/gqlgen/issues/2632
- https://github.com/99designs/gqlgen/issues/2357
- https://github.com/99designs/gqlgen/issues/1861
- https://github.com/99designs/gqlgen/issues/1138

The PR creates a new rendered template with functions that pass the requires representations to a generated function with the entity.  From here the user can apply the requires data as needed.

The output of the rendered templates looks like this:

```go
import (
	"context"
	"fmt"

	"github.com/mentat/graph/server/pkg/datasources"
)

// PopulateOrganizationRequires is the requires populator for the Organization entity.
func (ec *executionContext) PopulateOrganizationRequires(ctx context.Context, entity *datasources.Organization, reps map[string]interface{}) error {
	panic(fmt.Errorf("not implemented: PopulateOrganizationRequires"))
}
```

We (the Apollo team) think this approach is more flexible and future proof as it handles much more complex use cases like @requires nesting in repeated fields.  Our initial approach was to try and extend the existing requires functionality using recursive template rendering but this proved to be complex and difficult to test.

cc @brh55 @dariuszkuc 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
