### PR TITLE
Improve federation resolver selection

### DIFF
--- a/_examples/federation/accounts/graph/federation.go
+++ b/_examples/federation/accounts/graph/federation.go
@@ -197,8 +197,18 @@ func entityResolverNameForEmailHost(ctx context.Context, rep map[string]interfac
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["id"]; !ok {
+		val, ok = m["id"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findEmailHostByID", nil
@@ -214,8 +224,18 @@ func entityResolverNameForUser(ctx context.Context, rep map[string]interface{}) 
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["id"]; !ok {
+		val, ok = m["id"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findUserByID", nil

--- a/_examples/federation/products/graph/federation.go
+++ b/_examples/federation/products/graph/federation.go
@@ -213,8 +213,18 @@ func entityResolverNameForManufacturer(ctx context.Context, rep map[string]inter
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["id"]; !ok {
+		val, ok = m["id"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findManufacturerByID", nil
@@ -230,18 +240,33 @@ func entityResolverNameForProduct(ctx context.Context, rep map[string]interface{
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if val, ok = m["manufacturer"]; !ok {
+		val, ok = m["manufacturer"]
+		if !ok {
 			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
 			break
 		}
-		if _, ok = m["id"]; !ok {
+		val, ok = m["id"]
+		if !ok {
 			break
 		}
+		if allNull {
+			allNull = val == nil
+		}
 		m = rep
-		if _, ok = m["id"]; !ok {
+		val, ok = m["id"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findProductByManufacturerIDAndID", nil
@@ -253,8 +278,18 @@ func entityResolverNameForProduct(ctx context.Context, rep map[string]interface{
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["upc"]; !ok {
+		val, ok = m["upc"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findProductByUpc", nil

--- a/_examples/federation/reviews/graph/federation.go
+++ b/_examples/federation/reviews/graph/federation.go
@@ -209,18 +209,33 @@ func entityResolverNameForProduct(ctx context.Context, rep map[string]interface{
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if val, ok = m["manufacturer"]; !ok {
+		val, ok = m["manufacturer"]
+		if !ok {
 			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
 			break
 		}
-		if _, ok = m["id"]; !ok {
+		val, ok = m["id"]
+		if !ok {
 			break
 		}
+		if allNull {
+			allNull = val == nil
+		}
 		m = rep
-		if _, ok = m["id"]; !ok {
+		val, ok = m["id"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findProductByManufacturerIDAndID", nil
@@ -236,8 +251,18 @@ func entityResolverNameForUser(ctx context.Context, rep map[string]interface{}) 
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["id"]; !ok {
+		val, ok = m["id"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findUserByID", nil

--- a/plugin/federation/federation.gotpl
+++ b/plugin/federation/federation.gotpl
@@ -253,19 +253,30 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 						ok bool
 					)
 					_ = val
+					// if all of the KeyFields values for this resolver are null,
+					// we shouldn't use use it
+					allNull := true
 					{{- range $_, $keyField := .KeyFields }}
 						m = rep
 						{{- range $i, $field := .Field }}
-							if {{ if (ne $i $keyField.Field.LastIndex ) -}}val{{- else -}}_{{- end -}}, ok = m["{{.}}"]; !ok {
+							val, ok = m["{{.}}"]
+							if !ok {
 								break
 							}
 							{{- if (ne $i $keyField.Field.LastIndex ) }}
 								if m, ok = val.(map[string]interface{}); !ok {
 									break
 								}
+							{{- else}}
+								if allNull {
+									allNull = val == nil
+								}
 							{{- end}}
 						{{- end}}
 					{{- end }}
+					if allNull {
+						break
+					}
 					return "{{.ResolverName}}", nil
 				}
 			{{- end }}

--- a/plugin/federation/testdata/allthethings/generated/federation.go
+++ b/plugin/federation/testdata/allthethings/generated/federation.go
@@ -359,8 +359,18 @@ func entityResolverNameForExternalExtension(ctx context.Context, rep map[string]
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["upc"]; !ok {
+		val, ok = m["upc"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findExternalExtensionByUpc", nil
@@ -376,8 +386,18 @@ func entityResolverNameForHello(ctx context.Context, rep map[string]interface{})
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findHelloByName", nil
@@ -393,8 +413,18 @@ func entityResolverNameForMultiHelloMultiKey(ctx context.Context, rep map[string
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findManyMultiHelloMultiKeyByNames", nil
@@ -406,8 +436,18 @@ func entityResolverNameForMultiHelloMultiKey(ctx context.Context, rep map[string
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["key2"]; !ok {
+		val, ok = m["key2"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findManyMultiHelloMultiKeyByKey2s", nil
@@ -423,18 +463,33 @@ func entityResolverNameForNestedKey(ctx context.Context, rep map[string]interfac
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["id"]; !ok {
+		val, ok = m["id"]
+		if !ok {
 			break
 		}
+		if allNull {
+			allNull = val == nil
+		}
 		m = rep
-		if val, ok = m["hello"]; !ok {
+		val, ok = m["hello"]
+		if !ok {
 			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
 			break
 		}
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findNestedKeyByIDAndHelloName", nil
@@ -450,54 +505,85 @@ func entityResolverNameForVeryNestedKey(ctx context.Context, rep map[string]inte
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["id"]; !ok {
+		val, ok = m["id"]
+		if !ok {
 			break
 		}
+		if allNull {
+			allNull = val == nil
+		}
 		m = rep
-		if val, ok = m["hello"]; !ok {
+		val, ok = m["hello"]
+		if !ok {
 			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
 			break
 		}
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
 			break
+		}
+		if allNull {
+			allNull = val == nil
 		}
 		m = rep
-		if val, ok = m["world"]; !ok {
+		val, ok = m["world"]
+		if !ok {
 			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
 			break
 		}
-		if _, ok = m["foo"]; !ok {
+		val, ok = m["foo"]
+		if !ok {
 			break
+		}
+		if allNull {
+			allNull = val == nil
 		}
 		m = rep
-		if val, ok = m["world"]; !ok {
+		val, ok = m["world"]
+		if !ok {
 			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
 			break
 		}
-		if _, ok = m["bar"]; !ok {
+		val, ok = m["bar"]
+		if !ok {
 			break
+		}
+		if allNull {
+			allNull = val == nil
 		}
 		m = rep
-		if val, ok = m["more"]; !ok {
+		val, ok = m["more"]
+		if !ok {
 			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
 			break
 		}
-		if val, ok = m["world"]; !ok {
+		val, ok = m["world"]
+		if !ok {
 			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
 			break
 		}
-		if _, ok = m["foo"]; !ok {
+		val, ok = m["foo"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findVeryNestedKeyByIDAndHelloNameAndWorldFooAndWorldBarAndMoreWorldFoo", nil
@@ -513,8 +599,18 @@ func entityResolverNameForWorld(ctx context.Context, rep map[string]interface{})
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["foo"]; !ok {
+		val, ok = m["foo"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findWorldByFoo", nil
@@ -526,8 +622,18 @@ func entityResolverNameForWorld(ctx context.Context, rep map[string]interface{})
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["bar"]; !ok {
+		val, ok = m["bar"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findWorldByBar", nil

--- a/plugin/federation/testdata/entityresolver/entity.resolvers.go
+++ b/plugin/federation/testdata/entityresolver/entity.resolvers.go
@@ -12,9 +12,6 @@ import (
 	"github.com/99designs/gqlgen/plugin/federation/testdata/entityresolver/generated/model"
 )
 
-// FindWorldWithMultipleKeysByHelloNameAndFooBarValue shows we hit the FindWorldWithMultipleKeysByHelloNameAndFoo resolver
-const FindWorldWithMultipleKeysByHelloNameAndFooBarValue = 99
-
 // FindHelloByName is the resolver for the findHelloByName field.
 func (r *entityResolver) FindHelloByName(ctx context.Context, name string) (*model.Hello, error) {
 	return &model.Hello{

--- a/plugin/federation/testdata/entityresolver/entity.resolvers.go
+++ b/plugin/federation/testdata/entityresolver/entity.resolvers.go
@@ -12,6 +12,9 @@ import (
 	"github.com/99designs/gqlgen/plugin/federation/testdata/entityresolver/generated/model"
 )
 
+// FindWorldWithMultipleKeysByHelloNameAndFooBarValue shows we hit the FindWorldWithMultipleKeysByHelloNameAndFoo resolver
+const FindWorldWithMultipleKeysByHelloNameAndFooBarValue = 99
+
 // FindHelloByName is the resolver for the findHelloByName field.
 func (r *entityResolver) FindHelloByName(ctx context.Context, name string) (*model.Hello, error) {
 	return &model.Hello{
@@ -167,6 +170,7 @@ func (r *entityResolver) FindWorldWithMultipleKeysByHelloNameAndFoo(ctx context.
 			Name: helloName,
 		},
 		Foo: foo,
+		Bar: FindWorldWithMultipleKeysByHelloNameAndFooBarValue,
 	}, nil
 }
 

--- a/plugin/federation/testdata/entityresolver/generated/federation.go
+++ b/plugin/federation/testdata/entityresolver/generated/federation.go
@@ -579,8 +579,18 @@ func entityResolverNameForHello(ctx context.Context, rep map[string]interface{})
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findHelloByName", nil
@@ -596,12 +606,26 @@ func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep map[stri
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["key1"]; !ok {
+		val, ok = m["key1"]
+		if !ok {
 			break
 		}
+		if allNull {
+			allNull = val == nil
+		}
 		m = rep
-		if _, ok = m["key2"]; !ok {
+		val, ok = m["key2"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findHelloMultiSingleKeysByKey1AndKey2", nil
@@ -617,8 +641,18 @@ func entityResolverNameForHelloWithErrors(ctx context.Context, rep map[string]in
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findHelloWithErrorsByName", nil
@@ -634,8 +668,18 @@ func entityResolverNameForMultiHello(ctx context.Context, rep map[string]interfa
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findManyMultiHelloByNames", nil
@@ -651,8 +695,18 @@ func entityResolverNameForMultiHelloMultipleRequires(ctx context.Context, rep ma
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findManyMultiHelloMultipleRequiresByNames", nil
@@ -668,8 +722,18 @@ func entityResolverNameForMultiHelloRequires(ctx context.Context, rep map[string
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findManyMultiHelloRequiresByNames", nil
@@ -685,8 +749,18 @@ func entityResolverNameForMultiHelloWithError(ctx context.Context, rep map[strin
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findManyMultiHelloWithErrorByNames", nil
@@ -702,8 +776,18 @@ func entityResolverNameForMultiPlanetRequiresNested(ctx context.Context, rep map
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findManyMultiPlanetRequiresNestedByNames", nil
@@ -719,8 +803,18 @@ func entityResolverNameForPlanetMultipleRequires(ctx context.Context, rep map[st
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findPlanetMultipleRequiresByName", nil
@@ -736,8 +830,18 @@ func entityResolverNameForPlanetRequires(ctx context.Context, rep map[string]int
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findPlanetRequiresByName", nil
@@ -753,8 +857,18 @@ func entityResolverNameForPlanetRequiresNested(ctx context.Context, rep map[stri
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findPlanetRequiresNestedByName", nil
@@ -770,18 +884,33 @@ func entityResolverNameForWorld(ctx context.Context, rep map[string]interface{})
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if val, ok = m["hello"]; !ok {
+		val, ok = m["hello"]
+		if !ok {
 			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
 			break
 		}
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
 			break
 		}
+		if allNull {
+			allNull = val == nil
+		}
 		m = rep
-		if _, ok = m["foo"]; !ok {
+		val, ok = m["foo"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findWorldByHelloNameAndFoo", nil
@@ -797,8 +926,18 @@ func entityResolverNameForWorldName(ctx context.Context, rep map[string]interfac
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findWorldNameByName", nil
@@ -814,18 +953,33 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep map[str
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if val, ok = m["hello"]; !ok {
+		val, ok = m["hello"]
+		if !ok {
 			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
 			break
 		}
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
 			break
 		}
+		if allNull {
+			allNull = val == nil
+		}
 		m = rep
-		if _, ok = m["foo"]; !ok {
+		val, ok = m["foo"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findWorldWithMultipleKeysByHelloNameAndFoo", nil
@@ -837,8 +991,18 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep map[str
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["bar"]; !ok {
+		val, ok = m["bar"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findWorldWithMultipleKeysByBar", nil

--- a/plugin/federation/testdata/entityresolver/resolver.go
+++ b/plugin/federation/testdata/entityresolver/resolver.go
@@ -5,3 +5,6 @@ package entityresolver
 // It serves as dependency injection for your app, add any dependencies you require here.
 
 type Resolver struct{}
+
+// FindWorldWithMultipleKeysByHelloNameAndFooBarValue shows we hit the FindWorldWithMultipleKeysByHelloNameAndFoo resolver
+const FindWorldWithMultipleKeysByHelloNameAndFooBarValue = 99

--- a/plugin/federation/testdata/explicitrequires/generated/federation.go
+++ b/plugin/federation/testdata/explicitrequires/generated/federation.go
@@ -574,8 +574,18 @@ func entityResolverNameForHello(ctx context.Context, rep map[string]interface{})
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findHelloByName", nil
@@ -591,12 +601,26 @@ func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep map[stri
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["key1"]; !ok {
+		val, ok = m["key1"]
+		if !ok {
 			break
 		}
+		if allNull {
+			allNull = val == nil
+		}
 		m = rep
-		if _, ok = m["key2"]; !ok {
+		val, ok = m["key2"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findHelloMultiSingleKeysByKey1AndKey2", nil
@@ -612,8 +636,18 @@ func entityResolverNameForHelloWithErrors(ctx context.Context, rep map[string]in
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findHelloWithErrorsByName", nil
@@ -629,8 +663,18 @@ func entityResolverNameForMultiHello(ctx context.Context, rep map[string]interfa
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findManyMultiHelloByNames", nil
@@ -646,8 +690,18 @@ func entityResolverNameForMultiHelloMultipleRequires(ctx context.Context, rep ma
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findManyMultiHelloMultipleRequiresByNames", nil
@@ -663,8 +717,18 @@ func entityResolverNameForMultiHelloRequires(ctx context.Context, rep map[string
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findManyMultiHelloRequiresByNames", nil
@@ -680,8 +744,18 @@ func entityResolverNameForMultiHelloWithError(ctx context.Context, rep map[strin
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findManyMultiHelloWithErrorByNames", nil
@@ -697,8 +771,18 @@ func entityResolverNameForMultiPlanetRequiresNested(ctx context.Context, rep map
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findManyMultiPlanetRequiresNestedByNames", nil
@@ -714,8 +798,18 @@ func entityResolverNameForPlanetMultipleRequires(ctx context.Context, rep map[st
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findPlanetMultipleRequiresByName", nil
@@ -731,8 +825,18 @@ func entityResolverNameForPlanetRequires(ctx context.Context, rep map[string]int
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findPlanetRequiresByName", nil
@@ -748,8 +852,18 @@ func entityResolverNameForPlanetRequiresNested(ctx context.Context, rep map[stri
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findPlanetRequiresNestedByName", nil
@@ -765,18 +879,33 @@ func entityResolverNameForWorld(ctx context.Context, rep map[string]interface{})
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if val, ok = m["hello"]; !ok {
+		val, ok = m["hello"]
+		if !ok {
 			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
 			break
 		}
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
 			break
 		}
+		if allNull {
+			allNull = val == nil
+		}
 		m = rep
-		if _, ok = m["foo"]; !ok {
+		val, ok = m["foo"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findWorldByHelloNameAndFoo", nil
@@ -792,8 +921,18 @@ func entityResolverNameForWorldName(ctx context.Context, rep map[string]interfac
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findWorldNameByName", nil
@@ -809,18 +948,33 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep map[str
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if val, ok = m["hello"]; !ok {
+		val, ok = m["hello"]
+		if !ok {
 			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
 			break
 		}
-		if _, ok = m["name"]; !ok {
+		val, ok = m["name"]
+		if !ok {
 			break
 		}
+		if allNull {
+			allNull = val == nil
+		}
 		m = rep
-		if _, ok = m["foo"]; !ok {
+		val, ok = m["foo"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findWorldWithMultipleKeysByHelloNameAndFoo", nil
@@ -832,8 +986,18 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep map[str
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["bar"]; !ok {
+		val, ok = m["bar"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findWorldWithMultipleKeysByBar", nil

--- a/plugin/federation/testdata/federation2/generated/federation.go
+++ b/plugin/federation/testdata/federation2/generated/federation.go
@@ -177,8 +177,18 @@ func entityResolverNameForExternalExtension(ctx context.Context, rep map[string]
 			ok  bool
 		)
 		_ = val
+		// if all of the KeyFields values for this resolver are null,
+		// we shouldn't use use it
+		allNull := true
 		m = rep
-		if _, ok = m["upc"]; !ok {
+		val, ok = m["upc"]
+		if !ok {
+			break
+		}
+		if allNull {
+			allNull = val == nil
+		}
+		if allNull {
 			break
 		}
 		return "findExternalExtensionByUpc", nil


### PR DESCRIPTION
Just checking for existence of keys in the representations isn't enough.  If the values are null, we should skip the resolver.

Imagine the following case:

```graphql
type Location @key(fields: "id") @key(fields: "latitude longitude") {
  id: ID!
  latitude: Float!
  longitude: Float!
}
```

The Federation Router sends me the following query:
```graphql
query Location {
  _entities(representations: [{
        __typename: "GeoLocation",
        id: null,
        latitude: 37.7878792,
        longitude: -122.4027042
      }
    ]) {
    ... on GeoLocation {
      latitude
      longitude
      id
      fullAddress
      name
    }
  }
}
```

With the current logic, we'll select the `id` resolver, _even though the value is null_. With this change, we'll now see that the value for `id` is `null` and skip over it to select the `latitude longitude` resolver.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
