### PR TITLE
Fix code generation for federated multi-key, multi-entity types

### DIFF
--- a/plugin/federation/federation.gotpl
+++ b/plugin/federation/federation.gotpl
@@ -132,7 +132,13 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 			{{ range $_, $entity := .Entities }}
 				{{ if and .Resolvers .Multi -}}
 				case "{{.Def.Name}}":
-					{{range $i, $_ := .Resolvers -}}
+					resolverName, err := entityResolverNameFor{{.Def.Name}}(ctx, reps[0])
+					if err != nil {
+						return fmt.Errorf(`finding resolver for Entity "{{.Def.Name}}": %w`, err)
+					}
+					switch resolverName {
+					{{ range $i, $resolver := .Resolvers }}
+					case "{{.ResolverName}}":
 						_reps := make([]*{{.LookupInputType}}, len(reps))
 
 						for i, rep := range reps {
@@ -166,6 +172,9 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 						}
 						return nil
 					{{ end }}
+					default:
+                    	return fmt.Errorf("unknown resolver: %s", resolverName)
+					}
 				{{ end }}
 			{{- end }}
 		default:

--- a/plugin/federation/federation_test.go
+++ b/plugin/federation/federation_test.go
@@ -12,22 +12,24 @@ import (
 func TestWithEntities(t *testing.T) {
 	f, cfg := load(t, "testdata/allthethings/gqlgen.yml")
 
-	require.Equal(t, []string{"ExternalExtension", "Hello", "MoreNesting", "NestedKey", "VeryNestedKey", "World"}, cfg.Schema.Types["_Entity"].Types)
+	require.Equal(t, []string{"ExternalExtension", "Hello", "MoreNesting", "MultiHelloMultiKey", "NestedKey", "VeryNestedKey", "World"}, cfg.Schema.Types["_Entity"].Types)
 
-	require.Len(t, cfg.Schema.Types["Entity"].Fields, 6)
+	require.Len(t, cfg.Schema.Types["Entity"].Fields, 8)
 
 	require.Equal(t, "findExternalExtensionByUpc", cfg.Schema.Types["Entity"].Fields[0].Name)
 	require.Equal(t, "findHelloByName", cfg.Schema.Types["Entity"].Fields[1].Name)
 	// missing on purpose: all @external fields:
 	// require.Equal(t, "findMoreNestingByID", cfg.Schema.Types["Entity"].Fields[2].Name)
-	require.Equal(t, "findNestedKeyByIDAndHelloName", cfg.Schema.Types["Entity"].Fields[2].Name)
-	require.Equal(t, "findVeryNestedKeyByIDAndHelloNameAndWorldFooAndWorldBarAndMoreWorldFoo", cfg.Schema.Types["Entity"].Fields[3].Name)
-	require.Equal(t, "findWorldByFoo", cfg.Schema.Types["Entity"].Fields[4].Name)
-	require.Equal(t, "findWorldByBar", cfg.Schema.Types["Entity"].Fields[5].Name)
+	require.Equal(t, "findManyMultiHelloMultiKeyByNames", cfg.Schema.Types["Entity"].Fields[2].Name)
+	require.Equal(t, "findManyMultiHelloMultiKeyByKey2s", cfg.Schema.Types["Entity"].Fields[3].Name)
+	require.Equal(t, "findNestedKeyByIDAndHelloName", cfg.Schema.Types["Entity"].Fields[4].Name)
+	require.Equal(t, "findVeryNestedKeyByIDAndHelloNameAndWorldFooAndWorldBarAndMoreWorldFoo", cfg.Schema.Types["Entity"].Fields[5].Name)
+	require.Equal(t, "findWorldByFoo", cfg.Schema.Types["Entity"].Fields[6].Name)
+	require.Equal(t, "findWorldByBar", cfg.Schema.Types["Entity"].Fields[7].Name)
 
 	require.NoError(t, f.MutateConfig(cfg))
 
-	require.Len(t, f.Entities, 6)
+	require.Len(t, f.Entities, 7)
 
 	require.Equal(t, "ExternalExtension", f.Entities[0].Name)
 	require.Len(t, f.Entities[0].Resolvers, 1)
@@ -44,40 +46,49 @@ func TestWithEntities(t *testing.T) {
 	require.Equal(t, "MoreNesting", f.Entities[2].Name)
 	require.Len(t, f.Entities[2].Resolvers, 0)
 
-	require.Equal(t, "NestedKey", f.Entities[3].Name)
-	require.Len(t, f.Entities[3].Resolvers, 1)
-	require.Len(t, f.Entities[3].Resolvers[0].KeyFields, 2)
-	require.Equal(t, "id", f.Entities[3].Resolvers[0].KeyFields[0].Definition.Name)
+	require.Equal(t, "MultiHelloMultiKey", f.Entities[3].Name)
+	require.Len(t, f.Entities[3].Resolvers, 2)
+	require.Len(t, f.Entities[3].Resolvers[0].KeyFields, 1)
+	require.Len(t, f.Entities[3].Resolvers[1].KeyFields, 1)
+	require.Equal(t, "name", f.Entities[3].Resolvers[0].KeyFields[0].Definition.Name)
 	require.Equal(t, "String", f.Entities[3].Resolvers[0].KeyFields[0].Definition.Type.Name())
-	require.Equal(t, "helloName", f.Entities[3].Resolvers[0].KeyFields[1].Definition.Name)
-	require.Equal(t, "String", f.Entities[3].Resolvers[0].KeyFields[1].Definition.Type.Name())
+	require.Equal(t, "key2", f.Entities[3].Resolvers[1].KeyFields[0].Definition.Name)
+	require.Equal(t, "String", f.Entities[3].Resolvers[1].KeyFields[0].Definition.Type.Name())
 
-	require.Equal(t, "VeryNestedKey", f.Entities[4].Name)
+	require.Equal(t, "NestedKey", f.Entities[4].Name)
 	require.Len(t, f.Entities[4].Resolvers, 1)
-	require.Len(t, f.Entities[4].Resolvers[0].KeyFields, 5)
+	require.Len(t, f.Entities[4].Resolvers[0].KeyFields, 2)
 	require.Equal(t, "id", f.Entities[4].Resolvers[0].KeyFields[0].Definition.Name)
 	require.Equal(t, "String", f.Entities[4].Resolvers[0].KeyFields[0].Definition.Type.Name())
 	require.Equal(t, "helloName", f.Entities[4].Resolvers[0].KeyFields[1].Definition.Name)
 	require.Equal(t, "String", f.Entities[4].Resolvers[0].KeyFields[1].Definition.Type.Name())
-	require.Equal(t, "worldFoo", f.Entities[4].Resolvers[0].KeyFields[2].Definition.Name)
-	require.Equal(t, "String", f.Entities[4].Resolvers[0].KeyFields[2].Definition.Type.Name())
-	require.Equal(t, "worldBar", f.Entities[4].Resolvers[0].KeyFields[3].Definition.Name)
-	require.Equal(t, "Int", f.Entities[4].Resolvers[0].KeyFields[3].Definition.Type.Name())
-	require.Equal(t, "moreWorldFoo", f.Entities[4].Resolvers[0].KeyFields[4].Definition.Name)
-	require.Equal(t, "String", f.Entities[4].Resolvers[0].KeyFields[4].Definition.Type.Name())
 
-	require.Len(t, f.Entities[4].Requires, 2)
-	require.Equal(t, f.Entities[4].Requires[0].Name, "id")
-	require.Equal(t, f.Entities[4].Requires[1].Name, "helloSecondary")
-
-	require.Equal(t, "World", f.Entities[5].Name)
-	require.Len(t, f.Entities[5].Resolvers, 2)
-	require.Len(t, f.Entities[5].Resolvers[0].KeyFields, 1)
-	require.Equal(t, "foo", f.Entities[5].Resolvers[0].KeyFields[0].Definition.Name)
+	require.Equal(t, "VeryNestedKey", f.Entities[5].Name)
+	require.Len(t, f.Entities[5].Resolvers, 1)
+	require.Len(t, f.Entities[5].Resolvers[0].KeyFields, 5)
+	require.Equal(t, "id", f.Entities[5].Resolvers[0].KeyFields[0].Definition.Name)
 	require.Equal(t, "String", f.Entities[5].Resolvers[0].KeyFields[0].Definition.Type.Name())
-	require.Len(t, f.Entities[5].Resolvers[1].KeyFields, 1)
-	require.Equal(t, "bar", f.Entities[5].Resolvers[1].KeyFields[0].Definition.Name)
-	require.Equal(t, "Int", f.Entities[5].Resolvers[1].KeyFields[0].Definition.Type.Name())
+	require.Equal(t, "helloName", f.Entities[5].Resolvers[0].KeyFields[1].Definition.Name)
+	require.Equal(t, "String", f.Entities[5].Resolvers[0].KeyFields[1].Definition.Type.Name())
+	require.Equal(t, "worldFoo", f.Entities[5].Resolvers[0].KeyFields[2].Definition.Name)
+	require.Equal(t, "String", f.Entities[5].Resolvers[0].KeyFields[2].Definition.Type.Name())
+	require.Equal(t, "worldBar", f.Entities[5].Resolvers[0].KeyFields[3].Definition.Name)
+	require.Equal(t, "Int", f.Entities[5].Resolvers[0].KeyFields[3].Definition.Type.Name())
+	require.Equal(t, "moreWorldFoo", f.Entities[5].Resolvers[0].KeyFields[4].Definition.Name)
+	require.Equal(t, "String", f.Entities[5].Resolvers[0].KeyFields[4].Definition.Type.Name())
+
+	require.Len(t, f.Entities[5].Requires, 2)
+	require.Equal(t, f.Entities[5].Requires[0].Name, "id")
+	require.Equal(t, f.Entities[5].Requires[1].Name, "helloSecondary")
+
+	require.Equal(t, "World", f.Entities[6].Name)
+	require.Len(t, f.Entities[6].Resolvers, 2)
+	require.Len(t, f.Entities[6].Resolvers[0].KeyFields, 1)
+	require.Equal(t, "foo", f.Entities[6].Resolvers[0].KeyFields[0].Definition.Name)
+	require.Equal(t, "String", f.Entities[6].Resolvers[0].KeyFields[0].Definition.Type.Name())
+	require.Len(t, f.Entities[6].Resolvers[1].KeyFields, 1)
+	require.Equal(t, "bar", f.Entities[6].Resolvers[1].KeyFields[0].Definition.Name)
+	require.Equal(t, "Int", f.Entities[6].Resolvers[1].KeyFields[0].Definition.Type.Name())
 }
 
 func TestNoEntities(t *testing.T) {
@@ -124,8 +135,8 @@ func TestEntityInterfaces(t *testing.T) {
 func TestCodeGeneration(t *testing.T) {
 	f, cfg := load(t, "testdata/allthethings/gqlgen.yml")
 
-	require.Len(t, cfg.Schema.Types["_Entity"].Types, 6)
-	require.Len(t, f.Entities, 6)
+	require.Len(t, cfg.Schema.Types["_Entity"].Types, 7)
+	require.Len(t, f.Entities, 7)
 
 	require.NoError(t, f.MutateConfig(cfg))
 

--- a/plugin/federation/testdata/allthethings/generated/federation.go
+++ b/plugin/federation/testdata/allthethings/generated/federation.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/99designs/gqlgen/plugin/federation/fedruntime"
+	"github.com/99designs/gqlgen/plugin/federation/testdata/allthethings/model"
 )
 
 var (
@@ -65,6 +66,8 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 
 	isMulti := func(typeName string) bool {
 		switch typeName {
+		case "MultiHelloMultiKey":
+			return true
 		default:
 			return false
 		}
@@ -236,6 +239,65 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 
 		switch typeName {
 
+		case "MultiHelloMultiKey":
+			resolverName, err := entityResolverNameForMultiHelloMultiKey(ctx, reps[0])
+			if err != nil {
+				return fmt.Errorf(`finding resolver for Entity "MultiHelloMultiKey": %w`, err)
+			}
+			switch resolverName {
+
+			case "findManyMultiHelloMultiKeyByNames":
+				_reps := make([]*model.MultiHelloMultiKeyByNamesInput, len(reps))
+
+				for i, rep := range reps {
+					id0, err := ec.unmarshalNString2string(ctx, rep["name"])
+					if err != nil {
+						return errors.New(fmt.Sprintf("Field %s undefined in schema.", "name"))
+					}
+
+					_reps[i] = &model.MultiHelloMultiKeyByNamesInput{
+						Name: id0,
+					}
+				}
+
+				entities, err := ec.resolvers.Entity().FindManyMultiHelloMultiKeyByNames(ctx, _reps)
+				if err != nil {
+					return err
+				}
+
+				for i, entity := range entities {
+					list[idx[i]] = entity
+				}
+				return nil
+
+			case "findManyMultiHelloMultiKeyByKey2s":
+				_reps := make([]*model.MultiHelloMultiKeyByKey2sInput, len(reps))
+
+				for i, rep := range reps {
+					id0, err := ec.unmarshalNString2string(ctx, rep["key2"])
+					if err != nil {
+						return errors.New(fmt.Sprintf("Field %s undefined in schema.", "key2"))
+					}
+
+					_reps[i] = &model.MultiHelloMultiKeyByKey2sInput{
+						Key2: id0,
+					}
+				}
+
+				entities, err := ec.resolvers.Entity().FindManyMultiHelloMultiKeyByKey2s(ctx, _reps)
+				if err != nil {
+					return err
+				}
+
+				for i, entity := range entities {
+					list[idx[i]] = entity
+				}
+				return nil
+
+			default:
+				return fmt.Errorf("unknown resolver: %s", resolverName)
+			}
+
 		default:
 			return errors.New("unknown type: " + typeName)
 		}
@@ -321,6 +383,36 @@ func entityResolverNameForHello(ctx context.Context, rep map[string]interface{})
 		return "findHelloByName", nil
 	}
 	return "", fmt.Errorf("%w for Hello", ErrTypeNotFound)
+}
+
+func entityResolverNameForMultiHelloMultiKey(ctx context.Context, rep map[string]interface{}) (string, error) {
+	for {
+		var (
+			m   map[string]interface{}
+			val interface{}
+			ok  bool
+		)
+		_ = val
+		m = rep
+		if _, ok = m["name"]; !ok {
+			break
+		}
+		return "findManyMultiHelloMultiKeyByNames", nil
+	}
+	for {
+		var (
+			m   map[string]interface{}
+			val interface{}
+			ok  bool
+		)
+		_ = val
+		m = rep
+		if _, ok = m["key2"]; !ok {
+			break
+		}
+		return "findManyMultiHelloMultiKeyByKey2s", nil
+	}
+	return "", fmt.Errorf("%w for MultiHelloMultiKey", ErrTypeNotFound)
 }
 
 func entityResolverNameForNestedKey(ctx context.Context, rep map[string]interface{}) (string, error) {

--- a/plugin/federation/testdata/allthethings/model/federation.go
+++ b/plugin/federation/testdata/allthethings/model/federation.go
@@ -16,6 +16,13 @@ type World struct {
 
 func (World) IsEntity() {}
 
+type MultiHelloMultiKey struct {
+	Name string
+	Key2 int
+}
+
+func (MultiHelloMultiKey) IsEntity() {}
+
 type ExternalExtension struct {
 	UPC     string
 	Reviews []*World
@@ -46,3 +53,11 @@ type VeryNestedKey struct {
 }
 
 func (VeryNestedKey) IsEntity() {}
+
+type MultiHelloMultiKeyByNamesInput struct {
+	Names []string `json:"Names"`
+}
+
+type MultiHelloMultiKeyByKey2sInput struct {
+	Key2s []string `json:"Key2s"`
+}

--- a/plugin/federation/testdata/allthethings/schema.graphql
+++ b/plugin/federation/testdata/allthethings/schema.graphql
@@ -8,6 +8,13 @@ type World @key(fields: " foo   ") @key(fields: "bar") {
     bar: Int!
 }
 
+directive @entityResolver(multi: Boolean) on OBJECT
+
+type MultiHelloMultiKey @key(fields: "name") @key(fields:"key2") @entityResolver(multi: true) {
+    name: String!
+    key2: String!
+}
+
 extend type ExternalExtension @key(fields: "  upc    ") {
     upc: String! @external
     reviews: [World]

--- a/plugin/federation/testdata/entityresolver/generated/federation.go
+++ b/plugin/federation/testdata/entityresolver/generated/federation.go
@@ -328,140 +328,195 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 		switch typeName {
 
 		case "MultiHello":
-			_reps := make([]*model.MultiHelloByNamesInput, len(reps))
-
-			for i, rep := range reps {
-				id0, err := ec.unmarshalNString2string(ctx, rep["name"])
-				if err != nil {
-					return errors.New(fmt.Sprintf("Field %s undefined in schema.", "name"))
-				}
-
-				_reps[i] = &model.MultiHelloByNamesInput{
-					Name: id0,
-				}
-			}
-
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloByNames(ctx, _reps)
+			resolverName, err := entityResolverNameForMultiHello(ctx, reps[0])
 			if err != nil {
-				return err
+				return fmt.Errorf(`finding resolver for Entity "MultiHello": %w`, err)
 			}
+			switch resolverName {
 
-			for i, entity := range entities {
-				list[idx[i]] = entity
+			case "findManyMultiHelloByNames":
+				_reps := make([]*model.MultiHelloByNamesInput, len(reps))
+
+				for i, rep := range reps {
+					id0, err := ec.unmarshalNString2string(ctx, rep["name"])
+					if err != nil {
+						return errors.New(fmt.Sprintf("Field %s undefined in schema.", "name"))
+					}
+
+					_reps[i] = &model.MultiHelloByNamesInput{
+						Name: id0,
+					}
+				}
+
+				entities, err := ec.resolvers.Entity().FindManyMultiHelloByNames(ctx, _reps)
+				if err != nil {
+					return err
+				}
+
+				for i, entity := range entities {
+					list[idx[i]] = entity
+				}
+				return nil
+
+			default:
+				return fmt.Errorf("unknown resolver: %s", resolverName)
 			}
-			return nil
 
 		case "MultiHelloMultipleRequires":
-			_reps := make([]*model.MultiHelloMultipleRequiresByNamesInput, len(reps))
-
-			for i, rep := range reps {
-				id0, err := ec.unmarshalNString2string(ctx, rep["name"])
-				if err != nil {
-					return errors.New(fmt.Sprintf("Field %s undefined in schema.", "name"))
-				}
-
-				_reps[i] = &model.MultiHelloMultipleRequiresByNamesInput{
-					Name: id0,
-				}
-			}
-
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloMultipleRequiresByNames(ctx, _reps)
+			resolverName, err := entityResolverNameForMultiHelloMultipleRequires(ctx, reps[0])
 			if err != nil {
-				return err
+				return fmt.Errorf(`finding resolver for Entity "MultiHelloMultipleRequires": %w`, err)
 			}
+			switch resolverName {
 
-			for i, entity := range entities {
-				entity.Key1, err = ec.unmarshalNString2string(ctx, reps[i]["key1"])
+			case "findManyMultiHelloMultipleRequiresByNames":
+				_reps := make([]*model.MultiHelloMultipleRequiresByNamesInput, len(reps))
+
+				for i, rep := range reps {
+					id0, err := ec.unmarshalNString2string(ctx, rep["name"])
+					if err != nil {
+						return errors.New(fmt.Sprintf("Field %s undefined in schema.", "name"))
+					}
+
+					_reps[i] = &model.MultiHelloMultipleRequiresByNamesInput{
+						Name: id0,
+					}
+				}
+
+				entities, err := ec.resolvers.Entity().FindManyMultiHelloMultipleRequiresByNames(ctx, _reps)
 				if err != nil {
 					return err
 				}
-				entity.Key2, err = ec.unmarshalNString2string(ctx, reps[i]["key2"])
-				if err != nil {
-					return err
+
+				for i, entity := range entities {
+					entity.Key1, err = ec.unmarshalNString2string(ctx, reps[i]["key1"])
+					if err != nil {
+						return err
+					}
+					entity.Key2, err = ec.unmarshalNString2string(ctx, reps[i]["key2"])
+					if err != nil {
+						return err
+					}
+					list[idx[i]] = entity
 				}
-				list[idx[i]] = entity
+				return nil
+
+			default:
+				return fmt.Errorf("unknown resolver: %s", resolverName)
 			}
-			return nil
 
 		case "MultiHelloRequires":
-			_reps := make([]*model.MultiHelloRequiresByNamesInput, len(reps))
-
-			for i, rep := range reps {
-				id0, err := ec.unmarshalNString2string(ctx, rep["name"])
-				if err != nil {
-					return errors.New(fmt.Sprintf("Field %s undefined in schema.", "name"))
-				}
-
-				_reps[i] = &model.MultiHelloRequiresByNamesInput{
-					Name: id0,
-				}
-			}
-
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloRequiresByNames(ctx, _reps)
+			resolverName, err := entityResolverNameForMultiHelloRequires(ctx, reps[0])
 			if err != nil {
-				return err
+				return fmt.Errorf(`finding resolver for Entity "MultiHelloRequires": %w`, err)
 			}
+			switch resolverName {
 
-			for i, entity := range entities {
-				entity.Key1, err = ec.unmarshalNString2string(ctx, reps[i]["key1"])
+			case "findManyMultiHelloRequiresByNames":
+				_reps := make([]*model.MultiHelloRequiresByNamesInput, len(reps))
+
+				for i, rep := range reps {
+					id0, err := ec.unmarshalNString2string(ctx, rep["name"])
+					if err != nil {
+						return errors.New(fmt.Sprintf("Field %s undefined in schema.", "name"))
+					}
+
+					_reps[i] = &model.MultiHelloRequiresByNamesInput{
+						Name: id0,
+					}
+				}
+
+				entities, err := ec.resolvers.Entity().FindManyMultiHelloRequiresByNames(ctx, _reps)
 				if err != nil {
 					return err
 				}
-				list[idx[i]] = entity
+
+				for i, entity := range entities {
+					entity.Key1, err = ec.unmarshalNString2string(ctx, reps[i]["key1"])
+					if err != nil {
+						return err
+					}
+					list[idx[i]] = entity
+				}
+				return nil
+
+			default:
+				return fmt.Errorf("unknown resolver: %s", resolverName)
 			}
-			return nil
 
 		case "MultiHelloWithError":
-			_reps := make([]*model.MultiHelloWithErrorByNamesInput, len(reps))
-
-			for i, rep := range reps {
-				id0, err := ec.unmarshalNString2string(ctx, rep["name"])
-				if err != nil {
-					return errors.New(fmt.Sprintf("Field %s undefined in schema.", "name"))
-				}
-
-				_reps[i] = &model.MultiHelloWithErrorByNamesInput{
-					Name: id0,
-				}
-			}
-
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloWithErrorByNames(ctx, _reps)
+			resolverName, err := entityResolverNameForMultiHelloWithError(ctx, reps[0])
 			if err != nil {
-				return err
+				return fmt.Errorf(`finding resolver for Entity "MultiHelloWithError": %w`, err)
 			}
+			switch resolverName {
 
-			for i, entity := range entities {
-				list[idx[i]] = entity
-			}
-			return nil
+			case "findManyMultiHelloWithErrorByNames":
+				_reps := make([]*model.MultiHelloWithErrorByNamesInput, len(reps))
 
-		case "MultiPlanetRequiresNested":
-			_reps := make([]*model.MultiPlanetRequiresNestedByNamesInput, len(reps))
+				for i, rep := range reps {
+					id0, err := ec.unmarshalNString2string(ctx, rep["name"])
+					if err != nil {
+						return errors.New(fmt.Sprintf("Field %s undefined in schema.", "name"))
+					}
 
-			for i, rep := range reps {
-				id0, err := ec.unmarshalNString2string(ctx, rep["name"])
-				if err != nil {
-					return errors.New(fmt.Sprintf("Field %s undefined in schema.", "name"))
+					_reps[i] = &model.MultiHelloWithErrorByNamesInput{
+						Name: id0,
+					}
 				}
 
-				_reps[i] = &model.MultiPlanetRequiresNestedByNamesInput{
-					Name: id0,
-				}
-			}
-
-			entities, err := ec.resolvers.Entity().FindManyMultiPlanetRequiresNestedByNames(ctx, _reps)
-			if err != nil {
-				return err
-			}
-
-			for i, entity := range entities {
-				entity.World.Foo, err = ec.unmarshalNString2string(ctx, reps[i]["world"].(map[string]interface{})["foo"])
+				entities, err := ec.resolvers.Entity().FindManyMultiHelloWithErrorByNames(ctx, _reps)
 				if err != nil {
 					return err
 				}
-				list[idx[i]] = entity
+
+				for i, entity := range entities {
+					list[idx[i]] = entity
+				}
+				return nil
+
+			default:
+				return fmt.Errorf("unknown resolver: %s", resolverName)
 			}
-			return nil
+
+		case "MultiPlanetRequiresNested":
+			resolverName, err := entityResolverNameForMultiPlanetRequiresNested(ctx, reps[0])
+			if err != nil {
+				return fmt.Errorf(`finding resolver for Entity "MultiPlanetRequiresNested": %w`, err)
+			}
+			switch resolverName {
+
+			case "findManyMultiPlanetRequiresNestedByNames":
+				_reps := make([]*model.MultiPlanetRequiresNestedByNamesInput, len(reps))
+
+				for i, rep := range reps {
+					id0, err := ec.unmarshalNString2string(ctx, rep["name"])
+					if err != nil {
+						return errors.New(fmt.Sprintf("Field %s undefined in schema.", "name"))
+					}
+
+					_reps[i] = &model.MultiPlanetRequiresNestedByNamesInput{
+						Name: id0,
+					}
+				}
+
+				entities, err := ec.resolvers.Entity().FindManyMultiPlanetRequiresNestedByNames(ctx, _reps)
+				if err != nil {
+					return err
+				}
+
+				for i, entity := range entities {
+					entity.World.Foo, err = ec.unmarshalNString2string(ctx, reps[i]["world"].(map[string]interface{})["foo"])
+					if err != nil {
+						return err
+					}
+					list[idx[i]] = entity
+				}
+				return nil
+
+			default:
+				return fmt.Errorf("unknown resolver: %s", resolverName)
+			}
 
 		default:
 			return errors.New("unknown type: " + typeName)


### PR DESCRIPTION
If you try to generate code for a federated type with multi keys and multi entity (getMany) the resulting code does not compile, see the issue details here: https://github.com/99designs/gqlgen/issues/2870

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
