### PR TITLE
Adding duration scalar conforming to ISO8601 standard

### DIFF
--- a/docs/content/reference/scalars.md
+++ b/docs/content/reference/scalars.md
@@ -71,6 +71,23 @@ scalar Any
 
 Maps an arbitrary GraphQL value to a `interface{}` Go type.
 
+### Duration
+
+```graphql
+scalar Duration
+```
+This maps a `Duration` scalar value conforming to the `ISO8601` standard (ex.: `P1Y2D`)  to a `time.Duration` type.
+
+If you add to gqlgen.yml:
+```yaml
+models:
+  Duration:
+    model:
+      - github.com/99designs/gqlgen/graphql.Duration
+```
+
+And then add `scalar Duration` to `schema.graphql`
+
 ## Custom scalars with user defined types
 
 For user defined types you can implement the [graphql.Marshaler](https://pkg.go.dev/github.com/99designs/gqlgen/graphql#Marshaler) and [graphql.Unmarshaler](https://pkg.go.dev/github.com/99designs/gqlgen/graphql#Unmarshaler) or implement the [graphql.ContextMarshaler](https://pkg.go.dev/github.com/99designs/gqlgen/graphql#ContextMarshaler) and [graphql.ContextUnmarshaler](https://pkg.go.dev/github.com/99designs/gqlgen/graphql#ContextUnmarshaler) interfaces and they will be called.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.19
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/sosodev/duration v1.1.0
 	github.com/stretchr/testify v1.8.2
 	github.com/urfave/cli/v2 v2.25.5
 	github.com/vektah/gqlparser/v2 v2.5.10

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
+github.com/sosodev/duration v1.1.0 h1:kQcaiGbJaIsRqgQy7VGlZrVw1giWO+lDoX3MCPnpVO4=
+github.com/sosodev/duration v1.1.0/go.mod h1:RQIBBX0+fMLc/D9+Jb/fwvVmo0eZvDDEERAikUR6SDg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/graphql/duration.go
+++ b/graphql/duration.go
@@ -1,0 +1,30 @@
+package graphql
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	dur "github.com/sosodev/duration"
+)
+
+// UnmarshalDuration returns the duration from a string in ISO8601 format
+func UnmarshalDuration(v interface{}) (time.Duration, error) {
+	input, ok := v.(string)
+	if !ok {
+		return 0, fmt.Errorf("input must be a string")
+	}
+
+	d2, err := dur.Parse(input)
+	if err != nil {
+		return 0, err
+	}
+	return d2.ToTimeDuration(), nil
+}
+
+// MarshalDuration returns the duration on ISO8601 format
+func MarshalDuration(d time.Duration) Marshaler {
+	return WriterFunc(func(w io.Writer) {
+		_, _ = w.Write([]byte(dur.Format(d)))
+	})
+}

--- a/graphql/duration_test.go
+++ b/graphql/duration_test.go
@@ -1,0 +1,25 @@
+package graphql
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestDurationMarshaling(t *testing.T) {
+	t.Run("UnmarshalDuration", func(t *testing.T) {
+		d, err := UnmarshalDuration("P2Y")
+		assert.NoError(t, err)
+
+		assert.Equal(t, float64(365*24*2), d.Hours())
+	})
+	t.Run("MarshalDuration", func(t *testing.T) {
+		m := MarshalDuration(time.Hour * 365 * 24 * 2)
+
+		buf := new(bytes.Buffer)
+		m.MarshalGQL(buf)
+
+		assert.Equal(t, "P2Y", buf.String())
+	})
+}


### PR DESCRIPTION
I'm adding the Duration scalar following the ISO8601 standard, which converts to a time.Duration in Go.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
