### PR TITLE
ForceGenerate parameter to @goModel added.

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -281,11 +281,18 @@ func (c *Config) injectTypesFromSchema() error {
 					c.Models.Add(schemaType.Name, mv.(string))
 				}
 			}
+
 			if ma := bd.Arguments.ForName("models"); ma != nil {
 				if mvs, err := ma.Value.Value(nil); err == nil {
 					for _, mv := range mvs.([]interface{}) {
 						c.Models.Add(schemaType.Name, mv.(string))
 					}
+				}
+			}
+
+			if fg := bd.Arguments.ForName("forceGenerate"); fg != nil {
+				if mv, err := fg.Value.Value(nil); err == nil {
+					c.Models.ForceGenerate(schemaType.Name, mv.(bool))
 				}
 			}
 		}
@@ -329,8 +336,9 @@ func (c *Config) injectTypesFromSchema() error {
 }
 
 type TypeMapEntry struct {
-	Model  StringList              `yaml:"model"`
-	Fields map[string]TypeMapField `yaml:"fields,omitempty"`
+	Model         StringList              `yaml:"model,omitempty"`
+	ForceGenerate bool                    `yaml:"forceGenerate,omitempty"`
+	Fields        map[string]TypeMapField `yaml:"fields,omitempty"`
 
 	// Key is the Go name of the field.
 	ExtraFields map[string]ModelExtraField `yaml:"extraFields,omitempty"`
@@ -529,6 +537,12 @@ func (tm TypeMap) Add(name string, goType string) {
 	tm[name] = modelCfg
 }
 
+func (tm TypeMap) ForceGenerate(name string, forceGenerate bool) {
+	modelCfg := tm[name]
+	modelCfg.ForceGenerate = forceGenerate
+	tm[name] = modelCfg
+}
+
 type DirectiveConfig struct {
 	SkipRuntime bool `yaml:"skip_runtime"`
 }
@@ -584,6 +598,11 @@ func (c *Config) autobind() error {
 
 	for _, t := range c.Schema.Types {
 		if c.Models.UserDefined(t.Name) {
+			continue
+		}
+
+		if c.Models[t.Name].ForceGenerate {
+			delete(c.Models, t.Name)
 			continue
 		}
 

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -127,12 +127,13 @@ To start using them you first need to define them:
 directive @goModel(
 	model: String
 	models: [String!]
+	forceGenerate: Boolean
 ) on OBJECT | INPUT_OBJECT | SCALAR | ENUM | INTERFACE | UNION
 
 directive @goField(
 	forceResolver: Boolean
 	name: String
-  omittable: Boolean
+	omittable: Boolean
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 directive @goTag(


### PR DESCRIPTION
When using autobind directive in configuration, there is no chance to force gqlgen to generate a model if that name matched with model from the autobind package. One solution is rename the type name in graphql schema, but it is not an ideal way.
This PR solves this problem. For example if your package is defined in configuration like:

```yaml
autobind:
  - myproject/entity
```
And it have type, for example: Person.

```graphql
type Person {
  name: String
}
```
then it will autobind to myproject/entity.Person

If you need to exclude this model from autobind, you can define it like:
```graphql
type Person @goModel(forceGenerate: true) {
  name: String
}
```
I have:
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
