### PR TITLE
Assign ctx, fs, sel to _ so no warnings about unused variables

### DIFF
--- a/_examples/chat/generated.go
+++ b/_examples/chat/generated.go
@@ -540,6 +540,7 @@ func (ec *executionContext) _Chatroom_name(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_Chatroom_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Chatroom",
 		Field:      field,
@@ -584,6 +585,7 @@ func (ec *executionContext) _Chatroom_messages(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext_Chatroom_messages(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Chatroom",
 		Field:      field,
@@ -626,6 +628,7 @@ func (ec *executionContext) _Chatroom_subscription(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext_Chatroom_subscription(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Chatroom",
 		Field:      field,
@@ -674,6 +677,7 @@ func (ec *executionContext) _Message_id(ctx context.Context, field graphql.Colle
 }
 
 func (ec *executionContext) fieldContext_Message_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Message",
 		Field:      field,
@@ -718,6 +722,7 @@ func (ec *executionContext) _Message_text(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Message_text(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Message",
 		Field:      field,
@@ -762,6 +767,7 @@ func (ec *executionContext) _Message_createdBy(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext_Message_createdBy(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Message",
 		Field:      field,
@@ -806,6 +812,7 @@ func (ec *executionContext) _Message_createdAt(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext_Message_createdAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Message",
 		Field:      field,
@@ -836,6 +843,7 @@ func (ec *executionContext) _Message_subscription(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext_Message_subscription(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Message",
 		Field:      field,
@@ -884,6 +892,7 @@ func (ec *executionContext) _Mutation_post(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_Mutation_post(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Mutation",
 		Field:      field,
@@ -948,6 +957,7 @@ func (ec *executionContext) _Query_room(ctx context.Context, field graphql.Colle
 }
 
 func (ec *executionContext) fieldContext_Query_room(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -1008,6 +1018,7 @@ func (ec *executionContext) _Query___type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Query___type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -1082,6 +1093,7 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Query___schema(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -1154,6 +1166,7 @@ func (ec *executionContext) _Subscription_messageAdded(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext_Subscription_messageAdded(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Subscription",
 		Field:      field,
@@ -1221,6 +1234,7 @@ func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1262,6 +1276,7 @@ func (ec *executionContext) ___Directive_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___Directive_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1306,6 +1321,7 @@ func (ec *executionContext) ___Directive_locations(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Directive_locations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1350,6 +1366,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1404,6 +1421,7 @@ func (ec *executionContext) ___Directive_isRepeatable(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___Directive_isRepeatable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1448,6 +1466,7 @@ func (ec *executionContext) ___EnumValue_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___EnumValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1489,6 +1508,7 @@ func (ec *executionContext) ___EnumValue_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1533,6 +1553,7 @@ func (ec *executionContext) ___EnumValue_isDeprecated(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___EnumValue_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1574,6 +1595,7 @@ func (ec *executionContext) ___EnumValue_deprecationReason(ctx context.Context, 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1618,6 +1640,7 @@ func (ec *executionContext) ___Field_name(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1659,6 +1682,7 @@ func (ec *executionContext) ___Field_description(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Field_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1703,6 +1727,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1757,6 +1782,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1823,6 +1849,7 @@ func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Field_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1864,6 +1891,7 @@ func (ec *executionContext) ___Field_deprecationReason(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Field_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1908,6 +1936,7 @@ func (ec *executionContext) ___InputValue_name(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1949,6 +1978,7 @@ func (ec *executionContext) ___InputValue_description(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___InputValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1993,6 +2023,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2056,6 +2087,7 @@ func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2097,6 +2129,7 @@ func (ec *executionContext) ___Schema_description(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Schema_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2141,6 +2174,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext___Schema_types(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2207,6 +2241,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Schema_queryType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2270,6 +2305,7 @@ func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Schema_mutationType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2333,6 +2369,7 @@ func (ec *executionContext) ___Schema_subscriptionType(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Schema_subscriptionType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2399,6 +2436,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Schema_directives(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2455,6 +2493,7 @@ func (ec *executionContext) ___Type_kind(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2496,6 +2535,7 @@ func (ec *executionContext) ___Type_name(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2537,6 +2577,7 @@ func (ec *executionContext) ___Type_description(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2578,6 +2619,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_fields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2644,6 +2686,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_interfaces(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2707,6 +2750,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Type_possibleTypes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2770,6 +2814,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_enumValues(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2832,6 +2877,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_inputFields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2883,6 +2929,7 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_ofType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2946,6 +2993,7 @@ func (ec *executionContext) ___Type_specifiedByURL(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -3150,6 +3198,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3548,6 +3597,8 @@ func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3563,6 +3614,8 @@ func (ec *executionContext) unmarshalNID2string(ctx context.Context, v interface
 }
 
 func (ec *executionContext) marshalNID2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalID(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3573,10 +3626,14 @@ func (ec *executionContext) marshalNID2string(ctx context.Context, sel ast.Selec
 }
 
 func (ec *executionContext) marshalNMessage2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋchatᚐMessage(ctx context.Context, sel ast.SelectionSet, v Message) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec._Message(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNMessage2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋchatᚐMessageᚄ(ctx context.Context, sel ast.SelectionSet, v []Message) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3621,6 +3678,8 @@ func (ec *executionContext) marshalNMessage2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalNMessage2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋchatᚐMessage(ctx context.Context, sel ast.SelectionSet, v *Message) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3636,6 +3695,8 @@ func (ec *executionContext) unmarshalNString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3646,11 +3707,15 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 }
 
 func (ec *executionContext) marshalNSubscription2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋchatᚐSubscription(ctx context.Context, sel ast.SelectionSet, v Subscription) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := ec._Subscription(ctx, sel)
 	return res(ctx)
 }
 
 func (ec *executionContext) marshalNSubscription2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋchatᚐSubscription(ctx context.Context, sel ast.SelectionSet, v *Subscription) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3667,6 +3732,8 @@ func (ec *executionContext) unmarshalNTime2timeᚐTime(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalNTime2timeᚐTime(ctx context.Context, sel ast.SelectionSet, v time.Time) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalTime(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3677,10 +3744,14 @@ func (ec *executionContext) marshalNTime2timeᚐTime(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Directive(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3730,6 +3801,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2string(ctx context.Con
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3757,6 +3830,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2ᚕstringᚄ(ctx conte
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3801,18 +3876,26 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context
 }
 
 func (ec *executionContext) marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx context.Context, sel ast.SelectionSet, v introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___EnumValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx context.Context, sel ast.SelectionSet, v introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Field(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx context.Context, sel ast.SelectionSet, v introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___InputValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3857,10 +3940,14 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Type(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3905,6 +3992,8 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalN__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3920,6 +4009,8 @@ func (ec *executionContext) unmarshalN__TypeKind2string(ctx context.Context, v i
 }
 
 func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3935,6 +4026,8 @@ func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalOBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	return res
 }
@@ -3948,6 +4041,8 @@ func (ec *executionContext) unmarshalOBoolean2ᚖbool(ctx context.Context, v int
 }
 
 func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast.SelectionSet, v *bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3956,6 +4051,8 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 }
 
 func (ec *executionContext) marshalOChatroom2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋchatᚐChatroom(ctx context.Context, sel ast.SelectionSet, v *Chatroom) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3971,6 +4068,8 @@ func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3979,6 +4078,8 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4026,6 +4127,8 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 }
 
 func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4073,6 +4176,8 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4120,6 +4225,8 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx context.Context, sel ast.SelectionSet, v *introspection.Schema) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4127,6 +4234,8 @@ func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4174,6 +4283,8 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}

--- a/_examples/config/generated.go
+++ b/_examples/config/generated.go
@@ -432,6 +432,7 @@ func (ec *executionContext) _Mutation_createTodo(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext_Mutation_createTodo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Mutation",
 		Field:      field,
@@ -503,6 +504,7 @@ func (ec *executionContext) _Query_todos(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext_Query_todos(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -560,6 +562,7 @@ func (ec *executionContext) _Query___type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Query___type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -634,6 +637,7 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Query___schema(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -692,6 +696,7 @@ func (ec *executionContext) _Todo_id(ctx context.Context, field graphql.Collecte
 }
 
 func (ec *executionContext) fieldContext_Todo_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Todo",
 		Field:      field,
@@ -736,6 +741,7 @@ func (ec *executionContext) _Todo_databaseId(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Todo_databaseId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Todo",
 		Field:      field,
@@ -780,6 +786,7 @@ func (ec *executionContext) _Todo_text(ctx context.Context, field graphql.Collec
 }
 
 func (ec *executionContext) fieldContext_Todo_text(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Todo",
 		Field:      field,
@@ -824,6 +831,7 @@ func (ec *executionContext) _Todo_done(ctx context.Context, field graphql.Collec
 }
 
 func (ec *executionContext) fieldContext_Todo_done(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Todo",
 		Field:      field,
@@ -868,6 +876,7 @@ func (ec *executionContext) _Todo_user(ctx context.Context, field graphql.Collec
 }
 
 func (ec *executionContext) fieldContext_Todo_user(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Todo",
 		Field:      field,
@@ -906,6 +915,7 @@ func (ec *executionContext) _Todo_query(ctx context.Context, field graphql.Colle
 }
 
 func (ec *executionContext) fieldContext_Todo_query(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Todo",
 		Field:      field,
@@ -944,6 +954,7 @@ func (ec *executionContext) _Todo_mutation(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_Todo_mutation(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Todo",
 		Field:      field,
@@ -992,6 +1003,7 @@ func (ec *executionContext) _User_id(ctx context.Context, field graphql.Collecte
 }
 
 func (ec *executionContext) fieldContext_User_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1036,6 +1048,7 @@ func (ec *executionContext) _User_name(ctx context.Context, field graphql.Collec
 }
 
 func (ec *executionContext) fieldContext_User_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1080,6 +1093,7 @@ func (ec *executionContext) _User_role(ctx context.Context, field graphql.Collec
 }
 
 func (ec *executionContext) fieldContext_User_role(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1128,6 +1142,7 @@ func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1169,6 +1184,7 @@ func (ec *executionContext) ___Directive_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___Directive_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1213,6 +1229,7 @@ func (ec *executionContext) ___Directive_locations(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Directive_locations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1257,6 +1274,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1311,6 +1329,7 @@ func (ec *executionContext) ___Directive_isRepeatable(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___Directive_isRepeatable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1355,6 +1374,7 @@ func (ec *executionContext) ___EnumValue_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___EnumValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1396,6 +1416,7 @@ func (ec *executionContext) ___EnumValue_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1440,6 +1461,7 @@ func (ec *executionContext) ___EnumValue_isDeprecated(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___EnumValue_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1481,6 +1503,7 @@ func (ec *executionContext) ___EnumValue_deprecationReason(ctx context.Context, 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1525,6 +1548,7 @@ func (ec *executionContext) ___Field_name(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1566,6 +1590,7 @@ func (ec *executionContext) ___Field_description(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Field_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1610,6 +1635,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1664,6 +1690,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1730,6 +1757,7 @@ func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Field_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1771,6 +1799,7 @@ func (ec *executionContext) ___Field_deprecationReason(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Field_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1815,6 +1844,7 @@ func (ec *executionContext) ___InputValue_name(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1856,6 +1886,7 @@ func (ec *executionContext) ___InputValue_description(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___InputValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1900,6 +1931,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1963,6 +1995,7 @@ func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2004,6 +2037,7 @@ func (ec *executionContext) ___Schema_description(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Schema_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2048,6 +2082,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext___Schema_types(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2114,6 +2149,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Schema_queryType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2177,6 +2213,7 @@ func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Schema_mutationType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2240,6 +2277,7 @@ func (ec *executionContext) ___Schema_subscriptionType(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Schema_subscriptionType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2306,6 +2344,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Schema_directives(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2362,6 +2401,7 @@ func (ec *executionContext) ___Type_kind(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2403,6 +2443,7 @@ func (ec *executionContext) ___Type_name(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2444,6 +2485,7 @@ func (ec *executionContext) ___Type_description(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2485,6 +2527,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_fields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2551,6 +2594,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_interfaces(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2614,6 +2658,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Type_possibleTypes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2677,6 +2722,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_enumValues(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2739,6 +2785,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_inputFields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2790,6 +2837,7 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_ofType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2853,6 +2901,7 @@ func (ec *executionContext) ___Type_specifiedByURL(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2897,6 +2946,7 @@ func (ec *executionContext) _role_name(ctx context.Context, field graphql.Collec
 }
 
 func (ec *executionContext) fieldContext_role_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "role",
 		Field:      field,
@@ -3027,6 +3077,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3091,6 +3142,7 @@ func (ec *executionContext) _Todo(ctx context.Context, sel ast.SelectionSet, obj
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3562,6 +3614,7 @@ func (ec *executionContext) _role(ctx context.Context, sel ast.SelectionSet, obj
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3627,6 +3680,8 @@ func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3642,6 +3697,8 @@ func (ec *executionContext) unmarshalNID2string(ctx context.Context, v interface
 }
 
 func (ec *executionContext) marshalNID2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalID(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3657,6 +3714,8 @@ func (ec *executionContext) unmarshalNInt2int(ctx context.Context, v interface{}
 }
 
 func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.SelectionSet, v int) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalInt(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3667,6 +3726,8 @@ func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.Selecti
 }
 
 func (ec *executionContext) marshalNMutation2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋconfigᚐMutation(ctx context.Context, sel ast.SelectionSet, v *Mutation) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3682,6 +3743,8 @@ func (ec *executionContext) unmarshalNNewTodo2githubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalNQuery2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋconfigᚐQuery(ctx context.Context, sel ast.SelectionSet, v *Query) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3697,6 +3760,8 @@ func (ec *executionContext) unmarshalNString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3707,10 +3772,14 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 }
 
 func (ec *executionContext) marshalNTodo2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋconfigᚐTodo(ctx context.Context, sel ast.SelectionSet, v Todo) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec._Todo(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNTodo2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋconfigᚐTodoᚄ(ctx context.Context, sel ast.SelectionSet, v []*Todo) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3755,6 +3824,8 @@ func (ec *executionContext) marshalNTodo2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalNTodo2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋconfigᚐTodo(ctx context.Context, sel ast.SelectionSet, v *Todo) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3765,6 +3836,8 @@ func (ec *executionContext) marshalNTodo2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ
 }
 
 func (ec *executionContext) marshalNUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋconfigᚐUser(ctx context.Context, sel ast.SelectionSet, v *User) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3775,10 +3848,14 @@ func (ec *executionContext) marshalNUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Directive(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3828,6 +3905,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2string(ctx context.Con
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3855,6 +3934,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2ᚕstringᚄ(ctx conte
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3899,18 +3980,26 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context
 }
 
 func (ec *executionContext) marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx context.Context, sel ast.SelectionSet, v introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___EnumValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx context.Context, sel ast.SelectionSet, v introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Field(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx context.Context, sel ast.SelectionSet, v introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___InputValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3955,10 +4044,14 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Type(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4003,6 +4096,8 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalN__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -4018,6 +4113,8 @@ func (ec *executionContext) unmarshalN__TypeKind2string(ctx context.Context, v i
 }
 
 func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -4028,6 +4125,8 @@ func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel a
 }
 
 func (ec *executionContext) marshalNrole2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋconfigᚐUserRole(ctx context.Context, sel ast.SelectionSet, v UserRole) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec._role(ctx, sel, &v)
 }
 
@@ -4037,6 +4136,8 @@ func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalOBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	return res
 }
@@ -4050,6 +4151,8 @@ func (ec *executionContext) unmarshalOBoolean2ᚖbool(ctx context.Context, v int
 }
 
 func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast.SelectionSet, v *bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4078,6 +4181,8 @@ func (ec *executionContext) unmarshalOString2ᚕstringᚄ(ctx context.Context, v
 }
 
 func (ec *executionContext) marshalOString2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4104,6 +4209,8 @@ func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4112,6 +4219,8 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4159,6 +4268,8 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 }
 
 func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4206,6 +4317,8 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4253,6 +4366,8 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx context.Context, sel ast.SelectionSet, v *introspection.Schema) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4260,6 +4375,8 @@ func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4307,6 +4424,8 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}

--- a/_examples/dataloader/generated.go
+++ b/_examples/dataloader/generated.go
@@ -449,6 +449,7 @@ func (ec *executionContext) _Address_id(ctx context.Context, field graphql.Colle
 }
 
 func (ec *executionContext) fieldContext_Address_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Address",
 		Field:      field,
@@ -493,6 +494,7 @@ func (ec *executionContext) _Address_street(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Address_street(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Address",
 		Field:      field,
@@ -537,6 +539,7 @@ func (ec *executionContext) _Address_country(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Address_country(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Address",
 		Field:      field,
@@ -581,6 +584,7 @@ func (ec *executionContext) _Customer_id(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext_Customer_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Customer",
 		Field:      field,
@@ -625,6 +629,7 @@ func (ec *executionContext) _Customer_name(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_Customer_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Customer",
 		Field:      field,
@@ -666,6 +671,7 @@ func (ec *executionContext) _Customer_address(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext_Customer_address(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Customer",
 		Field:      field,
@@ -715,6 +721,7 @@ func (ec *executionContext) _Customer_orders(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Customer_orders(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Customer",
 		Field:      field,
@@ -769,6 +776,7 @@ func (ec *executionContext) _Item_name(ctx context.Context, field graphql.Collec
 }
 
 func (ec *executionContext) fieldContext_Item_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Item",
 		Field:      field,
@@ -813,6 +821,7 @@ func (ec *executionContext) _Order_id(ctx context.Context, field graphql.Collect
 }
 
 func (ec *executionContext) fieldContext_Order_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Order",
 		Field:      field,
@@ -857,6 +866,7 @@ func (ec *executionContext) _Order_date(ctx context.Context, field graphql.Colle
 }
 
 func (ec *executionContext) fieldContext_Order_date(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Order",
 		Field:      field,
@@ -901,6 +911,7 @@ func (ec *executionContext) _Order_amount(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Order_amount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Order",
 		Field:      field,
@@ -942,6 +953,7 @@ func (ec *executionContext) _Order_items(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext_Order_items(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Order",
 		Field:      field,
@@ -987,6 +999,7 @@ func (ec *executionContext) _Query_customers(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Query_customers(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -1038,6 +1051,7 @@ func (ec *executionContext) _Query_torture1d(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Query_torture1d(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -1100,6 +1114,7 @@ func (ec *executionContext) _Query_torture2d(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Query_torture2d(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -1162,6 +1177,7 @@ func (ec *executionContext) _Query___type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Query___type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -1236,6 +1252,7 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Query___schema(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -1294,6 +1311,7 @@ func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1335,6 +1353,7 @@ func (ec *executionContext) ___Directive_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___Directive_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1379,6 +1398,7 @@ func (ec *executionContext) ___Directive_locations(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Directive_locations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1423,6 +1443,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1477,6 +1498,7 @@ func (ec *executionContext) ___Directive_isRepeatable(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___Directive_isRepeatable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1521,6 +1543,7 @@ func (ec *executionContext) ___EnumValue_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___EnumValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1562,6 +1585,7 @@ func (ec *executionContext) ___EnumValue_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1606,6 +1630,7 @@ func (ec *executionContext) ___EnumValue_isDeprecated(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___EnumValue_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1647,6 +1672,7 @@ func (ec *executionContext) ___EnumValue_deprecationReason(ctx context.Context, 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1691,6 +1717,7 @@ func (ec *executionContext) ___Field_name(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1732,6 +1759,7 @@ func (ec *executionContext) ___Field_description(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Field_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1776,6 +1804,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1830,6 +1859,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1896,6 +1926,7 @@ func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Field_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1937,6 +1968,7 @@ func (ec *executionContext) ___Field_deprecationReason(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Field_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1981,6 +2013,7 @@ func (ec *executionContext) ___InputValue_name(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2022,6 +2055,7 @@ func (ec *executionContext) ___InputValue_description(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___InputValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2066,6 +2100,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2129,6 +2164,7 @@ func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2170,6 +2206,7 @@ func (ec *executionContext) ___Schema_description(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Schema_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2214,6 +2251,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext___Schema_types(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2280,6 +2318,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Schema_queryType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2343,6 +2382,7 @@ func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Schema_mutationType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2406,6 +2446,7 @@ func (ec *executionContext) ___Schema_subscriptionType(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Schema_subscriptionType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2472,6 +2513,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Schema_directives(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2528,6 +2570,7 @@ func (ec *executionContext) ___Type_kind(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2569,6 +2612,7 @@ func (ec *executionContext) ___Type_name(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2610,6 +2654,7 @@ func (ec *executionContext) ___Type_description(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2651,6 +2696,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_fields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2717,6 +2763,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_interfaces(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2780,6 +2827,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Type_possibleTypes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2843,6 +2891,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_enumValues(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2905,6 +2954,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_inputFields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2956,6 +3006,7 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_ofType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -3019,6 +3070,7 @@ func (ec *executionContext) ___Type_specifiedByURL(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -3117,6 +3169,7 @@ func (ec *executionContext) _Customer(ctx context.Context, sel ast.SelectionSet,
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3150,6 +3203,7 @@ func (ec *executionContext) _Customer(ctx context.Context, sel ast.SelectionSet,
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3271,6 +3325,7 @@ func (ec *executionContext) _Order(ctx context.Context, sel ast.SelectionSet, ob
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3346,6 +3401,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3365,6 +3421,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3384,6 +3441,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3762,6 +3820,8 @@ func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3772,6 +3832,8 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 }
 
 func (ec *executionContext) marshalNCustomer2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋdataloaderᚐCustomer(ctx context.Context, sel ast.SelectionSet, v *Customer) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3787,6 +3849,8 @@ func (ec *executionContext) unmarshalNFloat2float64(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalNFloat2float64(ctx context.Context, sel ast.SelectionSet, v float64) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalFloatContext(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3802,6 +3866,8 @@ func (ec *executionContext) unmarshalNInt2int(ctx context.Context, v interface{}
 }
 
 func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.SelectionSet, v int) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalInt(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3812,6 +3878,8 @@ func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.Selecti
 }
 
 func (ec *executionContext) marshalNItem2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋdataloaderᚐItem(ctx context.Context, sel ast.SelectionSet, v *Item) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3822,6 +3890,8 @@ func (ec *executionContext) marshalNItem2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ
 }
 
 func (ec *executionContext) marshalNOrder2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋdataloaderᚐOrder(ctx context.Context, sel ast.SelectionSet, v *Order) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3837,6 +3907,8 @@ func (ec *executionContext) unmarshalNString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3852,6 +3924,8 @@ func (ec *executionContext) unmarshalNTime2timeᚐTime(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalNTime2timeᚐTime(ctx context.Context, sel ast.SelectionSet, v time.Time) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalTime(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3862,10 +3936,14 @@ func (ec *executionContext) marshalNTime2timeᚐTime(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Directive(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3915,6 +3993,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2string(ctx context.Con
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3942,6 +4022,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2ᚕstringᚄ(ctx conte
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3986,18 +4068,26 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context
 }
 
 func (ec *executionContext) marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx context.Context, sel ast.SelectionSet, v introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___EnumValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx context.Context, sel ast.SelectionSet, v introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Field(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx context.Context, sel ast.SelectionSet, v introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___InputValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4042,10 +4132,14 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Type(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4090,6 +4184,8 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalN__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -4105,6 +4201,8 @@ func (ec *executionContext) unmarshalN__TypeKind2string(ctx context.Context, v i
 }
 
 func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -4115,6 +4213,8 @@ func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel a
 }
 
 func (ec *executionContext) marshalOAddress2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋdataloaderᚐAddress(ctx context.Context, sel ast.SelectionSet, v *Address) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4127,6 +4227,8 @@ func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalOBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	return res
 }
@@ -4140,6 +4242,8 @@ func (ec *executionContext) unmarshalOBoolean2ᚖbool(ctx context.Context, v int
 }
 
 func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast.SelectionSet, v *bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4148,6 +4252,8 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 }
 
 func (ec *executionContext) marshalOCustomer2ᚕᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋdataloaderᚐCustomer(ctx context.Context, sel ast.SelectionSet, v [][]*Customer) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4189,6 +4295,8 @@ func (ec *executionContext) marshalOCustomer2ᚕᚕᚖgithubᚗcomᚋ99designs�
 }
 
 func (ec *executionContext) marshalOCustomer2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋdataloaderᚐCustomerᚄ(ctx context.Context, sel ast.SelectionSet, v []*Customer) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4256,6 +4364,8 @@ func (ec *executionContext) unmarshalOInt2ᚕintᚄ(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalOInt2ᚕintᚄ(ctx context.Context, sel ast.SelectionSet, v []int) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4294,6 +4404,8 @@ func (ec *executionContext) unmarshalOInt2ᚕᚕint(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalOInt2ᚕᚕint(ctx context.Context, sel ast.SelectionSet, v [][]int) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4306,6 +4418,8 @@ func (ec *executionContext) marshalOInt2ᚕᚕint(ctx context.Context, sel ast.S
 }
 
 func (ec *executionContext) marshalOItem2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋdataloaderᚐItemᚄ(ctx context.Context, sel ast.SelectionSet, v []*Item) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4353,6 +4467,8 @@ func (ec *executionContext) marshalOItem2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalOOrder2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋdataloaderᚐOrderᚄ(ctx context.Context, sel ast.SelectionSet, v []*Order) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4408,6 +4524,8 @@ func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4416,6 +4534,8 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4463,6 +4583,8 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 }
 
 func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4510,6 +4632,8 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4557,6 +4681,8 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx context.Context, sel ast.SelectionSet, v *introspection.Schema) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4564,6 +4690,8 @@ func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4611,6 +4739,8 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}

--- a/_examples/embedding/subdir/directives.generated.go
+++ b/_examples/embedding/subdir/directives.generated.go
@@ -45,6 +45,8 @@ func (ec *executionContext) unmarshalN_FieldSet2string(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalN_FieldSet2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {

--- a/_examples/embedding/subdir/entity.generated.go
+++ b/_examples/embedding/subdir/entity.generated.go
@@ -56,6 +56,7 @@ func (ec *executionContext) __Service_sdl(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext__Service_sdl(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "_Service",
 		Field:      field,
@@ -121,6 +122,8 @@ func (ec *executionContext) __Service(ctx context.Context, sel ast.SelectionSet,
 // region    ***************************** type.gotpl *****************************
 
 func (ec *executionContext) marshalN_Service2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐService(ctx context.Context, sel ast.SelectionSet, v fedruntime.Service) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.__Service(ctx, sel, &v)
 }
 

--- a/_examples/embedding/subdir/gendir/generated.go
+++ b/_examples/embedding/subdir/gendir/generated.go
@@ -328,6 +328,7 @@ func (ec *executionContext) _Query_inSchemadir(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext_Query_inSchemadir(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -372,6 +373,7 @@ func (ec *executionContext) _Query_parentdir(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Query_parentdir(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -416,6 +418,7 @@ func (ec *executionContext) _Query_subdir(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Query_subdir(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -460,6 +463,7 @@ func (ec *executionContext) _Query__service(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Query__service(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -505,6 +509,7 @@ func (ec *executionContext) _Query___type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Query___type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -579,6 +584,7 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Query___schema(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -634,6 +640,7 @@ func (ec *executionContext) __Service_sdl(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext__Service_sdl(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "_Service",
 		Field:      field,
@@ -678,6 +685,7 @@ func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -719,6 +727,7 @@ func (ec *executionContext) ___Directive_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___Directive_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -763,6 +772,7 @@ func (ec *executionContext) ___Directive_locations(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Directive_locations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -807,6 +817,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -861,6 +872,7 @@ func (ec *executionContext) ___Directive_isRepeatable(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___Directive_isRepeatable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -905,6 +917,7 @@ func (ec *executionContext) ___EnumValue_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___EnumValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -946,6 +959,7 @@ func (ec *executionContext) ___EnumValue_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -990,6 +1004,7 @@ func (ec *executionContext) ___EnumValue_isDeprecated(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___EnumValue_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1031,6 +1046,7 @@ func (ec *executionContext) ___EnumValue_deprecationReason(ctx context.Context, 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1075,6 +1091,7 @@ func (ec *executionContext) ___Field_name(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1116,6 +1133,7 @@ func (ec *executionContext) ___Field_description(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Field_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1160,6 +1178,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1214,6 +1233,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1280,6 +1300,7 @@ func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Field_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1321,6 +1342,7 @@ func (ec *executionContext) ___Field_deprecationReason(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Field_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1365,6 +1387,7 @@ func (ec *executionContext) ___InputValue_name(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1406,6 +1429,7 @@ func (ec *executionContext) ___InputValue_description(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___InputValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1450,6 +1474,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1513,6 +1538,7 @@ func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1554,6 +1580,7 @@ func (ec *executionContext) ___Schema_description(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Schema_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1598,6 +1625,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext___Schema_types(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1664,6 +1692,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Schema_queryType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1727,6 +1756,7 @@ func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Schema_mutationType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1790,6 +1820,7 @@ func (ec *executionContext) ___Schema_subscriptionType(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Schema_subscriptionType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1856,6 +1887,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Schema_directives(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1912,6 +1944,7 @@ func (ec *executionContext) ___Type_kind(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -1953,6 +1986,7 @@ func (ec *executionContext) ___Type_name(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -1994,6 +2028,7 @@ func (ec *executionContext) ___Type_description(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2035,6 +2070,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_fields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2101,6 +2137,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_interfaces(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2164,6 +2201,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Type_possibleTypes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2227,6 +2265,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_enumValues(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2289,6 +2328,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_inputFields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2340,6 +2380,7 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_ofType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2403,6 +2444,7 @@ func (ec *executionContext) ___Type_specifiedByURL(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2450,6 +2492,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -2472,6 +2515,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -2494,6 +2538,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -2516,6 +2561,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -2933,6 +2979,8 @@ func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -2948,6 +2996,8 @@ func (ec *executionContext) unmarshalNString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -2963,6 +3013,8 @@ func (ec *executionContext) unmarshalN_FieldSet2string(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalN_FieldSet2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -2973,14 +3025,20 @@ func (ec *executionContext) marshalN_FieldSet2string(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalN_Service2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐService(ctx context.Context, sel ast.SelectionSet, v fedruntime.Service) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.__Service(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Directive(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3030,6 +3088,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2string(ctx context.Con
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3057,6 +3117,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2ᚕstringᚄ(ctx conte
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3101,18 +3163,26 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context
 }
 
 func (ec *executionContext) marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx context.Context, sel ast.SelectionSet, v introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___EnumValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx context.Context, sel ast.SelectionSet, v introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Field(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx context.Context, sel ast.SelectionSet, v introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___InputValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3157,10 +3227,14 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Type(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3205,6 +3279,8 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalN__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3220,6 +3296,8 @@ func (ec *executionContext) unmarshalN__TypeKind2string(ctx context.Context, v i
 }
 
 func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3235,6 +3313,8 @@ func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalOBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	return res
 }
@@ -3248,6 +3328,8 @@ func (ec *executionContext) unmarshalOBoolean2ᚖbool(ctx context.Context, v int
 }
 
 func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast.SelectionSet, v *bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3261,6 +3343,8 @@ func (ec *executionContext) unmarshalOString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalOString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	return res
 }
@@ -3274,6 +3358,8 @@ func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3282,6 +3368,8 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3329,6 +3417,8 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 }
 
 func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3376,6 +3466,8 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3423,6 +3515,8 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx context.Context, sel ast.SelectionSet, v *introspection.Schema) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3430,6 +3524,8 @@ func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3477,6 +3573,8 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}

--- a/_examples/embedding/subdir/prelude.generated.go
+++ b/_examples/embedding/subdir/prelude.generated.go
@@ -115,6 +115,7 @@ func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -156,6 +157,7 @@ func (ec *executionContext) ___Directive_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___Directive_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -200,6 +202,7 @@ func (ec *executionContext) ___Directive_locations(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Directive_locations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -244,6 +247,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -298,6 +302,7 @@ func (ec *executionContext) ___Directive_isRepeatable(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___Directive_isRepeatable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -342,6 +347,7 @@ func (ec *executionContext) ___EnumValue_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___EnumValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -383,6 +389,7 @@ func (ec *executionContext) ___EnumValue_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -427,6 +434,7 @@ func (ec *executionContext) ___EnumValue_isDeprecated(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___EnumValue_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -468,6 +476,7 @@ func (ec *executionContext) ___EnumValue_deprecationReason(ctx context.Context, 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -512,6 +521,7 @@ func (ec *executionContext) ___Field_name(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -553,6 +563,7 @@ func (ec *executionContext) ___Field_description(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Field_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -597,6 +608,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -651,6 +663,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -717,6 +730,7 @@ func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Field_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -758,6 +772,7 @@ func (ec *executionContext) ___Field_deprecationReason(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Field_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -802,6 +817,7 @@ func (ec *executionContext) ___InputValue_name(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -843,6 +859,7 @@ func (ec *executionContext) ___InputValue_description(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___InputValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -887,6 +904,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -950,6 +968,7 @@ func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -991,6 +1010,7 @@ func (ec *executionContext) ___Schema_description(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Schema_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1035,6 +1055,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext___Schema_types(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1101,6 +1122,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Schema_queryType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1164,6 +1186,7 @@ func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Schema_mutationType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1227,6 +1250,7 @@ func (ec *executionContext) ___Schema_subscriptionType(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Schema_subscriptionType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1293,6 +1317,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Schema_directives(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1349,6 +1374,7 @@ func (ec *executionContext) ___Type_kind(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -1390,6 +1416,7 @@ func (ec *executionContext) ___Type_name(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -1431,6 +1458,7 @@ func (ec *executionContext) ___Type_description(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -1472,6 +1500,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_fields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -1538,6 +1567,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_interfaces(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -1601,6 +1631,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Type_possibleTypes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -1664,6 +1695,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_enumValues(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -1726,6 +1758,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_inputFields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -1777,6 +1810,7 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_ofType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -1840,6 +1874,7 @@ func (ec *executionContext) ___Type_specifiedByURL(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2196,6 +2231,8 @@ func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -2211,6 +2248,8 @@ func (ec *executionContext) unmarshalNString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -2221,10 +2260,14 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Directive(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -2274,6 +2317,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2string(ctx context.Con
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -2301,6 +2346,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2ᚕstringᚄ(ctx conte
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -2345,18 +2392,26 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context
 }
 
 func (ec *executionContext) marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx context.Context, sel ast.SelectionSet, v introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___EnumValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx context.Context, sel ast.SelectionSet, v introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Field(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx context.Context, sel ast.SelectionSet, v introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___InputValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -2401,10 +2456,14 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Type(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -2449,6 +2508,8 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalN__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -2464,6 +2525,8 @@ func (ec *executionContext) unmarshalN__TypeKind2string(ctx context.Context, v i
 }
 
 func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -2479,6 +2542,8 @@ func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalOBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	return res
 }
@@ -2492,6 +2557,8 @@ func (ec *executionContext) unmarshalOBoolean2ᚖbool(ctx context.Context, v int
 }
 
 func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast.SelectionSet, v *bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -2505,6 +2572,8 @@ func (ec *executionContext) unmarshalOString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalOString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	return res
 }
@@ -2518,6 +2587,8 @@ func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -2526,6 +2597,8 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -2573,6 +2646,8 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 }
 
 func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -2620,6 +2695,8 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -2667,6 +2744,8 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx context.Context, sel ast.SelectionSet, v *introspection.Schema) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -2674,6 +2753,8 @@ func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -2721,6 +2802,8 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}

--- a/_examples/embedding/subdir/root.generated.go
+++ b/_examples/embedding/subdir/root.generated.go
@@ -82,6 +82,7 @@ func (ec *executionContext) _Query_inSchemadir(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext_Query_inSchemadir(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -126,6 +127,7 @@ func (ec *executionContext) _Query_parentdir(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Query_parentdir(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -170,6 +172,7 @@ func (ec *executionContext) _Query_subdir(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Query_subdir(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -214,6 +217,7 @@ func (ec *executionContext) _Query__service(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Query__service(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -259,6 +263,7 @@ func (ec *executionContext) _Query___type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Query___type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -333,6 +338,7 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Query___schema(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -394,6 +400,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -416,6 +423,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -438,6 +446,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -460,6 +469,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))

--- a/_examples/enum/api/exec.go
+++ b/_examples/enum/api/exec.go
@@ -458,6 +458,7 @@ func (ec *executionContext) _Query_int(ctx context.Context, field graphql.Collec
 }
 
 func (ec *executionContext) fieldContext_Query_int(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -510,6 +511,7 @@ func (ec *executionContext) _Query_string(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Query_string(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -562,6 +564,7 @@ func (ec *executionContext) _Query_bool(ctx context.Context, field graphql.Colle
 }
 
 func (ec *executionContext) fieldContext_Query_bool(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -614,6 +617,7 @@ func (ec *executionContext) _Query___type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Query___type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -688,6 +692,7 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Query___schema(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -746,6 +751,7 @@ func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -787,6 +793,7 @@ func (ec *executionContext) ___Directive_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___Directive_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -831,6 +838,7 @@ func (ec *executionContext) ___Directive_locations(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Directive_locations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -875,6 +883,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -929,6 +938,7 @@ func (ec *executionContext) ___Directive_isRepeatable(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___Directive_isRepeatable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -973,6 +983,7 @@ func (ec *executionContext) ___EnumValue_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___EnumValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1014,6 +1025,7 @@ func (ec *executionContext) ___EnumValue_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1058,6 +1070,7 @@ func (ec *executionContext) ___EnumValue_isDeprecated(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___EnumValue_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1099,6 +1112,7 @@ func (ec *executionContext) ___EnumValue_deprecationReason(ctx context.Context, 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1143,6 +1157,7 @@ func (ec *executionContext) ___Field_name(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1184,6 +1199,7 @@ func (ec *executionContext) ___Field_description(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Field_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1228,6 +1244,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1282,6 +1299,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1348,6 +1366,7 @@ func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Field_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1389,6 +1408,7 @@ func (ec *executionContext) ___Field_deprecationReason(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Field_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1433,6 +1453,7 @@ func (ec *executionContext) ___InputValue_name(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1474,6 +1495,7 @@ func (ec *executionContext) ___InputValue_description(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___InputValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1518,6 +1540,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1581,6 +1604,7 @@ func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1622,6 +1646,7 @@ func (ec *executionContext) ___Schema_description(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Schema_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1666,6 +1691,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext___Schema_types(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1732,6 +1758,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Schema_queryType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1795,6 +1822,7 @@ func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Schema_mutationType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1858,6 +1886,7 @@ func (ec *executionContext) ___Schema_subscriptionType(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Schema_subscriptionType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1924,6 +1953,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Schema_directives(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1980,6 +2010,7 @@ func (ec *executionContext) ___Type_kind(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2021,6 +2052,7 @@ func (ec *executionContext) ___Type_name(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2062,6 +2094,7 @@ func (ec *executionContext) ___Type_description(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2103,6 +2136,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_fields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2169,6 +2203,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_interfaces(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2232,6 +2267,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Type_possibleTypes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2295,6 +2331,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_enumValues(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2357,6 +2394,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_inputFields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2408,6 +2446,7 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_ofType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2471,6 +2510,7 @@ func (ec *executionContext) ___Type_specifiedByURL(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2518,6 +2558,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -2537,6 +2578,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -2556,6 +2598,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -2935,6 +2978,8 @@ func (ec *executionContext) unmarshalNBoolTyped2githubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalNBoolTyped2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋmodelᚐBoolTyped(ctx context.Context, sel ast.SelectionSet, v model.BoolTyped) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(marshalNBoolTyped2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋmodelᚐBoolTyped[v])
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -2962,6 +3007,8 @@ func (ec *executionContext) unmarshalNBoolUntyped2bool(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalNBoolUntyped2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(marshalNBoolUntyped2bool[v])
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -2988,6 +3035,8 @@ func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3004,6 +3053,8 @@ func (ec *executionContext) unmarshalNIntTyped2githubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalNIntTyped2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋmodelᚐIntTyped(ctx context.Context, sel ast.SelectionSet, v model.IntTyped) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(marshalNIntTyped2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋmodelᚐIntTyped[v])
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3031,6 +3082,8 @@ func (ec *executionContext) unmarshalNIntUntyped2int(ctx context.Context, v inte
 }
 
 func (ec *executionContext) marshalNIntUntyped2int(ctx context.Context, sel ast.SelectionSet, v int) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(marshalNIntUntyped2int[v])
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3057,6 +3110,8 @@ func (ec *executionContext) unmarshalNString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3073,6 +3128,8 @@ func (ec *executionContext) unmarshalNStringTyped2githubᚗcomᚋ99designsᚋgql
 }
 
 func (ec *executionContext) marshalNStringTyped2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋmodelᚐStringTyped(ctx context.Context, sel ast.SelectionSet, v model.StringTyped) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(marshalNStringTyped2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋmodelᚐStringTyped[v])
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3100,6 +3157,8 @@ func (ec *executionContext) unmarshalNStringUntyped2string(ctx context.Context, 
 }
 
 func (ec *executionContext) marshalNStringUntyped2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(marshalNStringUntyped2string[v])
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3121,10 +3180,14 @@ var (
 )
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Directive(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3174,6 +3237,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2string(ctx context.Con
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3201,6 +3266,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2ᚕstringᚄ(ctx conte
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3245,18 +3312,26 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context
 }
 
 func (ec *executionContext) marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx context.Context, sel ast.SelectionSet, v introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___EnumValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx context.Context, sel ast.SelectionSet, v introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Field(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx context.Context, sel ast.SelectionSet, v introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___InputValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3301,10 +3376,14 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Type(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3349,6 +3428,8 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalN__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3364,6 +3445,8 @@ func (ec *executionContext) unmarshalN__TypeKind2string(ctx context.Context, v i
 }
 
 func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3394,6 +3477,8 @@ func (ec *executionContext) unmarshalOBoolTyped2ᚕgithubᚗcomᚋ99designsᚋgq
 }
 
 func (ec *executionContext) marshalOBoolTyped2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋmodelᚐBoolTypedᚄ(ctx context.Context, sel ast.SelectionSet, v []model.BoolTyped) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3461,6 +3546,8 @@ func (ec *executionContext) unmarshalOBoolTyped2ᚖgithubᚗcomᚋ99designsᚋgq
 }
 
 func (ec *executionContext) marshalOBoolTyped2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋmodelᚐBoolTyped(ctx context.Context, sel ast.SelectionSet, v *model.BoolTyped) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3489,6 +3576,8 @@ func (ec *executionContext) unmarshalOBoolUntyped2ᚖbool(ctx context.Context, v
 }
 
 func (ec *executionContext) marshalOBoolUntyped2ᚖbool(ctx context.Context, sel ast.SelectionSet, v *bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3513,6 +3602,8 @@ func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalOBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	return res
 }
@@ -3526,6 +3617,8 @@ func (ec *executionContext) unmarshalOBoolean2ᚖbool(ctx context.Context, v int
 }
 
 func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast.SelectionSet, v *bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3554,6 +3647,8 @@ func (ec *executionContext) unmarshalOIntTyped2ᚕgithubᚗcomᚋ99designsᚋgql
 }
 
 func (ec *executionContext) marshalOIntTyped2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋmodelᚐIntTypedᚄ(ctx context.Context, sel ast.SelectionSet, v []model.IntTyped) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3621,6 +3716,8 @@ func (ec *executionContext) unmarshalOIntTyped2ᚖgithubᚗcomᚋ99designsᚋgql
 }
 
 func (ec *executionContext) marshalOIntTyped2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋmodelᚐIntTyped(ctx context.Context, sel ast.SelectionSet, v *model.IntTyped) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3649,6 +3746,8 @@ func (ec *executionContext) unmarshalOIntUntyped2ᚖint(ctx context.Context, v i
 }
 
 func (ec *executionContext) marshalOIntUntyped2ᚖint(ctx context.Context, sel ast.SelectionSet, v *int) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3688,6 +3787,8 @@ func (ec *executionContext) unmarshalOString2ᚕstringᚄ(ctx context.Context, v
 }
 
 func (ec *executionContext) marshalOString2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3714,6 +3815,8 @@ func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3742,6 +3845,8 @@ func (ec *executionContext) unmarshalOStringTyped2ᚕgithubᚗcomᚋ99designsᚋ
 }
 
 func (ec *executionContext) marshalOStringTyped2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋmodelᚐStringTypedᚄ(ctx context.Context, sel ast.SelectionSet, v []model.StringTyped) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3809,6 +3914,8 @@ func (ec *executionContext) unmarshalOStringTyped2ᚖgithubᚗcomᚋ99designsᚋ
 }
 
 func (ec *executionContext) marshalOStringTyped2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋmodelᚐStringTyped(ctx context.Context, sel ast.SelectionSet, v *model.StringTyped) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3837,6 +3944,8 @@ func (ec *executionContext) unmarshalOStringUntyped2ᚖstring(ctx context.Contex
 }
 
 func (ec *executionContext) marshalOStringUntyped2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3856,6 +3965,8 @@ var (
 )
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3903,6 +4014,8 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 }
 
 func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3950,6 +4063,8 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3997,6 +4112,8 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx context.Context, sel ast.SelectionSet, v *introspection.Schema) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4004,6 +4121,8 @@ func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4051,6 +4170,8 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}

--- a/_examples/federation/accounts/graph/generated.go
+++ b/_examples/federation/accounts/graph/generated.go
@@ -469,6 +469,7 @@ func (ec *executionContext) _EmailHost_id(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_EmailHost_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "EmailHost",
 		Field:      field,
@@ -513,6 +514,7 @@ func (ec *executionContext) _EmailHost_name(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_EmailHost_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "EmailHost",
 		Field:      field,
@@ -557,6 +559,7 @@ func (ec *executionContext) _Entity_findEmailHostByID(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext_Entity_findEmailHostByID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Entity",
 		Field:      field,
@@ -618,6 +621,7 @@ func (ec *executionContext) _Entity_findUserByID(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext_Entity_findUserByID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Entity",
 		Field:      field,
@@ -680,6 +684,7 @@ func (ec *executionContext) _Query_me(ctx context.Context, field graphql.Collect
 }
 
 func (ec *executionContext) fieldContext_Query_me(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -734,6 +739,7 @@ func (ec *executionContext) _Query__entities(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Query__entities(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -789,6 +795,7 @@ func (ec *executionContext) _Query__service(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Query__service(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -834,6 +841,7 @@ func (ec *executionContext) _Query___type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Query___type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -908,6 +916,7 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Query___schema(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -966,6 +975,7 @@ func (ec *executionContext) _User_id(ctx context.Context, field graphql.Collecte
 }
 
 func (ec *executionContext) fieldContext_User_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1010,6 +1020,7 @@ func (ec *executionContext) _User_host(ctx context.Context, field graphql.Collec
 }
 
 func (ec *executionContext) fieldContext_User_host(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1060,6 +1071,7 @@ func (ec *executionContext) _User_email(ctx context.Context, field graphql.Colle
 }
 
 func (ec *executionContext) fieldContext_User_email(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1104,6 +1116,7 @@ func (ec *executionContext) _User_username(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_User_username(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1145,6 +1158,7 @@ func (ec *executionContext) __Service_sdl(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext__Service_sdl(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "_Service",
 		Field:      field,
@@ -1189,6 +1203,7 @@ func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1230,6 +1245,7 @@ func (ec *executionContext) ___Directive_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___Directive_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1274,6 +1290,7 @@ func (ec *executionContext) ___Directive_locations(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Directive_locations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1318,6 +1335,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1372,6 +1390,7 @@ func (ec *executionContext) ___Directive_isRepeatable(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___Directive_isRepeatable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1416,6 +1435,7 @@ func (ec *executionContext) ___EnumValue_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___EnumValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1457,6 +1477,7 @@ func (ec *executionContext) ___EnumValue_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1501,6 +1522,7 @@ func (ec *executionContext) ___EnumValue_isDeprecated(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___EnumValue_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1542,6 +1564,7 @@ func (ec *executionContext) ___EnumValue_deprecationReason(ctx context.Context, 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1586,6 +1609,7 @@ func (ec *executionContext) ___Field_name(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1627,6 +1651,7 @@ func (ec *executionContext) ___Field_description(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Field_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1671,6 +1696,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1725,6 +1751,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1791,6 +1818,7 @@ func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Field_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1832,6 +1860,7 @@ func (ec *executionContext) ___Field_deprecationReason(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Field_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1876,6 +1905,7 @@ func (ec *executionContext) ___InputValue_name(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1917,6 +1947,7 @@ func (ec *executionContext) ___InputValue_description(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___InputValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1961,6 +1992,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2024,6 +2056,7 @@ func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2065,6 +2098,7 @@ func (ec *executionContext) ___Schema_description(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Schema_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2109,6 +2143,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext___Schema_types(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2175,6 +2210,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Schema_queryType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2238,6 +2274,7 @@ func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Schema_mutationType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2301,6 +2338,7 @@ func (ec *executionContext) ___Schema_subscriptionType(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Schema_subscriptionType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2367,6 +2405,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Schema_directives(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2423,6 +2462,7 @@ func (ec *executionContext) ___Type_kind(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2464,6 +2504,7 @@ func (ec *executionContext) ___Type_name(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2505,6 +2546,7 @@ func (ec *executionContext) ___Type_description(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2546,6 +2588,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_fields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2612,6 +2655,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_interfaces(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2675,6 +2719,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Type_possibleTypes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2738,6 +2783,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_enumValues(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2800,6 +2846,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_inputFields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2851,6 +2898,7 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_ofType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2914,6 +2962,7 @@ func (ec *executionContext) ___Type_specifiedByURL(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2935,6 +2984,8 @@ func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Conte
 // region    ************************** interface.gotpl ***************************
 
 func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, obj fedruntime.Entity) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
@@ -3028,6 +3079,7 @@ func (ec *executionContext) _Entity(ctx context.Context, sel ast.SelectionSet) g
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3050,6 +3102,7 @@ func (ec *executionContext) _Entity(ctx context.Context, sel ast.SelectionSet) g
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3114,6 +3167,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3133,6 +3187,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3155,6 +3210,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3626,6 +3682,8 @@ func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3636,10 +3694,14 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 }
 
 func (ec *executionContext) marshalNEmailHost2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋaccountsᚋgraphᚋmodelᚐEmailHost(ctx context.Context, sel ast.SelectionSet, v model.EmailHost) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec._EmailHost(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNEmailHost2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋaccountsᚋgraphᚋmodelᚐEmailHost(ctx context.Context, sel ast.SelectionSet, v *model.EmailHost) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3655,6 +3717,8 @@ func (ec *executionContext) unmarshalNID2string(ctx context.Context, v interface
 }
 
 func (ec *executionContext) marshalNID2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalID(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3670,6 +3734,8 @@ func (ec *executionContext) unmarshalNString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3680,10 +3746,14 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 }
 
 func (ec *executionContext) marshalNUser2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋaccountsᚋgraphᚋmodelᚐUser(ctx context.Context, sel ast.SelectionSet, v model.User) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec._User(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋaccountsᚋgraphᚋmodelᚐUser(ctx context.Context, sel ast.SelectionSet, v *model.User) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3699,6 +3769,8 @@ func (ec *executionContext) unmarshalN_Any2map(ctx context.Context, v interface{
 }
 
 func (ec *executionContext) marshalN_Any2map(ctx context.Context, sel ast.SelectionSet, v map[string]interface{}) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3732,6 +3804,8 @@ func (ec *executionContext) unmarshalN_Any2ᚕmapᚄ(ctx context.Context, v inte
 }
 
 func (ec *executionContext) marshalN_Any2ᚕmapᚄ(ctx context.Context, sel ast.SelectionSet, v []map[string]interface{}) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	for i := range v {
 		ret[i] = ec.marshalN_Any2map(ctx, sel, v[i])
@@ -3747,6 +3821,8 @@ func (ec *executionContext) marshalN_Any2ᚕmapᚄ(ctx context.Context, sel ast.
 }
 
 func (ec *executionContext) marshalN_Entity2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐEntity(ctx context.Context, sel ast.SelectionSet, v []fedruntime.Entity) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3790,6 +3866,8 @@ func (ec *executionContext) unmarshalN_FieldSet2string(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalN_FieldSet2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3800,14 +3878,20 @@ func (ec *executionContext) marshalN_FieldSet2string(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalN_Service2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐService(ctx context.Context, sel ast.SelectionSet, v fedruntime.Service) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.__Service(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Directive(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3857,6 +3941,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2string(ctx context.Con
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3884,6 +3970,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2ᚕstringᚄ(ctx conte
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3928,18 +4016,26 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context
 }
 
 func (ec *executionContext) marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx context.Context, sel ast.SelectionSet, v introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___EnumValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx context.Context, sel ast.SelectionSet, v introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Field(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx context.Context, sel ast.SelectionSet, v introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___InputValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3984,10 +4080,14 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Type(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4032,6 +4132,8 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalN__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -4047,6 +4149,8 @@ func (ec *executionContext) unmarshalN__TypeKind2string(ctx context.Context, v i
 }
 
 func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -4062,6 +4166,8 @@ func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalOBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	return res
 }
@@ -4075,6 +4181,8 @@ func (ec *executionContext) unmarshalOBoolean2ᚖbool(ctx context.Context, v int
 }
 
 func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast.SelectionSet, v *bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4088,6 +4196,8 @@ func (ec *executionContext) unmarshalOString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalOString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	return res
 }
@@ -4101,6 +4211,8 @@ func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4109,6 +4221,8 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalOUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋaccountsᚋgraphᚋmodelᚐUser(ctx context.Context, sel ast.SelectionSet, v *model.User) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4116,6 +4230,8 @@ func (ec *executionContext) marshalOUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ
 }
 
 func (ec *executionContext) marshalO_Entity2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐEntity(ctx context.Context, sel ast.SelectionSet, v fedruntime.Entity) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4123,6 +4239,8 @@ func (ec *executionContext) marshalO_Entity2githubᚗcomᚋ99designsᚋgqlgenᚋ
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4170,6 +4288,8 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 }
 
 func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4217,6 +4337,8 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4264,6 +4386,8 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx context.Context, sel ast.SelectionSet, v *introspection.Schema) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4271,6 +4395,8 @@ func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4318,6 +4444,8 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}

--- a/_examples/federation/products/graph/generated.go
+++ b/_examples/federation/products/graph/generated.go
@@ -536,6 +536,7 @@ func (ec *executionContext) _Entity_findManufacturerByID(ctx context.Context, fi
 }
 
 func (ec *executionContext) fieldContext_Entity_findManufacturerByID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Entity",
 		Field:      field,
@@ -597,6 +598,7 @@ func (ec *executionContext) _Entity_findProductByManufacturerIDAndID(ctx context
 }
 
 func (ec *executionContext) fieldContext_Entity_findProductByManufacturerIDAndID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Entity",
 		Field:      field,
@@ -664,6 +666,7 @@ func (ec *executionContext) _Entity_findProductByUpc(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext_Entity_findProductByUpc(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Entity",
 		Field:      field,
@@ -731,6 +734,7 @@ func (ec *executionContext) _Manufacturer_id(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Manufacturer_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Manufacturer",
 		Field:      field,
@@ -775,6 +779,7 @@ func (ec *executionContext) _Manufacturer_name(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext_Manufacturer_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Manufacturer",
 		Field:      field,
@@ -819,6 +824,7 @@ func (ec *executionContext) _Product_id(ctx context.Context, field graphql.Colle
 }
 
 func (ec *executionContext) fieldContext_Product_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Product",
 		Field:      field,
@@ -863,6 +869,7 @@ func (ec *executionContext) _Product_manufacturer(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext_Product_manufacturer(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Product",
 		Field:      field,
@@ -913,6 +920,7 @@ func (ec *executionContext) _Product_upc(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext_Product_upc(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Product",
 		Field:      field,
@@ -957,6 +965,7 @@ func (ec *executionContext) _Product_name(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Product_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Product",
 		Field:      field,
@@ -1001,6 +1010,7 @@ func (ec *executionContext) _Product_price(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_Product_price(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Product",
 		Field:      field,
@@ -1042,6 +1052,7 @@ func (ec *executionContext) _Query_topProducts(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext_Query_topProducts(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -1109,6 +1120,7 @@ func (ec *executionContext) _Query__entities(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Query__entities(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -1164,6 +1176,7 @@ func (ec *executionContext) _Query__service(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Query__service(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -1209,6 +1222,7 @@ func (ec *executionContext) _Query___type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Query___type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -1283,6 +1297,7 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Query___schema(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -1338,6 +1353,7 @@ func (ec *executionContext) __Service_sdl(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext__Service_sdl(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "_Service",
 		Field:      field,
@@ -1382,6 +1398,7 @@ func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1423,6 +1440,7 @@ func (ec *executionContext) ___Directive_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___Directive_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1467,6 +1485,7 @@ func (ec *executionContext) ___Directive_locations(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Directive_locations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1511,6 +1530,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1565,6 +1585,7 @@ func (ec *executionContext) ___Directive_isRepeatable(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___Directive_isRepeatable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1609,6 +1630,7 @@ func (ec *executionContext) ___EnumValue_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___EnumValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1650,6 +1672,7 @@ func (ec *executionContext) ___EnumValue_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1694,6 +1717,7 @@ func (ec *executionContext) ___EnumValue_isDeprecated(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___EnumValue_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1735,6 +1759,7 @@ func (ec *executionContext) ___EnumValue_deprecationReason(ctx context.Context, 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1779,6 +1804,7 @@ func (ec *executionContext) ___Field_name(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1820,6 +1846,7 @@ func (ec *executionContext) ___Field_description(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Field_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1864,6 +1891,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1918,6 +1946,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1984,6 +2013,7 @@ func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Field_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -2025,6 +2055,7 @@ func (ec *executionContext) ___Field_deprecationReason(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Field_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -2069,6 +2100,7 @@ func (ec *executionContext) ___InputValue_name(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2110,6 +2142,7 @@ func (ec *executionContext) ___InputValue_description(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___InputValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2154,6 +2187,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2217,6 +2251,7 @@ func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2258,6 +2293,7 @@ func (ec *executionContext) ___Schema_description(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Schema_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2302,6 +2338,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext___Schema_types(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2368,6 +2405,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Schema_queryType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2431,6 +2469,7 @@ func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Schema_mutationType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2494,6 +2533,7 @@ func (ec *executionContext) ___Schema_subscriptionType(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Schema_subscriptionType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2560,6 +2600,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Schema_directives(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2616,6 +2657,7 @@ func (ec *executionContext) ___Type_kind(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2657,6 +2699,7 @@ func (ec *executionContext) ___Type_name(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2698,6 +2741,7 @@ func (ec *executionContext) ___Type_description(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2739,6 +2783,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_fields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2805,6 +2850,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_interfaces(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2868,6 +2914,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Type_possibleTypes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2931,6 +2978,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_enumValues(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2993,6 +3041,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_inputFields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -3044,6 +3093,7 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_ofType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -3107,6 +3157,7 @@ func (ec *executionContext) ___Type_specifiedByURL(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -3128,6 +3179,8 @@ func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Conte
 // region    ************************** interface.gotpl ***************************
 
 func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, obj fedruntime.Entity) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
@@ -3177,6 +3230,7 @@ func (ec *executionContext) _Entity(ctx context.Context, sel ast.SelectionSet) g
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3199,6 +3253,7 @@ func (ec *executionContext) _Entity(ctx context.Context, sel ast.SelectionSet) g
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3221,6 +3276,7 @@ func (ec *executionContext) _Entity(ctx context.Context, sel ast.SelectionSet) g
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3388,6 +3444,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3407,6 +3464,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3429,6 +3487,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3846,6 +3905,8 @@ func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3861,6 +3922,8 @@ func (ec *executionContext) unmarshalNInt2int(ctx context.Context, v interface{}
 }
 
 func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.SelectionSet, v int) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalInt(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3871,10 +3934,14 @@ func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.Selecti
 }
 
 func (ec *executionContext) marshalNManufacturer2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋproductsᚋgraphᚋmodelᚐManufacturer(ctx context.Context, sel ast.SelectionSet, v model.Manufacturer) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec._Manufacturer(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNManufacturer2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋproductsᚋgraphᚋmodelᚐManufacturer(ctx context.Context, sel ast.SelectionSet, v *model.Manufacturer) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3885,10 +3952,14 @@ func (ec *executionContext) marshalNManufacturer2ᚖgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalNProduct2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋproductsᚋgraphᚋmodelᚐProduct(ctx context.Context, sel ast.SelectionSet, v model.Product) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec._Product(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNProduct2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋproductsᚋgraphᚋmodelᚐProduct(ctx context.Context, sel ast.SelectionSet, v *model.Product) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3904,6 +3975,8 @@ func (ec *executionContext) unmarshalNString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3919,6 +3992,8 @@ func (ec *executionContext) unmarshalN_Any2map(ctx context.Context, v interface{
 }
 
 func (ec *executionContext) marshalN_Any2map(ctx context.Context, sel ast.SelectionSet, v map[string]interface{}) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3952,6 +4027,8 @@ func (ec *executionContext) unmarshalN_Any2ᚕmapᚄ(ctx context.Context, v inte
 }
 
 func (ec *executionContext) marshalN_Any2ᚕmapᚄ(ctx context.Context, sel ast.SelectionSet, v []map[string]interface{}) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	for i := range v {
 		ret[i] = ec.marshalN_Any2map(ctx, sel, v[i])
@@ -3967,6 +4044,8 @@ func (ec *executionContext) marshalN_Any2ᚕmapᚄ(ctx context.Context, sel ast.
 }
 
 func (ec *executionContext) marshalN_Entity2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐEntity(ctx context.Context, sel ast.SelectionSet, v []fedruntime.Entity) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4010,6 +4089,8 @@ func (ec *executionContext) unmarshalN_FieldSet2string(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalN_FieldSet2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -4020,14 +4101,20 @@ func (ec *executionContext) marshalN_FieldSet2string(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalN_Service2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐService(ctx context.Context, sel ast.SelectionSet, v fedruntime.Service) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.__Service(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Directive(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4077,6 +4164,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2string(ctx context.Con
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -4104,6 +4193,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2ᚕstringᚄ(ctx conte
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4148,18 +4239,26 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context
 }
 
 func (ec *executionContext) marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx context.Context, sel ast.SelectionSet, v introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___EnumValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx context.Context, sel ast.SelectionSet, v introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Field(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx context.Context, sel ast.SelectionSet, v introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___InputValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4204,10 +4303,14 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Type(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4252,6 +4355,8 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalN__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -4267,6 +4372,8 @@ func (ec *executionContext) unmarshalN__TypeKind2string(ctx context.Context, v i
 }
 
 func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -4282,6 +4389,8 @@ func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalOBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	return res
 }
@@ -4295,6 +4404,8 @@ func (ec *executionContext) unmarshalOBoolean2ᚖbool(ctx context.Context, v int
 }
 
 func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast.SelectionSet, v *bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4311,6 +4422,8 @@ func (ec *executionContext) unmarshalOInt2ᚖint(ctx context.Context, v interfac
 }
 
 func (ec *executionContext) marshalOInt2ᚖint(ctx context.Context, sel ast.SelectionSet, v *int) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4319,6 +4432,8 @@ func (ec *executionContext) marshalOInt2ᚖint(ctx context.Context, sel ast.Sele
 }
 
 func (ec *executionContext) marshalOProduct2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋproductsᚋgraphᚋmodelᚐProduct(ctx context.Context, sel ast.SelectionSet, v []*model.Product) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4360,6 +4475,8 @@ func (ec *executionContext) marshalOProduct2ᚕᚖgithubᚗcomᚋ99designsᚋgql
 }
 
 func (ec *executionContext) marshalOProduct2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋproductsᚋgraphᚋmodelᚐProduct(ctx context.Context, sel ast.SelectionSet, v *model.Product) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4372,6 +4489,8 @@ func (ec *executionContext) unmarshalOString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalOString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	return res
 }
@@ -4385,6 +4504,8 @@ func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4393,6 +4514,8 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalO_Entity2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐEntity(ctx context.Context, sel ast.SelectionSet, v fedruntime.Entity) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4400,6 +4523,8 @@ func (ec *executionContext) marshalO_Entity2githubᚗcomᚋ99designsᚋgqlgenᚋ
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4447,6 +4572,8 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 }
 
 func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4494,6 +4621,8 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4541,6 +4670,8 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx context.Context, sel ast.SelectionSet, v *introspection.Schema) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4548,6 +4679,8 @@ func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4595,6 +4728,8 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}

--- a/_examples/federation/reviews/graph/generated.go
+++ b/_examples/federation/reviews/graph/generated.go
@@ -536,6 +536,7 @@ func (ec *executionContext) _EmailHost_id(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_EmailHost_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "EmailHost",
 		Field:      field,
@@ -580,6 +581,7 @@ func (ec *executionContext) _Entity_findProductByManufacturerIDAndID(ctx context
 }
 
 func (ec *executionContext) fieldContext_Entity_findProductByManufacturerIDAndID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Entity",
 		Field:      field,
@@ -643,6 +645,7 @@ func (ec *executionContext) _Entity_findUserByID(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext_Entity_findUserByID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Entity",
 		Field:      field,
@@ -710,6 +713,7 @@ func (ec *executionContext) _Manufacturer_id(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Manufacturer_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Manufacturer",
 		Field:      field,
@@ -754,6 +758,7 @@ func (ec *executionContext) _Product_id(ctx context.Context, field graphql.Colle
 }
 
 func (ec *executionContext) fieldContext_Product_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Product",
 		Field:      field,
@@ -798,6 +803,7 @@ func (ec *executionContext) _Product_manufacturer(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext_Product_manufacturer(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Product",
 		Field:      field,
@@ -843,6 +849,7 @@ func (ec *executionContext) _Product_reviews(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Product_reviews(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Product",
 		Field:      field,
@@ -895,6 +902,7 @@ func (ec *executionContext) _Query__entities(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Query__entities(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -950,6 +958,7 @@ func (ec *executionContext) _Query__service(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Query__service(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -995,6 +1004,7 @@ func (ec *executionContext) _Query___type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Query___type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -1069,6 +1079,7 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Query___schema(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -1127,6 +1138,7 @@ func (ec *executionContext) _Review_body(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext_Review_body(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Review",
 		Field:      field,
@@ -1171,6 +1183,7 @@ func (ec *executionContext) _Review_author(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_Review_author(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Review",
 		Field:      field,
@@ -1227,6 +1240,7 @@ func (ec *executionContext) _Review_product(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Review_product(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Review",
 		Field:      field,
@@ -1279,6 +1293,7 @@ func (ec *executionContext) _User_id(ctx context.Context, field graphql.Collecte
 }
 
 func (ec *executionContext) fieldContext_User_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1323,6 +1338,7 @@ func (ec *executionContext) _User_host(ctx context.Context, field graphql.Collec
 }
 
 func (ec *executionContext) fieldContext_User_host(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1371,6 +1387,7 @@ func (ec *executionContext) _User_email(ctx context.Context, field graphql.Colle
 }
 
 func (ec *executionContext) fieldContext_User_email(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1415,6 +1432,7 @@ func (ec *executionContext) _User_username(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_User_username(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1456,6 +1474,7 @@ func (ec *executionContext) _User_reviews(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_User_reviews(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1505,6 +1524,7 @@ func (ec *executionContext) __Service_sdl(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext__Service_sdl(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "_Service",
 		Field:      field,
@@ -1549,6 +1569,7 @@ func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1590,6 +1611,7 @@ func (ec *executionContext) ___Directive_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___Directive_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1634,6 +1656,7 @@ func (ec *executionContext) ___Directive_locations(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Directive_locations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1678,6 +1701,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1732,6 +1756,7 @@ func (ec *executionContext) ___Directive_isRepeatable(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___Directive_isRepeatable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1776,6 +1801,7 @@ func (ec *executionContext) ___EnumValue_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___EnumValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1817,6 +1843,7 @@ func (ec *executionContext) ___EnumValue_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1861,6 +1888,7 @@ func (ec *executionContext) ___EnumValue_isDeprecated(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___EnumValue_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1902,6 +1930,7 @@ func (ec *executionContext) ___EnumValue_deprecationReason(ctx context.Context, 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1946,6 +1975,7 @@ func (ec *executionContext) ___Field_name(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1987,6 +2017,7 @@ func (ec *executionContext) ___Field_description(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Field_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -2031,6 +2062,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -2085,6 +2117,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -2151,6 +2184,7 @@ func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Field_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -2192,6 +2226,7 @@ func (ec *executionContext) ___Field_deprecationReason(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Field_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -2236,6 +2271,7 @@ func (ec *executionContext) ___InputValue_name(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2277,6 +2313,7 @@ func (ec *executionContext) ___InputValue_description(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___InputValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2321,6 +2358,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2384,6 +2422,7 @@ func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2425,6 +2464,7 @@ func (ec *executionContext) ___Schema_description(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Schema_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2469,6 +2509,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext___Schema_types(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2535,6 +2576,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Schema_queryType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2598,6 +2640,7 @@ func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Schema_mutationType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2661,6 +2704,7 @@ func (ec *executionContext) ___Schema_subscriptionType(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Schema_subscriptionType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2727,6 +2771,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Schema_directives(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2783,6 +2828,7 @@ func (ec *executionContext) ___Type_kind(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2824,6 +2870,7 @@ func (ec *executionContext) ___Type_name(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2865,6 +2912,7 @@ func (ec *executionContext) ___Type_description(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2906,6 +2954,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_fields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2972,6 +3021,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_interfaces(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -3035,6 +3085,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Type_possibleTypes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -3098,6 +3149,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_enumValues(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -3160,6 +3212,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_inputFields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -3211,6 +3264,7 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_ofType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -3274,6 +3328,7 @@ func (ec *executionContext) ___Type_specifiedByURL(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -3295,6 +3350,8 @@ func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Conte
 // region    ************************** interface.gotpl ***************************
 
 func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, obj fedruntime.Entity) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
@@ -3397,6 +3454,7 @@ func (ec *executionContext) _Entity(ctx context.Context, sel ast.SelectionSet) g
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3419,6 +3477,7 @@ func (ec *executionContext) _Entity(ctx context.Context, sel ast.SelectionSet) g
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3568,6 +3627,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3590,6 +3650,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3718,6 +3779,7 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3754,6 +3816,7 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -4174,6 +4237,8 @@ func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -4184,6 +4249,8 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 }
 
 func (ec *executionContext) marshalNEmailHost2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋreviewsᚋgraphᚋmodelᚐEmailHost(ctx context.Context, sel ast.SelectionSet, v *model.EmailHost) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -4199,6 +4266,8 @@ func (ec *executionContext) unmarshalNID2string(ctx context.Context, v interface
 }
 
 func (ec *executionContext) marshalNID2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalID(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -4209,6 +4278,8 @@ func (ec *executionContext) marshalNID2string(ctx context.Context, sel ast.Selec
 }
 
 func (ec *executionContext) marshalNManufacturer2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋreviewsᚋgraphᚋmodelᚐManufacturer(ctx context.Context, sel ast.SelectionSet, v *model.Manufacturer) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -4219,10 +4290,14 @@ func (ec *executionContext) marshalNManufacturer2ᚖgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalNProduct2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋreviewsᚋgraphᚋmodelᚐProduct(ctx context.Context, sel ast.SelectionSet, v model.Product) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec._Product(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNProduct2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋreviewsᚋgraphᚋmodelᚐProduct(ctx context.Context, sel ast.SelectionSet, v *model.Product) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -4238,6 +4313,8 @@ func (ec *executionContext) unmarshalNString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -4248,10 +4325,14 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 }
 
 func (ec *executionContext) marshalNUser2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋreviewsᚋgraphᚋmodelᚐUser(ctx context.Context, sel ast.SelectionSet, v model.User) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec._User(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋreviewsᚋgraphᚋmodelᚐUser(ctx context.Context, sel ast.SelectionSet, v *model.User) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -4267,6 +4348,8 @@ func (ec *executionContext) unmarshalN_Any2map(ctx context.Context, v interface{
 }
 
 func (ec *executionContext) marshalN_Any2map(ctx context.Context, sel ast.SelectionSet, v map[string]interface{}) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -4300,6 +4383,8 @@ func (ec *executionContext) unmarshalN_Any2ᚕmapᚄ(ctx context.Context, v inte
 }
 
 func (ec *executionContext) marshalN_Any2ᚕmapᚄ(ctx context.Context, sel ast.SelectionSet, v []map[string]interface{}) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	for i := range v {
 		ret[i] = ec.marshalN_Any2map(ctx, sel, v[i])
@@ -4315,6 +4400,8 @@ func (ec *executionContext) marshalN_Any2ᚕmapᚄ(ctx context.Context, sel ast.
 }
 
 func (ec *executionContext) marshalN_Entity2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐEntity(ctx context.Context, sel ast.SelectionSet, v []fedruntime.Entity) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4358,6 +4445,8 @@ func (ec *executionContext) unmarshalN_FieldSet2string(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalN_FieldSet2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -4368,14 +4457,20 @@ func (ec *executionContext) marshalN_FieldSet2string(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalN_Service2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐService(ctx context.Context, sel ast.SelectionSet, v fedruntime.Service) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.__Service(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Directive(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4425,6 +4520,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2string(ctx context.Con
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -4452,6 +4549,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2ᚕstringᚄ(ctx conte
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4496,18 +4595,26 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context
 }
 
 func (ec *executionContext) marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx context.Context, sel ast.SelectionSet, v introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___EnumValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx context.Context, sel ast.SelectionSet, v introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Field(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx context.Context, sel ast.SelectionSet, v introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___InputValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4552,10 +4659,14 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Type(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4600,6 +4711,8 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalN__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -4615,6 +4728,8 @@ func (ec *executionContext) unmarshalN__TypeKind2string(ctx context.Context, v i
 }
 
 func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -4630,6 +4745,8 @@ func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalOBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	return res
 }
@@ -4643,6 +4760,8 @@ func (ec *executionContext) unmarshalOBoolean2ᚖbool(ctx context.Context, v int
 }
 
 func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast.SelectionSet, v *bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4651,6 +4770,8 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 }
 
 func (ec *executionContext) marshalOReview2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋreviewsᚋgraphᚋmodelᚐReview(ctx context.Context, sel ast.SelectionSet, v []*model.Review) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4692,6 +4813,8 @@ func (ec *executionContext) marshalOReview2ᚕᚖgithubᚗcomᚋ99designsᚋgqlg
 }
 
 func (ec *executionContext) marshalOReview2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋreviewsᚋgraphᚋmodelᚐReview(ctx context.Context, sel ast.SelectionSet, v *model.Review) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4704,6 +4827,8 @@ func (ec *executionContext) unmarshalOString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalOString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	return res
 }
@@ -4717,6 +4842,8 @@ func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4725,6 +4852,8 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalO_Entity2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐEntity(ctx context.Context, sel ast.SelectionSet, v fedruntime.Entity) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4732,6 +4861,8 @@ func (ec *executionContext) marshalO_Entity2githubᚗcomᚋ99designsᚋgqlgenᚋ
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4779,6 +4910,8 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 }
 
 func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4826,6 +4959,8 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4873,6 +5008,8 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx context.Context, sel ast.SelectionSet, v *introspection.Schema) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4880,6 +5017,8 @@ func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4927,6 +5066,8 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}

--- a/_examples/fileupload/generated.go
+++ b/_examples/fileupload/generated.go
@@ -448,6 +448,7 @@ func (ec *executionContext) _File_id(ctx context.Context, field graphql.Collecte
 }
 
 func (ec *executionContext) fieldContext_File_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "File",
 		Field:      field,
@@ -492,6 +493,7 @@ func (ec *executionContext) _File_name(ctx context.Context, field graphql.Collec
 }
 
 func (ec *executionContext) fieldContext_File_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "File",
 		Field:      field,
@@ -536,6 +538,7 @@ func (ec *executionContext) _File_content(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_File_content(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "File",
 		Field:      field,
@@ -580,6 +583,7 @@ func (ec *executionContext) _File_contentType(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext_File_contentType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "File",
 		Field:      field,
@@ -624,6 +628,7 @@ func (ec *executionContext) _Mutation_singleUpload(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext_Mutation_singleUpload(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Mutation",
 		Field:      field,
@@ -689,6 +694,7 @@ func (ec *executionContext) _Mutation_singleUploadWithPayload(ctx context.Contex
 }
 
 func (ec *executionContext) fieldContext_Mutation_singleUploadWithPayload(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Mutation",
 		Field:      field,
@@ -754,6 +760,7 @@ func (ec *executionContext) _Mutation_multipleUpload(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext_Mutation_multipleUpload(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Mutation",
 		Field:      field,
@@ -819,6 +826,7 @@ func (ec *executionContext) _Mutation_multipleUploadWithPayload(ctx context.Cont
 }
 
 func (ec *executionContext) fieldContext_Mutation_multipleUploadWithPayload(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Mutation",
 		Field:      field,
@@ -884,6 +892,7 @@ func (ec *executionContext) _Query_empty(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext_Query_empty(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -925,6 +934,7 @@ func (ec *executionContext) _Query___type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Query___type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -999,6 +1009,7 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Query___schema(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -1057,6 +1068,7 @@ func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1098,6 +1110,7 @@ func (ec *executionContext) ___Directive_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___Directive_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1142,6 +1155,7 @@ func (ec *executionContext) ___Directive_locations(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Directive_locations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1186,6 +1200,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1240,6 +1255,7 @@ func (ec *executionContext) ___Directive_isRepeatable(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___Directive_isRepeatable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1284,6 +1300,7 @@ func (ec *executionContext) ___EnumValue_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___EnumValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1325,6 +1342,7 @@ func (ec *executionContext) ___EnumValue_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1369,6 +1387,7 @@ func (ec *executionContext) ___EnumValue_isDeprecated(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___EnumValue_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1410,6 +1429,7 @@ func (ec *executionContext) ___EnumValue_deprecationReason(ctx context.Context, 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1454,6 +1474,7 @@ func (ec *executionContext) ___Field_name(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1495,6 +1516,7 @@ func (ec *executionContext) ___Field_description(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Field_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1539,6 +1561,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1593,6 +1616,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1659,6 +1683,7 @@ func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Field_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1700,6 +1725,7 @@ func (ec *executionContext) ___Field_deprecationReason(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Field_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1744,6 +1770,7 @@ func (ec *executionContext) ___InputValue_name(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1785,6 +1812,7 @@ func (ec *executionContext) ___InputValue_description(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___InputValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1829,6 +1857,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1892,6 +1921,7 @@ func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1933,6 +1963,7 @@ func (ec *executionContext) ___Schema_description(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Schema_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1977,6 +2008,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext___Schema_types(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2043,6 +2075,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Schema_queryType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2106,6 +2139,7 @@ func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Schema_mutationType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2169,6 +2203,7 @@ func (ec *executionContext) ___Schema_subscriptionType(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Schema_subscriptionType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2235,6 +2270,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Schema_directives(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2291,6 +2327,7 @@ func (ec *executionContext) ___Type_kind(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2332,6 +2369,7 @@ func (ec *executionContext) ___Type_name(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2373,6 +2411,7 @@ func (ec *executionContext) ___Type_description(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2414,6 +2453,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_fields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2480,6 +2520,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_interfaces(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2543,6 +2584,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Type_possibleTypes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2606,6 +2648,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_enumValues(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2668,6 +2711,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_inputFields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2719,6 +2763,7 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_ofType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2782,6 +2827,7 @@ func (ec *executionContext) ___Type_specifiedByURL(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2987,6 +3033,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3368,6 +3415,8 @@ func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3378,10 +3427,14 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 }
 
 func (ec *executionContext) marshalNFile2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfileuploadᚋmodelᚐFile(ctx context.Context, sel ast.SelectionSet, v model.File) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec._File(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNFile2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfileuploadᚋmodelᚐFileᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.File) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3426,6 +3479,8 @@ func (ec *executionContext) marshalNFile2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalNFile2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfileuploadᚋmodelᚐFile(ctx context.Context, sel ast.SelectionSet, v *model.File) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3441,6 +3496,8 @@ func (ec *executionContext) unmarshalNInt2int(ctx context.Context, v interface{}
 }
 
 func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.SelectionSet, v int) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalInt(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3456,6 +3513,8 @@ func (ec *executionContext) unmarshalNString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3471,6 +3530,8 @@ func (ec *executionContext) unmarshalNUpload2githubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalNUpload2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUpload(ctx context.Context, sel ast.SelectionSet, v graphql.Upload) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalUpload(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3498,6 +3559,8 @@ func (ec *executionContext) unmarshalNUpload2ᚕᚖgithubᚗcomᚋ99designsᚋgq
 }
 
 func (ec *executionContext) marshalNUpload2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUploadᚄ(ctx context.Context, sel ast.SelectionSet, v []*graphql.Upload) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	for i := range v {
 		ret[i] = ec.marshalNUpload2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUpload(ctx, sel, v[i])
@@ -3518,6 +3581,8 @@ func (ec *executionContext) unmarshalNUpload2ᚖgithubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalNUpload2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUpload(ctx context.Context, sel ast.SelectionSet, v *graphql.Upload) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3561,10 +3626,14 @@ func (ec *executionContext) unmarshalNUploadFile2ᚖgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Directive(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3614,6 +3683,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2string(ctx context.Con
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3641,6 +3712,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2ᚕstringᚄ(ctx conte
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3685,18 +3758,26 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context
 }
 
 func (ec *executionContext) marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx context.Context, sel ast.SelectionSet, v introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___EnumValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx context.Context, sel ast.SelectionSet, v introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Field(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx context.Context, sel ast.SelectionSet, v introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___InputValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3741,10 +3822,14 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Type(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3789,6 +3874,8 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalN__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3804,6 +3891,8 @@ func (ec *executionContext) unmarshalN__TypeKind2string(ctx context.Context, v i
 }
 
 func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3819,6 +3908,8 @@ func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalOBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	return res
 }
@@ -3832,6 +3923,8 @@ func (ec *executionContext) unmarshalOBoolean2ᚖbool(ctx context.Context, v int
 }
 
 func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast.SelectionSet, v *bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3848,6 +3941,8 @@ func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3856,6 +3951,8 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3903,6 +4000,8 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 }
 
 func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3950,6 +4049,8 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3997,6 +4098,8 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx context.Context, sel ast.SelectionSet, v *introspection.Schema) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4004,6 +4107,8 @@ func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4051,6 +4156,8 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}

--- a/_examples/scalars/generated.go
+++ b/_examples/scalars/generated.go
@@ -480,6 +480,7 @@ func (ec *executionContext) _Address_id(ctx context.Context, field graphql.Colle
 }
 
 func (ec *executionContext) fieldContext_Address_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Address",
 		Field:      field,
@@ -521,6 +522,7 @@ func (ec *executionContext) _Address_location(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext_Address_location(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Address",
 		Field:      field,
@@ -562,6 +564,7 @@ func (ec *executionContext) _Query_user(ctx context.Context, field graphql.Colle
 }
 
 func (ec *executionContext) fieldContext_Query_user(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -641,6 +644,7 @@ func (ec *executionContext) _Query_search(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Query_search(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -720,6 +724,7 @@ func (ec *executionContext) _Query_userByTier(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext_Query_userByTier(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -796,6 +801,7 @@ func (ec *executionContext) _Query___type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Query___type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -870,6 +876,7 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Query___schema(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -928,6 +935,7 @@ func (ec *executionContext) _User_id(ctx context.Context, field graphql.Collecte
 }
 
 func (ec *executionContext) fieldContext_User_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -972,6 +980,7 @@ func (ec *executionContext) _User_name(ctx context.Context, field graphql.Collec
 }
 
 func (ec *executionContext) fieldContext_User_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1013,6 +1022,7 @@ func (ec *executionContext) _User_created(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_User_created(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1054,6 +1064,7 @@ func (ec *executionContext) _User_modified(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_User_modified(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1095,6 +1106,7 @@ func (ec *executionContext) _User_valPrefs(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_User_valPrefs(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1136,6 +1148,7 @@ func (ec *executionContext) _User_ptrPrefs(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_User_ptrPrefs(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1180,6 +1193,7 @@ func (ec *executionContext) _User_isBanned(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_User_isBanned(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1224,6 +1238,7 @@ func (ec *executionContext) _User_primitiveResolver(ctx context.Context, field g
 }
 
 func (ec *executionContext) fieldContext_User_primitiveResolver(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1268,6 +1283,7 @@ func (ec *executionContext) _User_customResolver(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext_User_customResolver(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1309,6 +1325,7 @@ func (ec *executionContext) _User_address(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_User_address(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1356,6 +1373,7 @@ func (ec *executionContext) _User_tier(ctx context.Context, field graphql.Collec
 }
 
 func (ec *executionContext) fieldContext_User_tier(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -1400,6 +1418,7 @@ func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1441,6 +1460,7 @@ func (ec *executionContext) ___Directive_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___Directive_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1485,6 +1505,7 @@ func (ec *executionContext) ___Directive_locations(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Directive_locations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1529,6 +1550,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1583,6 +1605,7 @@ func (ec *executionContext) ___Directive_isRepeatable(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___Directive_isRepeatable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1627,6 +1650,7 @@ func (ec *executionContext) ___EnumValue_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___EnumValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1668,6 +1692,7 @@ func (ec *executionContext) ___EnumValue_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1712,6 +1737,7 @@ func (ec *executionContext) ___EnumValue_isDeprecated(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___EnumValue_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1753,6 +1779,7 @@ func (ec *executionContext) ___EnumValue_deprecationReason(ctx context.Context, 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1797,6 +1824,7 @@ func (ec *executionContext) ___Field_name(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1838,6 +1866,7 @@ func (ec *executionContext) ___Field_description(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Field_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1882,6 +1911,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1936,6 +1966,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -2002,6 +2033,7 @@ func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Field_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -2043,6 +2075,7 @@ func (ec *executionContext) ___Field_deprecationReason(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Field_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -2087,6 +2120,7 @@ func (ec *executionContext) ___InputValue_name(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2128,6 +2162,7 @@ func (ec *executionContext) ___InputValue_description(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___InputValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2172,6 +2207,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2235,6 +2271,7 @@ func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -2276,6 +2313,7 @@ func (ec *executionContext) ___Schema_description(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Schema_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2320,6 +2358,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext___Schema_types(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2386,6 +2425,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Schema_queryType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2449,6 +2489,7 @@ func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Schema_mutationType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2512,6 +2553,7 @@ func (ec *executionContext) ___Schema_subscriptionType(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Schema_subscriptionType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2578,6 +2620,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Schema_directives(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2634,6 +2677,7 @@ func (ec *executionContext) ___Type_kind(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2675,6 +2719,7 @@ func (ec *executionContext) ___Type_name(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2716,6 +2761,7 @@ func (ec *executionContext) ___Type_description(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2757,6 +2803,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_fields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2823,6 +2870,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_interfaces(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2886,6 +2934,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Type_possibleTypes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2949,6 +2998,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_enumValues(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -3011,6 +3061,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_inputFields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -3062,6 +3113,7 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_ofType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -3125,6 +3177,7 @@ func (ec *executionContext) ___Type_specifiedByURL(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -3254,6 +3307,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3273,6 +3327,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3295,6 +3350,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3382,6 +3438,7 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3418,6 +3475,7 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3810,6 +3868,8 @@ func (ec *executionContext) unmarshalNBanned2githubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalNBanned2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐBanned(ctx context.Context, sel ast.SelectionSet, v model.Banned) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return v
 }
 
@@ -3819,6 +3879,8 @@ func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3834,6 +3896,8 @@ func (ec *executionContext) unmarshalNDarkMode2ᚖgithubᚗcomᚋ99designsᚋgql
 }
 
 func (ec *executionContext) marshalNDarkMode2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐPrefs(ctx context.Context, sel ast.SelectionSet, v *model.Prefs) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3855,6 +3919,8 @@ func (ec *executionContext) unmarshalNID2githubᚗcomᚋ99designsᚋgqlgenᚋ_ex
 }
 
 func (ec *executionContext) marshalNID2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋexternalᚐObjectID(ctx context.Context, sel ast.SelectionSet, v external.ObjectID) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := model.MarshalID(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3871,6 +3937,8 @@ func (ec *executionContext) unmarshalNPoint2githubᚗcomᚋ99designsᚋgqlgenᚋ
 }
 
 func (ec *executionContext) marshalNPoint2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐPoint(ctx context.Context, sel ast.SelectionSet, v model.Point) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return v
 }
 
@@ -3881,6 +3949,8 @@ func (ec *executionContext) unmarshalNPoint2ᚖgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalNPoint2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐPoint(ctx context.Context, sel ast.SelectionSet, v *model.Point) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3896,6 +3966,8 @@ func (ec *executionContext) unmarshalNString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3912,10 +3984,14 @@ func (ec *executionContext) unmarshalNTier2githubᚗcomᚋ99designsᚋgqlgenᚋ_
 }
 
 func (ec *executionContext) marshalNTier2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐTier(ctx context.Context, sel ast.SelectionSet, v model.Tier) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return v
 }
 
 func (ec *executionContext) marshalNUser2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐUserᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.User) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3960,6 +4036,8 @@ func (ec *executionContext) marshalNUser2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalNUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐUser(ctx context.Context, sel ast.SelectionSet, v *model.User) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3970,10 +4048,14 @@ func (ec *executionContext) marshalNUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Directive(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4023,6 +4105,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2string(ctx context.Con
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -4050,6 +4134,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2ᚕstringᚄ(ctx conte
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4094,18 +4180,26 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context
 }
 
 func (ec *executionContext) marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx context.Context, sel ast.SelectionSet, v introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___EnumValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx context.Context, sel ast.SelectionSet, v introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Field(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx context.Context, sel ast.SelectionSet, v introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___InputValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4150,10 +4244,14 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Type(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4198,6 +4296,8 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalN__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -4213,6 +4313,8 @@ func (ec *executionContext) unmarshalN__TypeKind2string(ctx context.Context, v i
 }
 
 func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -4223,6 +4325,8 @@ func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel a
 }
 
 func (ec *executionContext) marshalOAddress2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐAddress(ctx context.Context, sel ast.SelectionSet, v model.Address) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec._Address(ctx, sel, &v)
 }
 
@@ -4233,6 +4337,8 @@ func (ec *executionContext) unmarshalOBanned2githubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalOBanned2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐBanned(ctx context.Context, sel ast.SelectionSet, v model.Banned) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return v
 }
 
@@ -4242,6 +4348,8 @@ func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalOBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	return res
 }
@@ -4255,6 +4363,8 @@ func (ec *executionContext) unmarshalOBoolean2ᚖbool(ctx context.Context, v int
 }
 
 func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast.SelectionSet, v *bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4268,6 +4378,8 @@ func (ec *executionContext) unmarshalODarkMode2githubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalODarkMode2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐPrefs(ctx context.Context, sel ast.SelectionSet, v model.Prefs) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := model.MarshalPreferences(&v)
 	return res
 }
@@ -4281,6 +4393,8 @@ func (ec *executionContext) unmarshalODarkMode2ᚖgithubᚗcomᚋ99designsᚋgql
 }
 
 func (ec *executionContext) marshalODarkMode2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐPrefs(ctx context.Context, sel ast.SelectionSet, v *model.Prefs) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4298,6 +4412,8 @@ func (ec *executionContext) unmarshalOPoint2ᚖgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalOPoint2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐPoint(ctx context.Context, sel ast.SelectionSet, v *model.Point) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4321,6 +4437,8 @@ func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4335,6 +4453,8 @@ func (ec *executionContext) unmarshalOTier2githubᚗcomᚋ99designsᚋgqlgenᚋ_
 }
 
 func (ec *executionContext) marshalOTier2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐTier(ctx context.Context, sel ast.SelectionSet, v model.Tier) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return v
 }
 
@@ -4344,6 +4464,8 @@ func (ec *executionContext) unmarshalOTimestamp2timeᚐTime(ctx context.Context,
 }
 
 func (ec *executionContext) marshalOTimestamp2timeᚐTime(ctx context.Context, sel ast.SelectionSet, v time.Time) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := model.MarshalTimestamp(v)
 	return res
 }
@@ -4357,6 +4479,8 @@ func (ec *executionContext) unmarshalOTimestamp2ᚖtimeᚐTime(ctx context.Conte
 }
 
 func (ec *executionContext) marshalOTimestamp2ᚖtimeᚐTime(ctx context.Context, sel ast.SelectionSet, v *time.Time) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4365,6 +4489,8 @@ func (ec *executionContext) marshalOTimestamp2ᚖtimeᚐTime(ctx context.Context
 }
 
 func (ec *executionContext) marshalOUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐUser(ctx context.Context, sel ast.SelectionSet, v *model.User) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4372,6 +4498,8 @@ func (ec *executionContext) marshalOUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4419,6 +4547,8 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 }
 
 func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4466,6 +4596,8 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4513,6 +4645,8 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx context.Context, sel ast.SelectionSet, v *introspection.Schema) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4520,6 +4654,8 @@ func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -4567,6 +4703,8 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}

--- a/_examples/selection/generated.go
+++ b/_examples/selection/generated.go
@@ -344,6 +344,7 @@ func (ec *executionContext) _Like_reaction(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_Like_reaction(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Like",
 		Field:      field,
@@ -388,6 +389,7 @@ func (ec *executionContext) _Like_sent(ctx context.Context, field graphql.Collec
 }
 
 func (ec *executionContext) fieldContext_Like_sent(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Like",
 		Field:      field,
@@ -429,6 +431,7 @@ func (ec *executionContext) _Like_selection(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Like_selection(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Like",
 		Field:      field,
@@ -470,6 +473,7 @@ func (ec *executionContext) _Like_collected(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Like_collected(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Like",
 		Field:      field,
@@ -514,6 +518,7 @@ func (ec *executionContext) _Post_message(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Post_message(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Post",
 		Field:      field,
@@ -558,6 +563,7 @@ func (ec *executionContext) _Post_sent(ctx context.Context, field graphql.Collec
 }
 
 func (ec *executionContext) fieldContext_Post_sent(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Post",
 		Field:      field,
@@ -599,6 +605,7 @@ func (ec *executionContext) _Post_selection(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Post_selection(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Post",
 		Field:      field,
@@ -640,6 +647,7 @@ func (ec *executionContext) _Post_collected(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Post_collected(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Post",
 		Field:      field,
@@ -681,6 +689,7 @@ func (ec *executionContext) _Query_events(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Query_events(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -722,6 +731,7 @@ func (ec *executionContext) _Query___type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Query___type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -796,6 +806,7 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Query___schema(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -854,6 +865,7 @@ func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -895,6 +907,7 @@ func (ec *executionContext) ___Directive_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___Directive_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -939,6 +952,7 @@ func (ec *executionContext) ___Directive_locations(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Directive_locations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -983,6 +997,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1037,6 +1052,7 @@ func (ec *executionContext) ___Directive_isRepeatable(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___Directive_isRepeatable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1081,6 +1097,7 @@ func (ec *executionContext) ___EnumValue_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___EnumValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1122,6 +1139,7 @@ func (ec *executionContext) ___EnumValue_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1166,6 +1184,7 @@ func (ec *executionContext) ___EnumValue_isDeprecated(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___EnumValue_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1207,6 +1226,7 @@ func (ec *executionContext) ___EnumValue_deprecationReason(ctx context.Context, 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1251,6 +1271,7 @@ func (ec *executionContext) ___Field_name(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1292,6 +1313,7 @@ func (ec *executionContext) ___Field_description(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Field_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1336,6 +1358,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1390,6 +1413,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1456,6 +1480,7 @@ func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Field_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1497,6 +1522,7 @@ func (ec *executionContext) ___Field_deprecationReason(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Field_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1541,6 +1567,7 @@ func (ec *executionContext) ___InputValue_name(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1582,6 +1609,7 @@ func (ec *executionContext) ___InputValue_description(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___InputValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1626,6 +1654,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1689,6 +1718,7 @@ func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1730,6 +1760,7 @@ func (ec *executionContext) ___Schema_description(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Schema_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1774,6 +1805,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext___Schema_types(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1840,6 +1872,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Schema_queryType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1903,6 +1936,7 @@ func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Schema_mutationType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1966,6 +2000,7 @@ func (ec *executionContext) ___Schema_subscriptionType(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Schema_subscriptionType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2032,6 +2067,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Schema_directives(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2088,6 +2124,7 @@ func (ec *executionContext) ___Type_kind(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2129,6 +2166,7 @@ func (ec *executionContext) ___Type_name(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2170,6 +2208,7 @@ func (ec *executionContext) ___Type_description(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2211,6 +2250,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_fields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2277,6 +2317,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_interfaces(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2340,6 +2381,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Type_possibleTypes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2403,6 +2445,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_enumValues(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2465,6 +2508,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_inputFields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2516,6 +2560,7 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_ofType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2579,6 +2624,7 @@ func (ec *executionContext) ___Type_specifiedByURL(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2600,6 +2646,8 @@ func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Conte
 // region    ************************** interface.gotpl ***************************
 
 func (ec *executionContext) _Event(ctx context.Context, sel ast.SelectionSet, obj Event) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
@@ -2745,6 +2793,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3123,6 +3172,8 @@ func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3133,6 +3184,8 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 }
 
 func (ec *executionContext) marshalNEvent2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋselectionᚐEvent(ctx context.Context, sel ast.SelectionSet, v Event) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3148,6 +3201,8 @@ func (ec *executionContext) unmarshalNString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3163,6 +3218,8 @@ func (ec *executionContext) unmarshalNTime2timeᚐTime(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalNTime2timeᚐTime(ctx context.Context, sel ast.SelectionSet, v time.Time) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalTime(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3173,10 +3230,14 @@ func (ec *executionContext) marshalNTime2timeᚐTime(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Directive(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3226,6 +3287,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2string(ctx context.Con
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3253,6 +3316,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2ᚕstringᚄ(ctx conte
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3297,18 +3362,26 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context
 }
 
 func (ec *executionContext) marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx context.Context, sel ast.SelectionSet, v introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___EnumValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx context.Context, sel ast.SelectionSet, v introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Field(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx context.Context, sel ast.SelectionSet, v introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___InputValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3353,10 +3426,14 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Type(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3401,6 +3478,8 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalN__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3416,6 +3495,8 @@ func (ec *executionContext) unmarshalN__TypeKind2string(ctx context.Context, v i
 }
 
 func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3431,6 +3512,8 @@ func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalOBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	return res
 }
@@ -3444,6 +3527,8 @@ func (ec *executionContext) unmarshalOBoolean2ᚖbool(ctx context.Context, v int
 }
 
 func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast.SelectionSet, v *bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3452,6 +3537,8 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 }
 
 func (ec *executionContext) marshalOEvent2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋselectionᚐEventᚄ(ctx context.Context, sel ast.SelectionSet, v []Event) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3519,6 +3606,8 @@ func (ec *executionContext) unmarshalOString2ᚕstringᚄ(ctx context.Context, v
 }
 
 func (ec *executionContext) marshalOString2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3545,6 +3634,8 @@ func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3553,6 +3644,8 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3600,6 +3693,8 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 }
 
 func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3647,6 +3742,8 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3694,6 +3791,8 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx context.Context, sel ast.SelectionSet, v *introspection.Schema) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3701,6 +3800,8 @@ func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3748,6 +3849,8 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}

--- a/_examples/starwars/generated/exec.go
+++ b/_examples/starwars/generated/exec.go
@@ -1058,6 +1058,7 @@ func (ec *executionContext) _Droid_id(ctx context.Context, field graphql.Collect
 }
 
 func (ec *executionContext) fieldContext_Droid_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Droid",
 		Field:      field,
@@ -1102,6 +1103,7 @@ func (ec *executionContext) _Droid_name(ctx context.Context, field graphql.Colle
 }
 
 func (ec *executionContext) fieldContext_Droid_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Droid",
 		Field:      field,
@@ -1143,6 +1145,7 @@ func (ec *executionContext) _Droid_friends(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_Droid_friends(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Droid",
 		Field:      field,
@@ -1187,6 +1190,7 @@ func (ec *executionContext) _Droid_friendsConnection(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext_Droid_friendsConnection(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Droid",
 		Field:      field,
@@ -1252,6 +1256,7 @@ func (ec *executionContext) _Droid_appearsIn(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Droid_appearsIn(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Droid",
 		Field:      field,
@@ -1293,6 +1298,7 @@ func (ec *executionContext) _Droid_primaryFunction(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext_Droid_primaryFunction(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Droid",
 		Field:      field,
@@ -1337,6 +1343,7 @@ func (ec *executionContext) _FriendsConnection_totalCount(ctx context.Context, f
 }
 
 func (ec *executionContext) fieldContext_FriendsConnection_totalCount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "FriendsConnection",
 		Field:      field,
@@ -1378,6 +1385,7 @@ func (ec *executionContext) _FriendsConnection_edges(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext_FriendsConnection_edges(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "FriendsConnection",
 		Field:      field,
@@ -1425,6 +1433,7 @@ func (ec *executionContext) _FriendsConnection_friends(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext_FriendsConnection_friends(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "FriendsConnection",
 		Field:      field,
@@ -1469,6 +1478,7 @@ func (ec *executionContext) _FriendsConnection_pageInfo(ctx context.Context, fie
 }
 
 func (ec *executionContext) fieldContext_FriendsConnection_pageInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "FriendsConnection",
 		Field:      field,
@@ -1521,6 +1531,7 @@ func (ec *executionContext) _FriendsEdge_cursor(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext_FriendsEdge_cursor(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "FriendsEdge",
 		Field:      field,
@@ -1562,6 +1573,7 @@ func (ec *executionContext) _FriendsEdge_node(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext_FriendsEdge_node(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "FriendsEdge",
 		Field:      field,
@@ -1606,6 +1618,7 @@ func (ec *executionContext) _Human_id(ctx context.Context, field graphql.Collect
 }
 
 func (ec *executionContext) fieldContext_Human_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Human",
 		Field:      field,
@@ -1650,6 +1663,7 @@ func (ec *executionContext) _Human_name(ctx context.Context, field graphql.Colle
 }
 
 func (ec *executionContext) fieldContext_Human_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Human",
 		Field:      field,
@@ -1694,6 +1708,7 @@ func (ec *executionContext) _Human_height(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Human_height(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Human",
 		Field:      field,
@@ -1746,6 +1761,7 @@ func (ec *executionContext) _Human_mass(ctx context.Context, field graphql.Colle
 }
 
 func (ec *executionContext) fieldContext_Human_mass(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Human",
 		Field:      field,
@@ -1787,6 +1803,7 @@ func (ec *executionContext) _Human_friends(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_Human_friends(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Human",
 		Field:      field,
@@ -1831,6 +1848,7 @@ func (ec *executionContext) _Human_friendsConnection(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext_Human_friendsConnection(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Human",
 		Field:      field,
@@ -1896,6 +1914,7 @@ func (ec *executionContext) _Human_appearsIn(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Human_appearsIn(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Human",
 		Field:      field,
@@ -1937,6 +1956,7 @@ func (ec *executionContext) _Human_starships(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Human_starships(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Human",
 		Field:      field,
@@ -1977,6 +1997,7 @@ func (ec *executionContext) _Human_query(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext_Human_query(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Human",
 		Field:      field,
@@ -2027,6 +2048,7 @@ func (ec *executionContext) _Human_mutation(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Human_mutation(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Human",
 		Field:      field,
@@ -2072,6 +2094,7 @@ func (ec *executionContext) _Mutation_createReview(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext_Mutation_createReview(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Mutation",
 		Field:      field,
@@ -2135,6 +2158,7 @@ func (ec *executionContext) _PageInfo_startCursor(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext_PageInfo_startCursor(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "PageInfo",
 		Field:      field,
@@ -2179,6 +2203,7 @@ func (ec *executionContext) _PageInfo_endCursor(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext_PageInfo_endCursor(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "PageInfo",
 		Field:      field,
@@ -2223,6 +2248,7 @@ func (ec *executionContext) _PageInfo_hasNextPage(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext_PageInfo_hasNextPage(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "PageInfo",
 		Field:      field,
@@ -2264,6 +2290,7 @@ func (ec *executionContext) _Query_hero(ctx context.Context, field graphql.Colle
 }
 
 func (ec *executionContext) fieldContext_Query_hero(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -2319,6 +2346,7 @@ func (ec *executionContext) _Query_reviews(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_Query_reviews(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -2382,6 +2410,7 @@ func (ec *executionContext) _Query_search(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Query_search(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -2434,6 +2463,7 @@ func (ec *executionContext) _Query_character(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Query_character(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -2486,6 +2516,7 @@ func (ec *executionContext) _Query_droid(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext_Query_droid(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -2552,6 +2583,7 @@ func (ec *executionContext) _Query_human(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext_Query_human(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -2626,6 +2658,7 @@ func (ec *executionContext) _Query_starship(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Query_starship(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -2688,6 +2721,7 @@ func (ec *executionContext) _Query___type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Query___type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -2762,6 +2796,7 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Query___schema(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -2820,6 +2855,7 @@ func (ec *executionContext) _Review_stars(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_Review_stars(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Review",
 		Field:      field,
@@ -2861,6 +2897,7 @@ func (ec *executionContext) _Review_commentary(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext_Review_commentary(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Review",
 		Field:      field,
@@ -2902,6 +2939,7 @@ func (ec *executionContext) _Review_time(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext_Review_time(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Review",
 		Field:      field,
@@ -2946,6 +2984,7 @@ func (ec *executionContext) _Starship_id(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext_Starship_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Starship",
 		Field:      field,
@@ -2990,6 +3029,7 @@ func (ec *executionContext) _Starship_name(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_Starship_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Starship",
 		Field:      field,
@@ -3034,6 +3074,7 @@ func (ec *executionContext) _Starship_length(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Starship_length(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Starship",
 		Field:      field,
@@ -3089,6 +3130,7 @@ func (ec *executionContext) _Starship_history(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext_Starship_history(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Starship",
 		Field:      field,
@@ -3133,6 +3175,7 @@ func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -3174,6 +3217,7 @@ func (ec *executionContext) ___Directive_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___Directive_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -3218,6 +3262,7 @@ func (ec *executionContext) ___Directive_locations(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Directive_locations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -3262,6 +3307,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -3316,6 +3362,7 @@ func (ec *executionContext) ___Directive_isRepeatable(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___Directive_isRepeatable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -3360,6 +3407,7 @@ func (ec *executionContext) ___EnumValue_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___EnumValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -3401,6 +3449,7 @@ func (ec *executionContext) ___EnumValue_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -3445,6 +3494,7 @@ func (ec *executionContext) ___EnumValue_isDeprecated(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___EnumValue_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -3486,6 +3536,7 @@ func (ec *executionContext) ___EnumValue_deprecationReason(ctx context.Context, 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -3530,6 +3581,7 @@ func (ec *executionContext) ___Field_name(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -3571,6 +3623,7 @@ func (ec *executionContext) ___Field_description(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Field_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -3615,6 +3668,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -3669,6 +3723,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -3735,6 +3790,7 @@ func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Field_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -3776,6 +3832,7 @@ func (ec *executionContext) ___Field_deprecationReason(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Field_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -3820,6 +3877,7 @@ func (ec *executionContext) ___InputValue_name(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -3861,6 +3919,7 @@ func (ec *executionContext) ___InputValue_description(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___InputValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -3905,6 +3964,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -3968,6 +4028,7 @@ func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -4009,6 +4070,7 @@ func (ec *executionContext) ___Schema_description(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Schema_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -4053,6 +4115,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext___Schema_types(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -4119,6 +4182,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Schema_queryType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -4182,6 +4246,7 @@ func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Schema_mutationType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -4245,6 +4310,7 @@ func (ec *executionContext) ___Schema_subscriptionType(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Schema_subscriptionType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -4311,6 +4377,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Schema_directives(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -4367,6 +4434,7 @@ func (ec *executionContext) ___Type_kind(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -4408,6 +4476,7 @@ func (ec *executionContext) ___Type_name(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -4449,6 +4518,7 @@ func (ec *executionContext) ___Type_description(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -4490,6 +4560,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_fields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -4556,6 +4627,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_interfaces(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -4619,6 +4691,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Type_possibleTypes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -4682,6 +4755,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_enumValues(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -4744,6 +4818,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_inputFields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -4795,6 +4870,7 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_ofType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -4858,6 +4934,7 @@ func (ec *executionContext) ___Type_specifiedByURL(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -4920,6 +4997,8 @@ func (ec *executionContext) unmarshalInputReviewInput(ctx context.Context, obj i
 // region    ************************** interface.gotpl ***************************
 
 func (ec *executionContext) _Character(ctx context.Context, sel ast.SelectionSet, obj models.Character) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
@@ -4943,6 +5022,8 @@ func (ec *executionContext) _Character(ctx context.Context, sel ast.SelectionSet
 }
 
 func (ec *executionContext) _SearchResult(ctx context.Context, sel ast.SelectionSet, obj models.SearchResult) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
@@ -5001,6 +5082,7 @@ func (ec *executionContext) _Droid(ctx context.Context, sel ast.SelectionSet, ob
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -5034,6 +5116,7 @@ func (ec *executionContext) _Droid(ctx context.Context, sel ast.SelectionSet, ob
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -5116,6 +5199,7 @@ func (ec *executionContext) _FriendsConnection(ctx context.Context, sel ast.Sele
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -5149,6 +5233,7 @@ func (ec *executionContext) _FriendsConnection(ctx context.Context, sel ast.Sele
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -5279,6 +5364,7 @@ func (ec *executionContext) _Human(ctx context.Context, sel ast.SelectionSet, ob
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -5312,6 +5398,7 @@ func (ec *executionContext) _Human(ctx context.Context, sel ast.SelectionSet, ob
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -5353,6 +5440,7 @@ func (ec *executionContext) _Human(ctx context.Context, sel ast.SelectionSet, ob
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -5533,6 +5621,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -5552,6 +5641,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -5574,6 +5664,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -5596,6 +5687,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -5615,6 +5707,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -5634,6 +5727,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -5653,6 +5747,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -5767,6 +5862,7 @@ func (ec *executionContext) _Starship(ctx context.Context, sel ast.SelectionSet,
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -6159,6 +6255,8 @@ func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -6169,6 +6267,8 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 }
 
 func (ec *executionContext) marshalNCharacter2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐCharacter(ctx context.Context, sel ast.SelectionSet, v models.Character) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -6185,6 +6285,8 @@ func (ec *executionContext) unmarshalNEpisode2githubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalNEpisode2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐEpisode(ctx context.Context, sel ast.SelectionSet, v models.Episode) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return v
 }
 
@@ -6206,6 +6308,8 @@ func (ec *executionContext) unmarshalNEpisode2ᚕgithubᚗcomᚋ99designsᚋgqlg
 }
 
 func (ec *executionContext) marshalNEpisode2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐEpisodeᚄ(ctx context.Context, sel ast.SelectionSet, v []models.Episode) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -6255,6 +6359,8 @@ func (ec *executionContext) unmarshalNFloat2float64(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalNFloat2float64(ctx context.Context, sel ast.SelectionSet, v float64) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalFloatContext(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -6265,10 +6371,14 @@ func (ec *executionContext) marshalNFloat2float64(ctx context.Context, sel ast.S
 }
 
 func (ec *executionContext) marshalNFriendsConnection2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐFriendsConnection(ctx context.Context, sel ast.SelectionSet, v models.FriendsConnection) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec._FriendsConnection(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNFriendsConnection2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐFriendsConnection(ctx context.Context, sel ast.SelectionSet, v *models.FriendsConnection) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -6279,6 +6389,8 @@ func (ec *executionContext) marshalNFriendsConnection2ᚖgithubᚗcomᚋ99design
 }
 
 func (ec *executionContext) marshalNFriendsEdge2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐFriendsEdge(ctx context.Context, sel ast.SelectionSet, v *models.FriendsEdge) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -6294,6 +6406,8 @@ func (ec *executionContext) unmarshalNID2string(ctx context.Context, v interface
 }
 
 func (ec *executionContext) marshalNID2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalID(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -6309,6 +6423,8 @@ func (ec *executionContext) unmarshalNInt2int(ctx context.Context, v interface{}
 }
 
 func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.SelectionSet, v int) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalInt(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -6336,6 +6452,8 @@ func (ec *executionContext) unmarshalNInt2ᚕintᚄ(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalNInt2ᚕintᚄ(ctx context.Context, sel ast.SelectionSet, v []int) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	for i := range v {
 		ret[i] = ec.marshalNInt2int(ctx, sel, v[i])
@@ -6368,6 +6486,8 @@ func (ec *executionContext) unmarshalNInt2ᚕᚕintᚄ(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalNInt2ᚕᚕintᚄ(ctx context.Context, sel ast.SelectionSet, v [][]int) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	for i := range v {
 		ret[i] = ec.marshalNInt2ᚕintᚄ(ctx, sel, v[i])
@@ -6383,18 +6503,26 @@ func (ec *executionContext) marshalNInt2ᚕᚕintᚄ(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalNMutation2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐMutation(ctx context.Context, sel ast.SelectionSet, v models.Mutation) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec._Mutation(ctx, sel)
 }
 
 func (ec *executionContext) marshalNPageInfo2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐPageInfo(ctx context.Context, sel ast.SelectionSet, v models.PageInfo) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec._PageInfo(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNQuery2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐQuery(ctx context.Context, sel ast.SelectionSet, v models.Query) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec._Query(ctx, sel)
 }
 
 func (ec *executionContext) marshalNReview2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐReviewᚄ(ctx context.Context, sel ast.SelectionSet, v []*models.Review) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -6439,6 +6567,8 @@ func (ec *executionContext) marshalNReview2ᚕᚖgithubᚗcomᚋ99designsᚋgqlg
 }
 
 func (ec *executionContext) marshalNReview2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐReview(ctx context.Context, sel ast.SelectionSet, v *models.Review) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -6454,6 +6584,8 @@ func (ec *executionContext) unmarshalNReviewInput2githubᚗcomᚋ99designsᚋgql
 }
 
 func (ec *executionContext) marshalNSearchResult2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐSearchResult(ctx context.Context, sel ast.SelectionSet, v models.SearchResult) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -6464,6 +6596,8 @@ func (ec *executionContext) marshalNSearchResult2githubᚗcomᚋ99designsᚋgqlg
 }
 
 func (ec *executionContext) marshalNSearchResult2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐSearchResultᚄ(ctx context.Context, sel ast.SelectionSet, v []models.SearchResult) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -6508,6 +6642,8 @@ func (ec *executionContext) marshalNSearchResult2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalNStarship2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐStarship(ctx context.Context, sel ast.SelectionSet, v *models.Starship) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -6523,6 +6659,8 @@ func (ec *executionContext) unmarshalNString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -6533,10 +6671,14 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Directive(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -6586,6 +6728,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2string(ctx context.Con
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -6613,6 +6757,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2ᚕstringᚄ(ctx conte
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -6657,18 +6803,26 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context
 }
 
 func (ec *executionContext) marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx context.Context, sel ast.SelectionSet, v introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___EnumValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx context.Context, sel ast.SelectionSet, v introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Field(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx context.Context, sel ast.SelectionSet, v introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___InputValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -6713,10 +6867,14 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Type(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -6761,6 +6919,8 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalN__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -6776,6 +6936,8 @@ func (ec *executionContext) unmarshalN__TypeKind2string(ctx context.Context, v i
 }
 
 func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -6791,6 +6953,8 @@ func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalOBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	return res
 }
@@ -6804,6 +6968,8 @@ func (ec *executionContext) unmarshalOBoolean2ᚖbool(ctx context.Context, v int
 }
 
 func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast.SelectionSet, v *bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -6812,6 +6978,8 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 }
 
 func (ec *executionContext) marshalOCharacter2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐCharacter(ctx context.Context, sel ast.SelectionSet, v models.Character) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -6819,6 +6987,8 @@ func (ec *executionContext) marshalOCharacter2githubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalOCharacter2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐCharacterᚄ(ctx context.Context, sel ast.SelectionSet, v []models.Character) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -6866,6 +7036,8 @@ func (ec *executionContext) marshalOCharacter2ᚕgithubᚗcomᚋ99designsᚋgqlg
 }
 
 func (ec *executionContext) marshalODroid2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐDroid(ctx context.Context, sel ast.SelectionSet, v *models.Droid) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -6882,6 +7054,8 @@ func (ec *executionContext) unmarshalOEpisode2ᚖgithubᚗcomᚋ99designsᚋgqlg
 }
 
 func (ec *executionContext) marshalOEpisode2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐEpisode(ctx context.Context, sel ast.SelectionSet, v *models.Episode) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -6894,11 +7068,15 @@ func (ec *executionContext) unmarshalOFloat2float64(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalOFloat2float64(ctx context.Context, sel ast.SelectionSet, v float64) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalFloatContext(v)
 	return graphql.WrapContextMarshaler(ctx, res)
 }
 
 func (ec *executionContext) marshalOFriendsEdge2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐFriendsEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*models.FriendsEdge) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -6946,6 +7124,8 @@ func (ec *executionContext) marshalOFriendsEdge2ᚕᚖgithubᚗcomᚋ99designs�
 }
 
 func (ec *executionContext) marshalOHuman2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐHuman(ctx context.Context, sel ast.SelectionSet, v *models.Human) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -6961,6 +7141,8 @@ func (ec *executionContext) unmarshalOID2ᚖstring(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalOID2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -6977,6 +7159,8 @@ func (ec *executionContext) unmarshalOInt2ᚖint(ctx context.Context, v interfac
 }
 
 func (ec *executionContext) marshalOInt2ᚖint(ctx context.Context, sel ast.SelectionSet, v *int) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -6991,6 +7175,8 @@ func (ec *executionContext) unmarshalOLengthUnit2githubᚗcomᚋ99designsᚋgqlg
 }
 
 func (ec *executionContext) marshalOLengthUnit2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐLengthUnit(ctx context.Context, sel ast.SelectionSet, v models.LengthUnit) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return v
 }
 
@@ -7004,6 +7190,8 @@ func (ec *executionContext) unmarshalOLengthUnit2ᚖgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalOLengthUnit2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐLengthUnit(ctx context.Context, sel ast.SelectionSet, v *models.LengthUnit) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -7011,6 +7199,8 @@ func (ec *executionContext) marshalOLengthUnit2ᚖgithubᚗcomᚋ99designsᚋgql
 }
 
 func (ec *executionContext) marshalOReview2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐReview(ctx context.Context, sel ast.SelectionSet, v *models.Review) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -7018,6 +7208,8 @@ func (ec *executionContext) marshalOReview2ᚖgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalOStarship2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐStarshipᚄ(ctx context.Context, sel ast.SelectionSet, v []*models.Starship) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -7065,6 +7257,8 @@ func (ec *executionContext) marshalOStarship2ᚕᚖgithubᚗcomᚋ99designsᚋgq
 }
 
 func (ec *executionContext) marshalOStarship2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐStarship(ctx context.Context, sel ast.SelectionSet, v *models.Starship) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -7077,6 +7271,8 @@ func (ec *executionContext) unmarshalOString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalOString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	return res
 }
@@ -7090,6 +7286,8 @@ func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -7103,6 +7301,8 @@ func (ec *executionContext) unmarshalOTime2timeᚐTime(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalOTime2timeᚐTime(ctx context.Context, sel ast.SelectionSet, v time.Time) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalTime(v)
 	return res
 }
@@ -7116,6 +7316,8 @@ func (ec *executionContext) unmarshalOTime2ᚖtimeᚐTime(ctx context.Context, v
 }
 
 func (ec *executionContext) marshalOTime2ᚖtimeᚐTime(ctx context.Context, sel ast.SelectionSet, v *time.Time) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -7124,6 +7326,8 @@ func (ec *executionContext) marshalOTime2ᚖtimeᚐTime(ctx context.Context, sel
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -7171,6 +7375,8 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 }
 
 func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -7218,6 +7424,8 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -7265,6 +7473,8 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx context.Context, sel ast.SelectionSet, v *introspection.Schema) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -7272,6 +7482,8 @@ func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -7319,6 +7531,8 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}

--- a/_examples/todo/generated.go
+++ b/_examples/todo/generated.go
@@ -555,6 +555,7 @@ func (ec *executionContext) _MyMutation_createTodo(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext_MyMutation_createTodo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "MyMutation",
 		Field:      field,
@@ -612,6 +613,7 @@ func (ec *executionContext) _MyMutation_updateTodo(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext_MyMutation_updateTodo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "MyMutation",
 		Field:      field,
@@ -669,6 +671,7 @@ func (ec *executionContext) _MyQuery_todo(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_MyQuery_todo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "MyQuery",
 		Field:      field,
@@ -726,6 +729,7 @@ func (ec *executionContext) _MyQuery_lastTodo(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext_MyQuery_lastTodo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "MyQuery",
 		Field:      field,
@@ -775,6 +779,7 @@ func (ec *executionContext) _MyQuery_todos(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_MyQuery_todos(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "MyQuery",
 		Field:      field,
@@ -821,6 +826,7 @@ func (ec *executionContext) _MyQuery___type(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_MyQuery___type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "MyQuery",
 		Field:      field,
@@ -892,6 +898,7 @@ func (ec *executionContext) _MyQuery___schema(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext_MyQuery___schema(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "MyQuery",
 		Field:      field,
@@ -947,6 +954,7 @@ func (ec *executionContext) _Todo_id(ctx context.Context, field graphql.Collecte
 }
 
 func (ec *executionContext) fieldContext_Todo_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Todo",
 		Field:      field,
@@ -988,6 +996,7 @@ func (ec *executionContext) _Todo_text(ctx context.Context, field graphql.Collec
 }
 
 func (ec *executionContext) fieldContext_Todo_text(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Todo",
 		Field:      field,
@@ -1053,6 +1062,7 @@ func (ec *executionContext) _Todo_done(ctx context.Context, field graphql.Collec
 }
 
 func (ec *executionContext) fieldContext_Todo_done(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Todo",
 		Field:      field,
@@ -1094,6 +1104,7 @@ func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1132,6 +1143,7 @@ func (ec *executionContext) ___Directive_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___Directive_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1173,6 +1185,7 @@ func (ec *executionContext) ___Directive_locations(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Directive_locations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1214,6 +1227,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1265,6 +1279,7 @@ func (ec *executionContext) ___Directive_isRepeatable(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___Directive_isRepeatable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1306,6 +1321,7 @@ func (ec *executionContext) ___EnumValue_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___EnumValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1344,6 +1360,7 @@ func (ec *executionContext) ___EnumValue_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1385,6 +1402,7 @@ func (ec *executionContext) ___EnumValue_isDeprecated(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___EnumValue_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1423,6 +1441,7 @@ func (ec *executionContext) ___EnumValue_deprecationReason(ctx context.Context, 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1464,6 +1483,7 @@ func (ec *executionContext) ___Field_name(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1502,6 +1522,7 @@ func (ec *executionContext) ___Field_description(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Field_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1543,6 +1564,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1594,6 +1616,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1657,6 +1680,7 @@ func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Field_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1695,6 +1719,7 @@ func (ec *executionContext) ___Field_deprecationReason(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Field_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1736,6 +1761,7 @@ func (ec *executionContext) ___InputValue_name(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1774,6 +1800,7 @@ func (ec *executionContext) ___InputValue_description(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___InputValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1815,6 +1842,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1875,6 +1903,7 @@ func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1913,6 +1942,7 @@ func (ec *executionContext) ___Schema_description(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Schema_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1954,6 +1984,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext___Schema_types(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2017,6 +2048,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Schema_queryType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2077,6 +2109,7 @@ func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Schema_mutationType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2137,6 +2170,7 @@ func (ec *executionContext) ___Schema_subscriptionType(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Schema_subscriptionType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2200,6 +2234,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Schema_directives(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2253,6 +2288,7 @@ func (ec *executionContext) ___Type_kind(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2291,6 +2327,7 @@ func (ec *executionContext) ___Type_name(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2329,6 +2366,7 @@ func (ec *executionContext) ___Type_description(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2367,6 +2405,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_fields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2430,6 +2469,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_interfaces(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2490,6 +2530,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Type_possibleTypes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2550,6 +2591,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_enumValues(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2609,6 +2651,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_inputFields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2657,6 +2700,7 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_ofType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2717,6 +2761,7 @@ func (ec *executionContext) ___Type_specifiedByURL(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2851,6 +2896,7 @@ func (ec *executionContext) _MyQuery(ctx context.Context, sel ast.SelectionSet) 
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -2870,6 +2916,7 @@ func (ec *executionContext) _MyQuery(ctx context.Context, sel ast.SelectionSet) 
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -2889,6 +2936,7 @@ func (ec *executionContext) _MyQuery(ctx context.Context, sel ast.SelectionSet) 
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3319,6 +3367,8 @@ func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3334,6 +3384,8 @@ func (ec *executionContext) unmarshalNID2int(ctx context.Context, v interface{})
 }
 
 func (ec *executionContext) marshalNID2int(ctx context.Context, sel ast.SelectionSet, v int) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalIntID(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3349,6 +3401,8 @@ func (ec *executionContext) unmarshalNMap2map(ctx context.Context, v interface{}
 }
 
 func (ec *executionContext) marshalNMap2map(ctx context.Context, sel ast.SelectionSet, v map[string]interface{}) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3371,6 +3425,8 @@ func (ec *executionContext) unmarshalNRole2githubᚗcomᚋ99designsᚋgqlgenᚋ_
 }
 
 func (ec *executionContext) marshalNRole2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋtodoᚐRole(ctx context.Context, sel ast.SelectionSet, v Role) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return v
 }
 
@@ -3380,6 +3436,8 @@ func (ec *executionContext) unmarshalNString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3390,10 +3448,14 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 }
 
 func (ec *executionContext) marshalNTodo2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋtodoᚐTodo(ctx context.Context, sel ast.SelectionSet, v Todo) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec._Todo(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNTodo2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋtodoᚐTodoᚄ(ctx context.Context, sel ast.SelectionSet, v []*Todo) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3438,6 +3500,8 @@ func (ec *executionContext) marshalNTodo2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalNTodo2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋtodoᚐTodo(ctx context.Context, sel ast.SelectionSet, v *Todo) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3453,10 +3517,14 @@ func (ec *executionContext) unmarshalNTodoInput2githubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Directive(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3506,6 +3574,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2string(ctx context.Con
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3533,6 +3603,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2ᚕstringᚄ(ctx conte
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3577,18 +3649,26 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context
 }
 
 func (ec *executionContext) marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx context.Context, sel ast.SelectionSet, v introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___EnumValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx context.Context, sel ast.SelectionSet, v introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Field(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx context.Context, sel ast.SelectionSet, v introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___InputValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3633,10 +3713,14 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Type(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3681,6 +3765,8 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalN__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3696,6 +3782,8 @@ func (ec *executionContext) unmarshalN__TypeKind2string(ctx context.Context, v i
 }
 
 func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3711,6 +3799,8 @@ func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalOBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	return res
 }
@@ -3724,6 +3814,8 @@ func (ec *executionContext) unmarshalOBoolean2ᚖbool(ctx context.Context, v int
 }
 
 func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast.SelectionSet, v *bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3740,6 +3832,8 @@ func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3748,6 +3842,8 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalOTodo2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋtodoᚐTodo(ctx context.Context, sel ast.SelectionSet, v *Todo) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3755,6 +3851,8 @@ func (ec *executionContext) marshalOTodo2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3802,6 +3900,8 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 }
 
 func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3849,6 +3949,8 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3896,6 +3998,8 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx context.Context, sel ast.SelectionSet, v *introspection.Schema) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3903,6 +4007,8 @@ func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3950,6 +4056,8 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}

--- a/_examples/type-system-extension/generated.go
+++ b/_examples/type-system-extension/generated.go
@@ -424,6 +424,7 @@ func (ec *executionContext) _MyMutation_createTodo(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext_MyMutation_createTodo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "MyMutation",
 		Field:      field,
@@ -509,6 +510,7 @@ func (ec *executionContext) _MyQuery_todos(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_MyQuery_todos(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "MyQuery",
 		Field:      field,
@@ -580,6 +582,7 @@ func (ec *executionContext) _MyQuery_todo(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext_MyQuery_todo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "MyQuery",
 		Field:      field,
@@ -642,6 +645,7 @@ func (ec *executionContext) _MyQuery___type(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_MyQuery___type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "MyQuery",
 		Field:      field,
@@ -716,6 +720,7 @@ func (ec *executionContext) _MyQuery___schema(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext_MyQuery___schema(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "MyQuery",
 		Field:      field,
@@ -774,6 +779,7 @@ func (ec *executionContext) _Todo_id(ctx context.Context, field graphql.Collecte
 }
 
 func (ec *executionContext) fieldContext_Todo_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Todo",
 		Field:      field,
@@ -818,6 +824,7 @@ func (ec *executionContext) _Todo_text(ctx context.Context, field graphql.Collec
 }
 
 func (ec *executionContext) fieldContext_Todo_text(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Todo",
 		Field:      field,
@@ -862,6 +869,7 @@ func (ec *executionContext) _Todo_state(ctx context.Context, field graphql.Colle
 }
 
 func (ec *executionContext) fieldContext_Todo_state(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Todo",
 		Field:      field,
@@ -926,6 +934,7 @@ func (ec *executionContext) _Todo_verified(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext_Todo_verified(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "Todo",
 		Field:      field,
@@ -970,6 +979,7 @@ func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1011,6 +1021,7 @@ func (ec *executionContext) ___Directive_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___Directive_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1055,6 +1066,7 @@ func (ec *executionContext) ___Directive_locations(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Directive_locations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1099,6 +1111,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___Directive_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1153,6 +1166,7 @@ func (ec *executionContext) ___Directive_isRepeatable(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___Directive_isRepeatable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Directive",
 		Field:      field,
@@ -1197,6 +1211,7 @@ func (ec *executionContext) ___EnumValue_name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext___EnumValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1238,6 +1253,7 @@ func (ec *executionContext) ___EnumValue_description(ctx context.Context, field 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1282,6 +1298,7 @@ func (ec *executionContext) ___EnumValue_isDeprecated(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___EnumValue_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1323,6 +1340,7 @@ func (ec *executionContext) ___EnumValue_deprecationReason(ctx context.Context, 
 }
 
 func (ec *executionContext) fieldContext___EnumValue_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__EnumValue",
 		Field:      field,
@@ -1367,6 +1385,7 @@ func (ec *executionContext) ___Field_name(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1408,6 +1427,7 @@ func (ec *executionContext) ___Field_description(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Field_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1452,6 +1472,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1506,6 +1527,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 }
 
 func (ec *executionContext) fieldContext___Field_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1572,6 +1594,7 @@ func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Field_isDeprecated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1613,6 +1636,7 @@ func (ec *executionContext) ___Field_deprecationReason(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Field_deprecationReason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Field",
 		Field:      field,
@@ -1657,6 +1681,7 @@ func (ec *executionContext) ___InputValue_name(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1698,6 +1723,7 @@ func (ec *executionContext) ___InputValue_description(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext___InputValue_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1742,6 +1768,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___InputValue_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1805,6 +1832,7 @@ func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__InputValue",
 		Field:      field,
@@ -1846,6 +1874,7 @@ func (ec *executionContext) ___Schema_description(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Schema_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1890,6 +1919,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext___Schema_types(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -1956,6 +1986,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Schema_queryType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2019,6 +2050,7 @@ func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Schema_mutationType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2082,6 +2114,7 @@ func (ec *executionContext) ___Schema_subscriptionType(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext___Schema_subscriptionType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2148,6 +2181,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 }
 
 func (ec *executionContext) fieldContext___Schema_directives(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Schema",
 		Field:      field,
@@ -2204,6 +2238,7 @@ func (ec *executionContext) ___Type_kind(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2245,6 +2280,7 @@ func (ec *executionContext) ___Type_name(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext___Type_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2286,6 +2322,7 @@ func (ec *executionContext) ___Type_description(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2327,6 +2364,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_fields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2393,6 +2431,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_interfaces(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2456,6 +2495,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext___Type_possibleTypes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2519,6 +2559,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext___Type_enumValues(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2581,6 +2622,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext___Type_inputFields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2632,6 +2674,7 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 }
 
 func (ec *executionContext) fieldContext___Type_ofType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2695,6 +2738,7 @@ func (ec *executionContext) ___Type_specifiedByURL(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object:     "__Type",
 		Field:      field,
@@ -2756,6 +2800,8 @@ func (ec *executionContext) unmarshalInputTodoInput(ctx context.Context, obj int
 // region    ************************** interface.gotpl ***************************
 
 func (ec *executionContext) _Data(ctx context.Context, sel ast.SelectionSet, obj Data) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
@@ -2772,6 +2818,8 @@ func (ec *executionContext) _Data(ctx context.Context, sel ast.SelectionSet, obj
 }
 
 func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj Node) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
@@ -2863,6 +2911,7 @@ func (ec *executionContext) _MyQuery(ctx context.Context, sel ast.SelectionSet) 
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -2885,6 +2934,7 @@ func (ec *executionContext) _MyQuery(ctx context.Context, sel ast.SelectionSet) 
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				var _ = fs
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
@@ -3317,6 +3367,8 @@ func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3332,6 +3384,8 @@ func (ec *executionContext) unmarshalNID2string(ctx context.Context, v interface
 }
 
 func (ec *executionContext) marshalNID2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalID(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3348,6 +3402,8 @@ func (ec *executionContext) unmarshalNState2githubᚗcomᚋ99designsᚋgqlgenᚋ
 }
 
 func (ec *executionContext) marshalNState2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋtypeᚑsystemᚑextensionᚐState(ctx context.Context, sel ast.SelectionSet, v State) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return v
 }
 
@@ -3357,6 +3413,8 @@ func (ec *executionContext) unmarshalNString2string(ctx context.Context, v inter
 }
 
 func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3367,10 +3425,14 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 }
 
 func (ec *executionContext) marshalNTodo2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋtypeᚑsystemᚑextensionᚐTodo(ctx context.Context, sel ast.SelectionSet, v Todo) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec._Todo(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNTodo2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋtypeᚑsystemᚑextensionᚐTodoᚄ(ctx context.Context, sel ast.SelectionSet, v []*Todo) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3415,6 +3477,8 @@ func (ec *executionContext) marshalNTodo2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalNTodo2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋtypeᚑsystemᚑextensionᚐTodo(ctx context.Context, sel ast.SelectionSet, v *Todo) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3430,10 +3494,14 @@ func (ec *executionContext) unmarshalNTodoInput2githubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Directive(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Directive) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3483,6 +3551,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2string(ctx context.Con
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3510,6 +3580,8 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2ᚕstringᚄ(ctx conte
 }
 
 func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3554,18 +3626,26 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context
 }
 
 func (ec *executionContext) marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx context.Context, sel ast.SelectionSet, v introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___EnumValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx context.Context, sel ast.SelectionSet, v introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Field(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx context.Context, sel ast.SelectionSet, v introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___InputValue(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3610,10 +3690,14 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	return ec.___Type(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -3658,6 +3742,8 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalN__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -3673,6 +3759,8 @@ func (ec *executionContext) unmarshalN__TypeKind2string(ctx context.Context, v i
 }
 
 func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalString(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -3688,6 +3776,8 @@ func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interf
 }
 
 func (ec *executionContext) marshalOBoolean2bool(ctx context.Context, sel ast.SelectionSet, v bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	res := graphql.MarshalBoolean(v)
 	return res
 }
@@ -3701,6 +3791,8 @@ func (ec *executionContext) unmarshalOBoolean2ᚖbool(ctx context.Context, v int
 }
 
 func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast.SelectionSet, v *bool) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3717,6 +3809,8 @@ func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v in
 }
 
 func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3725,6 +3819,8 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 }
 
 func (ec *executionContext) marshalOTodo2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋtypeᚑsystemᚑextensionᚐTodo(ctx context.Context, sel ast.SelectionSet, v *Todo) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3732,6 +3828,8 @@ func (ec *executionContext) marshalOTodo2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3779,6 +3877,8 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 }
 
 func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Field) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3826,6 +3926,8 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3873,6 +3975,8 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 }
 
 func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx context.Context, sel ast.SelectionSet, v *introspection.Schema) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3880,6 +3984,8 @@ func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}
@@ -3927,6 +4033,8 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 }
 
 func (ec *executionContext) marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	if v == nil {
 		return graphql.Null
 	}

--- a/codegen/field.gotpl
+++ b/codegen/field.gotpl
@@ -21,7 +21,7 @@ func (ec *executionContext) _{{$object.Name}}_{{$field.Name}}(ctx context.Contex
 			res := &{{ $field.TypeReference.Elem.GO | ref }}{}
 		{{- else }}
 			res := {{ $field.TypeReference.GO | ref }}{}
-		{{- end }} 
+		{{- end }}
 		fc.Result = res
 		return ec.{{ $field.TypeReference.MarshalFunc }}(ctx, field.Selections, res)
 	{{- else}}
@@ -73,6 +73,7 @@ func (ec *executionContext) _{{$object.Name}}_{{$field.Name}}(ctx context.Contex
 }
 
 func (ec *executionContext) {{ $field.FieldContextFunc }}(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	var _ = ctx
 	fc = &graphql.FieldContext{
 		Object: {{quote $field.Object.Name}},
 		Field: field,

--- a/codegen/interface.gotpl
+++ b/codegen/interface.gotpl
@@ -1,6 +1,8 @@
 {{- range $interface := .Interfaces }}
 
 func (ec *executionContext) _{{$interface.Name}}(ctx context.Context, sel ast.SelectionSet, obj {{$interface.Type | ref}}) graphql.Marshaler {
+	var _ = ctx
+	var _ = sel
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null

--- a/codegen/object.gotpl
+++ b/codegen/object.gotpl
@@ -49,6 +49,7 @@ func (ec *executionContext) _{{$object.Name}}(ctx context.Context, sel ast.Selec
 				field := field
 
 				innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+					var _ = fs
 					defer func() {
 						if r := recover(); r != nil {
 							ec.Error(ctx, ec.Recover(ctx, r))

--- a/codegen/type.gotpl
+++ b/codegen/type.gotpl
@@ -90,6 +90,8 @@
 
 	{{ with $type.MarshalFunc }}
 		func (ec *executionContext) {{ . }}(ctx context.Context, sel ast.SelectionSet, v {{ $type.GO | ref }}) graphql.Marshaler {
+			var _ = ctx
+			var _ = sel
 			{{- if or $type.IsPtrToSlice $type.IsPtrToIntf }}
 				return ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, *v)
 			{{- else if $type.IsSlice }}


### PR DESCRIPTION
alternative to https://github.com/99designs/gqlgen/pull/2999

Found a few more while doing development, gopls/vscode was warning about more variables that are undefined.
Instead of having even more complex logic for making variables _, just assigned them to nothing so they would get used.

That only leaves one left in generate.go for me

![image](https://github.com/99designs/gqlgen/assets/110087/e987c966-a0f2-4af9-bd15-7190bae03915)

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
