### PR TITLE
docs: update dataloader docs

### DIFF
--- a/docs/content/reference/dataloaders.md
+++ b/docs/content/reference/dataloaders.md
@@ -172,7 +172,7 @@ Add the dataloader middleware to your server...
 var srv http.Handler = handler.NewDefaultServer(generated.NewExecutableSchema(...))
 // wrap the query handler with middleware to inject dataloader in requests.
 // pass in your dataloader depenendicies, in this case the db connection.
-srv = dataloader.Middleware(db, srv)
+srv = loaders.Middleware(db, srv)
 // register the wrapped handler
 http.Handle("/query", srv)
 ```

--- a/docs/content/reference/dataloaders.md
+++ b/docs/content/reference/dataloaders.md
@@ -170,7 +170,8 @@ Add the dataloader middleware to your server...
 ```go
 // create the query handler
 var srv http.Handler = handler.NewDefaultServer(generated.NewExecutableSchema(...))
-// wrap the query handler with middleware to inject dataloader in requests
+// wrap the query handler with middleware to inject dataloader in requests.
+// pass in your dataloader depenendicies, in this case the db connection.
 srv = dataloader.Middleware(db, srv)
 // register the wrapped handler
 http.Handle("/query", srv)


### PR DESCRIPTION
This updates the docs to reflect a few optimizations the [community pointed out in the sample](https://github.com/zenyui/gqlgen-dataloader/issues/10). Also adds explicit example of registering the middleware on the server.

I have:
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
