### PR TITLE
chore: remove deprecated errcheck.ignore lint option

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,10 @@ run:
 
 linters-settings:
   errcheck:
-    ignore: fmt:.*,[rR]ead|[wW]rite|[cC]lose,io:Copy
+    exclude-functions:
+      - (io.Writer).Write
+      - io.Copy
+      - io.WriteString
   revive:
     enable-all-rules: false
     rules:
@@ -45,3 +48,4 @@ issues:
     - path: _test\.go
       linters:
         - dupl
+        - errcheck

--- a/client/websocket.go
+++ b/client/websocket.go
@@ -47,7 +47,7 @@ func (p *Client) Websocket(query string, options ...Option) *Subscription {
 // Grab a single response from a websocket based query
 func (p *Client) WebsocketOnce(query string, resp interface{}, options ...Option) error {
 	sock := p.Websocket(query, options...)
-	defer sock.Close()
+	defer func() { _ = sock.Close() }()
 	if reflect.ValueOf(resp).Kind() == reflect.Ptr {
 		return sock.Next(resp)
 	}

--- a/client/withfilesoption.go
+++ b/client/withfilesoption.go
@@ -55,7 +55,7 @@ func WithFiles() Option {
 		//
 		// {"query":"mutation ($input: Input!) {}","variables":{"input":{"file":{}}}
 		requestBody, _ := json.Marshal(bd)
-		bodyWriter.WriteField("operations", string(requestBody))
+		_ = bodyWriter.WriteField("operations", string(requestBody))
 
 		// --b7955bd2e1d17b67ac157b9e9ddb6238888caefc6f3541920a1debad284d
 		// Content-Disposition: form-data; name="map"
@@ -97,7 +97,7 @@ func WithFiles() Option {
 
 			mapData = `{` + strings.Join(mapDataFiles, ",") + `}`
 		}
-		bodyWriter.WriteField("map", mapData)
+		_ = bodyWriter.WriteField("map", mapData)
 
 		// --b7955bd2e1d17b67ac157b9e9ddb6238888caefc6f3541920a1debad284d
 		// Content-Disposition: form-data; name="0"; filename="tempFile"

--- a/graphql/handler/server.go
+++ b/graphql/handler/server.go
@@ -107,7 +107,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			resp := &graphql.Response{Errors: []*gqlerror.Error{gqlErr}}
 			b, _ := json.Marshal(resp)
 			w.WriteHeader(http.StatusUnprocessableEntity)
-			w.Write(b)
+			_, _ = w.Write(b)
 		}
 	}()
 
@@ -128,7 +128,7 @@ func sendError(w http.ResponseWriter, code int, errors ...*gqlerror.Error) {
 	if err != nil {
 		panic(err)
 	}
-	w.Write(b)
+	_, _ = w.Write(b)
 }
 
 func sendErrorf(w http.ResponseWriter, code int, format string, args ...interface{}) {

--- a/graphql/handler/transport/error.go
+++ b/graphql/handler/transport/error.go
@@ -18,7 +18,7 @@ func SendError(w http.ResponseWriter, code int, errors ...*gqlerror.Error) {
 	if err != nil {
 		panic(err)
 	}
-	w.Write(b)
+	_, _ = w.Write(b)
 }
 
 // SendErrorf wraps SendError to add formatted messages

--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -103,7 +103,7 @@ func (t Websocket) Do(w http.ResponseWriter, r *http.Request, exec graphql.Graph
 	switch ws.Subprotocol() {
 	default:
 		msg := websocket.FormatCloseMessage(websocket.CloseProtocolError, fmt.Sprintf("unsupported negotiated subprotocol %s", ws.Subprotocol()))
-		ws.WriteMessage(websocket.CloseMessage, msg)
+		_ = ws.WriteMessage(websocket.CloseMessage, msg)
 		return
 	case graphqlwsSubprotocol, "":
 		// clients are required to send a subprotocol, to be backward compatible with the previous implementation we select
@@ -272,7 +272,7 @@ func (c *wsConnection) run() {
 		if !c.MissingPongOk {
 			// Note: when the connection is closed by this deadline, the client
 			// will receive an "invalid close code"
-			c.conn.SetReadDeadline(time.Now().UTC().Add(2 * c.PingPongInterval))
+			_ = c.conn.SetReadDeadline(time.Now().UTC().Add(2 * c.PingPongInterval))
 		}
 		go c.ping(ctx)
 	}
@@ -312,7 +312,7 @@ func (c *wsConnection) run() {
 			c.receivedPong = true
 			c.mu.Unlock()
 			// Clear ReadTimeout -- 0 time val clears.
-			c.conn.SetReadDeadline(time.Time{})
+			_ = c.conn.SetReadDeadline(time.Time{})
 		default:
 			c.sendConnectionError("unexpected message %s", m.t)
 			c.close(websocket.CloseProtocolError, "unexpected message")
@@ -357,7 +357,7 @@ func (c *wsConnection) ping(ctx context.Context) {
 			// if we have not yet received a pong, don't reset the deadline.
 			c.mu.Lock()
 			if !c.MissingPongOk && c.receivedPong {
-				c.conn.SetReadDeadline(time.Now().UTC().Add(2 * c.PingPongInterval))
+				_ = c.conn.SetReadDeadline(time.Now().UTC().Add(2 * c.PingPongInterval))
 			}
 			c.receivedPong = false
 			c.mu.Unlock()


### PR DESCRIPTION
This PR replaces deprecated `errcheck` option `ignore` with `exclude-functions` and by using explicit blank identifiers. See https://github.com/kisielk/errcheck#the-deprecated-method and https://github.com/golangci/golangci-lint/pull/4673. Also, disables `errcheck` linter for tests.