### PR TITLE
Update `tools.go` url

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Still not convinced enough to use **gqlgen**? Compare **gqlgen** with other Go g
        cd example
        go mod init example
 
-2. Add `github.com/99designs/gqlgen` to your [project's tools.go](https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module)
+2. Add `github.com/99designs/gqlgen` to your [project's tools.go](https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module)
 
        printf '// +build tools\npackage tools\nimport (_ "github.com/99designs/gqlgen"\n _ "github.com/99designs/gqlgen/graphql/introspection")' | gofmt > tools.go
 

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -24,7 +24,7 @@ cd gqlgen-todos
 go mod init github.com/[username]/gqlgen-todos
 ```
 
-Next, create a `tools.go` file and add gqlgen as a [tool dependency for your module](https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module).
+Next, create a `tools.go` file and add gqlgen as a [tool dependency for your module](https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module).
 
 ```go
 //go:build tools


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

The Go wiki on GitHub has moved to go.dev.
https://github.com/golang/go/issues/61940
Therefore, this updated its url.

I have:
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
