### PR TITLE
fix fieldset.New bug when prefix slice has len < cap

### DIFF
--- a/plugin/federation/fieldset/fieldset.go
+++ b/plugin/federation/fieldset/fieldset.go
@@ -134,7 +134,7 @@ func parseUnnestedKeyFieldSet(raw string, prefix []string) Set {
 	ret := Set{}
 
 	for _, s := range strings.Fields(raw) {
-		next := append(prefix[:], s) //nolint:gocritic // slicing out on purpose
+		next := append(prefix[0:len(prefix):len(prefix)], s) // set cap=len in order to force slice reallocation
 		ret = append(ret, next)
 	}
 	return ret

--- a/plugin/federation/fieldset/fieldset_test.go
+++ b/plugin/federation/fieldset/fieldset_test.go
@@ -43,18 +43,37 @@ func TestNestedWithoutPrefix(t *testing.T) {
 }
 
 func TestWithPrefix(t *testing.T) {
-	fieldSet := New("foo bar{id}", []string{"prefix"})
+	t.Run("prefix with len=capacity", func(t *testing.T) {
+		fieldSet := New("foo bar{id}", []string{"prefix"})
 
-	require.Len(t, fieldSet, 2)
+		require.Len(t, fieldSet, 2)
 
-	require.Len(t, fieldSet[0], 2)
-	require.Equal(t, "prefix", fieldSet[0][0])
-	require.Equal(t, "foo", fieldSet[0][1])
+		require.Len(t, fieldSet[0], 2)
+		require.Equal(t, "prefix", fieldSet[0][0])
+		require.Equal(t, "foo", fieldSet[0][1])
 
-	require.Len(t, fieldSet[1], 3)
-	require.Equal(t, "prefix", fieldSet[1][0])
-	require.Equal(t, "bar", fieldSet[1][1])
-	require.Equal(t, "id", fieldSet[1][2])
+		require.Len(t, fieldSet[1], 3)
+		require.Equal(t, "prefix", fieldSet[1][0])
+		require.Equal(t, "bar", fieldSet[1][1])
+		require.Equal(t, "id", fieldSet[1][2])
+	})
+	t.Run("prefix with len<capacity", func(t *testing.T) {
+		prefix := make([]string, 0, 2)
+		prefix = append(prefix, "prefix")
+		fieldSet := New("foo bar{id}", prefix)
+
+		require.Len(t, fieldSet, 2)
+		t.Log(fieldSet)
+
+		require.Len(t, fieldSet[0], 2)
+		require.Equal(t, "prefix", fieldSet[0][0])
+		require.Equal(t, "foo", fieldSet[0][1])
+
+		require.Len(t, fieldSet[1], 3)
+		require.Equal(t, "prefix", fieldSet[1][0])
+		require.Equal(t, "bar", fieldSet[1][1])
+		require.Equal(t, "id", fieldSet[1][2])
+	})
 }
 
 func TestInvalid(t *testing.T) {


### PR DESCRIPTION
Accidentally inspected `gqlgen` source code and found a bug in `FieldSet.New` implementation which can be reproduced if `prefix` slice is "not full" (`length < capacity`). In this case internal function `parseUnnestedKeyFieldSet` will overwrite same slice element multiple times - which will lead to incorrect `FieldSet` construction.

Bug fix is pretty simple: we should set max capacity equal to length in `parseUnnestedKeyFieldSet` (using extended slicing operation `x[start:end:cap]`)

In order to cover this bug 1 test case were added: `TestWithPrefix/prefix with len<capacity`

From the brief source code search it looks like no code were exposed to this bug because prefix argument always passed as `nil`. But, as this is public library interface, someone can use this logic.

If it's possible - than removal of this argument can be considered (with potential breaking changes). 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
