### PR TITLE
Feature: Support Apollo Federation Auth Directives

### DIFF
--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -112,27 +112,27 @@ func (f *federation) InjectSourceEarly() *ast.Source {
 	directive @external on OBJECT | FIELD_DEFINITION
 	directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 	directive @inaccessible on
-		| ARGUMENT_DEFINITION
-		| ENUM
-		| ENUM_VALUE
-		| FIELD_DEFINITION
-		| INPUT_FIELD_DEFINITION
-		| INPUT_OBJECT
-		| INTERFACE
-		| OBJECT
-		| SCALAR
-		| UNION
+	  | ARGUMENT_DEFINITION
+	  | ENUM
+	  | ENUM_VALUE
+	  | FIELD_DEFINITION
+	  | INPUT_FIELD_DEFINITION
+	  | INPUT_OBJECT
+	  | INTERFACE
+	  | OBJECT
+	  | SCALAR
+	  | UNION
 	directive @interfaceObject on OBJECT
 	directive @link(import: [String!], url: String!) repeatable on SCHEMA
 	directive @override(from: String!) on FIELD_DEFINITION
 	directive @provides(fields: FieldSet!) on FIELD_DEFINITION
 	directive @requires(fields: FieldSet!) on FIELD_DEFINITION
 	directive @requiresScopes(scopes: [[federation__Scope!]!]!) on 
-		|	FIELD_DEFINITION
-		| OBJECT
-		| INTERFACE
-		| SCALAR
-		| ENUM
+	  | FIELD_DEFINITION
+	  | OBJECT
+	  | INTERFACE
+	  | SCALAR
+	  | ENUM
 	directive @shareable repeatable on FIELD_DEFINITION | OBJECT
 	directive @tag(name: String!) repeatable on
 	  | ARGUMENT_DEFINITION

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -128,7 +128,7 @@ func (f *federation) InjectSourceEarly() *ast.Source {
 	directive @provides(fields: FieldSet!) on FIELD_DEFINITION
 	directive @requires(fields: FieldSet!) on FIELD_DEFINITION
 	directive @requiresScopes(scopes: [[federation__Scope!]!]!) on 
-	  |	FIELD_DEFINITION
+		|	FIELD_DEFINITION
 		| OBJECT
 		| INTERFACE
 		| SCALAR


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

PR to support requiresScope and authenticated directives introduces in v2.5

I am still new to the repo, if there is an obvious place to test this I am happy to try. 

This is a enterprise feature and requires a graphql router instance that is authenticated with a liscense in order to try it out. Shipt has a license so I was able to test this out locally but it will be hard for me to create a minimal repo for other to test out without them having an enterprise license. 

If there are contributors here that would be willing to test it out, I can create a repo that is ready for 2 env vars `APOLLO_KEY` and `APOLLO_REF`. 

[Apollo Spec](https://www.apollographql.com/docs/federation/subgraph-spec/#subgraph-schema-additions)

Related issues: 
https://github.com/99designs/gqlgen/issues/2808

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
