### PR TITLE
fix(docs): convert an unnecessarily capitalized word to lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ models:
 
 - #### Using Explicit Resolvers
 
-If you want to Keep using the generated model, mark the field as requiring a resolver explicitly in `gqlgen.yml` like this:
+If you want to keep using the generated model, mark the field as requiring a resolver explicitly in `gqlgen.yml` like this:
 
 ```yaml
 # gqlgen.yml


### PR DESCRIPTION
This is a minor correction.
I thought it would be more appropriate to use "keep" instead of "Keep" as it appears in the text, so I've  fixed it.
