### PR TITLE
feat: always use latest apollo sandbox

### DIFF
--- a/graphql/playground/apollo_sandbox_playground.go
+++ b/graphql/playground/apollo_sandbox_playground.go
@@ -24,7 +24,7 @@ var apolloSandboxPage = template.Must(template.New("ApolloSandbox").Parse(`<!doc
 <body>
   <div style="width: 100vw; height: 100vh;" id='embedded-sandbox'></div>
   <!-- NOTE: New version available at https://embeddable-sandbox.cdn.apollographql.com/ -->
-  <script rel="preload" as="script" crossorigin="anonymous" type="text/javascript" src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js"></script>
+  <script rel="preload" as="script" crossorigin="anonymous" integrity="{{.mainSRI}}" type="text/javascript" src="https://embeddable-sandbox.cdn.apollographql.com/7212121cad97028b007e974956dc951ce89d683c/embeddable-sandbox.umd.production.min.js"></script>
   <script>
 {{- if .endpointIsAbsolute}}
 	const url = {{.endpoint}};
@@ -53,6 +53,7 @@ func ApolloSandboxHandler(title, endpoint string) http.HandlerFunc {
 			"title":              title,
 			"endpoint":           endpoint,
 			"endpointIsAbsolute": endpointHasScheme(endpoint),
+			"mainSRI": "sha256-/ldbSJ7EovavF815TfCN50qKB9AMvzskb9xiG71bmg2I=",
 		})
 		if err != nil {
 			panic(err)

--- a/graphql/playground/apollo_sandbox_playground.go
+++ b/graphql/playground/apollo_sandbox_playground.go
@@ -53,7 +53,7 @@ func ApolloSandboxHandler(title, endpoint string) http.HandlerFunc {
 			"title":              title,
 			"endpoint":           endpoint,
 			"endpointIsAbsolute": endpointHasScheme(endpoint),
-			"mainSRI": "sha256-/ldbSJ7EovavF815TfCN50qKB9AMvzskb9xiG71bmg2I=",
+			"mainSRI":            "sha256-/ldbSJ7EovavF815TfCN50qKB9AMvzskb9xiG71bmg2I=",
 		})
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
I am not sure whether there are any securiy concerns regarding loading latest apollo sanbox by default. For me, it makes sense to auto load the latest version.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
