### PR TITLE
Add ability to not fail when pong is not received.

### DIFF
--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -27,6 +27,15 @@ type (
 		CloseFunc             WebsocketCloseFunc
 		KeepAlivePingInterval time.Duration
 		PingPongInterval      time.Duration
+		/* If PingPongInterval has a non-0 duration, then when the server sends a ping
+		 * it sets a ReadDeadline of PingPongInterval*2 and if the client doesn't respond
+		 * with pong before that deadline is reached then the connection will die with a
+		 * 1006 error code.
+		 *
+		 * MissingPongOk if true, tells the server to not use a ReadDeadline such that a
+		 * missing/slow pong response from the client doesn't kill the connection.
+		 */
+		MissingPongOk bool
 
 		didInjectSubprotocols bool
 	}
@@ -39,6 +48,7 @@ type (
 		mu              sync.Mutex
 		keepAliveTicker *time.Ticker
 		pingPongTicker  *time.Ticker
+		receivedPong    bool
 		exec            graphql.GraphExecutor
 		closed          bool
 
@@ -246,9 +256,11 @@ func (c *wsConnection) run() {
 		c.pingPongTicker = time.NewTicker(c.PingPongInterval)
 		c.mu.Unlock()
 
-		// Note: when the connection is closed by this deadline, the client
-		// will receive an "invalid close code"
-		c.conn.SetReadDeadline(time.Now().UTC().Add(2 * c.PingPongInterval))
+		if !c.MissingPongOk {
+			// Note: when the connection is closed by this deadline, the client
+			// will receive an "invalid close code"
+			c.conn.SetReadDeadline(time.Now().UTC().Add(2 * c.PingPongInterval))
+		}
 		go c.ping(ctx)
 	}
 
@@ -283,7 +295,11 @@ func (c *wsConnection) run() {
 		case pingMessageType:
 			c.write(&message{t: pongMessageType, payload: m.payload})
 		case pongMessageType:
-			c.conn.SetReadDeadline(time.Now().UTC().Add(2 * c.PingPongInterval))
+			c.mu.Lock()
+			c.receivedPong = true
+			c.mu.Unlock()
+			// Clear ReadTimeout -- 0 time val clears.
+			c.conn.SetReadDeadline(time.Time{})
 		default:
 			c.sendConnectionError("unexpected message %s", m.t)
 			c.close(websocket.CloseProtocolError, "unexpected message")
@@ -312,6 +328,14 @@ func (c *wsConnection) ping(ctx context.Context) {
 			return
 		case <-c.pingPongTicker.C:
 			c.write(&message{t: pingMessageType, payload: json.RawMessage{}})
+			// The initial deadline for this method is set in run()
+			// if we have not yet received a pong, don't reset the deadline.
+			c.mu.Lock()
+			if !c.MissingPongOk && c.receivedPong {
+				c.conn.SetReadDeadline(time.Now().UTC().Add(2 * c.PingPongInterval))
+			}
+			c.receivedPong = false
+			c.mu.Unlock()
 		}
 	}
 }


### PR DESCRIPTION
I also changed how the read deadline set works a little, the reason for this is that the protocol allows for pong to be sent without a ping.

So setting a read deadline on receiving pong isn't great. Instead we should always set the read deadline on sending ping. Though to do this we need to know whether we have received a pong or not. Because if we set the read deadline when the previous ping still hasn't received the pong. Then it will never hit the deadline.

I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [X] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
