### PR TITLE
ensure HasOperationContext checks for nil

### DIFF
--- a/graphql/context_operation.go
+++ b/graphql/context_operation.go
@@ -73,8 +73,8 @@ func WithOperationContext(ctx context.Context, rc *OperationContext) context.Con
 //
 // Some errors can happen outside of an operation, eg json unmarshal errors.
 func HasOperationContext(ctx context.Context) bool {
-	_, ok := ctx.Value(operationCtx).(*OperationContext)
-	return ok
+	val, ok := ctx.Value(operationCtx).(*OperationContext)
+	return ok && val != nil
 }
 
 // This is just a convenient wrapper method for CollectFields

--- a/graphql/context_operation_test.go
+++ b/graphql/context_operation_test.go
@@ -3,10 +3,32 @@ package graphql
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/v2/ast"
 )
+
+// implement context.Context interface
+type testGraphRequestContext struct {
+	opContext *OperationContext
+}
+
+func (t *testGraphRequestContext) Deadline() (deadline time.Time, ok bool) {
+	return time.Time{}, false
+}
+
+func (t *testGraphRequestContext) Done() <-chan struct{} {
+	return nil
+}
+
+func (t *testGraphRequestContext) Err() error {
+	return nil
+}
+
+func (t *testGraphRequestContext) Value(key interface{}) interface{} {
+	return t.opContext
+}
 
 func TestGetOperationContext(t *testing.T) {
 	rc := &OperationContext{}
@@ -20,6 +42,15 @@ func TestGetOperationContext(t *testing.T) {
 
 	t.Run("without operation context", func(t *testing.T) {
 		ctx := context.Background()
+
+		require.False(t, HasOperationContext(ctx))
+		require.Panics(t, func() {
+			GetOperationContext(ctx)
+		})
+	})
+
+	t.Run("with nil operation context", func(t *testing.T) {
+		ctx := &testGraphRequestContext{opContext: nil}
 
 		require.False(t, HasOperationContext(ctx))
 		require.Panics(t, func() {


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

resolves: https://github.com/99designs/gqlgen/issues/2775

Upon merging:

- When calling `HasOperationContext`
   to check if there is a valid operation context,
   `GetOperationContext` will never panic when
   `HasOperationContext` returns true.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] (N/A) Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
