### PR TITLE
Fix plugin template resolution

### DIFF
--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -172,7 +172,7 @@ func parseTemplates(cfg Options, t *template.Template) (*template.Template, erro
 		fileSystem = cfg.TemplateFS
 	} else {
 		// load path relative to calling source file
-		_, callerFile, _, _ := runtime.Caller(1)
+		_, callerFile, _, _ := runtime.Caller(2)
 		rootDir := filepath.Dir(callerFile)
 		fileSystem = os.DirFS(rootDir)
 	}


### PR DESCRIPTION
- According to the documentation comment for [templates.Options], if the `Template` and `TemplateFS` fields are empty, it `Render` should find the `.gotpl` files from the calling plugin. However, it looks like this is broken since #2262 moved the resolution code to a separate helper function. This results in broken behavior in consumers such as [infiotinc/gqlgenc](https://github.com/infiotinc/gqlgenc) when they use the latest version of `gqlgen` as instead of finding the template from the plugin, the test template from this package is used which outputs only: `this is my test package`.
- The cause for this is that `runtime.Caller` was still only skipping one stack level which means that it was finding the `Render` function instead of its caller.

[templates.Options]: https://pkg.go.dev/github.com/99designs/gqlgen@v0.17.35/codegen/templates#Options

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
