### PR TITLE
chore: `run.skip-dirs` is deprecated in golangci-lint v1.57

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,5 @@
 run:
   tests: true
-  skip-dirs:
-    - bin
 
 linters-settings:
   errcheck:
@@ -33,6 +31,8 @@ linters:
     - unused
 
 issues:
+  exclude-dirs:
+    - bin
   exclude-rules:
     # Exclude some linters from running on tests files.
     - path: _test\.go


### PR DESCRIPTION
This PR replaces deprecated `run.skip-dirs` with `issues.exclude-dirs` in golangci-lint config. See https://github.com/golangci/golangci-lint/pull/4509.

Before PR:
```
❯ golangci-lint version
golangci-lint has version 1.57.2 built with go1.22.1 from 77a8601a on 2024-03-28T19:01:11Z
❯ golangci-lint run
WARN [config_reader] The configuration option `run.skip-dirs` is deprecated, please use `issues.exclude-dirs`. 
```

After PR:
```
❯ golangci-lint version
golangci-lint has version 1.57.2 built with go1.22.1 from 77a8601a on 2024-03-28T19:01:11Z
❯ golangci-lint run
```