### PR TITLE
refactor: change test asserts to be more idiomatic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,8 @@ linters-settings:
   testifylint:
     disable-all: true
     enable:
+      - bool-compare
+      - error-nil
       - expected-actual
 
 linters:

--- a/codegen/testserver/followschema/defaults_test.go
+++ b/codegen/testserver/followschema/defaults_test.go
@@ -13,9 +13,9 @@ import (
 func assertDefaults(t *testing.T, ret *DefaultParametersMirror) {
 	require.NotNil(t, ret)
 	require.NotNil(t, ret.FalsyBoolean)
-	require.Equal(t, false, *ret.FalsyBoolean)
+	require.False(t, *ret.FalsyBoolean)
 	require.NotNil(t, ret.TruthyBoolean)
-	require.Equal(t, true, *ret.TruthyBoolean)
+	require.True(t, *ret.TruthyBoolean)
 }
 
 func TestDefaults(t *testing.T) {

--- a/codegen/testserver/followschema/directive_test.go
+++ b/codegen/testserver/followschema/directive_test.go
@@ -224,7 +224,7 @@ func TestDirectives(t *testing.T) {
 
 			err := c.Post(`query { directiveNullableArg }`, &resp)
 
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, "Ok", *resp.DirectiveNullableArg)
 		})
 		t.Run("when function success on valid nullable arg directives", func(t *testing.T) {
@@ -234,7 +234,7 @@ func TestDirectives(t *testing.T) {
 
 			err := c.Post(`query { directiveNullableArg(arg: 1) }`, &resp)
 
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, "Ok", *resp.DirectiveNullableArg)
 		})
 		t.Run("when function success", func(t *testing.T) {
@@ -244,7 +244,7 @@ func TestDirectives(t *testing.T) {
 
 			err := c.Post(`query { directiveArg(arg: "test") }`, &resp)
 
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, "Ok", *resp.DirectiveArg)
 		})
 	})
@@ -351,7 +351,7 @@ func TestDirectives(t *testing.T) {
 
 			err := c.Post(`query { directiveInputNullable(arg: {text:"23",inner:{message:"1"}}) }`, &resp)
 
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, "Ok", *resp.DirectiveInputNullable)
 		})
 		t.Run("when function inner nullable success", func(t *testing.T) {
@@ -361,7 +361,7 @@ func TestDirectives(t *testing.T) {
 
 			err := c.Post(`query { directiveInputNullable(arg: {text:"23",nullableText:"23",inner:{message:"1"},innerNullable:{message:"success"}}) }`, &resp)
 
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, "Ok", *resp.DirectiveInputNullable)
 		})
 		t.Run("when arg has directive", func(t *testing.T) {
@@ -371,7 +371,7 @@ func TestDirectives(t *testing.T) {
 
 			err := c.Post(`query { directiveInputType(arg: {id: 1}) }`, &resp)
 
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, "Ok", *resp.DirectiveInputType)
 		})
 	})
@@ -387,7 +387,7 @@ func TestDirectives(t *testing.T) {
 
 			err := c.Post(`query { directiveObject{ text nullableText order} }`, &resp)
 
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, "Ok", resp.DirectiveObject.Text)
 			require.True(t, resp.DirectiveObject.NullableText == nil)
 			require.Equal(t, "Query_field", resp.DirectiveObject.Order[0])
@@ -404,7 +404,7 @@ func TestDirectives(t *testing.T) {
 
 			err := c.Post(`query { directiveObjectWithCustomGoModel{ nullableText } }`, &resp)
 
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.True(t, resp.DirectiveObjectWithCustomGoModel.NullableText == nil)
 		})
 	})
@@ -438,7 +438,7 @@ func TestDirectives(t *testing.T) {
 
 				err := c.WebsocketOnce(`subscription { directiveNullableArg }`, &resp)
 
-				require.Nil(t, err)
+				require.NoError(t, err)
 				require.Equal(t, "Ok", *resp.DirectiveNullableArg)
 			})
 			t.Run("when function success on valid nullable arg directives", func(t *testing.T) {
@@ -448,7 +448,7 @@ func TestDirectives(t *testing.T) {
 
 				err := c.WebsocketOnce(`subscription { directiveNullableArg(arg: 1) }`, &resp)
 
-				require.Nil(t, err)
+				require.NoError(t, err)
 				require.Equal(t, "Ok", *resp.DirectiveNullableArg)
 			})
 			t.Run("when function success", func(t *testing.T) {
@@ -458,7 +458,7 @@ func TestDirectives(t *testing.T) {
 
 				err := c.WebsocketOnce(`subscription { directiveArg(arg: "test") }`, &resp)
 
-				require.Nil(t, err)
+				require.NoError(t, err)
 				require.Equal(t, "Ok", *resp.DirectiveArg)
 			})
 		})

--- a/codegen/testserver/followschema/nulls_test.go
+++ b/codegen/testserver/followschema/nulls_test.go
@@ -85,7 +85,7 @@ func TestNullBubbling(t *testing.T) {
 		}
 		err := c.Post(`query { valid, errorList { id } }`, &resp)
 
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, 1, len(resp.ErrorList))
 		require.Nil(t, resp.ErrorList[0])
 		require.Equal(t, "Ok", resp.Valid)
@@ -114,7 +114,7 @@ func TestNullBubbling(t *testing.T) {
 		}
 
 		err := c.Post(`query { nullableArg(arg: null) }`, &resp)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, "Ok", *resp.NullableArg)
 	})
 
@@ -142,7 +142,7 @@ func TestNullBubbling(t *testing.T) {
 		var resp any
 		err := c.Post(`query { invalid }`, &resp)
 		require.Nil(t, resp)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Contains(t, err.Error(), `{"message":"ERROR","path":["invalid"]}`)
 	})
 }

--- a/codegen/testserver/followschema/v-ok_test.go
+++ b/codegen/testserver/followschema/v-ok_test.go
@@ -42,6 +42,6 @@ func TestOk(t *testing.T) {
 		}
 		err := c.Post(`query { vOkCaseNil { value } }`, &resp)
 		require.NoError(t, err)
-		require.Equal(t, true, resp.VOkCaseNil.Value == nil)
+		require.Nil(t, resp.VOkCaseNil.Value)
 	})
 }

--- a/codegen/testserver/singlefile/defaults_test.go
+++ b/codegen/testserver/singlefile/defaults_test.go
@@ -13,9 +13,9 @@ import (
 func assertDefaults(t *testing.T, ret *DefaultParametersMirror) {
 	require.NotNil(t, ret)
 	require.NotNil(t, ret.FalsyBoolean)
-	require.Equal(t, false, *ret.FalsyBoolean)
+	require.False(t, *ret.FalsyBoolean)
 	require.NotNil(t, ret.TruthyBoolean)
-	require.Equal(t, true, *ret.TruthyBoolean)
+	require.True(t, *ret.TruthyBoolean)
 }
 
 func TestDefaults(t *testing.T) {

--- a/codegen/testserver/singlefile/directive_test.go
+++ b/codegen/testserver/singlefile/directive_test.go
@@ -224,7 +224,7 @@ func TestDirectives(t *testing.T) {
 
 			err := c.Post(`query { directiveNullableArg }`, &resp)
 
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, "Ok", *resp.DirectiveNullableArg)
 		})
 		t.Run("when function success on valid nullable arg directives", func(t *testing.T) {
@@ -234,7 +234,7 @@ func TestDirectives(t *testing.T) {
 
 			err := c.Post(`query { directiveNullableArg(arg: 1) }`, &resp)
 
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, "Ok", *resp.DirectiveNullableArg)
 		})
 		t.Run("when function success", func(t *testing.T) {
@@ -244,7 +244,7 @@ func TestDirectives(t *testing.T) {
 
 			err := c.Post(`query { directiveArg(arg: "test") }`, &resp)
 
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, "Ok", *resp.DirectiveArg)
 		})
 	})

--- a/codegen/testserver/singlefile/nulls_test.go
+++ b/codegen/testserver/singlefile/nulls_test.go
@@ -85,7 +85,7 @@ func TestNullBubbling(t *testing.T) {
 		}
 		err := c.Post(`query { valid, errorList { id } }`, &resp)
 
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, 1, len(resp.ErrorList))
 		require.Nil(t, resp.ErrorList[0])
 		require.Equal(t, "Ok", resp.Valid)
@@ -114,7 +114,7 @@ func TestNullBubbling(t *testing.T) {
 		}
 
 		err := c.Post(`query { nullableArg(arg: null) }`, &resp)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, "Ok", *resp.NullableArg)
 	})
 
@@ -142,7 +142,7 @@ func TestNullBubbling(t *testing.T) {
 		var resp any
 		err := c.Post(`query { invalid }`, &resp)
 		require.Nil(t, resp)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Contains(t, err.Error(), `{"message":"ERROR","path":["invalid"]}`)
 	})
 }

--- a/codegen/testserver/singlefile/v-ok_test.go
+++ b/codegen/testserver/singlefile/v-ok_test.go
@@ -42,6 +42,6 @@ func TestOk(t *testing.T) {
 		}
 		err := c.Post(`query { vOkCaseNil { value } }`, &resp)
 		require.NoError(t, err)
-		require.Equal(t, true, resp.VOkCaseNil.Value == nil)
+		require.Nil(t, resp.VOkCaseNil.Value)
 	})
 }

--- a/graphql/executor/executor_test.go
+++ b/graphql/executor/executor_test.go
@@ -156,7 +156,7 @@ func TestExecutor(t *testing.T) {
 
 		t.Run("cache hits use document from cache", func(t *testing.T) {
 			doc, err := parser.ParseQuery(&ast.Source{Input: `query Bar {name}`})
-			require.Nil(t, err)
+			require.NoError(t, err)
 			cache.Add(ctx, qry, doc)
 
 			resp := query(exec, "Bar", qry)

--- a/graphql/handler/apollofederatedtracingv1/tracing_test.go
+++ b/graphql/handler/apollofederatedtracingv1/tracing_test.go
@@ -49,11 +49,11 @@ func TestApolloTracing(t *testing.T) {
 
 	tracing := respData.Extensions.FTV1
 	pbuf, err := base64.StdEncoding.DecodeString(tracing)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ftv1 := &generated.Trace{}
 	err = proto.Unmarshal(pbuf, ftv1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.NotZero(t, ftv1.StartTime.Nanos)
 	require.Less(t, ftv1.StartTime.Nanos, ftv1.EndTime.Nanos)
@@ -82,11 +82,11 @@ func TestApolloTracing_Concurrent(t *testing.T) {
 
 			tracing := respData.Extensions.FTV1
 			pbuf, err := base64.StdEncoding.DecodeString(tracing)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			ftv1 := &generated.Trace{}
 			err = proto.Unmarshal(pbuf, ftv1)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.NotZero(t, ftv1.StartTime.Nanos)
 		}()
 	}

--- a/graphql/handler/extension/introspection_test.go
+++ b/graphql/handler/extension/introspection_test.go
@@ -14,5 +14,5 @@ func TestIntrospection(t *testing.T) {
 		DisableIntrospection: true,
 	}
 	require.Nil(t, Introspection{}.MutateOperationContext(context.Background(), rc))
-	require.Equal(t, false, rc.DisableIntrospection)
+	require.False(t, rc.DisableIntrospection)
 }

--- a/graphql/handler/server_test.go
+++ b/graphql/handler/server_test.go
@@ -129,7 +129,7 @@ func TestServer(t *testing.T) {
 
 		t.Run("cache hits use document from cache", func(t *testing.T) {
 			doc, err := parser.ParseQuery(&ast.Source{Input: `query Bar {name}`})
-			require.Nil(t, err)
+			require.NoError(t, err)
 			cache.Add(ctx, qry, doc)
 
 			resp := get(srv, "/foo?query="+url.QueryEscape(qry))

--- a/graphql/handler/transport/reader_test.go
+++ b/graphql/handler/transport/reader_test.go
@@ -33,8 +33,7 @@ func TestBytesRead(t *testing.T) {
 	t.Run("fail to read if pointer is nil", func(t *testing.T) {
 		n, err := (&bytesReader{}).Read(nil)
 		require.Equal(t, 0, n)
-		require.NotNil(t, err)
-		require.Equal(t, "byte slice pointer is nil", err.Error())
+		require.EqualError(t, err, "byte slice pointer is nil")
 	})
 
 	t.Run("read using buffer", func(t *testing.T) {

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -382,8 +382,7 @@ func TestWebSocketErrorFunc(t *testing.T) {
 		h := testserver.New()
 		h.AddTransport(transport.Websocket{
 			ErrorFunc: func(_ context.Context, err error) {
-				require.Error(t, err)
-				assert.Equal(t, "websocket read: invalid message received", err.Error())
+				require.EqualError(t, err, "websocket read: invalid message received")
 				assert.IsType(t, transport.WebsocketError{}, err)
 				assert.True(t, err.(transport.WebsocketError).IsReadError)
 				errFuncCalled <- true

--- a/graphql/time_test.go
+++ b/graphql/time_test.go
@@ -16,9 +16,9 @@ func TestTime(t *testing.T) {
 		MarshalTime(initialTime).MarshalGQL(buf)
 
 		str, err := strconv.Unquote(buf.String())
-		require.Nil(t, err)
+		require.NoError(t, err)
 		newTime, err := UnmarshalTime(str)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.True(t, initialTime.Equal(newTime), "expected times %v and %v to equal", initialTime, newTime)
 	})


### PR DESCRIPTION
The PR refactors test asserts:

- Replace two lines `require.Error + require.Equal` with one line `require.EqualError`.
- Use `require.Error/require.NoError` instead of `require.NotNil/require.Nil` for errors because it's more explicit.
- Use `require.True/require.False` instead of `require.Equal` for booleans because it's shorter.