### PR TITLE
chore: lint _examples directory

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,10 @@ jobs:
         uses: golangci/golangci-lint-action@v5.0.0
         with:
           version: latest
-          # skip cache because of flaky behaviors
-          skip-build-cache: true
-          skip-pkg-cache: true
           args: '--timeout 5m'
+      - name: golangci-lint examples
+        uses: golangci/golangci-lint-action@v5.0.0
+        with:
+          version: latest
+          args: '--timeout 5m'
+          working-directory: _examples

--- a/_examples/fileupload/fileupload_test.go
+++ b/_examples/fileupload/fileupload_test.go
@@ -39,8 +39,8 @@ func TestFileUpload(t *testing.T) {
 			require.NotNil(t, file)
 			require.NotNil(t, file.File)
 			content, err := io.ReadAll(file.File)
-			require.Nil(t, err)
-			require.Equal(t, string(content), "test")
+			require.NoError(t, err)
+			require.Equal(t, "test", string(content))
 
 			return &model.File{
 				ID:          1,
@@ -63,7 +63,7 @@ func TestFileUpload(t *testing.T) {
 		}
 
 		err := gql.Post(mutation, &result, gqlclient.Var("file", aTxtFile), gqlclient.WithFiles())
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, 1, result.SingleUpload.ID)
 		require.Contains(t, result.SingleUpload.Name, "a.txt")
 		require.Equal(t, "test", result.SingleUpload.Content)
@@ -72,12 +72,12 @@ func TestFileUpload(t *testing.T) {
 
 	t.Run("valid single file upload with payload", func(t *testing.T) {
 		resolver.MutationResolver.SingleUploadWithPayload = func(ctx context.Context, req model.UploadFile) (*model.File, error) {
-			require.Equal(t, req.ID, 1)
+			require.Equal(t, 1, req.ID)
 			require.NotNil(t, req.File)
 			require.NotNil(t, req.File.File)
 			content, err := io.ReadAll(req.File.File)
-			require.Nil(t, err)
-			require.Equal(t, string(content), "test")
+			require.NoError(t, err)
+			require.Equal(t, "test", string(content))
 
 			return &model.File{
 				ID:          1,
@@ -100,7 +100,7 @@ func TestFileUpload(t *testing.T) {
 		}
 
 		err := gql.Post(mutation, &result, gqlclient.Var("req", map[string]interface{}{"id": 1, "file": aTxtFile}), gqlclient.WithFiles())
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, 1, result.SingleUploadWithPayload.ID)
 		require.Contains(t, result.SingleUploadWithPayload.Name, "a.txt")
 		require.Equal(t, "test", result.SingleUploadWithPayload.Content)
@@ -115,7 +115,7 @@ func TestFileUpload(t *testing.T) {
 			for i := range files {
 				require.NotNil(t, files[i].File)
 				content, err := io.ReadAll(files[i].File)
-				require.Nil(t, err)
+				require.NoError(t, err)
 				contents = append(contents, string(content))
 				resp = append(resp, &model.File{
 					ID:          i + 1,
@@ -141,7 +141,7 @@ func TestFileUpload(t *testing.T) {
 		}
 
 		err := gql.Post(mutation, &result, gqlclient.Var("files", []*os.File{a1TxtFile, b1TxtFile}), gqlclient.WithFiles())
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, 1, result.MultipleUpload[0].ID)
 		require.Equal(t, 2, result.MultipleUpload[1].ID)
 		for _, mu := range result.MultipleUpload {
@@ -165,7 +165,7 @@ func TestFileUpload(t *testing.T) {
 				require.NotNil(t, req[i].File)
 				require.NotNil(t, req[i].File.File)
 				content, err := io.ReadAll(req[i].File.File)
-				require.Nil(t, err)
+				require.NoError(t, err)
 				ids = append(ids, req[i].ID)
 				contents = append(contents, string(content))
 				resp = append(resp, &model.File{
@@ -196,7 +196,7 @@ func TestFileUpload(t *testing.T) {
 			{"id": 1, "file": a1TxtFile},
 			{"id": 2, "file": b1TxtFile},
 		}), gqlclient.WithFiles())
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, 1, result.MultipleUploadWithPayload[0].ID)
 		require.Equal(t, 2, result.MultipleUploadWithPayload[1].ID)
 		for _, mu := range result.MultipleUploadWithPayload {
@@ -271,7 +271,7 @@ func TestFileUpload(t *testing.T) {
 				{"id": 1, "file": a1TxtFile},
 				{"id": 2, "file": a1TxtFile},
 			}), gqlclient.WithFiles())
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, 1, result.MultipleUploadWithPayload[0].ID)
 			require.Contains(t, result.MultipleUploadWithPayload[0].Name, "a.txt")
 			require.Equal(t, "test1", result.MultipleUploadWithPayload[0].Content)

--- a/_examples/starwars/benchmarks_test.go
+++ b/_examples/starwars/benchmarks_test.go
@@ -29,6 +29,5 @@ func BenchmarkSimpleQueryNoArgs(b *testing.B) {
 		if rec.Body.String() != `{"data":{"search":[{"starships":[{"name":"X-Wing"},{"name":"Imperial shuttle"}]}]}}` {
 			b.Fatalf("Unexpected response: %s", rec.Body.String())
 		}
-
 	}
 }


### PR DESCRIPTION
The PR added a workflow action for linting the `_examples` directory. Also, fixes up lint issues.

`skip-build-cache` and `skip-pkg-cache` do not exist in `actions/golangci/golangci-lint-action@v5.0.0`. It was removed because the cache related to Go itself is already handled by `actions/setup-go`. See https://github.com/golangci/golangci-lint-action#compatibility.