### PR TITLE
docs: fix links to the docs latest version

### DIFF
--- a/docs/layouts/partials/version-banner.html
+++ b/docs/layouts/partials/version-banner.html
@@ -5,10 +5,10 @@
 
 {{ if (eq $currentVersion "master") }}
 	<div class="alert-warning">
-		You are looking at the docs for the unreleased <code>master</code> branch. The latest version is <a href="/{{$latestVersion}}">{{ $latestVersion }}</a>.
+		You are looking at the docs for the unreleased <code>master</code> branch. The latest version is <a href="../{{$latestVersion}}/">{{ $latestVersion }}</a>.
 	</div>
 {{ else if not (eq $latestVersion $currentVersion) }}
 	<div class="alert-warning">
-		You are looking at the docs for an older version ({{ $currentVersion }}). The latest version is <a href="/{{$latestVersion}}">{{ $latestVersion }}</a>.
+		You are looking at the docs for an older version ({{ $currentVersion }}). The latest version is <a href="../{{$latestVersion}}/">{{ $latestVersion }}</a>.
 	</div>
 {{ end }}


### PR DESCRIPTION
This PR fixes wrong links to the latest documentation.

### The problem

Open documentation for any non-latest version (or for `master`), e.g. [v0.17.44](https://gqlgen.com/v0.17.44/)

#### Actual 

The link to the latest version is non-existent page `https://gqlgen.com/v0.17.44/v0.17.45`

<img width="736" alt="image" src="https://github.com/99designs/gqlgen/assets/3228886/cc4b180f-284e-45f7-afe4-a1194f5f4fcc">

#### Expected

The link to the latest version is `https://gqlgen.com/v0.17.45/`
