### PR TITLE
Work with https://specs.apollo.dev/federation/v2.x

### DIFF
--- a/api/generate.go
+++ b/api/generate.go
@@ -32,7 +32,8 @@ func Generate(cfg *config.Config, option ...Option) error {
 			for _, v := range cfg.Sources {
 				cfg.Federation.Version = 1
 				urlString := urlRegex.FindStringSubmatch(v.Input)
-				if urlString != nil && urlString[1] == "https://specs.apollo.dev/federation/v2.7" {
+				// e.g. urlString[1] == "https://specs.apollo.dev/federation/v2.7"
+				if urlString != nil {
 					matches := versionRegex.FindStringSubmatch(urlString[1])
 					if matches[1] == "2" {
 						cfg.Federation.Version = 2


### PR DESCRIPTION
The contributor intended to allow any version 2.x (2.0, 2.1, etc.) to be version `2` but the conditional precluded this from happening, so I fixed it.

Signed-off-by: Steve Coffman <steve@khanacademy.org>
