### PR TITLE
return internal types in schema introspection

### DIFF
--- a/graphql/introspection/schema.go
+++ b/graphql/introspection/schema.go
@@ -2,7 +2,6 @@ package introspection
 
 import (
 	"sort"
-	"strings"
 
 	"github.com/vektah/gqlparser/v2/ast"
 )
@@ -22,9 +21,6 @@ func (s *Schema) Types() []Type {
 	typeIndex := map[string]Type{}
 	typeNames := make([]string, 0, len(s.schema.Types))
 	for _, typ := range s.schema.Types {
-		if strings.HasPrefix(typ.Name, "__") {
-			continue
-		}
 		typeNames = append(typeNames, typ.Name)
 		typeIndex[typ.Name] = *WrapTypeFromDef(s.schema, typ)
 	}

--- a/graphql/introspection/schema_test.go
+++ b/graphql/introspection/schema_test.go
@@ -1,0 +1,68 @@
+package introspection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+func TestSchema(t *testing.T) {
+	query := &ast.Definition{
+		Name: "Query",
+		Kind: ast.Object,
+	}
+
+	mutation := &ast.Definition{
+		Name: "Mutation",
+		Kind: ast.Object,
+	}
+
+	subscription := &ast.Definition{
+		Name: "Subscription",
+		Kind: ast.Object,
+	}
+
+	directive := &ast.Definition{
+		Name: "__Directive",
+		Kind: ast.Object,
+	}
+
+	schema := &Schema{
+		schema: &ast.Schema{
+			Query:        query,
+			Mutation:     mutation,
+			Subscription: subscription,
+			Types: map[string]*ast.Definition{
+				"Query":       query,
+				"Mutation":    mutation,
+				"__Directive": directive,
+			},
+			Description: "test description",
+		},
+	}
+
+	t.Run("description", func(t *testing.T) {
+		require.EqualValues(t, "test description", *schema.Description())
+	})
+
+	t.Run("query type", func(t *testing.T) {
+		require.Equal(t, "Query", *schema.QueryType().Name())
+	})
+
+	t.Run("mutation type", func(t *testing.T) {
+		require.Equal(t, "Mutation", *schema.MutationType().Name())
+	})
+
+	t.Run("subscription type", func(t *testing.T) {
+		require.Equal(t, "Subscription", *schema.SubscriptionType().Name())
+	})
+
+	t.Run("types", func(t *testing.T) {
+		types := schema.Types()
+		require.Len(t, types, 3)
+		require.Equal(t, "Mutation", *types[0].Name())
+		require.Equal(t, "Query", *types[1].Name())
+		require.Equal(t, "__Directive", *types[2].Name())
+	})
+}


### PR DESCRIPTION
Closes https://github.com/99designs/gqlgen/issues/2772

according to graphql spec:
```
types: return the set of all named types contained within this schema.
Any named type which can be found through a field of any introspection type must be included in this set.
```
source: https://github.com/graphql/graphql-spec/blob/main/spec/Section%204%20--%20Introspection.md#the-__schema-type

some clients libs (like HotChocolate for C#) depends on this behavior.


I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
