### PR TITLE
Added flag to omit interface checks

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	GoInitialisms                 GoInitialismsConfig        `yaml:"go_initialisms,omitempty"`
 	OmitSliceElementPointers      bool                       `yaml:"omit_slice_element_pointers,omitempty"`
 	OmitGetters                   bool                       `yaml:"omit_getters,omitempty"`
+	OmitInterfaceChecks           bool                       `yaml:"omit_interface_checks,omitempty"`
 	OmitComplexity                bool                       `yaml:"omit_complexity,omitempty"`
 	OmitGQLGenFileNotice          bool                       `yaml:"omit_gqlgen_file_notice,omitempty"`
 	OmitGQLGenVersionInFileNotice bool                       `yaml:"omit_gqlgen_version_in_file_notice,omitempty"`

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -46,6 +46,9 @@ resolver:
 # Optional: turn on to use []Thing instead of []*Thing
 # omit_slice_element_pointers: false
 
+# Optional: turn on to omit Is<Name>() methods to interface and unions
+# omit_interface_checks : true
+
 # Optional: turn on to skip generation of ComplexityRoot struct content and Complexity function
 # omit_complexity: false
 

--- a/init-templates/gqlgen.yml.gotmpl
+++ b/init-templates/gqlgen.yml.gotmpl
@@ -32,6 +32,9 @@ resolver:
 # Optional: turn on to use []Thing instead of []*Thing
 # omit_slice_element_pointers: false
 
+# Optional: turn on to omit Is<Name>() methods to interface and unions
+# omit_interface_checks : true
+
 # Optional: turn on to skip generation of ComplexityRoot struct content and Complexity function
 # omit_complexity: false
 

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -50,6 +50,7 @@ type Interface struct {
 	Name        string
 	Fields      []*Field
 	Implements  []string
+	OmitCheck   bool
 }
 
 type Object struct {
@@ -124,6 +125,7 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 				Name:        schemaType.Name,
 				Implements:  schemaType.Interfaces,
 				Fields:      fields,
+				OmitCheck:   cfg.OmitInterfaceChecks,
 			}
 
 			b.Interfaces = append(b.Interfaces, it)

--- a/plugin/modelgen/models.gotpl
+++ b/plugin/modelgen/models.gotpl
@@ -15,10 +15,12 @@
 {{- range $model := .Interfaces }}
 	{{ with .Description }} {{.|prefixLines "// "}} {{ end }}
 	type {{ goModelName .Name }} interface {
-		{{- range $impl := .Implements }}
-			Is{{ goModelName $impl }}()
+		{{- if not .OmitCheck }}
+			{{- range $impl := .Implements }}
+				Is{{ goModelName $impl }}()
+			{{- end }}
+			Is{{ goModelName .Name }}()
 		{{- end }}
-		Is{{ goModelName .Name }}()
 		{{- range $field := .Fields }}
 			{{- with .Description }}
 				{{.|prefixLines "// "}}


### PR DESCRIPTION
Added flag to omit `Is<Name>()` methods to interfaces and unions.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
