### PR TITLE
refactor: compile regex only once

### DIFF
--- a/api/generate.go
+++ b/api/generate.go
@@ -13,6 +13,11 @@ import (
 	"github.com/99designs/gqlgen/plugin/resolvergen"
 )
 
+var (
+	urlRegex     = regexp.MustCompile(`(?s)@link.*\(.*url:.*?"(.*?)"[^)]+\)`) // regex to grab the url of a link directive, should it exist
+	versionRegex = regexp.MustCompile(`v(\d+).(\d+)$`)                        // regex to grab the version number from a url
+)
+
 func Generate(cfg *config.Config, option ...Option) error {
 	_ = syscall.Unlink(cfg.Exec.Filename)
 	if cfg.Model.IsDefined() {
@@ -26,8 +31,6 @@ func Generate(cfg *config.Config, option ...Option) error {
 	plugins = append(plugins, resolvergen.New())
 	if cfg.Federation.IsDefined() {
 		if cfg.Federation.Version == 0 { // default to using the user's choice of version, but if unset, try to sort out which federation version to use
-			urlRegex := regexp.MustCompile(`(?s)@link.*\(.*url:.*?"(.*?)"[^)]+\)`) // regex to grab the url of a link directive, should it exist
-			versionRegex := regexp.MustCompile(`v(\d+).(\d+)$`)                    // regex to grab the version number from a url
 			// check the sources, and if one is marked as federation v2, we mark the entirety to be generated using that format
 			for _, v := range cfg.Sources {
 				cfg.Federation.Version = 1

--- a/client/client.go
+++ b/client/client.go
@@ -106,6 +106,8 @@ func (p *Client) RawPost(query string, options ...Option) (*Response, error) {
 	return respDataRaw, nil
 }
 
+var boundaryRegex = regexp.MustCompile(`multipart/form-data; ?boundary=.*`)
+
 func (p *Client) newRequest(query string, options ...Option) (*http.Request, error) {
 	bd := &Request{
 		Query: query,
@@ -124,7 +126,7 @@ func (p *Client) newRequest(query string, options ...Option) (*http.Request, err
 
 	contentType := bd.HTTP.Header.Get("Content-Type")
 	switch {
-	case regexp.MustCompile(`multipart/form-data; ?boundary=.*`).MatchString(contentType):
+	case boundaryRegex.MatchString(contentType):
 		break
 	case "application/json" == contentType:
 		requestBody, err := json.Marshal(bd)


### PR DESCRIPTION
This PR moves out the compiled regexp from the `api.Generate` and `Client.newRequest` functions to prevent recompilation each time these functions are called.