### PR TITLE
Add op ctx safety for apollo tracing

### DIFF
--- a/graphql/handler/apollofederatedtracingv1/tracing.go
+++ b/graphql/handler/apollofederatedtracingv1/tracing.go
@@ -41,7 +41,8 @@ func (Tracer) Validate(graphql.ExecutableSchema) error {
 }
 
 func (t *Tracer) shouldTrace(ctx context.Context) bool {
-	return graphql.GetOperationContext(ctx).Headers.Get("apollo-federation-include-trace") == "ftv1"
+	return graphql.HasOperationContext(ctx) &&
+		graphql.GetOperationContext(ctx).Headers.Get("apollo-federation-include-trace") == "ftv1"
 }
 
 func (t *Tracer) getTreeBuilder(ctx context.Context) *TreeBuilder {

--- a/graphql/handler/apollotracing/tracer.go
+++ b/graphql/handler/apollotracing/tracer.go
@@ -85,6 +85,10 @@ func (Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (interf
 }
 
 func (Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
+	if !graphql.HasOperationContext(ctx) {
+		return next(ctx)
+	}
+
 	rc := graphql.GetOperationContext(ctx)
 
 	start := rc.Stats.OperationStart

--- a/graphql/handler/apollotracing/tracer_test.go
+++ b/graphql/handler/apollotracing/tracer_test.go
@@ -2,6 +2,7 @@ package apollotracing_test
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -19,6 +20,12 @@ import (
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
+
+type alwaysError struct{}
+
+func (a *alwaysError) Read(p []byte) (int, error) {
+	return 0, io.ErrUnexpectedEOF
+}
 
 func TestApolloTracing(t *testing.T) {
 	now := time.Unix(0, 0)
@@ -92,8 +99,22 @@ func TestApolloTracing_withFail(t *testing.T) {
 	require.Equal(t, "PersistedQueryNotFound", respData.Errors[0].Message)
 }
 
+func TestApolloTracing_withUnexpectedEOF(t *testing.T) {
+	h := testserver.New()
+	h.AddTransport(transport.POST{})
+	h.Use(apollotracing.Tracer{})
+
+	resp := doRequestWithReader(h, http.MethodPost, "/graphql", &alwaysError{})
+	assert.Equal(t, http.StatusOK, resp.Code)
+}
+
 func doRequest(handler http.Handler, method, target, body string) *httptest.ResponseRecorder {
-	r := httptest.NewRequest(method, target, strings.NewReader(body))
+	return doRequestWithReader(handler, method, target, strings.NewReader(body))
+}
+
+func doRequestWithReader(handler http.Handler, method string, target string,
+	reader io.Reader) *httptest.ResponseRecorder {
+	r := httptest.NewRequest(method, target, reader)
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

Fixes https://github.com/99designs/gqlgen/issues/2708

If merged, this PR would:

* Add automated tests for both tracing and tracer to simulate a client disconnect
* Check for existence of operation context before proceeding to avoid panic


I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
