### PR TITLE
fix: failed to build _examples/websocket-initfunc/server/server.go (#3055)

### DIFF
--- a/_examples/websocket-initfunc/server/server.go
+++ b/_examples/websocket-initfunc/server/server.go
@@ -63,7 +63,7 @@ func main() {
 				return true
 			},
 		},
-		InitFunc: func(ctx context.Context, initPayload transport.InitPayload) (*transport.InitPayload, context.Context, error) {
+		InitFunc: func(ctx context.Context, initPayload transport.InitPayload) (context.Context, *transport.InitPayload, error) {
 			return webSocketInit(ctx, initPayload)
 		},
 	})


### PR DESCRIPTION
This PR will fix the https://github.com/99designs/gqlgen/issues/3055.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
