### PR TITLE
Add UintID type binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ models:
     model:
       - github.com/99designs/gqlgen/graphql.IntID # a go integer
       - github.com/99designs/gqlgen/graphql.ID # or a go string
+      - github.com/99designs/gqlgen/graphql.UintID # or a go uint
 ```
 
 This means gqlgen will be able to automatically bind to strings or ints for models you have written yourself, but the

--- a/graphql/id.go
+++ b/graphql/id.go
@@ -56,3 +56,32 @@ func UnmarshalIntID(v interface{}) (int, error) {
 		return 0, fmt.Errorf("%T is not an int", v)
 	}
 }
+
+func MarshalUintID(i uint) Marshaler {
+	return WriterFunc(func(w io.Writer) {
+		writeQuotedString(w, strconv.FormatUint(uint64(i), 10))
+	})
+}
+
+func UnmarshalUintID(v interface{}) (uint, error) {
+	switch v := v.(type) {
+	case string:
+		result, err := strconv.ParseUint(v, 10, 64)
+		return uint(result), err
+	case int:
+		return uint(v), nil
+	case int64:
+		return uint(v), nil
+	case int32:
+		return uint(v), nil
+	case uint32:
+		return uint(v), nil
+	case uint64:
+		return uint(v), nil
+	case json.Number:
+		result, err := strconv.ParseUint(string(v), 10, 64)
+		return uint(result), err
+	default:
+		return 0, fmt.Errorf("%T is not an uint", v)
+	}
+}

--- a/graphql/id_test.go
+++ b/graphql/id_test.go
@@ -65,3 +65,38 @@ func TestUnmarshalID(t *testing.T) {
 		})
 	}
 }
+
+func TestMarshalUintID(t *testing.T) {
+	assert.Equal(t, `"12"`, m2s(MarshalUintID(12)))
+}
+
+func TestUnMarshalUintID(t *testing.T) {
+
+	result, err := UnmarshalUintID("12")
+	assert.Equal(t, uint(12), result)
+	assert.NoError(t, err)
+
+	result, err = UnmarshalUintID(12)
+	assert.Equal(t, uint(12), result)
+	assert.NoError(t, err)
+
+	result, err = UnmarshalUintID(int64(12))
+	assert.Equal(t, uint(12), result)
+	assert.NoError(t, err)
+
+	result, err = UnmarshalUintID(int32(12))
+	assert.Equal(t, uint(12), result)
+	assert.NoError(t, err)
+
+	result, err = UnmarshalUintID(int(12))
+	assert.Equal(t, uint(12), result)
+	assert.NoError(t, err)
+
+	result, err = UnmarshalUintID(uint32(12))
+	assert.Equal(t, uint(12), result)
+	assert.NoError(t, err)
+
+	result, err = UnmarshalUintID(uint64(12))
+	assert.Equal(t, uint(12), result)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

I use Gorm to connect to database. By default it uses `uint` instead of `int`. I see that it type bindings for `int` to ID ( `string` ) works perfectly well. I'm lacking of automatic type bindings of `unit` to `ID`.


```graphql
Model {
  id: ID
}

```

```go

type Model struct {
  ID uint 
}
```

Now, default behaviour is to return `uint` id as `number`.
```json
{
  id: 123
}
```

I expect this model to return id as a `string`, to do so you need to extend type bindings

```yaml
models:
  ID: # The GraphQL type ID is backed by
    model:
      - github.com/99designs/gqlgen/graphql.IntID 
      - github.com/99designs/gqlgen/graphql.ID 
      - github.com/99designs/gqlgen/graphql.UintID # <------ add this little helper I wrote
```

in this case the result is supposed to be

```json
{
  id: "123"
}
```


