### PR TITLE
Return null if invalid enum is encountered

### DIFF
--- a/plugin/modelgen/models.gotpl
+++ b/plugin/modelgen/models.gotpl
@@ -98,7 +98,12 @@
 	}
 
 	func (e {{ goModelName .Name }}) MarshalGQL(w io.Writer) {
-		fmt.Fprint(w, strconv.Quote(e.String()))
+		switch e.IsValid() {
+		case true:
+			fmt.Fprint(w, strconv.Quote(e.String()))
+		case false:
+			graphql.Null.MarshalGQL(w)
+		}
 	}
 
 {{- end }}


### PR DESCRIPTION
Describe your PR and link to any relevant issues.

In the current scenario, invalid enums are propagated to the client. This PR sends a null instead - while the graphql spec insists on returning a type error, I found this to be less breaking.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
