### PR TITLE
Fix rand int docs link in Getting Started

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -135,7 +135,7 @@ type Resolver struct{
 }
 ```
 
-Returning to `graph/schema.resolvers.go`, let's implement the bodies of those automatically generated resolver functions.  For `CreateTodo`, we'll use the [`math.rand` package](https://pkg.go.dev/math/rand#Rand.Int) to simply return a todo with a randomly generated ID and store that in the in-memory todos list --- in a real app, you're likely to use a database or some other backend service.
+Returning to `graph/schema.resolvers.go`, let's implement the bodies of those automatically generated resolver functions.  For `CreateTodo`, we'll use the [`crypto.rand` package](https://pkg.go.dev/crypto/rand#Int) to simply return a todo with a randomly generated ID and store that in the in-memory todos list --- in a real app, you're likely to use a database or some other backend service.
 
 ```go
 func (r *mutationResolver) CreateTodo(ctx context.Context, input model.NewTodo) (*model.Todo, error) {


### PR DESCRIPTION
Hey y'all! Thanks for making this package!

I have a tiny documentation fix here, for the "Getting Started" section at: https://gqlgen.com/getting-started/

The docs currently link/reference to `math/rand`, but the sample code below it appears to be using `crypto/rand` -- this PR just updates the link in the text to match the sample code.

Thanks!

---
I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
