### PR TITLE
chore: remove deprecated build constraint

### DIFF
--- a/.github/workflows/check-init
+++ b/.github/workflows/check-init
@@ -5,7 +5,7 @@ export GO111MODULE=on
 gqlgen_dir=$(pwd)
 cd $(mktemp -d)
 go mod init inittest
-printf '// +build tools\npackage tools\nimport _ "github.com/99designs/gqlgen"' | gofmt > tools.go
+printf '//go:build tools\npackage tools\nimport _ "github.com/99designs/gqlgen"' | gofmt > tools.go
 go mod tidy
 go mod edit -replace=github.com/99designs/gqlgen="$gqlgen_dir"
 go mod tidy

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Still not convinced enough to use **gqlgen**? Compare **gqlgen** with other Go g
 
 2. Add `github.com/99designs/gqlgen` to your [project's tools.go](https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module)
 
-       printf '// +build tools\npackage tools\nimport (_ "github.com/99designs/gqlgen"\n _ "github.com/99designs/gqlgen/graphql/introspection")' | gofmt > tools.go
+       printf '//go:build tools\npackage tools\nimport (_ "github.com/99designs/gqlgen"\n _ "github.com/99designs/gqlgen/graphql/introspection")' | gofmt > tools.go
 
        go mod tidy
 

--- a/_examples/tools.go
+++ b/_examples/tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 package main
 

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -28,7 +28,6 @@ Next, create a `tools.go` file and add gqlgen as a [tool dependency for your mod
 
 ```go
 //go:build tools
-// +build tools
 
 package tools
 

--- a/internal/code/testdata/p/p.go
+++ b/internal/code/testdata/p/p.go
@@ -1,5 +1,4 @@
 //go:build private
-// +build private
 
 // This file is excluded from the build unless the "private" build tag is set.
 // This is used to test loading private packages.

--- a/internal/tools.go
+++ b/internal/tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 package main
 


### PR DESCRIPTION
This PR removes outdated in Go 1.21 `// +build` comments. According to the https://pkg.go.dev/cmd/go#hdr-Build_constraints:

> Go versions 1.16 and earlier used a different syntax for build constraints, with a "// +build" prefix. The gofmt command will add an equivalent //go:build constraint when encountering the older syntax.

