### PR TITLE
Fix gqlgen truncates tag value with colon

### DIFF
--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -568,17 +568,19 @@ func removeDuplicateTags(t string) string {
 			continue
 		}
 
-		processed[kv[0]] = true
+		key := kv[0]
+		value := strings.Join(kv[1:], ":")
+		processed[key] = true
 		if len(returnTags) > 0 {
 			returnTags = " " + returnTags
 		}
 
-		isContained := containsInvalidSpace(kv[1])
+		isContained := containsInvalidSpace(value)
 		if isContained {
-			panic(fmt.Errorf("tag value should not contain any leading or trailing spaces: %s", kv[1]))
+			panic(fmt.Errorf("tag value should not contain any leading or trailing spaces: %s", value))
 		}
 
-		returnTags = kv[0] + ":" + kv[1] + returnTags
+		returnTags = key + ":" + value + returnTags
 	}
 
 	return returnTags

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -534,6 +534,22 @@ func TestRemoveDuplicate(t *testing.T) {
 			want:      "gorm:\"unique;not null\" json:\"name,name2\"",
 			wantPanic: false,
 		},
+		{
+			name: "Test gorm tag with colon",
+			args: args{
+				t: "gorm:\"type:varchar(63);unique_index\"",
+			},
+			want:      "gorm:\"type:varchar(63);unique_index\"",
+			wantPanic: false,
+		},
+		{
+			name: "Test mix use of gorm and duplicate json tags with colon",
+			args: args{
+				t: "json:\"name0\" gorm:\"type:varchar(63);unique_index\" json:\"name,name2\"",
+			},
+			want:      "gorm:\"type:varchar(63);unique_index\" json:\"name,name2\"",
+			wantPanic: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fix #2687 gqlgen truncates tag value with colon


I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
