### PR TITLE
add close flag into wsConnection to avoid duplicate calls of CloseFunc

### DIFF
--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -526,7 +526,7 @@ func TestWebSocketCloseFunc(t *testing.T) {
 		}
 
 		select {
-		case _ = <-closeFuncCalled:
+		case <-closeFuncCalled:
 			assert.Fail(t, "The close handler was called more than once")
 		case <-time.NewTimer(time.Millisecond * 20).C:
 			// ok

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -500,6 +500,39 @@ func TestWebSocketCloseFunc(t *testing.T) {
 		}
 	})
 
+	t.Run("the on close handler gets called only once when the websocket is closed", func(t *testing.T) {
+		closeFuncCalled := make(chan bool, 1)
+		h := testserver.New()
+		h.AddTransport(transport.Websocket{
+			CloseFunc: func(_ context.Context, _closeCode int) {
+				closeFuncCalled <- true
+			},
+		})
+
+		srv := httptest.NewServer(h)
+		defer srv.Close()
+
+		c := wsConnect(srv.URL)
+		require.NoError(t, c.WriteJSON(&operationMessage{Type: connectionInitMsg}))
+		assert.Equal(t, connectionAckMsg, readOp(c).Type)
+		assert.Equal(t, connectionKeepAliveMsg, readOp(c).Type)
+		require.NoError(t, c.WriteJSON(&operationMessage{Type: connectionTerminateMsg}))
+
+		select {
+		case res := <-closeFuncCalled:
+			assert.True(t, res)
+		case <-time.NewTimer(time.Millisecond * 20).C:
+			assert.Fail(t, "The close handler was not called in time")
+		}
+
+		select {
+		case _ = <-closeFuncCalled:
+			assert.Fail(t, "The close handler was called more than once")
+		case <-time.NewTimer(time.Millisecond * 20).C:
+			// ok
+		}
+	})
+
 	t.Run("init func errors call the close handler", func(t *testing.T) {
 		h := testserver.New()
 		closeFuncCalled := make(chan bool, 1)


### PR DESCRIPTION
Fixes: https://github.com/99designs/gqlgen/issues/2679

I attempted the simplest way to resolve this issue by adding a guard flag. Unfortunately, the control flow in the `run` function is quite confusing. The next steps should likely focus on making it more predictable and straightforward.

To illustrate what I mean about the confusing control flow, consider the following example:

1. Let's assume that the [context](https://github.com/99designs/gqlgen/blob/af4d3943308b7a84464771e5ed6b578ba40ee0c3/graphql/handler/transport/websocket.go#L225) in the run function gets canceled due to a deadline set in the InitFunc. This was one of the workarounds proposed to [implement the closing transport for expiring tokens](https://github.com/99designs/gqlgen/issues/1727).
2. In such a scenario, [closeOnCancel](https://github.com/99designs/gqlgen/blob/af4d3943308b7a84464771e5ed6b578ba40ee0c3/graphql/handler/transport/websocket.go#L324) would be triggered, subsequently closing the wsConnection.
3. After that, the normal point of exit from the subroutine would be the error handler in [NextMessage()](https://github.com/99designs/gqlgen/blob/af4d3943308b7a84464771e5ed6b578ba40ee0c3/graphql/handler/transport/websocket.go#L266), which isn't straightforward either.
4. Due to this exit, a [deferred function](https://github.com/99designs/gqlgen/blob/af4d3943308b7a84464771e5ed6b578ba40ee0c3/graphql/handler/transport/websocket.go#L228) would be called, trying to close the wsConnection again. This happens with the `CloseAbnormalClosure` code, even though the closure might be normal.
5. A second call to `close()` doesn't panic or return an error since all errors are ignored inside [wsConnection.Close()](https://github.com/99designs/gqlgen/blob/af4d3943308b7a84464771e5ed6b578ba40ee0c3/graphql/handler/transport/websocket.go#L443-L453), but CloseFunc would be invoked again.

I also thought about removing the [deferred close code](https://github.com/99designs/gqlgen/blob/af4d3943308b7a84464771e5ed6b578ba40ee0c3/graphql/handler/transport/websocket.go#L226-L229) and adding explicit closures at every exit point of the subroutine. However, this approach seems riskier than adding a guard flag. There's no guarantee that resources would be released, for instance, if a panic occurred.

I would appreciate any feedback. Thank you.

I have:
 - [x] Added tests covering the bug/feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

