### PR TITLE
Update subsciptions documentation to correctly close channel

### DIFF
--- a/docs/content/recipes/subscriptions.md
+++ b/docs/content/recipes/subscriptions.md
@@ -121,6 +121,9 @@ func (r *subscriptionResolver) CurrentTime(ctx context.Context) (<-chan *model.T
 	// You can (and probably should) handle your channels in a central place outside of `schema.resolvers.go`.
 	// For this example we'll simply use a Goroutine with a simple loop.
 	go func() {
+		// Handle deregistration of the channel here. Note the `defer`
+    defer close(ch)
+
 		for {
 			// In our example we'll send the current time every second.
 			time.Sleep(1 * time.Second)
@@ -294,6 +297,8 @@ func (r *subscriptionResolver) CurrentTime(ctx context.Context) (<-chan *model.T
 	ch := make(chan *model.Time)
 
 	go func() {
+		defer close(ch)
+
 		for {
 			time.Sleep(1 * time.Second)
 			fmt.Println("Tick")


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

Added missing channel cleanup in Subscriptions example.
The channel should be closed after the go routine writing to channel exits. Hence added `defer close(ch)`

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
