### PR TITLE
Fix #2856: resolver receive previous implementation on render

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -33,5 +33,5 @@ type LateSourceInjector interface {
 
 // ResolverImplementer is used to generate code inside resolvers
 type ResolverImplementer interface {
-	Implement(field *codegen.Field) string
+	Implement(prevImplementation string, field *codegen.Field) string
 }

--- a/plugin/resolvergen/resolver.go
+++ b/plugin/resolvergen/resolver.go
@@ -257,12 +257,12 @@ type Resolver struct {
 	PrevDecl             *ast.FuncDecl
 	Comment              string
 	ImplementationStr    string
-	ImplementationRender func(r *codegen.Field) string
+	ImplementationRender func(prevImplementation string, r *codegen.Field) string
 }
 
 func (r *Resolver) Implementation() string {
 	if r.ImplementationRender != nil {
-		return r.ImplementationRender(r.Field)
+		return r.ImplementationRender(r.ImplementationStr, r.Field)
 	}
 	return r.ImplementationStr
 }

--- a/plugin/resolvergen/resolver.go
+++ b/plugin/resolvergen/resolver.go
@@ -127,14 +127,9 @@ func (m *Plugin) generatePerSchema(data *codegen.Data) error {
 			if !f.IsResolver {
 				continue
 			}
-
 			structName := templates.LcFirst(o.Name) + templates.UcFirst(data.Config.Resolver.Type)
 			comment := strings.TrimSpace(strings.TrimLeft(rewriter.GetMethodComment(structName, f.GoFieldName), `\`))
 			implementation := strings.TrimSpace(rewriter.GetMethodBody(structName, f.GoFieldName))
-			if implementation == "" {
-				// use default implementation, if no implementation was previously used
-				implementation = fmt.Sprintf("panic(fmt.Errorf(\"not implemented: %v - %v\"))", f.GoFieldName, f.Name)
-			}
 			resolver := Resolver{o, f, rewriter.GetPrevDecl(structName, f.GoFieldName), comment, implementation, nil}
 			var implExists bool
 			for _, p := range data.Plugins {
@@ -262,8 +257,15 @@ type Resolver struct {
 
 func (r *Resolver) Implementation() string {
 	if r.ImplementationRender != nil {
+		// use custom implementation
 		return r.ImplementationRender(r.ImplementationStr, r.Field)
 	}
+	// if not implementation was previously used, use default implementation
+	if r.ImplementationStr == "" {
+		// use default implementation, if no implementation was previously used
+		return fmt.Sprintf("panic(fmt.Errorf(\"not implemented: %v - %v\"))", r.Field.GoFieldName, r.Field.Name)
+	}
+	// use previously used implementation
 	return r.ImplementationStr
 }
 

--- a/plugin/resolvergen/resolver_test.go
+++ b/plugin/resolvergen/resolver_test.go
@@ -163,6 +163,6 @@ func assertNoErrors(t *testing.T, pkg string) {
 
 type implementorTest struct{}
 
-func (i *implementorTest) Implement(field *codegen.Field) string {
+func (i *implementorTest) Implement(_ string, _ *codegen.Field) string {
 	return "panic(\"implementor implemented me\")"
 }


### PR DESCRIPTION
Fix #2856

When implementing the `plugin.ResolverImplementer` (for example, to make a CRUD method), the original template initialization code will override that code.

This PR gives the resolver implementor the previous method body, so it will be empty if no previous body was created before.

It does break the interface, but I would assume its a minor inconvenience for anyone who uses this interface to update.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
