### PR TITLE
Update federation plugin

### DIFF
--- a/api/generate.go
+++ b/api/generate.go
@@ -32,7 +32,7 @@ func Generate(cfg *config.Config, option ...Option) error {
 			for _, v := range cfg.Sources {
 				cfg.Federation.Version = 1
 				urlString := urlRegex.FindStringSubmatch(v.Input)
-				if urlString != nil && urlString[1] == "https://specs.apollo.dev/federation/v2.0" {
+				if urlString != nil && urlString[1] == "https://specs.apollo.dev/federation/v2.7" {
 					cfg.Federation.Version = 2
 					break
 				}

--- a/api/testdata/federation2/graph/generated.go
+++ b/api/testdata/federation2/graph/generated.go
@@ -312,7 +312,13 @@ var sources = []*ast.Source{
 	  | UNION
 	directive @interfaceObject on OBJECT
 	directive @link(import: [String!], url: String!) repeatable on SCHEMA
-	directive @override(from: String!) on FIELD_DEFINITION
+	directive @override(from: String!, label: String) on FIELD_DEFINITION
+	directive @policy(policies: [[federation__Policy!]!]!) on 
+	  | FIELD_DEFINITION
+	  | OBJECT
+	  | INTERFACE
+	  | SCALAR
+	  | ENUM
 	directive @provides(fields: FieldSet!) on FIELD_DEFINITION
 	directive @requires(fields: FieldSet!) on FIELD_DEFINITION
 	directive @requiresScopes(scopes: [[federation__Scope!]!]!) on 
@@ -335,6 +341,7 @@ var sources = []*ast.Source{
 	  | UNION
 	scalar _Any
 	scalar FieldSet
+	scalar federation__Policy
 	scalar federation__Scope
 `, BuiltIn: true},
 	{Name: "../federation/entity.graphql", Input: `
@@ -3834,6 +3841,85 @@ func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel a
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNfederation__Policy2string(ctx context.Context, v interface{}) (string, error) {
+	res, err := graphql.UnmarshalString(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNfederation__Policy2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	res := graphql.MarshalString(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNfederation__Policy2ᚕstringᚄ(ctx context.Context, v interface{}) ([]string, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]string, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNfederation__Policy2string(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNfederation__Policy2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNfederation__Policy2string(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) unmarshalNfederation__Policy2ᚕᚕstringᚄ(ctx context.Context, v interface{}) ([][]string, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([][]string, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNfederation__Policy2ᚕstringᚄ(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNfederation__Policy2ᚕᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v [][]string) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNfederation__Policy2ᚕstringᚄ(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalNfederation__Scope2string(ctx context.Context, v interface{}) (string, error) {

--- a/api/testdata/federation2/graph/schema.graphqls
+++ b/api/testdata/federation2/graph/schema.graphqls
@@ -2,7 +2,7 @@
 #
 # https://gqlgen.com/getting-started/
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.0",
+  @link(url: "https://specs.apollo.dev/federation/v2.7",
         import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override", "@inaccessible"])
 
 type Todo {

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -62,6 +62,9 @@ func (f *federation) MutateConfig(cfg *config.Config) error {
 		"federation__Scope": {
 			Model: config.StringList{"github.com/99designs/gqlgen/graphql.String"},
 		},
+		"federation__Policy": {
+			Model: config.StringList{"github.com/99designs/gqlgen/graphql.String"},
+		},
 	}
 
 	for typeName, entry := range builtins {
@@ -85,6 +88,7 @@ func (f *federation) MutateConfig(cfg *config.Config) error {
 		cfg.Directives["inaccessible"] = config.DirectiveConfig{SkipRuntime: true}
 		cfg.Directives["authenticated"] = config.DirectiveConfig{SkipRuntime: true}
 		cfg.Directives["requiresScopes"] = config.DirectiveConfig{SkipRuntime: true}
+		cfg.Directives["policy"] = config.DirectiveConfig{SkipRuntime: true}
 		cfg.Directives["interfaceObject"] = config.DirectiveConfig{SkipRuntime: true}
 		cfg.Directives["composeDirective"] = config.DirectiveConfig{SkipRuntime: true}
 	}
@@ -126,7 +130,13 @@ func (f *federation) InjectSourceEarly() *ast.Source {
 	  | UNION
 	directive @interfaceObject on OBJECT
 	directive @link(import: [String!], url: String!) repeatable on SCHEMA
-	directive @override(from: String!) on FIELD_DEFINITION
+	directive @override(from: String!, label: String) on FIELD_DEFINITION
+	directive @policy(policies: [[federation__Policy!]!]!) on 
+	  | FIELD_DEFINITION
+	  | OBJECT
+	  | INTERFACE
+	  | SCALAR
+	  | ENUM
 	directive @provides(fields: FieldSet!) on FIELD_DEFINITION
 	directive @requires(fields: FieldSet!) on FIELD_DEFINITION
 	directive @requiresScopes(scopes: [[federation__Scope!]!]!) on 
@@ -149,6 +159,7 @@ func (f *federation) InjectSourceEarly() *ast.Source {
 	  | UNION
 	scalar _Any
 	scalar FieldSet
+	scalar federation__Policy
 	scalar federation__Scope
 `
 	}

--- a/plugin/federation/testdata/federation2/federation2.graphql
+++ b/plugin/federation/testdata/federation2/federation2.graphql
@@ -1,13 +1,13 @@
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.3",
-        import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override", "@inaccessible", "@interfaceObject"])
+  @link(url: "https://specs.apollo.dev/federation/v2.7",
+        import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override", "@inaccessible", "@interfaceObject", "Policy"])
 
 schema {
     query: CustomQuery
 }
 
 type Hello @key(fields:"name", resolvable: false) {
-  name: String!
+  name: String! @override(from: "old-service", label: "percent(5)")
 }
 
 type World @key(fields: "foo bar", resolvable: false) {

--- a/plugin/federation/testdata/multi/multi.graphqls
+++ b/plugin/federation/testdata/multi/multi.graphqls
@@ -1,5 +1,5 @@
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.3",
+  @link(url: "https://specs.apollo.dev/federation/v2.7",
         import: ["@key"])
 
 directive @entityResolver(multi: Boolean) on OBJECT


### PR DESCRIPTION
This PR updates the federation plugin to include missing features from v2.6 (`@policy`) as well as the upcoming v2.7 (progressive `@override` which uses a new optional `label` arg). 

It's not obvious to me if there are docs I need to update as well, please point me in the right direction if so.

v2.7 is not available yet but it'd be great to have this ready to go as soon as it is. Marking as WIP until this is supported in Apollo's Federation libs.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
