### PR TITLE
fix: stop loading package dependencies

### DIFF
--- a/internal/code/packages.go
+++ b/internal/code/packages.go
@@ -21,12 +21,10 @@ var (
 
 var mode = packages.NeedName |
 	packages.NeedFiles |
-	packages.NeedImports |
 	packages.NeedTypes |
 	packages.NeedSyntax |
 	packages.NeedTypesInfo |
-	packages.NeedModule |
-	packages.NeedDeps
+	packages.NeedModule
 
 type (
 	// Packages is a wrapper around x/tools/go/packages that maintains a (hopefully prewarmed) cache of packages
@@ -135,11 +133,6 @@ func (p *Packages) LoadAll(importPaths ...string) []*packages.Package {
 func (p *Packages) addToCache(pkg *packages.Package) {
 	imp := NormalizeVendor(pkg.PkgPath)
 	p.packages[imp] = pkg
-	for _, imp := range pkg.Imports {
-		if _, found := p.packages[NormalizeVendor(imp.PkgPath)]; !found {
-			p.addToCache(imp)
-		}
-	}
 }
 
 // Load works the same as LoadAll, except a single package at a time.
@@ -220,18 +213,9 @@ func (p *Packages) NameForPackage(importPath string) string {
 	return pkg.Name
 }
 
-// Evict removes a given package import path from the cache, along with any packages that depend on it. Further calls
-// to Load will fetch it from disk.
+// Evict removes a given package import path from the cache. Further calls to Load will fetch it from disk.
 func (p *Packages) Evict(importPath string) {
 	delete(p.packages, importPath)
-
-	for _, pkg := range p.packages {
-		for _, imported := range pkg.Imports {
-			if imported.PkgPath == importPath {
-				p.Evict(pkg.PkgPath)
-			}
-		}
-	}
 }
 
 func (p *Packages) ModTidy() error {

--- a/internal/code/packages_test.go
+++ b/internal/code/packages_test.go
@@ -30,14 +30,6 @@ func TestPackages(t *testing.T) {
 		require.Equal(t, 2, p.numLoadCalls)
 	})
 
-	t.Run("evicting a package also evicts its dependencies", func(t *testing.T) {
-		p := initialState(t)
-		p.Evict("github.com/99designs/gqlgen/internal/code/testdata/a")
-		require.Equal(t, "a", p.Load("github.com/99designs/gqlgen/internal/code/testdata/a").Name)
-		require.Equal(t, 2, p.numLoadCalls)
-		require.Equal(t, "b", p.Load("github.com/99designs/gqlgen/internal/code/testdata/b").Name)
-		require.Equal(t, 3, p.numLoadCalls)
-	})
 	t.Run("able to load private package with build tags", func(t *testing.T) {
 		p := initialState(t, WithBuildTags("private"))
 		p.Evict("github.com/99designs/gqlgen/internal/code/testdata/a")


### PR DESCRIPTION
fixes #2981 

Stop passing `NeedImports` and `NeedDeps` to `packages.Load()`.

Depending on the packages we are loading, these flags can cause gigabytes of extra data to be loaded, because they indicate we want type info for all transitive dependencies. This extra info is completely unused by gqlgen as far as I can tell.

Conceptually, if we are binding to types in a particular package, it doesn't make sense that we would need to know about the dependencies of that package, so I'm not sure why this data was ever being loaded. The `packages.Load` documentation is poor and the issue was likely never noticed because it only appears when binding to packages with many transitive dependencies.

Since we are no longer loading dependencies, I've also removed the logic around caching the dependencies.