### PR TITLE
chore: remove redundant empty lines

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,10 @@ run:
 linters-settings:
   errcheck:
     ignore: fmt:.*,[rR]ead|[wW]rite|[cC]lose,io:Copy
+  revive:
+    enable-all-rules: false
+    rules:
+      - name: empty-lines
   testifylint:
     disable-all: true
     enable:
@@ -26,6 +30,7 @@ linters:
     - misspell
     - nakedret
     - prealloc
+    - revive
     - staticcheck
     - testifylint
     - typecheck

--- a/codegen/directive.go
+++ b/codegen/directive.go
@@ -124,7 +124,6 @@ func (b *builder) getDirectives(list ast.DirectiveList) ([]*Directive, error) {
 			DirectiveDefinition: list[i].Definition,
 			Builtin:             b.Config.Directives[d.Name].SkipRuntime,
 		}
-
 	}
 
 	return dirs, nil

--- a/codegen/templates/templates_test.go
+++ b/codegen/templates/templates_test.go
@@ -333,7 +333,6 @@ func TestTemplateOverride(t *testing.T) {
 }
 
 func TestRenderFS(t *testing.T) {
-
 	tempDir := t.TempDir()
 
 	outDir := filepath.Join(tempDir, "output")

--- a/graphql/context_path.go
+++ b/graphql/context_path.go
@@ -34,7 +34,6 @@ func (fic *PathContext) Path() ast.Path {
 	if fic.ParentField != nil {
 		fieldPath := fic.ParentField.Path()
 		return append(fieldPath, path...)
-
 	}
 
 	return path

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -760,7 +760,6 @@ func TestWebsocketWithPingPongInterval(t *testing.T) {
 		assert.Equal(t, connectionKeepAliveMsg, readOp(c).Type)
 	})
 	t.Run("pong only messages are sent when configured with graphql-transport-ws", func(t *testing.T) {
-
 		h, srv := initialize(transport.Websocket{PongOnlyInterval: 10 * time.Millisecond})
 		defer srv.Close()
 
@@ -793,7 +792,6 @@ func TestWebsocketWithPingPongInterval(t *testing.T) {
 		msg = readOp(c)
 		assert.Equal(t, graphqltransportwsPongMsg, msg.Type)
 	})
-
 }
 
 func wsConnect(url string) *websocket.Conn {

--- a/graphql/id_test.go
+++ b/graphql/id_test.go
@@ -71,7 +71,6 @@ func TestMarshalUintID(t *testing.T) {
 }
 
 func TestUnMarshalUintID(t *testing.T) {
-
 	result, err := UnmarshalUintID("12")
 	assert.Equal(t, uint(12), result)
 	assert.NoError(t, err)

--- a/graphql/uuid_test.go
+++ b/graphql/uuid_test.go
@@ -13,7 +13,6 @@ func TestMarshalUUID(t *testing.T) {
 	})
 
 	t.Run("Valid Values", func(t *testing.T) {
-
 		var values = []struct {
 			input    uuid.UUID
 			expected string

--- a/internal/rewrite/rewriter.go
+++ b/internal/rewrite/rewriter.go
@@ -63,7 +63,6 @@ func (r *Rewriter) getFile(filename string) string {
 		}
 
 		r.files[filename] = string(b)
-
 	}
 
 	return r.files[filename]

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -182,7 +182,6 @@ func (f *federation) InjectSourceLate(schema *ast.Schema) *ast.Source {
 
 	var entities, resolvers, entityResolverInputDefinitions string
 	for _, e := range f.Entities {
-
 		if e.Def.Kind != ast.Interface {
 			if entities != "" {
 				entities += " | "
@@ -329,7 +328,6 @@ func (f *federation) GenerateCode(data *codegen.Data) error {
 
 			// add type info to entity
 			e.Type = obj.Type
-
 		}
 	}
 
@@ -416,7 +414,6 @@ func (f *federation) GenerateCode(data *codegen.Data) error {
 		if err != nil {
 			return err
 		}
-
 	}
 
 	return templates.Render(templates.Options{

--- a/plugin/federation/federation_test.go
+++ b/plugin/federation/federation_test.go
@@ -171,7 +171,6 @@ func TestCodeGenerationFederation2(t *testing.T) {
 // This test is to ensure that the input arguments are not
 // changed when cfg.OmitSliceElementPointers is false OR true
 func TestMultiWithOmitSliceElemPointersCfg(t *testing.T) {
-
 	staticRepsString := "reps: [HelloByNamesInput]!"
 	t.Run("OmitSliceElementPointers true", func(t *testing.T) {
 		f, cfg := load(t, "testdata/multi/multi.yml")
@@ -231,7 +230,6 @@ func TestHandlesArgumentGeneration(t *testing.T) {
 	raw := "foo bar baz(limit:4)"
 	requiresFieldSet := fieldset.New(raw, nil)
 	for _, field := range requiresFieldSet {
-
 		e.Requires = append(e.Requires, &Requires{
 			Name:  field.ToGoPrivate(),
 			Field: field,

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -176,7 +176,6 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 						uniqueMap[iface] = true
 					}
 				}
-
 			}
 
 			b.Models = append(b.Models, it)


### PR DESCRIPTION
The PR makes stylistic changes to improve readability by removing unnecessary lines at the beginning and end of blocks. These issues were found with the help of the `revive.empty-lines` check.