### PR TITLE
fix: avoid panic from tracing on bad request

### DIFF
--- a/graphql/handler/apollofederatedtracingv1/tracing.go
+++ b/graphql/handler/apollofederatedtracingv1/tracing.go
@@ -85,9 +85,11 @@ func (t *Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHan
 		return next(ctx)
 	}
 	tb := t.getTreeBuilder(ctx)
-	if tb != nil {
-		tb.StartTimer(ctx)
+	if tb == nil {
+		return next(ctx)
 	}
+
+	tb.StartTimer(ctx)
 
 	val := new(string)
 	graphql.RegisterExtension(ctx, "ftv1", val)


### PR DESCRIPTION
This fixes a panic which arises from the tracing components when a request has some defect which results in an error when creating the `OperationContext`. The transports consistently handle this by calling `DispatchError(graphql.WithOperationContext(ctx, rc), err)` where `rc` is the OperationContext which was not correctly constructed. This seems dangerous, because middleware may assume that if there in an `OperationContext` in the `context.Context` than they are being invoked on a normal codepath and can assume their other interceptors have been invoked in the normal order. Also, using a value returned by a function which also returned a non-nil error is very unusual. However, I have no idea what the impact of changing that dangerous behavior in the transports would be, so I opted to make the tracing component more resilient instead.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
