### PR TITLE
Fix test asserts: reverse expected and actual params

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,10 @@ run:
 linters-settings:
   errcheck:
     ignore: fmt:.*,[rR]ead|[wW]rite|[cC]lose,io:Copy
+  testifylint:
+    disable-all: true
+    enable:
+      - expected-actual
 
 linters:
   disable-all: true
@@ -23,6 +27,7 @@ linters:
     - nakedret
     - prealloc
     - staticcheck
+    - testifylint
     - typecheck
     - unconvert
     - unused

--- a/codegen/config/binder_test.go
+++ b/codegen/config/binder_test.go
@@ -28,7 +28,7 @@ func TestSlicePointerBinding(t *testing.T) {
 			panic(err)
 		}
 
-		require.Equal(t, ta.GO.String(), "[]*github.com/99designs/gqlgen/codegen/config/testdata/autobinding/chat.Message")
+		require.Equal(t, "[]*github.com/99designs/gqlgen/codegen/config/testdata/autobinding/chat.Message", ta.GO.String())
 	})
 
 	t.Run("with OmitSliceElementPointers", func(t *testing.T) {
@@ -41,7 +41,7 @@ func TestSlicePointerBinding(t *testing.T) {
 			panic(err)
 		}
 
-		require.Equal(t, ta.GO.String(), "[]github.com/99designs/gqlgen/codegen/config/testdata/autobinding/chat.Message")
+		require.Equal(t, "[]github.com/99designs/gqlgen/codegen/config/testdata/autobinding/chat.Message", ta.GO.String())
 	})
 }
 

--- a/codegen/config/config_test.go
+++ b/codegen/config/config_test.go
@@ -48,11 +48,11 @@ func TestReadConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		if runtime.GOOS == "windows" {
-			require.Equal(t, c.SchemaFilename[0], `testdata\cfg\glob\bar\bar with spaces.graphql`)
-			require.Equal(t, c.SchemaFilename[1], `testdata\cfg\glob\foo\foo.graphql`)
+			require.Equal(t, `testdata\cfg\glob\bar\bar with spaces.graphql`, c.SchemaFilename[0])
+			require.Equal(t, `testdata\cfg\glob\foo\foo.graphql`, c.SchemaFilename[1])
 		} else {
-			require.Equal(t, c.SchemaFilename[0], "testdata/cfg/glob/bar/bar with spaces.graphql")
-			require.Equal(t, c.SchemaFilename[1], "testdata/cfg/glob/foo/foo.graphql")
+			require.Equal(t, "testdata/cfg/glob/bar/bar with spaces.graphql", c.SchemaFilename[0])
+			require.Equal(t, "testdata/cfg/glob/foo/foo.graphql", c.SchemaFilename[1])
 		}
 	})
 

--- a/codegen/config/package_test.go
+++ b/codegen/config/package_test.go
@@ -14,7 +14,7 @@ func TestPackageConfig(t *testing.T) {
 
 		require.NoError(t, p.Check())
 
-		require.Equal(t, p.Package, "config_test_data")
+		require.Equal(t, "config_test_data", p.Package)
 		require.Equal(t, "github.com/99designs/gqlgen/codegen/config/testdata", p.ImportPath())
 
 		require.Equal(t, "config_test_data", p.Pkg().Name())
@@ -30,7 +30,7 @@ func TestPackageConfig(t *testing.T) {
 
 		require.NoError(t, p.Check())
 
-		require.Equal(t, p.Package, "wololo")
+		require.Equal(t, "wololo", p.Package)
 		require.Equal(t, "github.com/99designs/gqlgen/codegen/config/testdata", p.ImportPath())
 
 		require.Equal(t, "wololo", p.Pkg().Name())

--- a/codegen/config/resolver_test.go
+++ b/codegen/config/resolver_test.go
@@ -16,7 +16,7 @@ func TestResolverConfig(t *testing.T) {
 			require.NoError(t, p.Check())
 			require.NoError(t, p.Check())
 
-			require.Equal(t, p.Package, "config_test_data")
+			require.Equal(t, "config_test_data", p.Package)
 			require.Equal(t, "github.com/99designs/gqlgen/codegen/config/testdata", p.ImportPath())
 
 			require.Equal(t, "config_test_data", p.Pkg().Name())
@@ -33,7 +33,7 @@ func TestResolverConfig(t *testing.T) {
 			require.NoError(t, p.Check())
 			require.NoError(t, p.Check())
 
-			require.Equal(t, p.Package, "wololo")
+			require.Equal(t, "wololo", p.Package)
 			require.Equal(t, "github.com/99designs/gqlgen/codegen/config/testdata", p.ImportPath())
 
 			require.Equal(t, "wololo", p.Pkg().Name())
@@ -81,7 +81,7 @@ func TestResolverConfig(t *testing.T) {
 			require.NoError(t, p.Check())
 			require.NoError(t, p.Check())
 
-			require.Equal(t, p.Package, "config_test_data")
+			require.Equal(t, "config_test_data", p.Package)
 			require.Equal(t, "github.com/99designs/gqlgen/codegen/config/testdata", p.ImportPath())
 
 			require.Equal(t, "config_test_data", p.Pkg().Name())
@@ -98,7 +98,7 @@ func TestResolverConfig(t *testing.T) {
 			require.NoError(t, p.Check())
 			require.NoError(t, p.Check())
 
-			require.Equal(t, p.Package, "wololo")
+			require.Equal(t, "wololo", p.Package)
 			require.Equal(t, "github.com/99designs/gqlgen/codegen/config/testdata", p.ImportPath())
 
 			require.Equal(t, "wololo", p.Pkg().Name())
@@ -115,7 +115,7 @@ func TestResolverConfig(t *testing.T) {
 			require.NoError(t, p.Check())
 			require.NoError(t, p.Check())
 
-			require.Equal(t, p.Package, "config_test_data")
+			require.Equal(t, "config_test_data", p.Package)
 			require.Equal(t, "github.com/99designs/gqlgen/codegen/config/testdata", p.ImportPath())
 
 			require.Equal(t, "config_test_data", p.Pkg().Name())

--- a/codegen/field_test.go
+++ b/codegen/field_test.go
@@ -190,7 +190,7 @@ func TestField_CallArgs(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
-			require.Equal(t, tc.CallArgs(), tc.Expected)
+			require.Equal(t, tc.Expected, tc.CallArgs())
 		})
 	}
 }

--- a/codegen/templates/templates_test.go
+++ b/codegen/templates/templates_test.go
@@ -308,7 +308,7 @@ func Test_wordWalker(t *testing.T) {
 
 	for i, at := range theTests {
 		t.Run(fmt.Sprintf("wordWalker-%d", i), func(t *testing.T) {
-			require.Equal(t, at.input, at.expected)
+			require.Equal(t, at.expected, at.input)
 		})
 	}
 }

--- a/codegen/testserver/followschema/defaults_test.go
+++ b/codegen/testserver/followschema/defaults_test.go
@@ -13,9 +13,9 @@ import (
 func assertDefaults(t *testing.T, ret *DefaultParametersMirror) {
 	require.NotNil(t, ret)
 	require.NotNil(t, ret.FalsyBoolean)
-	require.Equal(t, *ret.FalsyBoolean, false)
+	require.Equal(t, false, *ret.FalsyBoolean)
 	require.NotNil(t, ret.TruthyBoolean)
-	require.Equal(t, *ret.TruthyBoolean, true)
+	require.Equal(t, true, *ret.TruthyBoolean)
 }
 
 func TestDefaults(t *testing.T) {

--- a/codegen/testserver/followschema/directive_test.go
+++ b/codegen/testserver/followschema/directive_test.go
@@ -301,7 +301,7 @@ func TestDirectives(t *testing.T) {
 
 			c.MustPost(`query { directiveField@logged(id:"testes_id") }`, &resp)
 
-			require.Equal(t, resp.DirectiveField, `testes_id`)
+			require.Equal(t, `testes_id`, resp.DirectiveField)
 		})
 		t.Run("without field directive", func(t *testing.T) {
 			var resp struct {

--- a/codegen/testserver/followschema/embedded_test.go
+++ b/codegen/testserver/followschema/embedded_test.go
@@ -40,7 +40,7 @@ func TestEmbedded(t *testing.T) {
 		}
 		err := c.Post(`query { embeddedCase1 { exportedEmbeddedPointerExportedMethod } }`, &resp)
 		require.NoError(t, err)
-		require.Equal(t, resp.EmbeddedCase1.ExportedEmbeddedPointerExportedMethod, "ExportedEmbeddedPointerExportedMethodResponse")
+		require.Equal(t, "ExportedEmbeddedPointerExportedMethodResponse", resp.EmbeddedCase1.ExportedEmbeddedPointerExportedMethod)
 	})
 
 	t.Run("embedded case 2", func(t *testing.T) {
@@ -51,7 +51,7 @@ func TestEmbedded(t *testing.T) {
 		}
 		err := c.Post(`query { embeddedCase2 { unexportedEmbeddedPointerExportedMethod } }`, &resp)
 		require.NoError(t, err)
-		require.Equal(t, resp.EmbeddedCase2.UnexportedEmbeddedPointerExportedMethod, "UnexportedEmbeddedPointerExportedMethodResponse")
+		require.Equal(t, "UnexportedEmbeddedPointerExportedMethodResponse", resp.EmbeddedCase2.UnexportedEmbeddedPointerExportedMethod)
 	})
 
 	t.Run("embedded case 3", func(t *testing.T) {
@@ -62,6 +62,6 @@ func TestEmbedded(t *testing.T) {
 		}
 		err := c.Post(`query { embeddedCase3 { unexportedEmbeddedInterfaceExportedMethod } }`, &resp)
 		require.NoError(t, err)
-		require.Equal(t, resp.EmbeddedCase3.UnexportedEmbeddedInterfaceExportedMethod, "UnexportedEmbeddedInterfaceExportedMethod")
+		require.Equal(t, "UnexportedEmbeddedInterfaceExportedMethod", resp.EmbeddedCase3.UnexportedEmbeddedInterfaceExportedMethod)
 	})
 }

--- a/codegen/testserver/followschema/enums_test.go
+++ b/codegen/testserver/followschema/enums_test.go
@@ -26,7 +26,7 @@ func TestEnumsResolver(t *testing.T) {
 			enumInInput(input: {enum: OK})
 		}
 		`, &resp)
-		require.Equal(t, resp.EnumInInput, EnumTestOk)
+		require.Equal(t, EnumTestOk, resp.EnumInInput)
 	})
 
 	t.Run("input with invalid enum value", func(t *testing.T) {

--- a/codegen/testserver/followschema/mutation_with_custom_scalar_test.go
+++ b/codegen/testserver/followschema/mutation_with_custom_scalar_test.go
@@ -30,7 +30,7 @@ func TestErrorInsideMutationArgument(t *testing.T) {
 			&resp,
 			client.Var("input", input),
 		)
-		require.Equal(t, resp["updateSomething"], "Hello world")
+		require.Equal(t, "Hello world", resp["updateSomething"])
 		require.NoError(t, err)
 	})
 

--- a/codegen/testserver/followschema/nulls_test.go
+++ b/codegen/testserver/followschema/nulls_test.go
@@ -86,7 +86,7 @@ func TestNullBubbling(t *testing.T) {
 		err := c.Post(`query { valid, errorList { id } }`, &resp)
 
 		require.Nil(t, err)
-		require.Equal(t, len(resp.ErrorList), 1)
+		require.Equal(t, 1, len(resp.ErrorList))
 		require.Nil(t, resp.ErrorList[0])
 		require.Equal(t, "Ok", resp.Valid)
 	})

--- a/codegen/testserver/followschema/ptr_to_ptr_input_test.go
+++ b/codegen/testserver/followschema/ptr_to_ptr_input_test.go
@@ -77,14 +77,14 @@ func TestPtrToPtr(t *testing.T) {
 		err := c.Post(`mutation { updatePtrToPtr(input: { name: "newName" }) { name, inner { key, value }, stupidInner { key, value }}}`, &resp)
 		require.NoError(t, err)
 
-		require.Equal(t, resp.UpdatedPtrToPtr.Name, "newName")
+		require.Equal(t, "newName", resp.UpdatedPtrToPtr.Name)
 		require.NotNil(t, resp.UpdatedPtrToPtr.Inner)
-		require.Equal(t, resp.UpdatedPtrToPtr.Inner.Key, "oldKey")
-		require.Equal(t, resp.UpdatedPtrToPtr.Inner.Value, "oldValue")
+		require.Equal(t, "oldKey", resp.UpdatedPtrToPtr.Inner.Key)
+		require.Equal(t, "oldValue", resp.UpdatedPtrToPtr.Inner.Value)
 		require.NotNil(t, resp.UpdatedPtrToPtr.StupidInner)
 		require.NotNil(t, ******resp.UpdatedPtrToPtr.StupidInner)
-		require.Equal(t, (******resp.UpdatedPtrToPtr.StupidInner).Key, "oldStupidKey")
-		require.Equal(t, (******resp.UpdatedPtrToPtr.StupidInner).Value, "oldStupidValue")
+		require.Equal(t, "oldStupidKey", (******resp.UpdatedPtrToPtr.StupidInner).Key)
+		require.Equal(t, "oldStupidValue", (******resp.UpdatedPtrToPtr.StupidInner).Value)
 	})
 
 	t.Run("pointer to pointer input non-null", func(t *testing.T) {
@@ -101,14 +101,14 @@ func TestPtrToPtr(t *testing.T) {
 		}`, &resp)
 		require.NoError(t, err)
 
-		require.Equal(t, resp.UpdatedPtrToPtr.Name, "oldName")
+		require.Equal(t, "oldName", resp.UpdatedPtrToPtr.Name)
 		require.NotNil(t, resp.UpdatedPtrToPtr.Inner)
-		require.Equal(t, resp.UpdatedPtrToPtr.Inner.Key, "newKey")
-		require.Equal(t, resp.UpdatedPtrToPtr.Inner.Value, "newValue")
+		require.Equal(t, "newKey", resp.UpdatedPtrToPtr.Inner.Key)
+		require.Equal(t, "newValue", resp.UpdatedPtrToPtr.Inner.Value)
 		require.NotNil(t, resp.UpdatedPtrToPtr.StupidInner)
 		require.NotNil(t, ******resp.UpdatedPtrToPtr.StupidInner)
-		require.Equal(t, (******resp.UpdatedPtrToPtr.StupidInner).Key, "oldStupidKey")
-		require.Equal(t, (******resp.UpdatedPtrToPtr.StupidInner).Value, "oldStupidValue")
+		require.Equal(t, "oldStupidKey", (******resp.UpdatedPtrToPtr.StupidInner).Key)
+		require.Equal(t, "oldStupidValue", (******resp.UpdatedPtrToPtr.StupidInner).Value)
 	})
 
 	t.Run("pointer to pointer input null", func(t *testing.T) {
@@ -117,12 +117,12 @@ func TestPtrToPtr(t *testing.T) {
 		err := c.Post(`mutation { updatePtrToPtr(input: { inner: null }) { name, inner { key, value }, stupidInner { key, value }}}`, &resp)
 		require.NoError(t, err)
 
-		require.Equal(t, resp.UpdatedPtrToPtr.Name, "oldName")
+		require.Equal(t, "oldName", resp.UpdatedPtrToPtr.Name)
 		require.Nil(t, resp.UpdatedPtrToPtr.Inner)
 		require.NotNil(t, resp.UpdatedPtrToPtr.StupidInner)
 		require.NotNil(t, ******resp.UpdatedPtrToPtr.StupidInner)
-		require.Equal(t, (******resp.UpdatedPtrToPtr.StupidInner).Key, "oldStupidKey")
-		require.Equal(t, (******resp.UpdatedPtrToPtr.StupidInner).Value, "oldStupidValue")
+		require.Equal(t, "oldStupidKey", (******resp.UpdatedPtrToPtr.StupidInner).Key)
+		require.Equal(t, "oldStupidValue", (******resp.UpdatedPtrToPtr.StupidInner).Value)
 	})
 
 	t.Run("many pointers input non-null", func(t *testing.T) {
@@ -139,14 +139,14 @@ func TestPtrToPtr(t *testing.T) {
 		}`, &resp)
 		require.NoError(t, err)
 
-		require.Equal(t, resp.UpdatedPtrToPtr.Name, "oldName")
+		require.Equal(t, "oldName", resp.UpdatedPtrToPtr.Name)
 		require.NotNil(t, resp.UpdatedPtrToPtr.Inner)
-		require.Equal(t, resp.UpdatedPtrToPtr.Inner.Key, "oldKey")
-		require.Equal(t, resp.UpdatedPtrToPtr.Inner.Value, "oldValue")
+		require.Equal(t, "oldKey", resp.UpdatedPtrToPtr.Inner.Key)
+		require.Equal(t, "oldValue", resp.UpdatedPtrToPtr.Inner.Value)
 		require.NotNil(t, resp.UpdatedPtrToPtr.StupidInner)
 		require.NotNil(t, ******resp.UpdatedPtrToPtr.StupidInner)
-		require.Equal(t, (******resp.UpdatedPtrToPtr.StupidInner).Key, "newKey")
-		require.Equal(t, (******resp.UpdatedPtrToPtr.StupidInner).Value, "newValue")
+		require.Equal(t, "newKey", (******resp.UpdatedPtrToPtr.StupidInner).Key)
+		require.Equal(t, "newValue", (******resp.UpdatedPtrToPtr.StupidInner).Value)
 	})
 
 	t.Run("many pointers input null", func(t *testing.T) {
@@ -155,10 +155,10 @@ func TestPtrToPtr(t *testing.T) {
 		err := c.Post(`mutation { updatePtrToPtr(input: { stupidInner: null }) { name, inner { key, value }, stupidInner { key, value }}}`, &resp)
 		require.NoError(t, err)
 
-		require.Equal(t, resp.UpdatedPtrToPtr.Name, "oldName")
+		require.Equal(t, "oldName", resp.UpdatedPtrToPtr.Name)
 		require.NotNil(t, resp.UpdatedPtrToPtr.Inner)
-		require.Equal(t, resp.UpdatedPtrToPtr.Inner.Key, "oldKey")
-		require.Equal(t, resp.UpdatedPtrToPtr.Inner.Value, "oldValue")
+		require.Equal(t, "oldKey", resp.UpdatedPtrToPtr.Inner.Key)
+		require.Equal(t, "oldValue", resp.UpdatedPtrToPtr.Inner.Value)
 		require.Nil(t, resp.UpdatedPtrToPtr.StupidInner)
 	})
 }

--- a/codegen/testserver/followschema/response_extension_test.go
+++ b/codegen/testserver/followschema/response_extension_test.go
@@ -30,5 +30,5 @@ func TestResponseExtension(t *testing.T) {
 	c := client.New(srv)
 
 	raw, _ := c.RawPost(`query { valid }`)
-	require.Equal(t, raw.Extensions["example"], "value")
+	require.Equal(t, "value", raw.Extensions["example"])
 }

--- a/codegen/testserver/followschema/v-ok_test.go
+++ b/codegen/testserver/followschema/v-ok_test.go
@@ -31,7 +31,7 @@ func TestOk(t *testing.T) {
 		}
 		err := c.Post(`query { vOkCaseValue { value } }`, &resp)
 		require.NoError(t, err)
-		require.Equal(t, resp.VOkCaseValue.Value, "hi")
+		require.Equal(t, "hi", resp.VOkCaseValue.Value)
 	})
 
 	t.Run("v ok case nil", func(t *testing.T) {

--- a/codegen/testserver/singlefile/defaults_test.go
+++ b/codegen/testserver/singlefile/defaults_test.go
@@ -13,9 +13,9 @@ import (
 func assertDefaults(t *testing.T, ret *DefaultParametersMirror) {
 	require.NotNil(t, ret)
 	require.NotNil(t, ret.FalsyBoolean)
-	require.Equal(t, *ret.FalsyBoolean, false)
+	require.Equal(t, false, *ret.FalsyBoolean)
 	require.NotNil(t, ret.TruthyBoolean)
-	require.Equal(t, *ret.TruthyBoolean, true)
+	require.Equal(t, true, *ret.TruthyBoolean)
 }
 
 func TestDefaults(t *testing.T) {

--- a/codegen/testserver/singlefile/defer_test.go
+++ b/codegen/testserver/singlefile/defer_test.go
@@ -238,9 +238,9 @@ func TestDefer(t *testing.T) {
 			}
 		}
 
-		assert.Equal(t, valuesByPath["deferCase2.0"], []string{"test defer 1", "test defer 2", "test defer 3"})
-		assert.Equal(t, valuesByPath["deferCase2.1"], []string{"test defer 1", "test defer 2", "test defer 3"})
-		assert.Equal(t, valuesByPath["deferCase2.2"], []string{"test defer 1", "test defer 2", "test defer 3"})
+		assert.Equal(t, []string{"test defer 1", "test defer 2", "test defer 3"}, valuesByPath["deferCase2.0"])
+		assert.Equal(t, []string{"test defer 1", "test defer 2", "test defer 3"}, valuesByPath["deferCase2.1"])
+		assert.Equal(t, []string{"test defer 1", "test defer 2", "test defer 3"}, valuesByPath["deferCase2.2"])
 
 		for i := range resp.Data.DeferCase2 {
 			resp.Data.DeferCase2[i].Values = valuesByPath["deferCase2."+strconv.FormatInt(int64(i), 10)]

--- a/codegen/testserver/singlefile/directive_test.go
+++ b/codegen/testserver/singlefile/directive_test.go
@@ -301,7 +301,7 @@ func TestDirectives(t *testing.T) {
 
 			c.MustPost(`query { directiveField@logged(id:"testes_id") }`, &resp)
 
-			require.Equal(t, resp.DirectiveField, `testes_id`)
+			require.Equal(t, `testes_id`, resp.DirectiveField)
 		})
 		t.Run("without field directive", func(t *testing.T) {
 			var resp struct {

--- a/codegen/testserver/singlefile/embedded_test.go
+++ b/codegen/testserver/singlefile/embedded_test.go
@@ -40,7 +40,7 @@ func TestEmbedded(t *testing.T) {
 		}
 		err := c.Post(`query { embeddedCase1 { exportedEmbeddedPointerExportedMethod } }`, &resp)
 		require.NoError(t, err)
-		require.Equal(t, resp.EmbeddedCase1.ExportedEmbeddedPointerExportedMethod, "ExportedEmbeddedPointerExportedMethodResponse")
+		require.Equal(t, "ExportedEmbeddedPointerExportedMethodResponse", resp.EmbeddedCase1.ExportedEmbeddedPointerExportedMethod)
 	})
 
 	t.Run("embedded case 2", func(t *testing.T) {
@@ -51,7 +51,7 @@ func TestEmbedded(t *testing.T) {
 		}
 		err := c.Post(`query { embeddedCase2 { unexportedEmbeddedPointerExportedMethod } }`, &resp)
 		require.NoError(t, err)
-		require.Equal(t, resp.EmbeddedCase2.UnexportedEmbeddedPointerExportedMethod, "UnexportedEmbeddedPointerExportedMethodResponse")
+		require.Equal(t, "UnexportedEmbeddedPointerExportedMethodResponse", resp.EmbeddedCase2.UnexportedEmbeddedPointerExportedMethod)
 	})
 
 	t.Run("embedded case 3", func(t *testing.T) {
@@ -62,6 +62,6 @@ func TestEmbedded(t *testing.T) {
 		}
 		err := c.Post(`query { embeddedCase3 { unexportedEmbeddedInterfaceExportedMethod } }`, &resp)
 		require.NoError(t, err)
-		require.Equal(t, resp.EmbeddedCase3.UnexportedEmbeddedInterfaceExportedMethod, "UnexportedEmbeddedInterfaceExportedMethod")
+		require.Equal(t, "UnexportedEmbeddedInterfaceExportedMethod", resp.EmbeddedCase3.UnexportedEmbeddedInterfaceExportedMethod)
 	})
 }

--- a/codegen/testserver/singlefile/enums_test.go
+++ b/codegen/testserver/singlefile/enums_test.go
@@ -26,7 +26,7 @@ func TestEnumsResolver(t *testing.T) {
 			enumInInput(input: {enum: OK})
 		}
 		`, &resp)
-		require.Equal(t, resp.EnumInInput, EnumTestOk)
+		require.Equal(t, EnumTestOk, resp.EnumInInput)
 	})
 
 	t.Run("input with invalid enum value", func(t *testing.T) {

--- a/codegen/testserver/singlefile/mutation_with_custom_scalar_test.go
+++ b/codegen/testserver/singlefile/mutation_with_custom_scalar_test.go
@@ -30,7 +30,7 @@ func TestErrorInsideMutationArgument(t *testing.T) {
 			&resp,
 			client.Var("input", input),
 		)
-		require.Equal(t, resp["updateSomething"], "Hello world")
+		require.Equal(t, "Hello world", resp["updateSomething"])
 		require.NoError(t, err)
 	})
 

--- a/codegen/testserver/singlefile/nulls_test.go
+++ b/codegen/testserver/singlefile/nulls_test.go
@@ -86,7 +86,7 @@ func TestNullBubbling(t *testing.T) {
 		err := c.Post(`query { valid, errorList { id } }`, &resp)
 
 		require.Nil(t, err)
-		require.Equal(t, len(resp.ErrorList), 1)
+		require.Equal(t, 1, len(resp.ErrorList))
 		require.Nil(t, resp.ErrorList[0])
 		require.Equal(t, "Ok", resp.Valid)
 	})

--- a/codegen/testserver/singlefile/ptr_to_ptr_input_test.go
+++ b/codegen/testserver/singlefile/ptr_to_ptr_input_test.go
@@ -77,14 +77,14 @@ func TestPtrToPtr(t *testing.T) {
 		err := c.Post(`mutation { updatePtrToPtr(input: { name: "newName" }) { name, inner { key, value }, stupidInner { key, value }}}`, &resp)
 		require.NoError(t, err)
 
-		require.Equal(t, resp.UpdatedPtrToPtr.Name, "newName")
+		require.Equal(t, "newName", resp.UpdatedPtrToPtr.Name)
 		require.NotNil(t, resp.UpdatedPtrToPtr.Inner)
-		require.Equal(t, resp.UpdatedPtrToPtr.Inner.Key, "oldKey")
-		require.Equal(t, resp.UpdatedPtrToPtr.Inner.Value, "oldValue")
+		require.Equal(t, "oldKey", resp.UpdatedPtrToPtr.Inner.Key)
+		require.Equal(t, "oldValue", resp.UpdatedPtrToPtr.Inner.Value)
 		require.NotNil(t, resp.UpdatedPtrToPtr.StupidInner)
 		require.NotNil(t, ******resp.UpdatedPtrToPtr.StupidInner)
-		require.Equal(t, (******resp.UpdatedPtrToPtr.StupidInner).Key, "oldStupidKey")
-		require.Equal(t, (******resp.UpdatedPtrToPtr.StupidInner).Value, "oldStupidValue")
+		require.Equal(t, "oldStupidKey", (******resp.UpdatedPtrToPtr.StupidInner).Key)
+		require.Equal(t, "oldStupidValue", (******resp.UpdatedPtrToPtr.StupidInner).Value)
 	})
 
 	t.Run("pointer to pointer input non-null", func(t *testing.T) {
@@ -101,14 +101,14 @@ func TestPtrToPtr(t *testing.T) {
 		}`, &resp)
 		require.NoError(t, err)
 
-		require.Equal(t, resp.UpdatedPtrToPtr.Name, "oldName")
+		require.Equal(t, "oldName", resp.UpdatedPtrToPtr.Name)
 		require.NotNil(t, resp.UpdatedPtrToPtr.Inner)
-		require.Equal(t, resp.UpdatedPtrToPtr.Inner.Key, "newKey")
-		require.Equal(t, resp.UpdatedPtrToPtr.Inner.Value, "newValue")
+		require.Equal(t, "newKey", resp.UpdatedPtrToPtr.Inner.Key)
+		require.Equal(t, "newValue", resp.UpdatedPtrToPtr.Inner.Value)
 		require.NotNil(t, resp.UpdatedPtrToPtr.StupidInner)
 		require.NotNil(t, ******resp.UpdatedPtrToPtr.StupidInner)
-		require.Equal(t, (******resp.UpdatedPtrToPtr.StupidInner).Key, "oldStupidKey")
-		require.Equal(t, (******resp.UpdatedPtrToPtr.StupidInner).Value, "oldStupidValue")
+		require.Equal(t, "oldStupidKey", (******resp.UpdatedPtrToPtr.StupidInner).Key)
+		require.Equal(t, "oldStupidValue", (******resp.UpdatedPtrToPtr.StupidInner).Value)
 	})
 
 	t.Run("pointer to pointer input null", func(t *testing.T) {
@@ -117,12 +117,12 @@ func TestPtrToPtr(t *testing.T) {
 		err := c.Post(`mutation { updatePtrToPtr(input: { inner: null }) { name, inner { key, value }, stupidInner { key, value }}}`, &resp)
 		require.NoError(t, err)
 
-		require.Equal(t, resp.UpdatedPtrToPtr.Name, "oldName")
+		require.Equal(t, "oldName", resp.UpdatedPtrToPtr.Name)
 		require.Nil(t, resp.UpdatedPtrToPtr.Inner)
 		require.NotNil(t, resp.UpdatedPtrToPtr.StupidInner)
 		require.NotNil(t, ******resp.UpdatedPtrToPtr.StupidInner)
-		require.Equal(t, (******resp.UpdatedPtrToPtr.StupidInner).Key, "oldStupidKey")
-		require.Equal(t, (******resp.UpdatedPtrToPtr.StupidInner).Value, "oldStupidValue")
+		require.Equal(t, "oldStupidKey", (******resp.UpdatedPtrToPtr.StupidInner).Key)
+		require.Equal(t, "oldStupidValue", (******resp.UpdatedPtrToPtr.StupidInner).Value)
 	})
 
 	t.Run("many pointers input non-null", func(t *testing.T) {
@@ -139,14 +139,14 @@ func TestPtrToPtr(t *testing.T) {
 		}`, &resp)
 		require.NoError(t, err)
 
-		require.Equal(t, resp.UpdatedPtrToPtr.Name, "oldName")
+		require.Equal(t, "oldName", resp.UpdatedPtrToPtr.Name)
 		require.NotNil(t, resp.UpdatedPtrToPtr.Inner)
-		require.Equal(t, resp.UpdatedPtrToPtr.Inner.Key, "oldKey")
-		require.Equal(t, resp.UpdatedPtrToPtr.Inner.Value, "oldValue")
+		require.Equal(t, "oldKey", resp.UpdatedPtrToPtr.Inner.Key)
+		require.Equal(t, "oldValue", resp.UpdatedPtrToPtr.Inner.Value)
 		require.NotNil(t, resp.UpdatedPtrToPtr.StupidInner)
 		require.NotNil(t, ******resp.UpdatedPtrToPtr.StupidInner)
-		require.Equal(t, (******resp.UpdatedPtrToPtr.StupidInner).Key, "newKey")
-		require.Equal(t, (******resp.UpdatedPtrToPtr.StupidInner).Value, "newValue")
+		require.Equal(t, "newKey", (******resp.UpdatedPtrToPtr.StupidInner).Key)
+		require.Equal(t, "newValue", (******resp.UpdatedPtrToPtr.StupidInner).Value)
 	})
 
 	t.Run("many pointers input null", func(t *testing.T) {
@@ -155,10 +155,10 @@ func TestPtrToPtr(t *testing.T) {
 		err := c.Post(`mutation { updatePtrToPtr(input: { stupidInner: null }) { name, inner { key, value }, stupidInner { key, value }}}`, &resp)
 		require.NoError(t, err)
 
-		require.Equal(t, resp.UpdatedPtrToPtr.Name, "oldName")
+		require.Equal(t, "oldName", resp.UpdatedPtrToPtr.Name)
 		require.NotNil(t, resp.UpdatedPtrToPtr.Inner)
-		require.Equal(t, resp.UpdatedPtrToPtr.Inner.Key, "oldKey")
-		require.Equal(t, resp.UpdatedPtrToPtr.Inner.Value, "oldValue")
+		require.Equal(t, "oldKey", resp.UpdatedPtrToPtr.Inner.Key)
+		require.Equal(t, "oldValue", resp.UpdatedPtrToPtr.Inner.Value)
 		require.Nil(t, resp.UpdatedPtrToPtr.StupidInner)
 	})
 }

--- a/codegen/testserver/singlefile/response_extension_test.go
+++ b/codegen/testserver/singlefile/response_extension_test.go
@@ -30,5 +30,5 @@ func TestResponseExtension(t *testing.T) {
 	c := client.New(srv)
 
 	raw, _ := c.RawPost(`query { valid }`)
-	require.Equal(t, raw.Extensions["example"], "value")
+	require.Equal(t, "value", raw.Extensions["example"])
 }

--- a/codegen/testserver/singlefile/v-ok_test.go
+++ b/codegen/testserver/singlefile/v-ok_test.go
@@ -31,7 +31,7 @@ func TestOk(t *testing.T) {
 		}
 		err := c.Post(`query { vOkCaseValue { value } }`, &resp)
 		require.NoError(t, err)
-		require.Equal(t, resp.VOkCaseValue.Value, "hi")
+		require.Equal(t, "hi", resp.VOkCaseValue.Value)
 	})
 
 	t.Run("v ok case nil", func(t *testing.T) {

--- a/codegen/testserver/singlefile/variadic_test.go
+++ b/codegen/testserver/singlefile/variadic_test.go
@@ -26,9 +26,9 @@ func TestVariadic(t *testing.T) {
 	}
 	err := c.Post(`query { variadicModel { value(rank: 1) } }`, &resp)
 	require.NoError(t, err)
-	require.Equal(t, resp.VariadicModel.Value, "1")
+	require.Equal(t, "1", resp.VariadicModel.Value)
 
 	err = c.Post(`query { variadicModel { value(rank: 2) } }`, &resp)
 	require.NoError(t, err)
-	require.Equal(t, resp.VariadicModel.Value, "2")
+	require.Equal(t, "2", resp.VariadicModel.Value)
 }

--- a/graphql/handler/extension/apq_test.go
+++ b/graphql/handler/extension/apq_test.go
@@ -60,7 +60,7 @@ func TestAPQ(t *testing.T) {
 		}
 
 		err := extension.AutomaticPersistedQuery{graphql.MapCache{}}.MutateOperationParameters(ctx, params)
-		require.Equal(t, err.Message, "PersistedQueryNotFound")
+		require.Equal(t, "PersistedQueryNotFound", err.Message)
 	})
 
 	t.Run("with hash miss and query", func(t *testing.T) {
@@ -129,7 +129,7 @@ func TestAPQ(t *testing.T) {
 		}
 
 		err := extension.AutomaticPersistedQuery{graphql.MapCache{}}.MutateOperationParameters(ctx, params)
-		require.Equal(t, err.Message, "invalid APQ extension data")
+		require.Equal(t, "invalid APQ extension data", err.Message)
 	})
 
 	t.Run("with invalid extension version", func(t *testing.T) {
@@ -142,7 +142,7 @@ func TestAPQ(t *testing.T) {
 			},
 		}
 		err := extension.AutomaticPersistedQuery{graphql.MapCache{}}.MutateOperationParameters(ctx, params)
-		require.Equal(t, err.Message, "unsupported APQ version")
+		require.Equal(t, "unsupported APQ version", err.Message)
 	})
 
 	t.Run("with hash mismatch", func(t *testing.T) {
@@ -158,7 +158,7 @@ func TestAPQ(t *testing.T) {
 		}
 
 		err := extension.AutomaticPersistedQuery{graphql.MapCache{}}.MutateOperationParameters(ctx, params)
-		require.Equal(t, err.Message, "provided APQ hash does not match query")
+		require.Equal(t, "provided APQ hash does not match query", err.Message)
 	})
 }
 

--- a/graphql/handler/transport/http_form_multipart_test.go
+++ b/graphql/handler/transport/http_form_multipart_test.go
@@ -46,8 +46,8 @@ func TestFileUpload(t *testing.T) {
 	t.Run("valid single file upload", func(t *testing.T) {
 		es.ExecFunc = func(ctx context.Context) graphql.ResponseHandler {
 			op := graphql.GetOperationContext(ctx).Operation
-			require.Equal(t, len(op.VariableDefinitions), 1)
-			require.Equal(t, op.VariableDefinitions[0].Variable, "file")
+			require.Equal(t, 1, len(op.VariableDefinitions))
+			require.Equal(t, "file", op.VariableDefinitions[0].Variable)
 			return graphql.OneShot(&graphql.Response{Data: []byte(`{"singleUpload":"test"}`)})
 		}
 
@@ -72,8 +72,8 @@ func TestFileUpload(t *testing.T) {
 	t.Run("valid single file upload with payload", func(t *testing.T) {
 		es.ExecFunc = func(ctx context.Context) graphql.ResponseHandler {
 			op := graphql.GetOperationContext(ctx).Operation
-			require.Equal(t, len(op.VariableDefinitions), 1)
-			require.Equal(t, op.VariableDefinitions[0].Variable, "req")
+			require.Equal(t, 1, len(op.VariableDefinitions))
+			require.Equal(t, "req", op.VariableDefinitions[0].Variable)
 			return graphql.OneShot(&graphql.Response{Data: []byte(`{"singleUploadWithPayload":"test"}`)})
 		}
 
@@ -98,8 +98,8 @@ func TestFileUpload(t *testing.T) {
 	t.Run("valid file list upload", func(t *testing.T) {
 		es.ExecFunc = func(ctx context.Context) graphql.ResponseHandler {
 			op := graphql.GetOperationContext(ctx).Operation
-			require.Equal(t, len(op.VariableDefinitions), 1)
-			require.Equal(t, op.VariableDefinitions[0].Variable, "files")
+			require.Equal(t, 1, len(op.VariableDefinitions))
+			require.Equal(t, "files", op.VariableDefinitions[0].Variable)
 			return graphql.OneShot(&graphql.Response{Data: []byte(`{"multipleUpload":[{"id":1},{"id":2}]}`)})
 		}
 
@@ -130,8 +130,8 @@ func TestFileUpload(t *testing.T) {
 	t.Run("valid file list upload with payload", func(t *testing.T) {
 		es.ExecFunc = func(ctx context.Context) graphql.ResponseHandler {
 			op := graphql.GetOperationContext(ctx).Operation
-			require.Equal(t, len(op.VariableDefinitions), 1)
-			require.Equal(t, op.VariableDefinitions[0].Variable, "req")
+			require.Equal(t, 1, len(op.VariableDefinitions))
+			require.Equal(t, "req", op.VariableDefinitions[0].Variable)
 			return graphql.OneShot(&graphql.Response{Data: []byte(`{"multipleUploadWithPayload":[{"id":1},{"id":2}]}`)})
 		}
 
@@ -163,8 +163,8 @@ func TestFileUpload(t *testing.T) {
 		test := func(uploadMaxMemory int64) {
 			es.ExecFunc = func(ctx context.Context) graphql.ResponseHandler {
 				op := graphql.GetOperationContext(ctx).Operation
-				require.Equal(t, len(op.VariableDefinitions), 1)
-				require.Equal(t, op.VariableDefinitions[0].Variable, "req")
+				require.Equal(t, 1, len(op.VariableDefinitions))
+				require.Equal(t, "req", op.VariableDefinitions[0].Variable)
 				return graphql.OneShot(&graphql.Response{Data: []byte(`{"multipleUploadWithPayload":[{"id":1},{"id":2}]}`)})
 			}
 			multipartForm.MaxMemory = uploadMaxMemory

--- a/graphql/handler/transport/http_form_urlencode_test.go
+++ b/graphql/handler/transport/http_form_urlencode_test.go
@@ -38,22 +38,22 @@ func TestUrlEncodedForm(t *testing.T) {
 	t.Run("decode failure json", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", "notjson", "application/x-www-form-urlencoded")
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
-		assert.Equal(t, resp.Header().Get("Content-Type"), "application/json")
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 		assert.Equal(t, `{"errors":[{"message":"Unexpected Name \"notjson\"","locations":[{"line":1,"column":1}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("decode failure urlencoded", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", "query=%7Bnot-good", "application/x-www-form-urlencoded")
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
-		assert.Equal(t, resp.Header().Get("Content-Type"), "application/json")
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 		assert.Equal(t, `{"errors":[{"message":"Expected Name, found \u003cInvalid\u003e","locations":[{"line":1,"column":6}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("parse query failure", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query":{"wrong": "format"}}`, "application/x-www-form-urlencoded")
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
-		assert.Equal(t, resp.Header().Get("Content-Type"), "application/json")
-		assert.Equal(t, resp.Body.String(), `{"errors":[{"message":"could not cleanup body: json: cannot unmarshal object into Go struct field RawParams.query of type string"}],"data":null}`)
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
+		assert.Equal(t, `{"errors":[{"message":"could not cleanup body: json: cannot unmarshal object into Go struct field RawParams.query of type string"}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("validate content type", func(t *testing.T) {

--- a/graphql/handler/transport/http_graphql_test.go
+++ b/graphql/handler/transport/http_graphql_test.go
@@ -32,28 +32,28 @@ func TestGRAPHQL(t *testing.T) {
 	t.Run("parse failure", func(t *testing.T) {
 		resp := doGraphqlRequest(h, "POST", "/graphql", `{"!"}`)
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
-		assert.Equal(t, resp.Header().Get("Content-Type"), "application/json")
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 		assert.Equal(t, `{"errors":[{"message":"Expected Name, found String","locations":[{"line":1,"column":3}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("parse query failure", func(t *testing.T) {
 		resp := doGraphqlRequest(h, "POST", "/graphql", `%7B%H7U6Z`)
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
-		assert.Equal(t, resp.Header().Get("Content-Type"), "application/json")
-		assert.Equal(t, resp.Body.String(), `{"errors":[{"message":"could not cleanup body: invalid URL escape \"%H7\""}],"data":null}`)
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
+		assert.Equal(t, `{"errors":[{"message":"could not cleanup body: invalid URL escape \"%H7\""}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("validation failure", func(t *testing.T) {
 		resp := doGraphqlRequest(h, "POST", "/graphql", `{ title }`)
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
-		assert.Equal(t, resp.Header().Get("Content-Type"), "application/json")
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 		assert.Equal(t, `{"errors":[{"message":"Cannot query field \"title\" on type \"Query\".","locations":[{"line":1,"column":3}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("execution failure", func(t *testing.T) {
 		resp := doGraphqlRequest(h, "POST", "/graphql", `mutation { name }`)
 		assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-		assert.Equal(t, resp.Header().Get("Content-Type"), "application/json")
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 		assert.Equal(t, `{"errors":[{"message":"mutations are not supported"}],"data":null}`, resp.Body.String())
 	})
 

--- a/graphql/handler/transport/http_post_test.go
+++ b/graphql/handler/transport/http_post_test.go
@@ -26,35 +26,35 @@ func TestPOST(t *testing.T) {
 	t.Run("decode failure", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", "notjson", "application/json")
 		assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
-		assert.Equal(t, resp.Header().Get("Content-Type"), "application/json")
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 		assert.Equal(t, `{"errors":[{"message":"json request body could not be decoded: invalid character 'o' in literal null (expecting 'u') body:notjson"}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("parse failure", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query": "!"}`, "application/json")
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
-		assert.Equal(t, resp.Header().Get("Content-Type"), "application/json")
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 		assert.Equal(t, `{"errors":[{"message":"Unexpected !","locations":[{"line":1,"column":1}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("validation failure", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query": "{ title }"}`, "application/json")
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
-		assert.Equal(t, resp.Header().Get("Content-Type"), "application/json")
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 		assert.Equal(t, `{"errors":[{"message":"Cannot query field \"title\" on type \"Query\".","locations":[{"line":1,"column":3}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("invalid variable", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query": "query($id:Int!){find(id:$id)}","variables":{"id":false}}`, "application/json")
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
-		assert.Equal(t, resp.Header().Get("Content-Type"), "application/json")
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 		assert.Equal(t, `{"errors":[{"message":"cannot use bool as Int","path":["variable","id"],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("execution failure", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query": "mutation { name }"}`, "application/json")
 		assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-		assert.Equal(t, resp.Header().Get("Content-Type"), "application/json")
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 		assert.Equal(t, `{"errors":[{"message":"mutations are not supported"}],"data":null}`, resp.Body.String())
 	})
 

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -301,8 +301,8 @@ func TestWebsocketInitFunc(t *testing.T) {
 
 		time.Sleep(time.Millisecond * 10)
 		m := readOp(c)
-		assert.Equal(t, m.Type, connectionErrorMsg)
-		assert.Equal(t, string(m.Payload), `{"message":"beep boop"}`)
+		assert.Equal(t, connectionErrorMsg, m.Type)
+		assert.Equal(t, `{"message":"beep boop"}`, string(m.Payload))
 	})
 	t.Run("accept connection if WebsocketInitFunc is provided and is accepting connection", func(t *testing.T) {
 		h := testserver.New()
@@ -383,7 +383,7 @@ func TestWebSocketErrorFunc(t *testing.T) {
 		h.AddTransport(transport.Websocket{
 			ErrorFunc: func(_ context.Context, err error) {
 				require.Error(t, err)
-				assert.Equal(t, err.Error(), "websocket read: invalid message received")
+				assert.Equal(t, "websocket read: invalid message received", err.Error())
 				assert.IsType(t, transport.WebsocketError{}, err)
 				assert.True(t, err.(transport.WebsocketError).IsReadError)
 				errFuncCalled <- true

--- a/graphql/handler_test.go
+++ b/graphql/handler_test.go
@@ -51,7 +51,7 @@ func TestAddUploadToOperations(t *testing.T) {
 		err := request.AddUpload(upload, key, path)
 		require.Nil(t, err)
 
-		require.Equal(t, request, expected)
+		require.Equal(t, expected, request)
 	})
 
 	t.Run("valid nested variable", func(t *testing.T) {
@@ -87,6 +87,6 @@ func TestAddUploadToOperations(t *testing.T) {
 		err := request.AddUpload(upload, key, path)
 		require.Nil(t, err)
 
-		require.Equal(t, request, expected)
+		require.Equal(t, expected, request)
 	})
 }

--- a/plugin/federation/federation_entityresolver_test.go
+++ b/plugin/federation/federation_entityresolver_test.go
@@ -48,8 +48,8 @@ func TestEntityResolver(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		require.Equal(t, resp.Entities[0].Name, "first name - 1")
-		require.Equal(t, resp.Entities[1].Name, "first name - 2")
+		require.Equal(t, "first name - 1", resp.Entities[0].Name)
+		require.Equal(t, "first name - 2", resp.Entities[1].Name)
 	})
 
 	t.Run("HelloWithError entities", func(t *testing.T) {
@@ -99,11 +99,11 @@ func TestEntityResolver(t *testing.T) {
 		require.Contains(t, errMessages, "resolving Entity \"HelloWithErrors\": error resolving HelloWithErrorsByName")
 
 		require.Len(t, resp.Entities, 5)
-		require.Equal(t, resp.Entities[0].Name, "first name - 1")
-		require.Equal(t, resp.Entities[1].Name, "first name - 2")
-		require.Equal(t, resp.Entities[2].Name, "")
-		require.Equal(t, resp.Entities[3].Name, "first name - 3")
-		require.Equal(t, resp.Entities[4].Name, "")
+		require.Equal(t, "first name - 1", resp.Entities[0].Name)
+		require.Equal(t, "first name - 2", resp.Entities[1].Name)
+		require.Equal(t, "", resp.Entities[2].Name)
+		require.Equal(t, "first name - 3", resp.Entities[3].Name)
+		require.Equal(t, "", resp.Entities[4].Name)
 	})
 
 	t.Run("World entities with nested key", func(t *testing.T) {
@@ -141,10 +141,10 @@ func TestEntityResolver(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		require.Equal(t, resp.Entities[0].Foo, "foo 1")
-		require.Equal(t, resp.Entities[0].Hello.Name, "world name - 1")
-		require.Equal(t, resp.Entities[1].Foo, "foo 2")
-		require.Equal(t, resp.Entities[1].Hello.Name, "world name - 2")
+		require.Equal(t, "foo 1", resp.Entities[0].Foo)
+		require.Equal(t, "world name - 1", resp.Entities[0].Hello.Name)
+		require.Equal(t, "foo 2", resp.Entities[1].Foo)
+		require.Equal(t, "world name - 2", resp.Entities[1].Hello.Name)
 	})
 
 	t.Run("World entities with multiple keys", func(t *testing.T) {
@@ -181,9 +181,9 @@ func TestEntityResolver(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		require.Equal(t, resp.Entities[0].Foo, "foo 1")
-		require.Equal(t, resp.Entities[0].Hello.Name, "world name - 1")
-		require.Equal(t, resp.Entities[1].Bar, 11)
+		require.Equal(t, "foo 1", resp.Entities[0].Foo)
+		require.Equal(t, "world name - 1", resp.Entities[0].Hello.Name)
+		require.Equal(t, 11, resp.Entities[1].Bar)
 	})
 
 	t.Run("Hello WorldName entities (heterogeneous)", func(t *testing.T) {
@@ -265,10 +265,10 @@ func TestEntityResolver(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		require.Equal(t, resp.Entities[0].Name, "earth")
-		require.Equal(t, resp.Entities[0].Diameter, 12)
-		require.Equal(t, resp.Entities[1].Name, "mars")
-		require.Equal(t, resp.Entities[1].Diameter, 10)
+		require.Equal(t, "earth", resp.Entities[0].Name)
+		require.Equal(t, 12, resp.Entities[0].Diameter)
+		require.Equal(t, "mars", resp.Entities[1].Name)
+		require.Equal(t, 10, resp.Entities[1].Diameter)
 	})
 
 	t.Run("PlanetRequires entities with multiple required fields directive", func(t *testing.T) {
@@ -303,12 +303,12 @@ func TestEntityResolver(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		require.Equal(t, resp.Entities[0].Name, "earth")
-		require.Equal(t, resp.Entities[0].Diameter, 12)
-		require.Equal(t, resp.Entities[0].Density, 800)
-		require.Equal(t, resp.Entities[1].Name, "mars")
-		require.Equal(t, resp.Entities[1].Diameter, 10)
-		require.Equal(t, resp.Entities[1].Density, 850)
+		require.Equal(t, "earth", resp.Entities[0].Name)
+		require.Equal(t, 12, resp.Entities[0].Diameter)
+		require.Equal(t, 800, resp.Entities[0].Density)
+		require.Equal(t, "mars", resp.Entities[1].Name)
+		require.Equal(t, 10, resp.Entities[1].Diameter)
+		require.Equal(t, 850, resp.Entities[1].Density)
 	})
 
 	t.Run("PlanetRequiresNested entities with requires directive having nested field", func(t *testing.T) {
@@ -346,10 +346,10 @@ func TestEntityResolver(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		require.Equal(t, resp.Entities[0].Name, "earth")
-		require.Equal(t, resp.Entities[0].World.Foo, "A")
-		require.Equal(t, resp.Entities[1].Name, "mars")
-		require.Equal(t, resp.Entities[1].World.Foo, "B")
+		require.Equal(t, "earth", resp.Entities[0].Name)
+		require.Equal(t, "A", resp.Entities[0].World.Foo)
+		require.Equal(t, "mars", resp.Entities[1].Name)
+		require.Equal(t, "B", resp.Entities[1].World.Foo)
 	})
 }
 
@@ -499,10 +499,10 @@ func TestMultiEntityResolver(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		require.Equal(t, resp.Entities[0].Name, "first name - 1")
-		require.Equal(t, resp.Entities[0].Key1, "key1 - 1")
-		require.Equal(t, resp.Entities[1].Name, "first name - 2")
-		require.Equal(t, resp.Entities[1].Key1, "key1 - 2")
+		require.Equal(t, "first name - 1", resp.Entities[0].Name)
+		require.Equal(t, "key1 - 1", resp.Entities[0].Key1)
+		require.Equal(t, "first name - 2", resp.Entities[1].Name)
+		require.Equal(t, "key1 - 2", resp.Entities[1].Key1)
 	})
 
 	t.Run("MultiHelloMultipleRequires entities with multiple required fields", func(t *testing.T) {
@@ -537,12 +537,12 @@ func TestMultiEntityResolver(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		require.Equal(t, resp.Entities[0].Name, "first name - 1")
-		require.Equal(t, resp.Entities[0].Key1, "key1 - 1")
-		require.Equal(t, resp.Entities[0].Key2, "key2 - 1")
-		require.Equal(t, resp.Entities[1].Name, "first name - 2")
-		require.Equal(t, resp.Entities[1].Key1, "key1 - 2")
-		require.Equal(t, resp.Entities[1].Key2, "key2 - 2")
+		require.Equal(t, "first name - 1", resp.Entities[0].Name)
+		require.Equal(t, "key1 - 1", resp.Entities[0].Key1)
+		require.Equal(t, "key2 - 1", resp.Entities[0].Key2)
+		require.Equal(t, "first name - 2", resp.Entities[1].Name)
+		require.Equal(t, "key1 - 2", resp.Entities[1].Key1)
+		require.Equal(t, "key2 - 2", resp.Entities[1].Key2)
 	})
 
 	t.Run("MultiPlanetRequiresNested entities with requires directive having nested field", func(t *testing.T) {
@@ -580,10 +580,10 @@ func TestMultiEntityResolver(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		require.Equal(t, resp.Entities[0].Name, "earth")
-		require.Equal(t, resp.Entities[0].World.Foo, "A")
-		require.Equal(t, resp.Entities[1].Name, "mars")
-		require.Equal(t, resp.Entities[1].World.Foo, "B")
+		require.Equal(t, "earth", resp.Entities[0].Name)
+		require.Equal(t, "A", resp.Entities[0].World.Foo)
+		require.Equal(t, "mars", resp.Entities[1].Name)
+		require.Equal(t, "B", resp.Entities[1].World.Foo)
 	})
 }
 

--- a/plugin/federation/federation_explicitrequires_test.go
+++ b/plugin/federation/federation_explicitrequires_test.go
@@ -48,10 +48,10 @@ func TestExplicitRequires(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		require.Equal(t, resp.Entities[0].Name, "earth")
-		require.Equal(t, resp.Entities[0].Diameter, 12)
-		require.Equal(t, resp.Entities[1].Name, "mars")
-		require.Equal(t, resp.Entities[1].Diameter, 10)
+		require.Equal(t, "earth", resp.Entities[0].Name)
+		require.Equal(t, 12, resp.Entities[0].Diameter)
+		require.Equal(t, "mars", resp.Entities[1].Name)
+		require.Equal(t, 10, resp.Entities[1].Diameter)
 	})
 
 	t.Run("PlanetRequires entities with multiple required fields directive", func(t *testing.T) {
@@ -86,12 +86,12 @@ func TestExplicitRequires(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		require.Equal(t, resp.Entities[0].Name, "earth")
-		require.Equal(t, resp.Entities[0].Diameter, 12)
-		require.Equal(t, resp.Entities[0].Density, 800)
-		require.Equal(t, resp.Entities[1].Name, "mars")
-		require.Equal(t, resp.Entities[1].Diameter, 10)
-		require.Equal(t, resp.Entities[1].Density, 850)
+		require.Equal(t, "earth", resp.Entities[0].Name)
+		require.Equal(t, 12, resp.Entities[0].Diameter)
+		require.Equal(t, 800, resp.Entities[0].Density)
+		require.Equal(t, "mars", resp.Entities[1].Name)
+		require.Equal(t, 10, resp.Entities[1].Diameter)
+		require.Equal(t, 850, resp.Entities[1].Density)
 	})
 
 	t.Run("PlanetRequiresNested entities with requires directive having nested field", func(t *testing.T) {
@@ -129,10 +129,10 @@ func TestExplicitRequires(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		require.Equal(t, resp.Entities[0].Name, "earth")
-		require.Equal(t, resp.Entities[0].World.Foo, "A")
-		require.Equal(t, resp.Entities[1].Name, "mars")
-		require.Equal(t, resp.Entities[1].World.Foo, "B")
+		require.Equal(t, "earth", resp.Entities[0].Name)
+		require.Equal(t, "A", resp.Entities[0].World.Foo)
+		require.Equal(t, "mars", resp.Entities[1].Name)
+		require.Equal(t, "B", resp.Entities[1].World.Foo)
 	})
 }
 
@@ -172,10 +172,10 @@ func TestMultiExplicitRequires(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		require.Equal(t, resp.Entities[0].Name, "first name - 1")
-		require.Equal(t, resp.Entities[0].Key1, "key1 - 1")
-		require.Equal(t, resp.Entities[1].Name, "first name - 2")
-		require.Equal(t, resp.Entities[1].Key1, "key1 - 2")
+		require.Equal(t, "first name - 1", resp.Entities[0].Name)
+		require.Equal(t, "key1 - 1", resp.Entities[0].Key1)
+		require.Equal(t, "first name - 2", resp.Entities[1].Name)
+		require.Equal(t, "key1 - 2", resp.Entities[1].Key1)
 	})
 
 	t.Run("MultiHelloMultipleRequires entities with multiple required fields", func(t *testing.T) {
@@ -210,12 +210,12 @@ func TestMultiExplicitRequires(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		require.Equal(t, resp.Entities[0].Name, "first name - 1")
-		require.Equal(t, resp.Entities[0].Key1, "key1 - 1")
-		require.Equal(t, resp.Entities[0].Key2, "key2 - 1")
-		require.Equal(t, resp.Entities[1].Name, "first name - 2")
-		require.Equal(t, resp.Entities[1].Key1, "key1 - 2")
-		require.Equal(t, resp.Entities[1].Key2, "key2 - 2")
+		require.Equal(t, "first name - 1", resp.Entities[0].Name)
+		require.Equal(t, "key1 - 1", resp.Entities[0].Key1)
+		require.Equal(t, "key2 - 1", resp.Entities[0].Key2)
+		require.Equal(t, "first name - 2", resp.Entities[1].Name)
+		require.Equal(t, "key1 - 2", resp.Entities[1].Key1)
+		require.Equal(t, "key2 - 2", resp.Entities[1].Key2)
 	})
 
 	t.Run("MultiPlanetRequiresNested entities with requires directive having nested field", func(t *testing.T) {
@@ -253,9 +253,9 @@ func TestMultiExplicitRequires(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		require.Equal(t, resp.Entities[0].Name, "earth")
-		require.Equal(t, resp.Entities[0].World.Foo, "A")
-		require.Equal(t, resp.Entities[1].Name, "mars")
-		require.Equal(t, resp.Entities[1].World.Foo, "B")
+		require.Equal(t, "earth", resp.Entities[0].Name)
+		require.Equal(t, "A", resp.Entities[0].World.Foo)
+		require.Equal(t, "mars", resp.Entities[1].Name)
+		require.Equal(t, "B", resp.Entities[1].World.Foo)
 	})
 }

--- a/plugin/federation/federation_test.go
+++ b/plugin/federation/federation_test.go
@@ -80,8 +80,8 @@ func TestWithEntities(t *testing.T) {
 	require.Equal(t, "String", f.Entities[5].Resolvers[0].KeyFields[4].Definition.Type.Name())
 
 	require.Len(t, f.Entities[5].Requires, 2)
-	require.Equal(t, f.Entities[5].Requires[0].Name, "id")
-	require.Equal(t, f.Entities[5].Requires[1].Name, "helloSecondary")
+	require.Equal(t, "id", f.Entities[5].Requires[0].Name)
+	require.Equal(t, "helloSecondary", f.Entities[5].Requires[1].Name)
 
 	require.Equal(t, "World", f.Entities[6].Name)
 	require.Len(t, f.Entities[6].Resolvers, 2)

--- a/plugin/federation/fieldset/fieldset_test.go
+++ b/plugin/federation/fieldset/fieldset_test.go
@@ -113,13 +113,13 @@ func TestInvalid(t *testing.T) {
 }
 
 func TestToGo(t *testing.T) {
-	require.Equal(t, Field{"foo"}.ToGo(), "Foo")
-	require.Equal(t, Field{"foo", "bar"}.ToGo(), "FooBar")
-	require.Equal(t, Field{"bar", "id"}.ToGo(), "BarID")
+	require.Equal(t, "Foo", Field{"foo"}.ToGo())
+	require.Equal(t, "FooBar", Field{"foo", "bar"}.ToGo())
+	require.Equal(t, "BarID", Field{"bar", "id"}.ToGo())
 }
 
 func TestToGoPrivate(t *testing.T) {
-	require.Equal(t, Field{"foo"}.ToGoPrivate(), "foo")
-	require.Equal(t, Field{"foo", "bar"}.ToGoPrivate(), "fooBar")
-	require.Equal(t, Field{"bar", "id"}.ToGoPrivate(), "barID")
+	require.Equal(t, "foo", Field{"foo"}.ToGoPrivate())
+	require.Equal(t, "fooBar", Field{"foo", "bar"}.ToGoPrivate())
+	require.Equal(t, "barID", Field{"bar", "id"}.ToGoPrivate())
 }

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -283,18 +283,18 @@ func TestModelGeneration(t *testing.T) {
 	})
 
 	t.Run("nullable input fields can be made omittable with goField", func(t *testing.T) {
-		require.IsType(t, out.MissingInput{}.NullString, graphql.Omittable[*string]{})
-		require.IsType(t, out.MissingInput{}.NullEnum, graphql.Omittable[*out.MissingEnum]{})
-		require.IsType(t, out.MissingInput{}.NullObject, graphql.Omittable[*out.ExistingInput]{})
+		require.IsType(t, graphql.Omittable[*string]{}, out.MissingInput{}.NullString)
+		require.IsType(t, graphql.Omittable[*out.MissingEnum]{}, out.MissingInput{}.NullEnum)
+		require.IsType(t, graphql.Omittable[*out.ExistingInput]{}, out.MissingInput{}.NullObject)
 	})
 
 	t.Run("extra fields are present", func(t *testing.T) {
 		var m out.ExtraFieldsTest
 
-		require.IsType(t, m.FieldInt, int64(0))
-		require.IsType(t, m.FieldInternalType, extrafields.Type{})
+		require.IsType(t, int64(0), m.FieldInt)
+		require.IsType(t, extrafields.Type{}, m.FieldInternalType)
 		require.IsType(t, m.FieldStringPtr, new(string))
-		require.IsType(t, m.FieldIntSlice, []int64{})
+		require.IsType(t, []int64{}, m.FieldIntSlice)
 	})
 }
 
@@ -390,15 +390,15 @@ func TestModelGenerationNullableInputOmittable(t *testing.T) {
 	require.NoError(t, p.MutateConfig(cfg))
 
 	t.Run("nullable input fields are omittable", func(t *testing.T) {
-		require.IsType(t, out_nullable_input_omittable.MissingInput{}.Name, graphql.Omittable[*string]{})
-		require.IsType(t, out_nullable_input_omittable.MissingInput{}.Enum, graphql.Omittable[*out_nullable_input_omittable.MissingEnum]{})
-		require.IsType(t, out_nullable_input_omittable.MissingInput{}.NullString, graphql.Omittable[*string]{})
-		require.IsType(t, out_nullable_input_omittable.MissingInput{}.NullEnum, graphql.Omittable[*out_nullable_input_omittable.MissingEnum]{})
-		require.IsType(t, out_nullable_input_omittable.MissingInput{}.NullObject, graphql.Omittable[*out_nullable_input_omittable.ExistingInput]{})
+		require.IsType(t, graphql.Omittable[*string]{}, out_nullable_input_omittable.MissingInput{}.Name)
+		require.IsType(t, graphql.Omittable[*out_nullable_input_omittable.MissingEnum]{}, out_nullable_input_omittable.MissingInput{}.Enum)
+		require.IsType(t, graphql.Omittable[*string]{}, out_nullable_input_omittable.MissingInput{}.NullString)
+		require.IsType(t, graphql.Omittable[*out_nullable_input_omittable.MissingEnum]{}, out_nullable_input_omittable.MissingInput{}.NullEnum)
+		require.IsType(t, graphql.Omittable[*out_nullable_input_omittable.ExistingInput]{}, out_nullable_input_omittable.MissingInput{}.NullObject)
 	})
 
 	t.Run("non-nullable input fields are not omittable", func(t *testing.T) {
-		require.IsType(t, out_nullable_input_omittable.MissingInput{}.NonNullString, "")
+		require.IsType(t, "", out_nullable_input_omittable.MissingInput{}.NonNullString)
 	})
 }
 


### PR DESCRIPTION
This PR fixes tests. It reverses passed parameters to the [assert.Equal](https://pkg.go.dev/github.com/stretchr/testify@v1.9.0/assert#Equal) according to the signature (`actual` after `expected`):

```
func Equal(t TestingT), expected, actual interface{}, msgAndArgs ...interface{}) bool
```

Additionally, the PR enables `testifylint` linter to automatically detect this type of issues.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
