### PR TITLE
Federation: Update docs to use IntrospectAndCompose

### DIFF
--- a/docs/content/recipes/federation.md
+++ b/docs/content/recipes/federation.md
@@ -124,14 +124,16 @@ npm install --save @apollo/gateway apollo-server graphql
 
 ```typescript
 const { ApolloServer } = require('apollo-server');
-const { ApolloGateway } = require("@apollo/gateway");
+const { ApolloGateway, IntrospectAndCompose } = require("@apollo/gateway");
 
 const gateway = new ApolloGateway({
-    serviceList: [
-        { name: 'accounts', url: 'http://localhost:4001/query' },
-        { name: 'products', url: 'http://localhost:4002/query' },
-        { name: 'reviews', url: 'http://localhost:4003/query' }
-    ],
+    supergraphSdl: new IntrospectAndCompose({
+        subgraphs: [
+            { name: 'accounts', url: 'http://localhost:4001/query' },
+            { name: 'products', url: 'http://localhost:4002/query' },
+            { name: 'reviews', url: 'http://localhost:4003/query' }
+        ]
+    })
 });
 
 const server = new ApolloServer({


### PR DESCRIPTION
`serviceList` now gets a deprecation warning to use IntrospectAndCompose instead. We update our docs to avoid referring to deprecated services