### PR TITLE
Breaking API: Allow WebsocketInitFunc to add payload to Ack (#4)

### DIFF
--- a/_examples/websocket-initfunc/server/server.go
+++ b/_examples/websocket-initfunc/server/server.go
@@ -18,12 +18,12 @@ import (
 	"github.com/rs/cors"
 )
 
-func webSocketInit(ctx context.Context, initPayload transport.InitPayload) (context.Context, error) {
+func webSocketInit(ctx context.Context, initPayload transport.InitPayload) (context.Context, *transport.InitPayload, error) {
 	// Get the token from payload
 	payload := initPayload["authToken"]
 	token, ok := payload.(string)
 	if !ok || token == "" {
-		return nil, errors.New("authToken not found in transport payload")
+		return nil, nil, errors.New("authToken not found in transport payload")
 	}
 
 	// Perform token verification and authentication...
@@ -32,7 +32,7 @@ func webSocketInit(ctx context.Context, initPayload transport.InitPayload) (cont
 	// put it in context
 	ctxNew := context.WithValue(ctx, "username", userId)
 
-	return ctxNew, nil
+	return ctxNew, nil, nil
 }
 
 const defaultPort = "8080"
@@ -62,7 +62,7 @@ func main() {
 				return true
 			},
 		},
-		InitFunc: func(ctx context.Context, initPayload transport.InitPayload) (context.Context, error) {
+		InitFunc: func(ctx context.Context, initPayload transport.InitPayload) (*transport.InitPayload, context.Context, error) {
 			return webSocketInit(ctx, initPayload)
 		},
 	})


### PR DESCRIPTION
* Allow WebsocketInitFunc to add payload to Ack

The connection ACK message in the protocol for both graphql-ws and graphql-transport-ws allows for a payload in the connection ack message.

We really wanted to use this to establish better telemetry in our use of websockets in graphql.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
