### PR TITLE
Add case for resolvers_always_return_pointers:false in explicit requires generation. 

### DIFF
--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -420,9 +420,12 @@ func (f *federation) GenerateCode(data *codegen.Data) error {
 	}
 
 	return templates.Render(templates.Options{
-		PackageName:     data.Config.Federation.Package,
-		Filename:        data.Config.Federation.Filename,
-		Data:            f,
+		PackageName: data.Config.Federation.Package,
+		Filename:    data.Config.Federation.Filename,
+		Data: struct {
+			federation
+			UsePointers bool
+		}{*f, data.Config.ResolversAlwaysReturnPointers},
 		GeneratedHeader: true,
 		Packages:        data.Config.Packages,
 		Template:        federationTemplate,

--- a/plugin/federation/federation.gotpl
+++ b/plugin/federation/federation.gotpl
@@ -6,6 +6,7 @@
 
 {{ reserveImport "github.com/99designs/gqlgen/plugin/federation/fedruntime" }}
 {{ $options := .PackageOptions }}
+{{ $usePointers := .UsePointers }}
 
 var (
 	ErrUnknownType = errors.New("unknown type")
@@ -105,7 +106,7 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 							return fmt.Errorf(`resolving Entity "{{$entity.Def.Name}}": %w`, err)
 						}
 						{{ if and (index $options "explicit_requires") $entity.Requires }}
-							err = ec.Populate{{$entity.Def.Name}}Requires(ctx, entity, rep)
+							err = ec.Populate{{$entity.Def.Name}}Requires(ctx, {{- if (not $usePointers) -}}&{{- end -}}entity, rep)
 							if err != nil {
 								return fmt.Errorf(`populating requires for Entity "{{$entity.Def.Name}}": %w`, err)
 							}


### PR DESCRIPTION
This PR addresses an edge case when resolvers_always_return_pointers:false.  The template code now adds an ampersand to return the pointer to the entity when the resolver returns a non-pointer.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
