### PR TITLE
Fix sample code at getting-started.md (crypt rand -> math rand )

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -130,6 +130,8 @@ We just need to implement these two methods to get our server working:
 First we need somewhere to track our state, lets put it in `graph/resolver.go`. The `graph/resolver.go` file is where we declare our app's dependencies, like our database. It gets initialized once in `server.go` when we create the graph.
 
 ```go
+import "example/graph/model"
+
 type Resolver struct{
 	todos []*model.Todo
 }
@@ -139,10 +141,9 @@ Returning to `graph/schema.resolvers.go`, let's implement the bodies of those au
 
 ```go
 func (r *mutationResolver) CreateTodo(ctx context.Context, input model.NewTodo) (*model.Todo, error) {
-	rand, _ := rand.Int(rand.Reader, big.NewInt(100))
 	todo := &model.Todo{
 		Text: input.Text,
-		ID:   fmt.Sprintf("T%d", rand),
+		ID:   fmt.Sprintf("T%d", rand.Intn(100)),
 		User: &model.User{ID: input.UserID, Name: "user " + input.UserID},
 	}
 	r.todos = append(r.todos, todo)

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -182,6 +182,7 @@ query findTodos {
   todos {
     text
     done
+    id
     user {
       name
     }


### PR DESCRIPTION
Hello

I am gqlgen beginner. 
When I run sample code in getting-startd.md, I found small mistake.

[description](https://github.com/99designs/gqlgen/blob/master/docs/content/getting-started.md?plain=1#L138) said "use math/rand" but sample code use crypt/rand.
I think best choice for sample is math/rand (because it is simple) , so made PR to change sample code to use math/rand.

Please check PR and comment on my misstake (and merge if OK).

crypt/math
https://pkg.go.dev/crypto/rand#Int

math/rand
https://pkg.go.dev/math/rand#Int

and 2 mod
 - add todo id to sample request to show random id
 - add import to resolver.go (because sample code without "import" doesn't work in my environment.)

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

test
![スクリーンショット 2023-08-12 13 15 23](https://github.com/99designs/gqlgen/assets/1812140/a7dfa53d-97da-4325-aa27-890290c42498)

discord
https://discord.com/channels/831012771810377778/831012771810377781/1139783831575076914
