### PR TITLE
Add @interfaceObject and @composeDirective at Federation 2 directive lists.

### DIFF
--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -85,6 +85,8 @@ func (f *federation) MutateConfig(cfg *config.Config) error {
 		cfg.Directives["inaccessible"] = config.DirectiveConfig{SkipRuntime: true}
 		cfg.Directives["authenticated"] = config.DirectiveConfig{SkipRuntime: true}
 		cfg.Directives["requiresScopes"] = config.DirectiveConfig{SkipRuntime: true}
+		cfg.Directives["interfaceObject"] = config.DirectiveConfig{SkipRuntime: true}
+		cfg.Directives["composeDirective"] = config.DirectiveConfig{SkipRuntime: true}
 	}
 
 	return nil
@@ -183,7 +185,11 @@ func (f *federation) InjectSourceLate(schema *ast.Schema) *ast.Source {
 				}
 				entityResolverInputDefinitions += "input " + r.InputTypeName + " {\n"
 				for _, keyField := range r.KeyFields {
-					entityResolverInputDefinitions += fmt.Sprintf("\t%s: %s\n", keyField.Field.ToGo(), keyField.Definition.Type.String())
+					entityResolverInputDefinitions += fmt.Sprintf(
+						"\t%s: %s\n",
+						keyField.Field.ToGo(),
+						keyField.Definition.Type.String(),
+					)
 				}
 				entityResolverInputDefinitions += "}"
 				resolvers += fmt.Sprintf("\t%s(reps: [%s]!): [%s]\n", r.ResolverName, r.InputTypeName, e.Name)

--- a/plugin/federation/testdata/federation2/federation2.graphql
+++ b/plugin/federation/testdata/federation2/federation2.graphql
@@ -1,6 +1,6 @@
 extend schema
   @link(url: "https://specs.apollo.dev/federation/v2.3",
-        import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override", "@inaccessible"])
+        import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override", "@inaccessible", "@interfaceObject"])
 
 schema {
     query: CustomQuery
@@ -23,4 +23,3 @@ extend type ExternalExtension @key(fields: "  upc    ") {
 type CustomQuery {
   hello: Hello!
 }
-


### PR DESCRIPTION
This is just an update of PR #2699 
---
This PR excludes the federation 2 directives added in #2635 from being added to `DirectiveRoot`. Without this exclusion, usage of `@interfaceObject` or `@composeDirective` fails at runtime with something like:

```json
{
  "data": null,
  "errors": [
    {
      "message": "directive interfaceObject is not implemented",
      "path": [
        "startTest",
        "currentQuestion"
      ]
    }
  ],
  "extensions": {
    "valueCompletion": [
      {
        "message": "Cannot return null for non-nullable field Mutation.startTest",
        "path": []
      }
    ]
  }
}
```
---
Currently, when using `@interfaceObject`, the GraphQL schema generates the directive template in the auto-generated file because those directives are not included in the list of federation directives, and so are not excluded from the code generation.

So, it causes a "not implemented" error when using `@interfaceObject` even though this directive is a federation 2.3 directive.

This commit just adds those directives to the list.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
