### PR TITLE
chore: update Automatic Persisted Queries Link

### DIFF
--- a/docs/content/reference/apq.md
+++ b/docs/content/reference/apq.md
@@ -14,7 +14,7 @@ to register query hash with original query on a server.
 ## Usage
 
 In order to enable Automatic Persisted Queries you need to change your client. For more information see
-[Automatic Persisted Queries Link](https://www.apollographql.com/docs/resources/graphql-glossary/#automatic-persisted-queries-apq) documentation.
+[Automatic Persisted Queries Link](https://www.apollographql.com/docs/resources/glossary/#automatic-persisted-queries) documentation.
 
 For the server you need to implement the `graphql.Cache` interface and pass an instance to
 the `extension.AutomaticPersistedQuery` type. Make sure the extension is applied to your GraphQL handler.


### PR DESCRIPTION
Current url hash does not match `automatic persisted queries`. 
Therefore, this changed it.

* https://www.apollographql.com/docs/resources/graphql-glossary/#automatic-persisted-queries-apq

* https://www.apollographql.com/docs/resources/glossary/#automatic-persisted-queries

I have:
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
