### PR TITLE
Ability to use forceGenerate and extraFields together

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -600,12 +600,7 @@ func (c *Config) autobind() error {
 	ps := c.Packages.LoadAll(c.AutoBind...)
 
 	for _, t := range c.Schema.Types {
-		if c.Models.UserDefined(t.Name) {
-			continue
-		}
-
-		if c.Models[t.Name].ForceGenerate {
-			delete(c.Models, t.Name)
+		if c.Models.UserDefined(t.Name) || c.Models[t.Name].ForceGenerate {
 			continue
 		}
 
@@ -621,6 +616,10 @@ func (c *Config) autobind() error {
 	}
 
 	for i, t := range c.Models {
+		if t.ForceGenerate {
+			continue
+		}
+
 		for j, m := range t.Model {
 			pkg, typename := code.PkgAndType(m)
 

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -165,6 +165,12 @@ type User @goModel(model: "github.com/my/app/models.User") {
 		@goTag(key: "xorm", value: "-")
 		@goTag(key: "yaml")
 }
+
+# This make sense when autobind activated.
+type Person @goModel(forceGenerate: true) {
+	id: ID!
+	name: String!
+}
 ```
 
 The builtin directives `goField`, `goModel` and `goTag` are automatically registered to `skip_runtime`. Any directives registered as `skip_runtime` will not exposed during introspection and are used during code generation only.


### PR DESCRIPTION
gqlgen.yaml:
```yaml
autobind:
  - mypkg
models:
  Person:
    forceGenerate: true
    extraFields:
      IsAdmin:
        type: bool
```

schema:
```graphql
type Person {
  id: ID!
  name: String!
}
```

Сurrent behavior:
```go
type Person struct {
	ID                              string      `json:"id"`
	Name                            string      `json:"name"`
}
```

Expected behavior (this PR fix it):
```go
type Person struct {
	ID                              string      `json:"id"`
	Name                            string      `json:"name"`
	IsAdmin                            bool      `json:"isAdmin"`
}
```

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
