### PR TITLE
chore: simplify generating examples in release script

### DIFF
--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -6,10 +6,9 @@ Assuming the next version is $NEW_VERSION=v0.16.0 or something like that.
 ./bin/release $NEW_VERSION
 ```
 2. git-chglog -o CHANGELOG.md
-3. go generate ./...; cd _examples; go generate ./...; cd ..
+3. go generate ./...
 4. git commit and push the CHANGELOG.md
 5. Go to https://github.com/99designs/gqlgen/releases and draft new release, autogenerate the release notes, and Create a discussion for this release
 6. Comment on the release discussion with any really important notes (breaking changes)
 
 I used https://github.com/git-chglog/git-chglog to automate the changelog maintenance process for now. We could just as easily use go releaser to make the whole thing automated.
-

--- a/bin/release
+++ b/bin/release
@@ -27,7 +27,7 @@ package graphql
 
 const Version = "$VERSION"
 EOF
-go generate ./...; cd _examples; go generate ./...; cd ..
+go generate ./...
 git add .
 
 git commit -m "release $VERSION"
@@ -40,7 +40,7 @@ package graphql
 
 const Version = "$VERSION-dev"
 EOF
-go generate ./...; cd _examples; go generate ./...; cd ..
+go generate ./...
 git add .
 git commit -m "$VERSION postrelease bump"
 git push origin HEAD:master


### PR DESCRIPTION
This PR implements changes similar to those in #3033, but specifically for the `bin/release` script.