### PR TITLE
fix flaky test TestSubscriptions

### DIFF
--- a/codegen/testserver/followschema/subscription_test.go
+++ b/codegen/testserver/followschema/subscription_test.go
@@ -130,6 +130,9 @@ func TestSubscriptions(t *testing.T) {
 	})
 
 	t.Run("will parse init payload", func(t *testing.T) {
+		runtime.GC() // ensure no go-routines left from preceding tests
+		initialGoroutineCount := runtime.NumGoroutine()
+
 		sub := c.WebsocketWithPayload(`subscription { initPayload }`, map[string]interface{}{
 			"Authorization": "Bearer of the curse",
 			"number":        32,
@@ -155,6 +158,14 @@ func TestSubscriptions(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "strings = []interface {}{\"hello\", \"world\"}", msg.resp.InitPayload)
 		sub.Close()
+
+		// need a little bit of time for goroutines to settle
+		start := time.Now()
+		for time.Since(start).Seconds() < 2 && initialGoroutineCount != runtime.NumGoroutine() {
+			time.Sleep(5 * time.Millisecond)
+		}
+
+		require.Equal(t, initialGoroutineCount, runtime.NumGoroutine())
 	})
 
 	t.Run("websocket gets errors", func(t *testing.T) {

--- a/codegen/testserver/singlefile/subscription_test.go
+++ b/codegen/testserver/singlefile/subscription_test.go
@@ -130,6 +130,9 @@ func TestSubscriptions(t *testing.T) {
 	})
 
 	t.Run("will parse init payload", func(t *testing.T) {
+		runtime.GC() // ensure no go-routines left from preceding tests
+		initialGoroutineCount := runtime.NumGoroutine()
+
 		sub := c.WebsocketWithPayload(`subscription { initPayload }`, map[string]interface{}{
 			"Authorization": "Bearer of the curse",
 			"number":        32,
@@ -155,6 +158,14 @@ func TestSubscriptions(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "strings = []interface {}{\"hello\", \"world\"}", msg.resp.InitPayload)
 		sub.Close()
+
+		// need a little bit of time for goroutines to settle
+		start := time.Now()
+		for time.Since(start).Seconds() < 2 && initialGoroutineCount != runtime.NumGoroutine() {
+			time.Sleep(5 * time.Millisecond)
+		}
+
+		require.Equal(t, initialGoroutineCount, runtime.NumGoroutine())
 	})
 
 	t.Run("websocket gets errors", func(t *testing.T) {


### PR DESCRIPTION
The test failed in https://github.com/99designs/gqlgen/pull/2770

I noticed that the pattern of waiting for goroutines to match the number they were at the start of the test was missing from the second subtest.

I triggered the failure locally with
```
go test -race -test.run  'TestSubscriptions' -count 10000
```
This takes 3-4 minutes for me.

After the change, the test no longer failed after 10k iterations.

I noticed that there's a second copy of the same test and copied the fix to it too.