### PR TITLE
vikstrous/dataloadgen replaces recommended dataloader package in example docs

### DIFF
--- a/docs/content/reference/dataloaders.md
+++ b/docs/content/reference/dataloaders.md
@@ -161,7 +161,7 @@ func GetUser(ctx context.Context, userID string) (*model.User, error) {
 }
 
 // GetUsers returns many users by ids efficiently
-func GetUsers(ctx context.Context, userIDs []string) ([]*model.User, []error) {
+func GetUsers(ctx context.Context, userIDs []string) ([]*model.User, error) {
 	loaders := For(ctx)
 	return loaders.UserLoader.LoadAll(ctx, userIDs)
 }

--- a/docs/content/reference/dataloaders.md
+++ b/docs/content/reference/dataloaders.md
@@ -72,7 +72,7 @@ go get github.com/vikstrous/dataloadgen
 Next, we implement a data loader and a middleware for injecting the data loader on a request context.
 
 ```go
-package loaders
+package loader
 
 import (
 	"context"
@@ -84,16 +84,46 @@ import (
 	"github.com/vikstrous/dataloadgen"
 )
 
-type loadersKey struct{}
+// Get returns the Loaders bundle from the context. It must be used only in XXXXXXXXXXXX resolvers where Middleware has put the Loaders struct into the context already.
+func Get(ctx context.Context) *Loaders {
+	return ctx.Value(ctxKey{}).(*Loaders)
+}
 
-// userReader reads Users from a database
-type userReader struct {
+
+// Loaders provide access for loading various objects from the underlying object's storage system while batching concurrent requests and caching responses.
+type Loaders struct {
+	User *dataloadgen.Loader[string, *model.User]
+}
+
+// Middleware injects data loaders into the context
+func Middleware(conn *sql.DB, next http.Handler) http.Handler {
+	// return a middleware that injects the loader to the request context
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Note that the loaders are being created per-request. This is important because they contain caching and batching logic that must be request-scoped.
+		loaders := newLoaders(conn)
+		r = r.WithContext(context.WithValue(r.Context(), ctxKey{}, loaders))
+		next.ServeHTTP(w, r)
+	})
+}
+
+type ctxKey struct{}
+
+// newLoaders creates the Loaders struct
+func newLoaders(conn *sql.DB) *Loaders {
+	ur := &userFetcher{db: conn}
+	return &Loaders{
+		User: dataloadgen.NewLoader(ur.getUsers, dataloadgen.WithWait(time.Millisecond)),
+	}
+}
+
+// userFetcher reads Users from a database
+type userFetcher struct {
 	db *sql.DB
 }
 
 // getUsers implements a batch function that can retrieve many users by ID,
 // for use in a dataloader
-func (u *userReader) getUsers(ctx context.Context, userIDs []string) ([]*model.User, []error) {
+func (u *userFetcher) getUsers(ctx context.Context, userIDs []string) ([]*model.User, []error) {
 	stmt, err := u.db.PrepareContext(ctx, `SELECT id, name FROM users WHERE id IN (?`+strings.Repeat(",?", len(userIDs)-1)+`)`)
 	if err != nil {
 		return nil, []error{err}
@@ -116,36 +146,7 @@ func (u *userReader) getUsers(ctx context.Context, userIDs []string) ([]*model.U
 		}
 		users = append(users, &user)
 	}
-	return users, errors
-}
-
-// Loaders wrap your data loaders to inject via middleware
-type Loaders struct {
-	User *dataloadgen.Loader[string, *model.User]
-}
-
-// NewLoaders instantiates data loaders for the middleware
-func NewLoaders(conn *sql.DB) *Loaders {
-	// define the data loader
-	ur := &userReader{db: conn}
-	return &Loaders{
-		User: dataloadgen.NewLoader(ur.getUsers, dataloadgen.WithWait(time.Millisecond)),
-	}
-}
-
-// Middleware injects data loaders into the context
-func Middleware(conn *sql.DB, next http.Handler) http.Handler {
-	// return a middleware that injects the loader to the request context
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		loader := NewLoaders(conn)
-		r = r.WithContext(context.WithValue(r.Context(), loadersKey{}, loader))
-		next.ServeHTTP(w, r)
-	})
-}
-
-// Get returns the dataloader for a given context
-func Get(ctx context.Context) *Loaders {
-	return ctx.Value(loadersKey{}).(*Loaders)
+	return users, errs
 }
 
 ```
@@ -164,7 +165,7 @@ http.Handle("/query", srv)
 Now lets update our resolver to call the dataloader:
 ```go
 func (r *todoResolver) User(ctx context.Context, obj *model.Todo) (*model.User, error) {
-	return loaders.Get(ctx).User.LoadAll(ctx, obj.UserID)
+	return loaders.Get(ctx).User.Load(ctx, obj.UserID)
 }
 ```
 
@@ -173,3 +174,5 @@ The end result? Just 2 queries!
 SELECT id, todo, user_id FROM todo
 SELECT id, name from user WHERE id IN (?,?,?,?,?)
 ```
+
+You can see an end-to-end example [here](https://github.com/vikstrous/dataloadgen-example).

--- a/docs/content/reference/dataloaders.md
+++ b/docs/content/reference/dataloaders.md
@@ -134,7 +134,7 @@ func NewLoaders(conn *sql.DB) *Loaders {
 	// define the data loader
 	ur := &userReader{db: conn}
 	return &Loaders{
-		UserLoader: dataloader.NewBatchedLoader(ur.getUsers, dataloader.WithWait[string, *model.User](time.Millisecond)),
+		UserLoader: dataloadgen.NewLoader(ur.getUsers, dataloadgen.WithWait(time.Millisecond)),
 	}
 }
 

--- a/docs/content/reference/dataloaders.md
+++ b/docs/content/reference/dataloaders.md
@@ -153,7 +153,6 @@ func For(ctx context.Context) *Loaders {
 	return ctx.Value(loadersKey).(*Loaders)
 }
 
-
 // GetUser returns single user by id efficiently
 func GetUser(ctx context.Context, userID string) (*model.User, error) {
 	loaders := For(ctx)


### PR DESCRIPTION
This replaces the recommended dataloader package in example docs from [graph-gophers/dataloader](https://github.com/graph-gophers/dataloader) to [vikstrous/dataloadgen](https://github.com/vikstrous/dataloadgen)

This closes #2755
I updated the docs for the dataloader example in this PR.
I simplified the code so there would be less boilerplate.
I updated userIds to userIDs to follow the more common convention in Go.

~I haven't tested the example code.~
~I haven't made an example repo like this one https://github.com/zenyui/gqlgen-dataloader, but I'm thinking I can make one.~
There's an example repo at https://github.com/vikstrous/dataloadgen-example now.

~I recommend not merging this as is, but I want to get some feedback before I continue.~