### PR TITLE
refactor: simplify test asserts

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,8 +12,11 @@ linters-settings:
     disable-all: true
     enable:
       - bool-compare
+      - compares
+      - error-is-as
       - error-nil
       - expected-actual
+      - nil-compare
 
 linters:
   disable-all: true

--- a/codegen/config/config_test.go
+++ b/codegen/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -103,7 +102,7 @@ func TestLoadConfigFromDefaultLocation(t *testing.T) {
 		require.NoError(t, err)
 
 		cfg, err = LoadConfigFromDefaultLocations()
-		require.True(t, errors.Is(err, fs.ErrNotExist))
+		require.ErrorIs(t, err, fs.ErrNotExist)
 	})
 }
 
@@ -126,7 +125,7 @@ func TestLoadDefaultConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		cfg, err = LoadDefaultConfig()
-		require.True(t, errors.Is(err, fs.ErrNotExist))
+		require.ErrorIs(t, err, fs.ErrNotExist)
 	})
 }
 

--- a/codegen/testserver/followschema/directive_test.go
+++ b/codegen/testserver/followschema/directive_test.go
@@ -389,7 +389,7 @@ func TestDirectives(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, "Ok", resp.DirectiveObject.Text)
-			require.True(t, resp.DirectiveObject.NullableText == nil)
+			require.Nil(t, resp.DirectiveObject.NullableText)
 			require.Equal(t, "Query_field", resp.DirectiveObject.Order[0])
 			require.Equal(t, "order2_1", resp.DirectiveObject.Order[1])
 			require.Equal(t, "order1_2", resp.DirectiveObject.Order[2])
@@ -405,7 +405,7 @@ func TestDirectives(t *testing.T) {
 			err := c.Post(`query { directiveObjectWithCustomGoModel{ nullableText } }`, &resp)
 
 			require.NoError(t, err)
-			require.True(t, resp.DirectiveObjectWithCustomGoModel.NullableText == nil)
+			require.Nil(t, resp.DirectiveObjectWithCustomGoModel.NullableText)
 		})
 	})
 

--- a/codegen/testserver/followschema/useptr_test.go
+++ b/codegen/testserver/followschema/useptr_test.go
@@ -10,5 +10,5 @@ import (
 func TestUserPtr(t *testing.T) {
 	s := &Stub{}
 	r := reflect.TypeOf(s.QueryResolver.OptionalUnion)
-	require.True(t, r.Out(0).Kind() == reflect.Interface)
+	require.Equal(t, reflect.Interface, r.Out(0).Kind())
 }

--- a/codegen/testserver/singlefile/directive_test.go
+++ b/codegen/testserver/singlefile/directive_test.go
@@ -389,7 +389,7 @@ func TestDirectives(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, "Ok", resp.DirectiveObject.Text)
-			require.True(t, resp.DirectiveObject.NullableText == nil)
+			require.Nil(t, resp.DirectiveObject.NullableText)
 			require.Equal(t, "Query_field", resp.DirectiveObject.Order[0])
 			require.Equal(t, "order2_1", resp.DirectiveObject.Order[1])
 			require.Equal(t, "order1_2", resp.DirectiveObject.Order[2])
@@ -405,7 +405,7 @@ func TestDirectives(t *testing.T) {
 			err := c.Post(`query { directiveObjectWithCustomGoModel{ nullableText } }`, &resp)
 
 			require.NoError(t, err)
-			require.True(t, resp.DirectiveObjectWithCustomGoModel.NullableText == nil)
+			require.Nil(t, resp.DirectiveObjectWithCustomGoModel.NullableText)
 		})
 	})
 

--- a/codegen/testserver/singlefile/useptr_test.go
+++ b/codegen/testserver/singlefile/useptr_test.go
@@ -10,5 +10,5 @@ import (
 func TestUserPtr(t *testing.T) {
 	s := &Stub{}
 	r := reflect.TypeOf(s.QueryResolver.OptionalUnion)
-	require.True(t, r.Out(0).Kind() == reflect.Interface)
+	require.Equal(t, reflect.Interface, r.Out(0).Kind())
 }

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -63,7 +63,7 @@ func TestModelGeneration(t *testing.T) {
 		for _, commentGroup := range node.Comments {
 			text := commentGroup.Text()
 			words := strings.Split(text, " ")
-			require.True(t, len(words) > 1, "expected description %q to have more than one word", text)
+			require.Greaterf(t, len(words), 1, "expected description %q to have more than one word", text)
 		}
 	})
 
@@ -81,7 +81,7 @@ func TestModelGeneration(t *testing.T) {
 		}
 
 		for _, tag := range expectedTags {
-			require.True(t, strings.Contains(fileText, tag), "\nexpected:\n"+tag+"\ngot\n"+fileText)
+			require.Contains(t, fileText, tag, "\nexpected:\n"+tag+"\ngot\n"+fileText)
 		}
 	})
 
@@ -99,7 +99,7 @@ func TestModelGeneration(t *testing.T) {
 		}
 
 		for _, tag := range expectedTags {
-			require.True(t, strings.Contains(fileText, tag), "\nexpected:\n"+tag+"\ngot\n"+fileText)
+			require.Contains(t, fileText, tag, "\nexpected:\n"+tag+"\ngot\n"+fileText)
 		}
 	})
 


### PR DESCRIPTION
The PR simplifies tests:

- Replace `require.True(t, errors.Is` with `require.ErrorIs`
- Replace `require.True(t, val == nil)` with `require.Nil(t, val)`
- Replace `require.True(t, strings.Contains` with `require.Contains(t,`