### PR TITLE
Fix apollo integrity hash

### DIFF
--- a/graphql/playground/apollo_sandbox_playground.go
+++ b/graphql/playground/apollo_sandbox_playground.go
@@ -53,7 +53,7 @@ func ApolloSandboxHandler(title, endpoint string) http.HandlerFunc {
 			"title":              title,
 			"endpoint":           endpoint,
 			"endpointIsAbsolute": endpointHasScheme(endpoint),
-			"mainSRI":            "sha256-/ldbSJ7EovavF815TfCN50qKB9AMvzskb9xiG71bmg2I=",
+			"mainSRI":            "sha256-ldbSJ7EovavF815TfCN50qKB9AMvzskb9xiG71bmg2I=",
 		})
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Hello,

It looks like the integrity hash of the apollo playground is wrong (actual: `sha256-/ldbSJ7EovavF815TfCN50qKB9AMvzskb9xiG71bmg2I=`, expected: `sha256-ldbSJ7EovavF815TfCN50qKB9AMvzskb9xiG71bmg2I=`).

As a workaround, I just copied the file `apollo_sandbox_playground.go`, the `endpointHasScheme` function from `playground.go` to my project, and then changed the `mainSRI` to `sha256-ldbSJ7EovavF815TfCN50qKB9AMvzskb9xiG71bmg2I=`.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

Closes #2703.