### PR TITLE
Return `null` instead of zero value uuid

### DIFF
--- a/graphql/uuid.go
+++ b/graphql/uuid.go
@@ -2,16 +2,15 @@ package graphql
 
 import (
 	"fmt"
-	"io"
-	"strconv"
 
 	"github.com/google/uuid"
 )
 
 func MarshalUUID(id uuid.UUID) Marshaler {
-	return WriterFunc(func(w io.Writer) {
-		_, _ = io.WriteString(w, strconv.Quote(id.String()))
-	})
+	if id == uuid.Nil {
+		return Null
+	}
+	return MarshalString(id.String())
 }
 
 func UnmarshalUUID(v any) (uuid.UUID, error) {

--- a/graphql/uuid_test.go
+++ b/graphql/uuid_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMarshalUUID(t *testing.T) {
 	t.Run("Null Values", func(t *testing.T) {
-		assert.Equal(t, uuid.Nil, uuid.MustParse("00000000-0000-0000-0000-000000000000"))
+		assert.Equal(t, "null", m2s(MarshalUUID(uuid.Nil)))
 	})
 
 	t.Run("Valid Values", func(t *testing.T) {


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

Return `null` instead of the zero value uuid. I think this will be better and easier for the end user for null checking.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
