### PR TITLE
Omittable can now be serialized as json

### DIFF
--- a/graphql/omittable.go
+++ b/graphql/omittable.go
@@ -1,11 +1,18 @@
 package graphql
 
+import "encoding/json"
+
 // Omittable is a wrapper around a value that also stores whether it is set
 // or not.
 type Omittable[T any] struct {
 	value T
 	set   bool
 }
+
+var (
+	_ json.Marshaler   = Omittable[struct{}]{}
+	_ json.Unmarshaler = (*Omittable[struct{}])(nil)
+)
 
 func OmittableOf[T any](value T) Omittable[T] {
 	return Omittable[T]{
@@ -32,4 +39,20 @@ func (o Omittable[T]) ValueOK() (T, bool) {
 
 func (o Omittable[T]) IsSet() bool {
 	return o.set
+}
+
+func (o Omittable[T]) MarshalJSON() ([]byte, error) {
+	if !o.set {
+		return []byte("null"), nil
+	}
+	return json.Marshal(o.value)
+}
+
+func (o *Omittable[T]) UnmarshalJSON(bytes []byte) error {
+	err := json.Unmarshal(bytes, &o.value)
+	if err != nil {
+		return err
+	}
+	o.set = true
+	return nil
 }

--- a/graphql/omittable_test.go
+++ b/graphql/omittable_test.go
@@ -1,0 +1,88 @@
+package graphql
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOmittable_MarshalJSON(t *testing.T) {
+	s := "test"
+	testCases := []struct {
+		name         string
+		input        any
+		expectedJSON string
+	}{
+		{
+			name:         "simple string",
+			input:        struct{ Value Omittable[string] }{Value: OmittableOf("simple string")},
+			expectedJSON: `{"Value": "simple string"}`,
+		},
+		{
+			name:         "string pointer",
+			input:        struct{ Value Omittable[*string] }{Value: OmittableOf(&s)},
+			expectedJSON: `{"Value": "test"}`,
+		},
+		{
+			name:         "omitted integer",
+			input:        struct{ Value Omittable[int] }{},
+			expectedJSON: `{"Value": null}`,
+		},
+		{
+			name:         "omittable omittable",
+			input:        struct{ Value Omittable[Omittable[uint64]] }{Value: OmittableOf(OmittableOf(uint64(42)))},
+			expectedJSON: `{"Value": 42}`,
+		},
+		{
+			name: "omittable struct",
+			input: struct {
+				Value Omittable[struct{ Inner string }]
+			}{Value: OmittableOf(struct{ Inner string }{})},
+			expectedJSON: `{"Value": {"Inner": ""}}`,
+		},
+		{
+			name: "omitted struct",
+			input: struct {
+				Value Omittable[struct{ Inner string }]
+			}{},
+			expectedJSON: `{"Value": null}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(tc.input)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.expectedJSON, string(data))
+		})
+	}
+}
+
+func TestOmittable_UnmarshalJSON(t *testing.T) {
+	var s struct {
+		String        Omittable[string]
+		OmittedString Omittable[string]
+		StringPointer Omittable[*string]
+		NullInt       Omittable[int]
+	}
+
+	err := json.Unmarshal([]byte(`
+	{
+		"String": "simple string",
+		"StringPointer": "string pointer",
+		"NullInt": null
+	}`), &s)
+
+	require.NoError(t, err)
+	assert.Equal(t, "simple string", s.String.Value())
+	assert.True(t, s.String.IsSet())
+	assert.False(t, s.OmittedString.IsSet())
+	assert.True(t, s.StringPointer.IsSet())
+	if assert.NotNil(t, s.StringPointer.Value()) {
+		assert.EqualValues(t, "string pointer", *s.StringPointer.Value())
+	}
+	assert.True(t, s.NullInt.IsSet())
+	assert.Zero(t, s.NullInt.Value())
+}


### PR DESCRIPTION
The `Omittable` struct lacks the necessary JSON unmarshaller and marshaller implementations. As a result, instances of this struct are serialized as empty JSON objects (`{}`) even when they contain data.


For instance, consider the following Go struct:
```go
struct {
	ID     graphql.Omittable[*string]     `json:"id,omitempty"`
	Bool   graphql.Omittable[*bool]       `json:"bool,omitempty"`
	Str    graphql.Omittable[*string]     `json:"str,omitempty"`
}
```

This struct is being serialized as:
```json
{
  "id": {},
  "bool": {},
  "str": {},
}
```

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
