### PR TITLE
Remove dedupExchange 

### DIFF
--- a/integration/src/__test__/integration.spec.ts
+++ b/integration/src/__test__/integration.spec.ts
@@ -10,7 +10,7 @@ import {
     Observable,
     Operation,
 } from '@apollo/client/core';
-import {HttpLink} from '@apollo/client/link/http';
+import { HttpLink } from '@apollo/client/link/http';
 
 import { print } from "graphql";
 import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
@@ -35,7 +35,6 @@ import {
 import {
     cacheExchange,
     Client,
-    dedupExchange,
     subscriptionExchange,
 } from "urql";
 import { isFragmentReady, useFragment } from "../generated";
@@ -370,7 +369,6 @@ describe("URQL SSE client", () => {
     const client = new Client({
         url: uri,
         exchanges: [
-            dedupExchange,
             cacheExchange,
             subscriptionExchange({
                 enableAllOperations: true,


### PR DESCRIPTION
dedupExchange was deprecated in v4.0.0 and  is removed now.  That release note says

>- Deprecate the `dedupExchange`. The functionality of deduplicating queries and subscriptions has now been moved into and absorbed by the `Client`.
  Previously, the `Client` already started doing some work to share results between
  queries, and to avoid dispatching operations as needed. It now only dispatches operations
  strictly when the `dedupExchange` would allow so as well, moving its logic into the
  `Client`

In this release they just 
> Remove deprecated `dedupExchange`
