### PR TITLE
graphql/uint: Fix unmarshalling of negative numbers

### DIFF
--- a/graphql/uint.go
+++ b/graphql/uint.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -19,8 +20,16 @@ func UnmarshalUint(v interface{}) (uint, error) {
 		u64, err := strconv.ParseUint(v, 10, 64)
 		return uint(u64), err
 	case int:
+		if v < 0 {
+			return 0, errors.New("cannot convert negative numbers to uint")
+		}
+
 		return uint(v), nil
 	case int64:
+		if v < 0 {
+			return 0, errors.New("cannot convert negative numbers to uint")
+		}
+
 		return uint(v), nil
 	case json.Number:
 		u64, err := strconv.ParseUint(string(v), 10, 64)
@@ -41,8 +50,16 @@ func UnmarshalUint64(v interface{}) (uint64, error) {
 	case string:
 		return strconv.ParseUint(v, 10, 64)
 	case int:
+		if v < 0 {
+			return 0, errors.New("cannot convert negative numbers to uint64")
+		}
+
 		return uint64(v), nil
 	case int64:
+		if v < 0 {
+			return 0, errors.New("cannot convert negative numbers to uint64")
+		}
+
 		return uint64(v), nil
 	case json.Number:
 		return strconv.ParseUint(string(v), 10, 64)
@@ -66,8 +83,16 @@ func UnmarshalUint32(v interface{}) (uint32, error) {
 		}
 		return uint32(iv), nil
 	case int:
+		if v < 0 {
+			return 0, errors.New("cannot convert negative numbers to uint32")
+		}
+
 		return uint32(v), nil
 	case int64:
+		if v < 0 {
+			return 0, errors.New("cannot convert negative numbers to uint32")
+		}
+
 		return uint32(v), nil
 	case json.Number:
 		iv, err := strconv.ParseUint(string(v), 10, 32)

--- a/graphql/uint_test.go
+++ b/graphql/uint_test.go
@@ -19,6 +19,11 @@ func TestUint(t *testing.T) {
 		assert.Equal(t, uint(123), mustUnmarshalUint(json.Number("123")))
 		assert.Equal(t, uint(123), mustUnmarshalUint("123"))
 	})
+
+	t.Run("can't unmarshal negative numbers", func(t *testing.T) {
+		_, err := UnmarshalUint(-123)
+		assert.EqualError(t, err, "cannot convert negative numbers to uint")
+	})
 }
 
 func mustUnmarshalUint(v interface{}) uint {
@@ -42,6 +47,11 @@ func TestUint32(t *testing.T) {
 		assert.Equal(t, uint32(123), mustUnmarshalUint32("123"))
 		assert.Equal(t, uint32(4294967295), mustUnmarshalUint32("4294967295"))
 	})
+
+	t.Run("can't unmarshal negative numbers", func(t *testing.T) {
+		_, err := UnmarshalUint32(-123)
+		assert.EqualError(t, err, "cannot convert negative numbers to uint32")
+	})
 }
 
 func mustUnmarshalUint32(v interface{}) uint32 {
@@ -62,6 +72,11 @@ func TestUint64(t *testing.T) {
 		assert.Equal(t, uint64(123), mustUnmarshalUint64(int64(123)))
 		assert.Equal(t, uint64(123), mustUnmarshalUint64(json.Number("123")))
 		assert.Equal(t, uint64(123), mustUnmarshalUint64("123"))
+	})
+
+	t.Run("can't unmarshal negative numbers", func(t *testing.T) {
+		_, err := UnmarshalUint64(-123)
+		assert.EqualError(t, err, "cannot convert negative numbers to uint64")
 	})
 }
 


### PR DESCRIPTION
Converting a negative number to uint directly returns a really big number. For example,

	v := -5
	fmt.Println(uint(v)) // 18446744073709551611

So we should handle this cases explicitly and return an error.

I ran into this issue at work (we use this lib) and saw this PR that was abandoned https://github.com/99designs/gqlgen/pull/2659, so I just picked up where it left off and implemented it without generics as @StevenACoffman said here https://github.com/99designs/gqlgen/pull/2659#issuecomment-1580719872 (it was pretty overkill tbh)

Describe your PR and link to any relevant issues. 

I have:
 - [ X ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ? ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
   - Didn't find any documentation to update