### PR TITLE
docs: short-lived dataloader in sample

### DIFF
--- a/docs/content/reference/dataloaders.md
+++ b/docs/content/reference/dataloaders.md
@@ -147,10 +147,11 @@ func NewLoaders(conn *sql.DB) *Loaders {
 }
 
 // Middleware injects data loaders into the context
-func Middleware(loaders *Loaders, next http.Handler) http.Handler {
+func Middleware(conn *sql.DB, next http.Handler) http.Handler {
 	// return a middleware that injects the loader to the request context
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r = r.WithContext(context.WithValue(r.Context(), loadersKey, loaders))
+		loader := NewLoaders(conn)
+		r = r.WithContext(context.WithValue(r.Context(), loadersKey, loader))
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

This addresses the comment @vikstrous raised ([PR](https://github.com/99designs/gqlgen/pull/2770#issuecomment-1703915045)) by making the data loader request-scoped (like the sample repo is)

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
