### PR TITLE
refactor: use 'any' instead of 'interface{}' for consistency

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters-settings:
     enable-all-rules: false
     rules:
       - name: empty-lines
+      - name: use-any
   testifylint:
     disable-all: true
     enable:
@@ -52,3 +53,10 @@ issues:
       linters:
         - dupl
         - errcheck
+    # Disable revive.use-any for backwards compatibility
+    - path: graphql/map.go
+      text: "use-any: since GO 1.18 'interface{}' can be replaced by 'any'"
+    - path: codegen/testserver/followschema/resolver.go
+      text: "use-any: since GO 1.18 'interface{}' can be replaced by 'any'"
+    - path: codegen/testserver/singlefile/resolver.go
+      text: "use-any: since GO 1.18 'interface{}' can be replaced by 'any'"

--- a/_examples/chat/chat_test.go
+++ b/_examples/chat/chat_test.go
@@ -44,7 +44,7 @@ func TestChatSubscriptions(t *testing.T) {
 			require.Equal(t, "system", msg.resp.MessageAdded.CreatedBy)
 
 			go func() {
-				var resp interface{}
+				var resp any
 				err := c.Post(fmt.Sprintf(`mutation {
 					a:post(text:"Hello!", roomName:"#gophers%d", username:"vektah") { id }
 					b:post(text:"Hello Vektah!", roomName:"#gophers%d", username:"andrey") { id }

--- a/_examples/chat/resolvers.go
+++ b/_examples/chat/resolvers.go
@@ -35,7 +35,7 @@ func New() Config {
 			Rooms: sync.Map{},
 		},
 		Directives: DirectiveRoot{
-			User: func(ctx context.Context, obj interface{}, next graphql.Resolver, username string) (res interface{}, err error) {
+			User: func(ctx context.Context, obj any, next graphql.Resolver, username string) (res any, err error) {
 				return next(context.WithValue(ctx, ckey("username"), username))
 			},
 		},
@@ -73,7 +73,7 @@ func (r *mutationResolver) Post(ctx context.Context, text string, username strin
 	}
 
 	room.Messages = append(room.Messages, *message)
-	room.Observers.Range(func(_, v interface{}) bool {
+	room.Observers.Range(func(_, v any) bool {
 		observer := v.(*Observer)
 		if observer.Username == "" || observer.Username == message.CreatedBy {
 			observer.Message <- message

--- a/_examples/dataloader/dataloader_test.go
+++ b/_examples/dataloader/dataloader_test.go
@@ -14,7 +14,7 @@ func TestTodo(t *testing.T) {
 	c := client.New(LoaderMiddleware(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: &Resolver{}}))))
 
 	t.Run("create a new todo", func(t *testing.T) {
-		var resp interface{}
+		var resp any
 		c.MustPost(`{
 		  customers {
 			name
@@ -73,7 +73,7 @@ func TestTodo(t *testing.T) {
 
 	t.Run("introspection", func(t *testing.T) {
 		// Make sure we can run the graphiql introspection query without errors
-		var resp interface{}
+		var resp any
 		c.MustPost(introspection.Query, &resp)
 	})
 

--- a/_examples/fileupload/fileupload_test.go
+++ b/_examples/fileupload/fileupload_test.go
@@ -99,7 +99,7 @@ func TestFileUpload(t *testing.T) {
 			SingleUploadWithPayload *model.File
 		}
 
-		err := gql.Post(mutation, &result, gqlclient.Var("req", map[string]interface{}{"id": 1, "file": aTxtFile}), gqlclient.WithFiles())
+		err := gql.Post(mutation, &result, gqlclient.Var("req", map[string]any{"id": 1, "file": aTxtFile}), gqlclient.WithFiles())
 		require.NoError(t, err)
 		require.Equal(t, 1, result.SingleUploadWithPayload.ID)
 		require.Contains(t, result.SingleUploadWithPayload.Name, "a.txt")
@@ -192,7 +192,7 @@ func TestFileUpload(t *testing.T) {
 			MultipleUploadWithPayload []*model.File
 		}
 
-		err := gql.Post(mutation, &result, gqlclient.Var("req", []map[string]interface{}{
+		err := gql.Post(mutation, &result, gqlclient.Var("req", []map[string]any{
 			{"id": 1, "file": a1TxtFile},
 			{"id": 2, "file": b1TxtFile},
 		}), gqlclient.WithFiles())
@@ -267,7 +267,7 @@ func TestFileUpload(t *testing.T) {
 				MultipleUploadWithPayload []*model.File
 			}
 
-			err := gql.Post(mutation, &result, gqlclient.Var("req", []map[string]interface{}{
+			err := gql.Post(mutation, &result, gqlclient.Var("req", []map[string]any{
 				{"id": 1, "file": a1TxtFile},
 				{"id": 2, "file": a1TxtFile},
 			}), gqlclient.WithFiles())

--- a/_examples/scalars/model/model.go
+++ b/_examples/scalars/model/model.go
@@ -22,7 +22,7 @@ func (b Banned) MarshalGQL(w io.Writer) {
 	}
 }
 
-func (b *Banned) UnmarshalGQL(v interface{}) error {
+func (b *Banned) UnmarshalGQL(v any) error {
 	switch v := v.(type) {
 	case string:
 		*b = strings.ToLower(v) == "true"
@@ -53,7 +53,7 @@ type Point struct {
 	Y int
 }
 
-func (p *Point) UnmarshalGQL(v interface{}) error {
+func (p *Point) UnmarshalGQL(v any) error {
 	pointStr, ok := v.(string)
 	if !ok {
 		return fmt.Errorf("points must be strings")
@@ -90,7 +90,7 @@ func MarshalTimestamp(t time.Time) graphql.Marshaler {
 
 // Unmarshal{Typename} is only required if the scalar appears as an input. The raw values have already been decoded
 // from json into int/float64/bool/nil/map[string]interface/[]interface
-func UnmarshalTimestamp(v interface{}) (time.Time, error) {
+func UnmarshalTimestamp(v any) (time.Time, error) {
 	if tmpStr, ok := v.(int64); ok {
 		return time.Unix(tmpStr, 0), nil
 	}
@@ -105,7 +105,7 @@ func MarshalID(id external.ObjectID) graphql.Marshaler {
 }
 
 // And the same for the unmarshaler
-func UnmarshalID(v interface{}) (external.ObjectID, error) {
+func UnmarshalID(v any) (external.ObjectID, error) {
 	str, ok := v.(string)
 	if !ok {
 		return 0, fmt.Errorf("ids must be strings")
@@ -163,7 +163,7 @@ func (e Tier) String() string {
 	}
 }
 
-func (e *Tier) UnmarshalGQL(v interface{}) error {
+func (e *Tier) UnmarshalGQL(v any) error {
 	str, ok := v.(string)
 	if !ok {
 		return fmt.Errorf("enums must be strings")
@@ -186,7 +186,7 @@ func MarshalPreferences(p *Prefs) graphql.Marshaler {
 	return graphql.MarshalBoolean(p.DarkMode)
 }
 
-func UnmarshalPreferences(v interface{}) (*Prefs, error) {
+func UnmarshalPreferences(v any) (*Prefs, error) {
 	tmp, err := graphql.UnmarshalBoolean(v)
 	if err != nil {
 		return nil, err

--- a/_examples/scalars/scalar_test.go
+++ b/_examples/scalars/scalar_test.go
@@ -73,7 +73,7 @@ func TestScalars(t *testing.T) {
 
 	t.Run("introspection", func(t *testing.T) {
 		// Make sure we can run the graphiql introspection query without errors
-		var resp interface{}
+		var resp any
 		c.MustPost(introspection.Query, &resp)
 	})
 }

--- a/_examples/starwars/server/server.go
+++ b/_examples/starwars/server/server.go
@@ -15,7 +15,7 @@ import (
 
 func main() {
 	srv := handler.NewDefaultServer(generated.NewExecutableSchema(starwars.NewResolver()))
-	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		rc := graphql.GetFieldContext(ctx)
 		fmt.Println("Entered", rc.Object, rc.Field.Name)
 		res, err = next(ctx)

--- a/_examples/starwars/starwars_test.go
+++ b/_examples/starwars/starwars_test.go
@@ -220,7 +220,7 @@ func TestStarwars(t *testing.T) {
 
 	t.Run("introspection", func(t *testing.T) {
 		// Make sure we can run the graphiql introspection query without errors
-		var resp interface{}
+		var resp any
 		c.MustPost(introspection.Query, &resp)
 	})
 

--- a/_examples/todo/server/server.go
+++ b/_examples/todo/server/server.go
@@ -14,7 +14,7 @@ import (
 
 func main() {
 	srv := handler.NewDefaultServer(todo.NewExecutableSchema(todo.New()))
-	srv.SetRecoverFunc(func(ctx context.Context, err interface{}) (userMessage error) {
+	srv.SetRecoverFunc(func(ctx context.Context, err any) (userMessage error) {
 		// send this panic somewhere
 		log.Print(err)
 		debug.PrintStack()

--- a/_examples/todo/todo.go
+++ b/_examples/todo/todo.go
@@ -39,7 +39,7 @@ func New() Config {
 			lastID: 4,
 		},
 	}
-	c.Directives.HasRole = func(ctx context.Context, obj interface{}, next graphql.Resolver, role Role) (interface{}, error) {
+	c.Directives.HasRole = func(ctx context.Context, obj any, next graphql.Resolver, role Role) (any, error) {
 		switch role {
 		case RoleAdmin:
 			// No admin for you!
@@ -57,7 +57,7 @@ func New() Config {
 
 		return next(ctx)
 	}
-	c.Directives.User = func(ctx context.Context, obj interface{}, next graphql.Resolver, id int) (interface{}, error) {
+	c.Directives.User = func(ctx context.Context, obj any, next graphql.Resolver, id int) (any, error) {
 		return next(context.WithValue(ctx, ckey("userId"), id))
 	}
 	return c
@@ -124,7 +124,7 @@ func (r *MutationResolver) CreateTodo(ctx context.Context, todo TodoInput) (*Tod
 	return newTodo, nil
 }
 
-func (r *MutationResolver) UpdateTodo(ctx context.Context, id int, changes map[string]interface{}) (*Todo, error) {
+func (r *MutationResolver) UpdateTodo(ctx context.Context, id int, changes map[string]any) (*Todo, error) {
 	var affectedTodo *Todo
 
 	for i := 0; i < len(r.todos); i++ {

--- a/_examples/todo/todo_test.go
+++ b/_examples/todo/todo_test.go
@@ -166,7 +166,7 @@ func TestTodo(t *testing.T) {
 
 	t.Run("introspection", func(t *testing.T) {
 		// Make sure we can run the graphiql introspection query without errors
-		var resp interface{}
+		var resp any
 		c.MustPost(introspection.Query, &resp)
 	})
 
@@ -184,7 +184,7 @@ func TestSkipAndIncludeDirectives(t *testing.T) {
 	c := client.New(handler.NewDefaultServer(NewExecutableSchema(New())))
 
 	t.Run("skip on field", func(t *testing.T) {
-		var resp map[string]interface{}
+		var resp map[string]any
 		c.MustPost(`{ todo(id: 1) @skip(if:true) { __typename } }`, &resp)
 		_, ok := resp["todo"]
 		require.False(t, ok)
@@ -192,7 +192,7 @@ func TestSkipAndIncludeDirectives(t *testing.T) {
 
 	t.Run("skip on variable", func(t *testing.T) {
 		q := `query Test($cond: Boolean!) { todo(id: 1) @skip(if: $cond) { __typename } }`
-		var resp map[string]interface{}
+		var resp map[string]any
 
 		c.MustPost(q, &resp, client.Var("cond", true))
 		_, ok := resp["todo"]
@@ -239,7 +239,7 @@ func TestSkipAndIncludeDirectives(t *testing.T) {
 
 	t.Run("include on field", func(t *testing.T) {
 		q := `query Test($cond: Boolean!) { todo(id: 1) @include(if: $cond) { __typename } }`
-		var resp map[string]interface{}
+		var resp map[string]any
 
 		c.MustPost(q, &resp, client.Var("cond", true))
 		_, ok := resp["todo"]
@@ -264,7 +264,7 @@ func TestSkipAndIncludeDirectives(t *testing.T) {
 		}
 		q := `query Test($skip: Boolean!, $include: Boolean!) { todo(id: 1) @skip(if: $skip) @include(if: $include) { __typename } }`
 		for _, tc := range table {
-			var resp map[string]interface{}
+			var resp map[string]any
 			c.MustPost(q, &resp, client.Var("skip", tc.Skip), client.Var("include", tc.Include))
 			_, ok := resp["todo"]
 			require.Equal(t, tc.Expected, ok)
@@ -272,7 +272,7 @@ func TestSkipAndIncludeDirectives(t *testing.T) {
 	})
 
 	t.Run("skip with default query argument", func(t *testing.T) {
-		var resp map[string]interface{}
+		var resp map[string]any
 		c.MustPost(`query Test($skip: Boolean = true) { todo(id: 1) @skip(if: $skip) { __typename } }`, &resp)
 		_, ok := resp["todo"]
 		require.False(t, ok)

--- a/_examples/type-system-extension/directive.go
+++ b/_examples/type-system-extension/directive.go
@@ -7,37 +7,37 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 )
 
-func EnumLogging(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+func EnumLogging(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 	rc := graphql.GetFieldContext(ctx)
 	log.Printf("enum logging: %v, %s, %T, %+v", rc.Path(), rc.Field.Name, obj, obj)
 	return next(ctx)
 }
 
-func FieldLogging(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+func FieldLogging(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 	rc := graphql.GetFieldContext(ctx)
 	log.Printf("field logging: %v, %s, %T, %+v", rc.Path(), rc.Field.Name, obj, obj)
 	return next(ctx)
 }
 
-func InputLogging(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+func InputLogging(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 	rc := graphql.GetFieldContext(ctx)
 	log.Printf("input object logging: %v, %s, %T, %+v", rc.Path(), rc.Field.Name, obj, obj)
 	return next(ctx)
 }
 
-func ObjectLogging(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+func ObjectLogging(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 	rc := graphql.GetFieldContext(ctx)
 	log.Printf("object logging: %v, %s, %T, %+v", rc.Path(), rc.Field.Name, obj, obj)
 	return next(ctx)
 }
 
-func ScalarLogging(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+func ScalarLogging(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 	rc := graphql.GetFieldContext(ctx)
 	log.Printf("scalar logging: %v, %s, %T, %+v", rc.Path(), rc.Field.Name, obj, obj)
 	return next(ctx)
 }
 
-func UnionLogging(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+func UnionLogging(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 	rc := graphql.GetFieldContext(ctx)
 	log.Printf("union logging: %v, %s, %T, %+v", rc.Path(), rc.Field.Name, obj, obj)
 	return next(ctx)

--- a/api/generate.go
+++ b/api/generate.go
@@ -90,7 +90,7 @@ func Generate(cfg *config.Config, option ...Option) error {
 		}
 	}
 	// Merge again now that the generated models have been injected into the typemap
-	data_plugins := make([]interface{}, len(plugins))
+	data_plugins := make([]any, len(plugins))
 	for index := range plugins {
 		data_plugins[index] = plugins[index]
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -29,18 +29,18 @@ type (
 
 	// Request represents an outgoing GraphQL request
 	Request struct {
-		Query         string                 `json:"query"`
-		Variables     map[string]interface{} `json:"variables,omitempty"`
-		OperationName string                 `json:"operationName,omitempty"`
-		Extensions    map[string]interface{} `json:"extensions,omitempty"`
-		HTTP          *http.Request          `json:"-"`
+		Query         string         `json:"query"`
+		Variables     map[string]any `json:"variables,omitempty"`
+		OperationName string         `json:"operationName,omitempty"`
+		Extensions    map[string]any `json:"extensions,omitempty"`
+		HTTP          *http.Request  `json:"-"`
 	}
 
 	// Response is a GraphQL layer response from a handler.
 	Response struct {
-		Data       interface{}
+		Data       any
 		Errors     json.RawMessage
-		Extensions map[string]interface{}
+		Extensions map[string]any
 	}
 )
 
@@ -56,7 +56,7 @@ func New(h http.Handler, opts ...Option) *Client {
 }
 
 // MustPost is a convenience wrapper around Post that automatically panics on error
-func (p *Client) MustPost(query string, response interface{}, options ...Option) {
+func (p *Client) MustPost(query string, response any, options ...Option) {
 	if err := p.Post(query, response, options...); err != nil {
 		panic(err)
 	}
@@ -64,7 +64,7 @@ func (p *Client) MustPost(query string, response interface{}, options ...Option)
 
 // Post sends a http POST request to the graphql endpoint with the given query then unpacks
 // the response into the given object.
-func (p *Client) Post(query string, response interface{}, options ...Option) error {
+func (p *Client) Post(query string, response any, options ...Option) error {
 	respDataRaw, err := p.RawPost(query, options...)
 	if err != nil {
 		return err
@@ -146,7 +146,7 @@ func (p *Client) SetCustomDecodeConfig(dc *mapstructure.DecoderConfig) {
 	p.dc = dc
 }
 
-func unpack(data interface{}, into interface{}, customDc *mapstructure.DecoderConfig) error {
+func unpack(data any, into any, customDc *mapstructure.DecoderConfig) error {
 	dc := &mapstructure.DecoderConfig{
 		TagName:     "json",
 		ErrorUnused: true,

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -26,8 +26,8 @@ func TestClient(t *testing.T) {
 		}
 		require.Equal(t, `{"query":"user(id:$id){name}","variables":{"id":1}}`, string(b))
 
-		err = json.NewEncoder(w).Encode(map[string]interface{}{
-			"data": map[string]interface{}{
+		err = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
 				"name": "bob",
 			},
 		})
@@ -155,8 +155,8 @@ func TestAddExtensions(t *testing.T) {
 			panic(err)
 		}
 		require.Equal(t, `{"query":"user(id:1){name}","extensions":{"persistedQuery":{"sha256Hash":"ceec2897e2da519612279e63f24658c3e91194cbb2974744fa9007a7e1e9f9e7","version":1}}}`, string(b))
-		err = json.NewEncoder(w).Encode(map[string]interface{}{
-			"data": map[string]interface{}{
+		err = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
 				"Name": "Bob",
 			},
 		})
@@ -171,7 +171,7 @@ func TestAddExtensions(t *testing.T) {
 		Name string
 	}
 	c.MustPost("user(id:1){name}", &resp,
-		client.Extensions(map[string]interface{}{"persistedQuery": map[string]interface{}{"version": 1, "sha256Hash": "ceec2897e2da519612279e63f24658c3e91194cbb2974744fa9007a7e1e9f9e7"}}),
+		client.Extensions(map[string]any{"persistedQuery": map[string]any{"version": 1, "sha256Hash": "ceec2897e2da519612279e63f24658c3e91194cbb2974744fa9007a7e1e9f9e7"}}),
 	)
 }
 
@@ -188,7 +188,7 @@ func TestSetCustomDecodeConfig(t *testing.T) {
 		TagName:     "json",
 		ErrorUnused: true,
 		ZeroFields:  true,
-		DecodeHook: func(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+		DecodeHook: func(f reflect.Type, t reflect.Type, data any) (any, error) {
 			if t != reflect.TypeOf(time.Time{}) {
 				return data, nil
 			}

--- a/client/options.go
+++ b/client/options.go
@@ -3,10 +3,10 @@ package client
 import "net/http"
 
 // Var adds a variable into the outgoing request
-func Var(name string, value interface{}) Option {
+func Var(name string, value any) Option {
 	return func(bd *Request) {
 		if bd.Variables == nil {
-			bd.Variables = map[string]interface{}{}
+			bd.Variables = map[string]any{}
 		}
 
 		bd.Variables[name] = value
@@ -21,7 +21,7 @@ func Operation(name string) Option {
 }
 
 // Extensions sets the extensions to be sent with the outgoing request
-func Extensions(extensions map[string]interface{}) Option {
+func Extensions(extensions map[string]any) Option {
 	return func(bd *Request) {
 		bd.Extensions = extensions
 	}

--- a/client/sse.go
+++ b/client/sse.go
@@ -12,22 +12,22 @@ import (
 
 type SSE struct {
 	Close func() error
-	Next  func(response interface{}) error
+	Next  func(response any) error
 }
 
 type SSEResponse struct {
-	Data       interface{}            `json:"data"`
-	Label      string                 `json:"label"`
-	Path       []interface{}          `json:"path"`
-	HasNext    bool                   `json:"hasNext"`
-	Errors     json.RawMessage        `json:"errors"`
-	Extensions map[string]interface{} `json:"extensions"`
+	Data       any             `json:"data"`
+	Label      string          `json:"label"`
+	Path       []any           `json:"path"`
+	HasNext    bool            `json:"hasNext"`
+	Errors     json.RawMessage `json:"errors"`
+	Extensions map[string]any  `json:"extensions"`
 }
 
 func errorSSE(err error) *SSE {
 	return &SSE{
 		Close: func() error { return nil },
-		Next: func(response interface{}) error {
+		Next: func(response any) error {
 			return err
 		},
 	}
@@ -62,7 +62,7 @@ func (p *Client) SSE(ctx context.Context, query string, options ...Option) *SSE 
 			srv.Close()
 			return nil
 		},
-		Next: func(response interface{}) error {
+		Next: func(response any) error {
 			for {
 				line, err := reader.ReadLine()
 				if err != nil {

--- a/client/websocket.go
+++ b/client/websocket.go
@@ -28,13 +28,13 @@ type operationMessage struct {
 
 type Subscription struct {
 	Close func() error
-	Next  func(response interface{}) error
+	Next  func(response any) error
 }
 
 func errorSubscription(err error) *Subscription {
 	return &Subscription{
 		Close: func() error { return nil },
-		Next: func(response interface{}) error {
+		Next: func(response any) error {
 			return err
 		},
 	}
@@ -45,7 +45,7 @@ func (p *Client) Websocket(query string, options ...Option) *Subscription {
 }
 
 // Grab a single response from a websocket based query
-func (p *Client) WebsocketOnce(query string, resp interface{}, options ...Option) error {
+func (p *Client) WebsocketOnce(query string, resp any, options ...Option) error {
 	sock := p.Websocket(query, options...)
 	defer func() { _ = sock.Close() }()
 	if reflect.ValueOf(resp).Kind() == reflect.Ptr {
@@ -55,7 +55,7 @@ func (p *Client) WebsocketOnce(query string, resp interface{}, options ...Option
 	return sock.Next(&resp)
 }
 
-func (p *Client) WebsocketWithPayload(query string, initPayload map[string]interface{}, options ...Option) *Subscription {
+func (p *Client) WebsocketWithPayload(query string, initPayload map[string]any, options ...Option) *Subscription {
 	r, err := p.newRequest(query, options...)
 	if err != nil {
 		return errorSubscription(fmt.Errorf("request: %w", err))
@@ -113,7 +113,7 @@ func (p *Client) WebsocketWithPayload(query string, initPayload map[string]inter
 			srv.Close()
 			return c.Close()
 		},
-		Next: func(response interface{}) error {
+		Next: func(response any) error {
 			for {
 				var op operationMessage
 				err := c.ReadJSON(&op)

--- a/client/withfilesoption.go
+++ b/client/withfilesoption.go
@@ -17,12 +17,12 @@ type fileFormDataMap struct {
 	file   *os.File
 }
 
-func findFiles(parentMapKey string, variables map[string]interface{}) []*fileFormDataMap {
+func findFiles(parentMapKey string, variables map[string]any) []*fileFormDataMap {
 	files := []*fileFormDataMap{}
 	for key, value := range variables {
-		if v, ok := value.(map[string]interface{}); ok {
+		if v, ok := value.(map[string]any); ok {
 			files = append(files, findFiles(parentMapKey+"."+key, v)...)
-		} else if v, ok := value.([]map[string]interface{}); ok {
+		} else if v, ok := value.([]map[string]any); ok {
 			for i, arr := range v {
 				files = append(files, findFiles(fmt.Sprintf(`%s.%s.%d`, parentMapKey, key, i), arr)...)
 			}

--- a/client/withfilesoption_test.go
+++ b/client/withfilesoption_test.go
@@ -114,7 +114,7 @@ func TestWithFiles(t *testing.T) {
 
 		var resp struct{}
 		c.MustPost("{ id }", &resp,
-			client.Var("input", map[string]interface{}{
+			client.Var("input", map[string]any{
 				"files": []*os.File{tempFile1, tempFile2},
 			}),
 			client.WithFiles(),
@@ -170,9 +170,9 @@ func TestWithFiles(t *testing.T) {
 
 		var resp struct{}
 		c.MustPost("{ id }", &resp,
-			client.Var("req", map[string]interface{}{
+			client.Var("req", map[string]any{
 				"files": []*os.File{tempFile1, tempFile2},
-				"foo": map[string]interface{}{
+				"foo": map[string]any{
 					"bar": tempFile3,
 				},
 			}),

--- a/codegen/args.go
+++ b/codegen/args.go
@@ -19,11 +19,11 @@ type ArgSet struct {
 type FieldArgument struct {
 	*ast.ArgumentDefinition
 	TypeReference *config.TypeReference
-	VarName       string      // The name of the var in go
-	Object        *Object     // A link back to the parent object
-	Default       interface{} // The default value
+	VarName       string  // The name of the var in go
+	Object        *Object // A link back to the parent object
+	Default       any     // The default value
 	Directives    []*Directive
-	Value         interface{} // value set in Data
+	Value         any // value set in Data
 }
 
 // ImplDirectives get not Builtin and location ARGUMENT_DEFINITION directive

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -305,7 +305,7 @@ func (c *Config) injectTypesFromSchema() error {
 
 			if ma := bd.Arguments.ForName("models"); ma != nil {
 				if mvs, err := ma.Value.Value(nil); err == nil {
-					for _, mv := range mvs.([]interface{}) {
+					for _, mv := range mvs.([]any) {
 						c.Models.Add(schemaType.Name, mv.(string))
 					}
 				}
@@ -482,7 +482,7 @@ type ModelExtraField struct {
 
 type StringList []string
 
-func (a *StringList) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (a *StringList) UnmarshalYAML(unmarshal func(any) error) error {
 	var single string
 	err := unmarshal(&single)
 	if err == nil {

--- a/codegen/config/testdata/autobinding/scalars/model/model.go
+++ b/codegen/config/testdata/autobinding/scalars/model/model.go
@@ -16,7 +16,7 @@ func (b Banned) MarshalGQL(w io.Writer) {
 	}
 }
 
-func (b *Banned) UnmarshalGQL(v interface{}) error {
+func (b *Banned) UnmarshalGQL(v any) error {
 	switch v := v.(type) {
 	case string:
 		*b = strings.ToLower(v) == "true"

--- a/codegen/data.go
+++ b/codegen/data.go
@@ -34,7 +34,7 @@ type Data struct {
 	MutationRoot     *Object
 	SubscriptionRoot *Object
 	AugmentedSources []AugmentedSource
-	Plugins          []interface{}
+	Plugins          []any
 }
 
 func (d *Data) HasEmbeddableSources() bool {
@@ -77,7 +77,7 @@ func (d *Data) Directives() DirectiveList {
 	return res
 }
 
-func BuildData(cfg *config.Config, plugins ...interface{}) (*Data, error) {
+func BuildData(cfg *config.Config, plugins ...any) (*Data, error) {
 	// We reload all packages to allow packages to be compared correctly.
 	cfg.ReloadAllPackages()
 

--- a/codegen/directive.go
+++ b/codegen/directive.go
@@ -92,7 +92,7 @@ func (b *builder) buildDirectives() (map[string]*Directive, error) {
 func (b *builder) getDirectives(list ast.DirectiveList) ([]*Directive, error) {
 	dirs := make([]*Directive, len(list))
 	for i, d := range list {
-		argValues := make(map[string]interface{}, len(d.Arguments))
+		argValues := make(map[string]any, len(d.Arguments))
 		for _, da := range d.Arguments {
 			val, err := da.Value.Value(nil)
 			if err != nil {

--- a/codegen/field.go
+++ b/codegen/field.go
@@ -31,7 +31,7 @@ type Field struct {
 	NoErr            bool             // If this is bound to a go method, does that method have an error as the second argument
 	VOkFunc          bool             // If this is bound to a go method, is it of shape (interface{}, bool)
 	Object           *Object          // A link back to the parent object
-	Default          interface{}      // The default value
+	Default          any              // The default value
 	Stream           bool             // does this field return a channel?
 	Directives       []*Directive
 }

--- a/codegen/field_test.go
+++ b/codegen/field_test.go
@@ -78,7 +78,7 @@ type Embed struct {
 	}
 }
 
-func parseScope(input interface{}, packageName string) (*types.Scope, error) {
+func parseScope(input any, packageName string) (*types.Scope, error) {
 	// test setup to parse the types
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, "test.go", input, 0)

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -52,7 +52,7 @@ type Options struct {
 	// FileNotice is notice written below the package line
 	FileNotice string
 	// Data will be passed to the template execution.
-	Data  interface{}
+	Data  any
 	Funcs template.FuncMap
 
 	// Packages cache, you can find me on config.Config
@@ -215,7 +215,7 @@ func Funcs() template.FuncMap {
 		"add": func(a, b int) int {
 			return a + b
 		},
-		"render": func(filename string, tpldata interface{}) (*bytes.Buffer, error) {
+		"render": func(filename string, tpldata any) (*bytes.Buffer, error) {
 			return render(resolveName(filename, 0), tpldata)
 		},
 	}
@@ -567,7 +567,7 @@ func rawQuote(s string) string {
 	return "`" + strings.ReplaceAll(s, "`", "`+\"`\"+`") + "`"
 }
 
-func notNil(field string, data interface{}) bool {
+func notNil(field string, data any) bool {
 	v := reflect.ValueOf(data)
 
 	if v.Kind() == reflect.Ptr {
@@ -581,7 +581,7 @@ func notNil(field string, data interface{}) bool {
 	return val.IsValid() && !val.IsNil()
 }
 
-func Dump(val interface{}) string {
+func Dump(val any) string {
 	switch val := val.(type) {
 	case int:
 		return strconv.Itoa(val)
@@ -595,13 +595,13 @@ func Dump(val interface{}) string {
 		return strconv.FormatBool(val)
 	case nil:
 		return "nil"
-	case []interface{}:
+	case []any:
 		var parts []string
 		for _, part := range val {
 			parts = append(parts, Dump(part))
 		}
 		return "[]interface{}{" + strings.Join(parts, ",") + "}"
-	case map[string]interface{}:
+	case map[string]any:
 		buf := bytes.Buffer{}
 		buf.WriteString("map[string]interface{}{")
 		var keys []string
@@ -641,7 +641,7 @@ func resolveName(name string, skip int) string {
 	return filepath.Join(filepath.Dir(callerFile), name)
 }
 
-func render(filename string, tpldata interface{}) (*bytes.Buffer, error) {
+func render(filename string, tpldata any) (*bytes.Buffer, error) {
 	t := template.New("").Funcs(Funcs())
 
 	b, err := os.ReadFile(filename)

--- a/codegen/testserver/followschema/bytes.go
+++ b/codegen/testserver/followschema/bytes.go
@@ -13,7 +13,7 @@ func MarshalBytes(b []byte) graphql.Marshaler {
 	})
 }
 
-func UnmarshalBytes(v interface{}) ([]byte, error) {
+func UnmarshalBytes(v any) ([]byte, error) {
 	switch v := v.(type) {
 	case string:
 		return []byte(v), nil

--- a/codegen/testserver/followschema/complexity_test.go
+++ b/codegen/testserver/followschema/complexity_test.go
@@ -71,7 +71,7 @@ func TestComplexityFuncs(t *testing.T) {
 		}
 
 		var resp struct {
-			Overlapping interface{}
+			Overlapping any
 		}
 		err := c.Post(`query { overlapping { oneFoo, twoFoo, oldFoo, newFoo, new_foo } }`, &resp)
 
@@ -90,7 +90,7 @@ func TestComplexityFuncs(t *testing.T) {
 		}
 
 		var resp struct {
-			Overlapping interface{}
+			Overlapping any
 		}
 		c.MustPost(`query { overlapping { newFoo } }`, &resp)
 
@@ -107,7 +107,7 @@ func TestComplexityFuncs(t *testing.T) {
 			}, nil
 		}
 
-		var resp interface{}
+		var resp any
 		err := c.Post(`query {
 			a: overlapping { newFoo },
 			b: overlapping { newFoo },

--- a/codegen/testserver/followschema/directive_test.go
+++ b/codegen/testserver/followschema/directive_test.go
@@ -91,7 +91,7 @@ func TestDirectives(t *testing.T) {
 	srv := handler.NewDefaultServer(NewExecutableSchema(Config{
 		Resolvers: resolvers,
 		Directives: DirectiveRoot{
-			Length: func(ctx context.Context, obj interface{}, next graphql.Resolver, min int, max *int, message *string) (interface{}, error) {
+			Length: func(ctx context.Context, obj any, next graphql.Resolver, min int, max *int, message *string) (any, error) {
 				e := func(msg string) error {
 					if message == nil {
 						return fmt.Errorf(msg)
@@ -112,7 +112,7 @@ func TestDirectives(t *testing.T) {
 				}
 				return res, nil
 			},
-			Range: func(ctx context.Context, obj interface{}, next graphql.Resolver, min *int, max *int) (interface{}, error) {
+			Range: func(ctx context.Context, obj any, next graphql.Resolver, min *int, max *int) (any, error) {
 				res, err := next(ctx)
 				if err != nil {
 					return nil, err
@@ -148,32 +148,32 @@ func TestDirectives(t *testing.T) {
 				}
 				return nil, fmt.Errorf("unsupported type %T", res)
 			},
-			Custom: func(ctx context.Context, obj interface{}, next graphql.Resolver) (interface{}, error) {
+			Custom: func(ctx context.Context, obj any, next graphql.Resolver) (any, error) {
 				return next(ctx)
 			},
-			Logged: func(ctx context.Context, obj interface{}, next graphql.Resolver, id string) (interface{}, error) {
+			Logged: func(ctx context.Context, obj any, next graphql.Resolver, id string) (any, error) {
 				return next(context.WithValue(ctx, ckey("request_id"), &id))
 			},
-			ToNull: func(ctx context.Context, obj interface{}, next graphql.Resolver) (interface{}, error) {
+			ToNull: func(ctx context.Context, obj any, next graphql.Resolver) (any, error) {
 				return nil, nil
 			},
-			Directive1: func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+			Directive1: func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 				return next(ctx)
 			},
-			Directive2: func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+			Directive2: func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 				return next(ctx)
 			},
-			Directive3: func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+			Directive3: func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 				return next(ctx)
 			},
-			Order1: func(ctx context.Context, obj interface{}, next graphql.Resolver, location string) (res interface{}, err error) {
+			Order1: func(ctx context.Context, obj any, next graphql.Resolver, location string) (res any, err error) {
 				order := []string{location}
 				res, err = next(ctx)
 				od := res.(*ObjectDirectives)
 				od.Order = append(order, od.Order...)
 				return od, err
 			},
-			Order2: func(ctx context.Context, obj interface{}, next graphql.Resolver, location string) (res interface{}, err error) {
+			Order2: func(ctx context.Context, obj any, next graphql.Resolver, location string) (res any, err error) {
 				order := []string{location}
 				res, err = next(ctx)
 				od := res.(*ObjectDirectives)
@@ -184,12 +184,12 @@ func TestDirectives(t *testing.T) {
 		},
 	}))
 
-	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		path, _ := ctx.Value(ckey("path")).([]int)
 		return next(context.WithValue(ctx, ckey("path"), append(path, 1)))
 	})
 
-	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		path, _ := ctx.Value(ckey("path")).([]int)
 		return next(context.WithValue(ctx, ckey("path"), append(path, 2)))
 	})

--- a/codegen/testserver/followschema/embedded.go
+++ b/codegen/testserver/followschema/embedded.go
@@ -7,7 +7,7 @@ type EmbeddedCase1 struct {
 }
 
 // Empty interface
-type Empty interface{}
+type Empty any
 
 // ExportedEmbeddedPointerAfterInterface model
 type ExportedEmbeddedPointerAfterInterface struct{}

--- a/codegen/testserver/followschema/enums_test.go
+++ b/codegen/testserver/followschema/enums_test.go
@@ -47,7 +47,7 @@ func TestEnumsResolver(t *testing.T) {
 		err := c.Post(`query ($input: InputWithEnumValue) {
 			enumInInput(input: $input)
 		}
-		`, &resp, client.Var("input", map[string]interface{}{"enum": "INVALID"}))
+		`, &resp, client.Var("input", map[string]any{"enum": "INVALID"}))
 		require.EqualError(t, err, `http 422: {"errors":[{"message":"INVALID is not a valid EnumTest","path":["variable","input","enum"],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`)
 	})
 }

--- a/codegen/testserver/followschema/interfaces_test.go
+++ b/codegen/testserver/followschema/interfaces_test.go
@@ -65,7 +65,7 @@ func TestInterfaces(t *testing.T) {
 			NewExecutableSchema(Config{
 				Resolvers: resolvers,
 				Directives: DirectiveRoot{
-					MakeNil: func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+					MakeNil: func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 						return nil, nil
 					},
 				},
@@ -74,7 +74,7 @@ func TestInterfaces(t *testing.T) {
 
 		c := client.New(srv)
 
-		var resp interface{}
+		var resp any
 		c.MustPost(`{ noShape { area } }`, &resp)
 	})
 
@@ -88,7 +88,7 @@ func TestInterfaces(t *testing.T) {
 			NewExecutableSchema(Config{
 				Resolvers: resolvers,
 				Directives: DirectiveRoot{
-					MakeTypedNil: func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+					MakeTypedNil: func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 						var circle *Circle
 						return circle, nil
 					},
@@ -98,7 +98,7 @@ func TestInterfaces(t *testing.T) {
 
 		c := client.New(srv)
 
-		var resp interface{}
+		var resp any
 		c.MustPost(`{ noShapeTypedNil { area } }`, &resp)
 	})
 
@@ -112,7 +112,7 @@ func TestInterfaces(t *testing.T) {
 			NewExecutableSchema(Config{
 				Resolvers: resolvers,
 				Directives: DirectiveRoot{
-					MakeTypedNil: func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+					MakeTypedNil: func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 						var dog *Dog // return a typed nil, not just nil
 						return dog, nil
 					},
@@ -122,7 +122,7 @@ func TestInterfaces(t *testing.T) {
 
 		c := client.New(srv)
 
-		var resp interface{}
+		var resp any
 		c.MustPost(`{ animal { species } }`, &resp)
 	})
 

--- a/codegen/testserver/followschema/introspection_test.go
+++ b/codegen/testserver/followschema/introspection_test.go
@@ -21,7 +21,7 @@ func TestIntrospection(t *testing.T) {
 		srv.AddTransport(transport.POST{})
 		c := client.New(srv)
 
-		var resp interface{}
+		var resp any
 		err := c.Post(introspection.Query, &resp)
 		require.EqualError(t, err, "[{\"message\":\"introspection disabled\",\"path\":[\"__schema\"]}]")
 	})
@@ -33,7 +33,7 @@ func TestIntrospection(t *testing.T) {
 			NewExecutableSchema(Config{Resolvers: resolvers}),
 		))
 
-		var resp interface{}
+		var resp any
 		err := c.Post(introspection.Query, &resp)
 		require.NoError(t, err)
 
@@ -73,7 +73,7 @@ func TestIntrospection(t *testing.T) {
 		})
 		c := client.New(srv)
 
-		var resp interface{}
+		var resp any
 		err := c.Post(introspection.Query, &resp)
 		require.EqualError(t, err, "[{\"message\":\"introspection disabled\",\"path\":[\"__schema\"]}]")
 	})

--- a/codegen/testserver/followschema/maps.go
+++ b/codegen/testserver/followschema/maps.go
@@ -13,7 +13,7 @@ type CustomScalar struct {
 	value int64
 }
 
-func (s *CustomScalar) UnmarshalGQL(v interface{}) (err error) {
+func (s *CustomScalar) UnmarshalGQL(v any) (err error) {
 	switch v := v.(type) {
 	case string:
 		s.value, err = strconv.ParseInt(v, 10, 64)

--- a/codegen/testserver/followschema/maps_test.go
+++ b/codegen/testserver/followschema/maps_test.go
@@ -12,11 +12,11 @@ import (
 
 func TestMaps(t *testing.T) {
 	resolver := &Stub{}
-	resolver.QueryResolver.MapStringInterface = func(ctx context.Context, in map[string]interface{}) (i map[string]interface{}, e error) {
+	resolver.QueryResolver.MapStringInterface = func(ctx context.Context, in map[string]any) (i map[string]any, e error) {
 		validateMapItemsType(t, in)
 		return in, nil
 	}
-	resolver.QueryResolver.MapNestedStringInterface = func(ctx context.Context, in *NestedMapInput) (i map[string]interface{}, e error) {
+	resolver.QueryResolver.MapNestedStringInterface = func(ctx context.Context, in *NestedMapInput) (i map[string]any, e error) {
 		if in == nil {
 			return nil, nil
 		}
@@ -29,7 +29,7 @@ func TestMaps(t *testing.T) {
 	))
 	t.Run("unset", func(t *testing.T) {
 		var resp struct {
-			MapStringInterface map[string]interface{}
+			MapStringInterface map[string]any
 		}
 		err := c.Post(`query { mapStringInterface { a, b, c, nested { value } } }`, &resp)
 		require.NoError(t, err)
@@ -38,7 +38,7 @@ func TestMaps(t *testing.T) {
 
 	t.Run("nil", func(t *testing.T) {
 		var resp struct {
-			MapStringInterface map[string]interface{}
+			MapStringInterface map[string]any
 		}
 		err := c.Post(`query { mapStringInterface(in: null) { a, b, c, nested { value } } }`, &resp)
 		require.NoError(t, err)
@@ -47,7 +47,7 @@ func TestMaps(t *testing.T) {
 
 	t.Run("values", func(t *testing.T) {
 		var resp struct {
-			MapStringInterface map[string]interface{}
+			MapStringInterface map[string]any
 		}
 		err := c.Post(`query($value: CustomScalar!) { mapStringInterface(in: { a: "a", b: null, c: 42, nested: { value: $value } }) { a, b, c, nested { value } } }`, &resp, client.Var("value", "17"))
 		require.NoError(t, err)
@@ -55,13 +55,13 @@ func TestMaps(t *testing.T) {
 		require.Nil(t, resp.MapStringInterface["b"])
 		require.Equal(t, "42", resp.MapStringInterface["c"])
 		require.NotNil(t, resp.MapStringInterface["nested"])
-		require.IsType(t, map[string]interface{}{}, resp.MapStringInterface["nested"])
-		require.Equal(t, "17", (resp.MapStringInterface["nested"].(map[string]interface{}))["value"])
+		require.IsType(t, map[string]any{}, resp.MapStringInterface["nested"])
+		require.Equal(t, "17", (resp.MapStringInterface["nested"].(map[string]any))["value"])
 	})
 
 	t.Run("nested", func(t *testing.T) {
 		var resp struct {
-			MapNestedStringInterface map[string]interface{}
+			MapNestedStringInterface map[string]any
 		}
 		err := c.Post(`query { mapNestedStringInterface(in: { map: { a: "a", c: "42", nested: { value: 31 } } }) { a, b, c, nested { value } } }`, &resp)
 		require.NoError(t, err)
@@ -69,13 +69,13 @@ func TestMaps(t *testing.T) {
 		require.Nil(t, resp.MapNestedStringInterface["b"])
 		require.Equal(t, "42", resp.MapNestedStringInterface["c"])
 		require.NotNil(t, resp.MapNestedStringInterface["nested"])
-		require.IsType(t, map[string]interface{}{}, resp.MapNestedStringInterface["nested"])
-		require.Equal(t, "31", (resp.MapNestedStringInterface["nested"].(map[string]interface{}))["value"])
+		require.IsType(t, map[string]any{}, resp.MapNestedStringInterface["nested"])
+		require.Equal(t, "31", (resp.MapNestedStringInterface["nested"].(map[string]any))["value"])
 	})
 
 	t.Run("nested nil", func(t *testing.T) {
 		var resp struct {
-			MapNestedStringInterface map[string]interface{}
+			MapNestedStringInterface map[string]any
 		}
 		err := c.Post(`query { mapNestedStringInterface(in: { map: null }) { a, b, c, nested { value } } }`, &resp)
 		require.NoError(t, err)
@@ -83,7 +83,7 @@ func TestMaps(t *testing.T) {
 	})
 }
 
-func validateMapItemsType(t *testing.T, in map[string]interface{}) {
+func validateMapItemsType(t *testing.T, in map[string]any) {
 	for k, v := range in {
 		switch k {
 		case "a":

--- a/codegen/testserver/followschema/middleware_test.go
+++ b/codegen/testserver/followschema/middleware_test.go
@@ -37,17 +37,17 @@ func TestMiddleware(t *testing.T) {
 	srv := handler.NewDefaultServer(
 		NewExecutableSchema(Config{Resolvers: resolvers}),
 	)
-	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		path, _ := ctx.Value(ckey("path")).([]int)
 		return next(context.WithValue(ctx, ckey("path"), append(path, 1)))
 	})
 
-	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		path, _ := ctx.Value(ckey("path")).([]int)
 		return next(context.WithValue(ctx, ckey("path"), append(path, 2)))
 	})
 
-	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		fc := graphql.GetFieldContext(ctx)
 		mu.Lock()
 		areMethods[fc.Field.Name] = fc.IsMethod

--- a/codegen/testserver/followschema/models.go
+++ b/codegen/testserver/followschema/models.go
@@ -49,7 +49,7 @@ type EmbeddedPointer struct {
 
 type MarshalPanic string
 
-func (m *MarshalPanic) UnmarshalGQL(v interface{}) error {
+func (m *MarshalPanic) UnmarshalGQL(v any) error {
 	panic("BOOM")
 }
 

--- a/codegen/testserver/followschema/mutation_with_custom_scalar.go
+++ b/codegen/testserver/followschema/mutation_with_custom_scalar.go
@@ -11,7 +11,7 @@ var re = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-
 
 type Email string
 
-func (value *Email) UnmarshalGQL(v interface{}) error {
+func (value *Email) UnmarshalGQL(v any) error {
 	input, ok := v.(string)
 	if !ok {
 		return fmt.Errorf("email expects a string value")

--- a/codegen/testserver/followschema/mutation_with_custom_scalar_test.go
+++ b/codegen/testserver/followschema/mutation_with_custom_scalar_test.go
@@ -19,9 +19,9 @@ func TestErrorInsideMutationArgument(t *testing.T) {
 	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
 
 	t.Run("mutation with correct input doesn't return error", func(t *testing.T) {
-		var resp map[string]interface{}
-		input := map[string]interface{}{
-			"nesting": map[string]interface{}{
+		var resp map[string]any
+		input := map[string]any{
+			"nesting": map[string]any{
 				"field": "email@example.com",
 			},
 		}
@@ -35,9 +35,9 @@ func TestErrorInsideMutationArgument(t *testing.T) {
 	})
 
 	t.Run("mutation with incorrect input returns full path", func(t *testing.T) {
-		var resp map[string]interface{}
-		input := map[string]interface{}{
-			"nesting": map[string]interface{}{
+		var resp map[string]any
+		input := map[string]any{
+			"nesting": map[string]any{
 				"field": "not-an-email",
 			},
 		}

--- a/codegen/testserver/followschema/nulls_test.go
+++ b/codegen/testserver/followschema/nulls_test.go
@@ -119,7 +119,7 @@ func TestNullBubbling(t *testing.T) {
 	})
 
 	t.Run("concurrent null detection", func(t *testing.T) {
-		var resp interface{}
+		var resp any
 		resolvers.ErrorsResolver.A = func(ctx context.Context, obj *Errors) (i *Error, e error) { return nil, nil }
 		resolvers.ErrorsResolver.B = func(ctx context.Context, obj *Errors) (i *Error, e error) { return nil, nil }
 		resolvers.ErrorsResolver.C = func(ctx context.Context, obj *Errors) (i *Error, e error) { return nil, nil }

--- a/codegen/testserver/followschema/panics_test.go
+++ b/codegen/testserver/followschema/panics_test.go
@@ -26,7 +26,7 @@ func TestPanics(t *testing.T) {
 	}
 
 	srv := handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers}))
-	srv.SetRecoverFunc(func(ctx context.Context, err interface{}) (userMessage error) {
+	srv.SetRecoverFunc(func(ctx context.Context, err any) (userMessage error) {
 		return fmt.Errorf("panic: %v", err)
 	})
 
@@ -40,28 +40,28 @@ func TestPanics(t *testing.T) {
 	c := client.New(srv)
 
 	t.Run("panics in marshallers will not kill server", func(t *testing.T) {
-		var resp interface{}
+		var resp any
 		err := c.Post(`query { panics { fieldScalarMarshal } }`, &resp)
 
 		require.EqualError(t, err, "http 422: {\"errors\":[{\"message\":\"presented: panic: BOOM\"}],\"data\":null}")
 	})
 
 	t.Run("panics in unmarshalers will not kill server", func(t *testing.T) {
-		var resp interface{}
+		var resp any
 		err := c.Post(`query { panics { argUnmarshal(u: ["aa", "bb"]) } }`, &resp)
 
 		require.EqualError(t, err, "[{\"message\":\"presented: input: panics.argUnmarshal panic: BOOM\",\"path\":[\"panics\",\"argUnmarshal\"]}]")
 	})
 
 	t.Run("panics in funcs unmarshal return errors", func(t *testing.T) {
-		var resp interface{}
+		var resp any
 		err := c.Post(`query { panics { fieldFuncMarshal(u: ["aa", "bb"]) } }`, &resp)
 
 		require.EqualError(t, err, "[{\"message\":\"presented: input: panics.fieldFuncMarshal panic: BOOM\",\"path\":[\"panics\",\"fieldFuncMarshal\"]}]")
 	})
 
 	t.Run("panics in funcs marshal return errors", func(t *testing.T) {
-		var resp interface{}
+		var resp any
 		err := c.Post(`query { panics { fieldFuncMarshal(u: []) } }`, &resp)
 
 		require.EqualError(t, err, "http 422: {\"errors\":[{\"message\":\"presented: panic: BOOM\"}],\"data\":null}")

--- a/codegen/testserver/followschema/scalar_context.go
+++ b/codegen/testserver/followschema/scalar_context.go
@@ -22,7 +22,7 @@ func (StringFromContextInterface) MarshalGQLContext(ctx context.Context, w io.Wr
 	return nil
 }
 
-func (i *StringFromContextInterface) UnmarshalGQLContext(ctx context.Context, v interface{}) error {
+func (i *StringFromContextInterface) UnmarshalGQLContext(ctx context.Context, v any) error {
 	i.OperationName = graphql.GetFieldContext(ctx).Field.Name
 	return nil
 }
@@ -34,6 +34,6 @@ func MarshalStringFromContextFunction(v string) graphql.ContextMarshaler {
 	})
 }
 
-func UnmarshalStringFromContextFunction(ctx context.Context, v interface{}) (string, error) {
+func UnmarshalStringFromContextFunction(ctx context.Context, v any) (string, error) {
 	return graphql.GetFieldContext(ctx).Field.Name, nil
 }

--- a/codegen/testserver/followschema/subscription_test.go
+++ b/codegen/testserver/followschema/subscription_test.go
@@ -89,12 +89,12 @@ func TestSubscriptions(t *testing.T) {
 	srv := handler.NewDefaultServer(
 		NewExecutableSchema(Config{Resolvers: resolvers}),
 	)
-	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		path, _ := ctx.Value(ckey("path")).([]int)
 		return next(context.WithValue(ctx, ckey("path"), append(path, 1)))
 	})
 
-	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		path, _ := ctx.Value(ckey("path")).([]int)
 		return next(context.WithValue(ctx, ckey("path"), append(path, 2)))
 	})
@@ -133,7 +133,7 @@ func TestSubscriptions(t *testing.T) {
 		runtime.GC() // ensure no go-routines left from preceding tests
 		initialGoroutineCount := runtime.NumGoroutine()
 
-		sub := c.WebsocketWithPayload(`subscription { initPayload }`, map[string]interface{}{
+		sub := c.WebsocketWithPayload(`subscription { initPayload }`, map[string]any{
 			"Authorization": "Bearer of the curse",
 			"number":        32,
 			"strings":       []string{"hello", "world"},

--- a/codegen/testserver/followschema/thirdparty.go
+++ b/codegen/testserver/followschema/thirdparty.go
@@ -21,7 +21,7 @@ func MarshalThirdParty(tp ThirdParty) graphql.Marshaler {
 	})
 }
 
-func UnmarshalThirdParty(input interface{}) (ThirdParty, error) {
+func UnmarshalThirdParty(input any) (ThirdParty, error) {
 	switch input := input.(type) {
 	case string:
 		return ThirdParty{str: input}, nil

--- a/codegen/testserver/singlefile/bytes.go
+++ b/codegen/testserver/singlefile/bytes.go
@@ -13,7 +13,7 @@ func MarshalBytes(b []byte) graphql.Marshaler {
 	})
 }
 
-func UnmarshalBytes(v interface{}) ([]byte, error) {
+func UnmarshalBytes(v any) ([]byte, error) {
 	switch v := v.(type) {
 	case string:
 		return []byte(v), nil

--- a/codegen/testserver/singlefile/complexity_test.go
+++ b/codegen/testserver/singlefile/complexity_test.go
@@ -71,7 +71,7 @@ func TestComplexityFuncs(t *testing.T) {
 		}
 
 		var resp struct {
-			Overlapping interface{}
+			Overlapping any
 		}
 		err := c.Post(`query { overlapping { oneFoo, twoFoo, oldFoo, newFoo, new_foo } }`, &resp)
 
@@ -90,7 +90,7 @@ func TestComplexityFuncs(t *testing.T) {
 		}
 
 		var resp struct {
-			Overlapping interface{}
+			Overlapping any
 		}
 		c.MustPost(`query { overlapping { newFoo } }`, &resp)
 
@@ -107,7 +107,7 @@ func TestComplexityFuncs(t *testing.T) {
 			}, nil
 		}
 
-		var resp interface{}
+		var resp any
 		err := c.Post(`query {
 			a: overlapping { newFoo },
 			b: overlapping { newFoo },

--- a/codegen/testserver/singlefile/defer_test.go
+++ b/codegen/testserver/singlefile/defer_test.go
@@ -77,11 +77,11 @@ func TestDefer(t *testing.T) {
 					Values []string
 				}
 			}
-			Label      string                 `json:"label"`
-			Path       []interface{}          `json:"path"`
-			HasNext    bool                   `json:"hasNext"`
-			Errors     json.RawMessage        `json:"errors"`
-			Extensions map[string]interface{} `json:"extensions"`
+			Label      string          `json:"label"`
+			Path       []any           `json:"path"`
+			HasNext    bool            `json:"hasNext"`
+			Errors     json.RawMessage `json:"errors"`
+			Extensions map[string]any  `json:"extensions"`
 		}
 		var resp response
 
@@ -112,11 +112,11 @@ func TestDefer(t *testing.T) {
 			Data struct {
 				Values []string `json:"values"`
 			}
-			Label      string                 `json:"label"`
-			Path       []interface{}          `json:"path"`
-			HasNext    bool                   `json:"hasNext"`
-			Errors     json.RawMessage        `json:"errors"`
-			Extensions map[string]interface{} `json:"extensions"`
+			Label      string          `json:"label"`
+			Path       []any           `json:"path"`
+			HasNext    bool            `json:"hasNext"`
+			Errors     json.RawMessage `json:"errors"`
+			Extensions map[string]any  `json:"extensions"`
 		}
 
 		var valueResp valuesResponse
@@ -127,7 +127,7 @@ func TestDefer(t *testing.T) {
 				Values: []string{"test defer 1", "test defer 2", "test defer 3"},
 			},
 			Label: "values",
-			Path:  []interface{}{"deferCase1"},
+			Path:  []any{"deferCase1"},
 		}
 
 		require.NoError(t, sse.Next(&valueResp))
@@ -156,11 +156,11 @@ func TestDefer(t *testing.T) {
 					Values []string
 				}
 			}
-			Label      string                 `json:"label"`
-			Path       []interface{}          `json:"path"`
-			HasNext    bool                   `json:"hasNext"`
-			Errors     json.RawMessage        `json:"errors"`
-			Extensions map[string]interface{} `json:"extensions"`
+			Label      string          `json:"label"`
+			Path       []any           `json:"path"`
+			HasNext    bool            `json:"hasNext"`
+			Errors     json.RawMessage `json:"errors"`
+			Extensions map[string]any  `json:"extensions"`
 		}
 		var resp response
 
@@ -203,11 +203,11 @@ func TestDefer(t *testing.T) {
 			Data struct {
 				Values []string `json:"values"`
 			}
-			Label      string                 `json:"label"`
-			Path       []interface{}          `json:"path"`
-			HasNext    bool                   `json:"hasNext"`
-			Errors     json.RawMessage        `json:"errors"`
-			Extensions map[string]interface{} `json:"extensions"`
+			Label      string          `json:"label"`
+			Path       []any           `json:"path"`
+			HasNext    bool            `json:"hasNext"`
+			Errors     json.RawMessage `json:"errors"`
+			Extensions map[string]any  `json:"extensions"`
 		}
 
 		valuesByPath := make(map[string][]string, 2)

--- a/codegen/testserver/singlefile/directive_test.go
+++ b/codegen/testserver/singlefile/directive_test.go
@@ -91,7 +91,7 @@ func TestDirectives(t *testing.T) {
 	srv := handler.NewDefaultServer(NewExecutableSchema(Config{
 		Resolvers: resolvers,
 		Directives: DirectiveRoot{
-			Length: func(ctx context.Context, obj interface{}, next graphql.Resolver, min int, max *int, message *string) (interface{}, error) {
+			Length: func(ctx context.Context, obj any, next graphql.Resolver, min int, max *int, message *string) (any, error) {
 				e := func(msg string) error {
 					if message == nil {
 						return fmt.Errorf(msg)
@@ -112,7 +112,7 @@ func TestDirectives(t *testing.T) {
 				}
 				return res, nil
 			},
-			Range: func(ctx context.Context, obj interface{}, next graphql.Resolver, min *int, max *int) (interface{}, error) {
+			Range: func(ctx context.Context, obj any, next graphql.Resolver, min *int, max *int) (any, error) {
 				res, err := next(ctx)
 				if err != nil {
 					return nil, err
@@ -148,32 +148,32 @@ func TestDirectives(t *testing.T) {
 				}
 				return nil, fmt.Errorf("unsupported type %T", res)
 			},
-			Custom: func(ctx context.Context, obj interface{}, next graphql.Resolver) (interface{}, error) {
+			Custom: func(ctx context.Context, obj any, next graphql.Resolver) (any, error) {
 				return next(ctx)
 			},
-			Logged: func(ctx context.Context, obj interface{}, next graphql.Resolver, id string) (interface{}, error) {
+			Logged: func(ctx context.Context, obj any, next graphql.Resolver, id string) (any, error) {
 				return next(context.WithValue(ctx, ckey("request_id"), &id))
 			},
-			ToNull: func(ctx context.Context, obj interface{}, next graphql.Resolver) (interface{}, error) {
+			ToNull: func(ctx context.Context, obj any, next graphql.Resolver) (any, error) {
 				return nil, nil
 			},
-			Directive1: func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+			Directive1: func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 				return next(ctx)
 			},
-			Directive2: func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+			Directive2: func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 				return next(ctx)
 			},
-			Directive3: func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+			Directive3: func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 				return next(ctx)
 			},
-			Order1: func(ctx context.Context, obj interface{}, next graphql.Resolver, location string) (res interface{}, err error) {
+			Order1: func(ctx context.Context, obj any, next graphql.Resolver, location string) (res any, err error) {
 				order := []string{location}
 				res, err = next(ctx)
 				od := res.(*ObjectDirectives)
 				od.Order = append(order, od.Order...)
 				return od, err
 			},
-			Order2: func(ctx context.Context, obj interface{}, next graphql.Resolver, location string) (res interface{}, err error) {
+			Order2: func(ctx context.Context, obj any, next graphql.Resolver, location string) (res any, err error) {
 				order := []string{location}
 				res, err = next(ctx)
 				od := res.(*ObjectDirectives)
@@ -184,12 +184,12 @@ func TestDirectives(t *testing.T) {
 		},
 	}))
 
-	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		path, _ := ctx.Value(ckey("path")).([]int)
 		return next(context.WithValue(ctx, ckey("path"), append(path, 1)))
 	})
 
-	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		path, _ := ctx.Value(ckey("path")).([]int)
 		return next(context.WithValue(ctx, ckey("path"), append(path, 2)))
 	})

--- a/codegen/testserver/singlefile/embedded.go
+++ b/codegen/testserver/singlefile/embedded.go
@@ -7,7 +7,7 @@ type EmbeddedCase1 struct {
 }
 
 // Empty interface
-type Empty interface{}
+type Empty any
 
 // ExportedEmbeddedPointerAfterInterface model
 type ExportedEmbeddedPointerAfterInterface struct{}

--- a/codegen/testserver/singlefile/enums_test.go
+++ b/codegen/testserver/singlefile/enums_test.go
@@ -47,7 +47,7 @@ func TestEnumsResolver(t *testing.T) {
 		err := c.Post(`query ($input: InputWithEnumValue) {
 			enumInInput(input: $input)
 		}
-		`, &resp, client.Var("input", map[string]interface{}{"enum": "INVALID"}))
+		`, &resp, client.Var("input", map[string]any{"enum": "INVALID"}))
 		require.EqualError(t, err, `http 422: {"errors":[{"message":"INVALID is not a valid EnumTest","path":["variable","input","enum"],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`)
 	})
 }

--- a/codegen/testserver/singlefile/interfaces_test.go
+++ b/codegen/testserver/singlefile/interfaces_test.go
@@ -65,7 +65,7 @@ func TestInterfaces(t *testing.T) {
 			NewExecutableSchema(Config{
 				Resolvers: resolvers,
 				Directives: DirectiveRoot{
-					MakeNil: func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+					MakeNil: func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 						return nil, nil
 					},
 				},
@@ -74,7 +74,7 @@ func TestInterfaces(t *testing.T) {
 
 		c := client.New(srv)
 
-		var resp interface{}
+		var resp any
 		c.MustPost(`{ noShape { area } }`, &resp)
 	})
 
@@ -88,7 +88,7 @@ func TestInterfaces(t *testing.T) {
 			NewExecutableSchema(Config{
 				Resolvers: resolvers,
 				Directives: DirectiveRoot{
-					MakeTypedNil: func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+					MakeTypedNil: func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 						var circle *Circle
 						return circle, nil
 					},
@@ -98,7 +98,7 @@ func TestInterfaces(t *testing.T) {
 
 		c := client.New(srv)
 
-		var resp interface{}
+		var resp any
 		c.MustPost(`{ noShapeTypedNil { area } }`, &resp)
 	})
 
@@ -112,7 +112,7 @@ func TestInterfaces(t *testing.T) {
 			NewExecutableSchema(Config{
 				Resolvers: resolvers,
 				Directives: DirectiveRoot{
-					MakeTypedNil: func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+					MakeTypedNil: func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 						var dog *Dog // return a typed nil, not just nil
 						return dog, nil
 					},
@@ -122,7 +122,7 @@ func TestInterfaces(t *testing.T) {
 
 		c := client.New(srv)
 
-		var resp interface{}
+		var resp any
 		c.MustPost(`{ animal { species } }`, &resp)
 	})
 

--- a/codegen/testserver/singlefile/introspection_test.go
+++ b/codegen/testserver/singlefile/introspection_test.go
@@ -21,7 +21,7 @@ func TestIntrospection(t *testing.T) {
 		srv.AddTransport(transport.POST{})
 		c := client.New(srv)
 
-		var resp interface{}
+		var resp any
 		err := c.Post(introspection.Query, &resp)
 		require.EqualError(t, err, "[{\"message\":\"introspection disabled\",\"path\":[\"__schema\"]}]")
 	})
@@ -33,7 +33,7 @@ func TestIntrospection(t *testing.T) {
 			NewExecutableSchema(Config{Resolvers: resolvers}),
 		))
 
-		var resp interface{}
+		var resp any
 		err := c.Post(introspection.Query, &resp)
 		require.NoError(t, err)
 
@@ -73,7 +73,7 @@ func TestIntrospection(t *testing.T) {
 		})
 		c := client.New(srv)
 
-		var resp interface{}
+		var resp any
 		err := c.Post(introspection.Query, &resp)
 		require.EqualError(t, err, "[{\"message\":\"introspection disabled\",\"path\":[\"__schema\"]}]")
 	})

--- a/codegen/testserver/singlefile/maps.go
+++ b/codegen/testserver/singlefile/maps.go
@@ -13,7 +13,7 @@ type CustomScalar struct {
 	value int64
 }
 
-func (s *CustomScalar) UnmarshalGQL(v interface{}) (err error) {
+func (s *CustomScalar) UnmarshalGQL(v any) (err error) {
 	switch v := v.(type) {
 	case string:
 		s.value, err = strconv.ParseInt(v, 10, 64)

--- a/codegen/testserver/singlefile/maps_test.go
+++ b/codegen/testserver/singlefile/maps_test.go
@@ -12,11 +12,11 @@ import (
 
 func TestMaps(t *testing.T) {
 	resolver := &Stub{}
-	resolver.QueryResolver.MapStringInterface = func(ctx context.Context, in map[string]interface{}) (i map[string]interface{}, e error) {
+	resolver.QueryResolver.MapStringInterface = func(ctx context.Context, in map[string]any) (i map[string]any, e error) {
 		validateMapItemsType(t, in)
 		return in, nil
 	}
-	resolver.QueryResolver.MapNestedStringInterface = func(ctx context.Context, in *NestedMapInput) (i map[string]interface{}, e error) {
+	resolver.QueryResolver.MapNestedStringInterface = func(ctx context.Context, in *NestedMapInput) (i map[string]any, e error) {
 		if in == nil {
 			return nil, nil
 		}
@@ -29,7 +29,7 @@ func TestMaps(t *testing.T) {
 	))
 	t.Run("unset", func(t *testing.T) {
 		var resp struct {
-			MapStringInterface map[string]interface{}
+			MapStringInterface map[string]any
 		}
 		err := c.Post(`query { mapStringInterface { a, b, c, nested { value } } }`, &resp)
 		require.NoError(t, err)
@@ -38,7 +38,7 @@ func TestMaps(t *testing.T) {
 
 	t.Run("nil", func(t *testing.T) {
 		var resp struct {
-			MapStringInterface map[string]interface{}
+			MapStringInterface map[string]any
 		}
 		err := c.Post(`query { mapStringInterface(in: null) { a, b, c, nested { value } } }`, &resp)
 		require.NoError(t, err)
@@ -47,7 +47,7 @@ func TestMaps(t *testing.T) {
 
 	t.Run("values", func(t *testing.T) {
 		var resp struct {
-			MapStringInterface map[string]interface{}
+			MapStringInterface map[string]any
 		}
 		err := c.Post(`query($value: CustomScalar!) { mapStringInterface(in: { a: "a", b: null, c: 42, nested: { value: $value } }) { a, b, c, nested { value } } }`, &resp, client.Var("value", "17"))
 		require.NoError(t, err)
@@ -55,13 +55,13 @@ func TestMaps(t *testing.T) {
 		require.Nil(t, resp.MapStringInterface["b"])
 		require.Equal(t, "42", resp.MapStringInterface["c"])
 		require.NotNil(t, resp.MapStringInterface["nested"])
-		require.IsType(t, map[string]interface{}{}, resp.MapStringInterface["nested"])
-		require.Equal(t, "17", (resp.MapStringInterface["nested"].(map[string]interface{}))["value"])
+		require.IsType(t, map[string]any{}, resp.MapStringInterface["nested"])
+		require.Equal(t, "17", (resp.MapStringInterface["nested"].(map[string]any))["value"])
 	})
 
 	t.Run("nested", func(t *testing.T) {
 		var resp struct {
-			MapNestedStringInterface map[string]interface{}
+			MapNestedStringInterface map[string]any
 		}
 		err := c.Post(`query { mapNestedStringInterface(in: { map: { a: "a", c: "42", nested: { value: 31 } } }) { a, b, c, nested { value } } }`, &resp)
 		require.NoError(t, err)
@@ -69,13 +69,13 @@ func TestMaps(t *testing.T) {
 		require.Nil(t, resp.MapNestedStringInterface["b"])
 		require.Equal(t, "42", resp.MapNestedStringInterface["c"])
 		require.NotNil(t, resp.MapNestedStringInterface["nested"])
-		require.IsType(t, map[string]interface{}{}, resp.MapNestedStringInterface["nested"])
-		require.Equal(t, "31", (resp.MapNestedStringInterface["nested"].(map[string]interface{}))["value"])
+		require.IsType(t, map[string]any{}, resp.MapNestedStringInterface["nested"])
+		require.Equal(t, "31", (resp.MapNestedStringInterface["nested"].(map[string]any))["value"])
 	})
 
 	t.Run("nested nil", func(t *testing.T) {
 		var resp struct {
-			MapNestedStringInterface map[string]interface{}
+			MapNestedStringInterface map[string]any
 		}
 		err := c.Post(`query { mapNestedStringInterface(in: { map: null }) { a, b, c, nested { value } } }`, &resp)
 		require.NoError(t, err)
@@ -83,7 +83,7 @@ func TestMaps(t *testing.T) {
 	})
 }
 
-func validateMapItemsType(t *testing.T, in map[string]interface{}) {
+func validateMapItemsType(t *testing.T, in map[string]any) {
 	for k, v := range in {
 		switch k {
 		case "a":

--- a/codegen/testserver/singlefile/middleware_test.go
+++ b/codegen/testserver/singlefile/middleware_test.go
@@ -45,17 +45,17 @@ func TestMiddleware(t *testing.T) {
 	srv := handler.NewDefaultServer(
 		NewExecutableSchema(Config{Resolvers: resolvers}),
 	)
-	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		path, _ := ctx.Value(ckey("path")).([]int)
 		return next(context.WithValue(ctx, ckey("path"), append(path, 1)))
 	})
 
-	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		path, _ := ctx.Value(ckey("path")).([]int)
 		return next(context.WithValue(ctx, ckey("path"), append(path, 2)))
 	})
 
-	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		fc := graphql.GetFieldContext(ctx)
 		mu.Lock()
 		areMethods[fc.Field.Name] = fc.IsMethod
@@ -64,7 +64,7 @@ func TestMiddleware(t *testing.T) {
 		return next(ctx)
 	})
 
-	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		fc := graphql.GetFieldContext(ctx)
 		if fc.Field.Name != "user" {
 			return next(ctx)

--- a/codegen/testserver/singlefile/models.go
+++ b/codegen/testserver/singlefile/models.go
@@ -49,7 +49,7 @@ type EmbeddedPointer struct {
 
 type MarshalPanic string
 
-func (m *MarshalPanic) UnmarshalGQL(v interface{}) error {
+func (m *MarshalPanic) UnmarshalGQL(v any) error {
 	panic("BOOM")
 }
 

--- a/codegen/testserver/singlefile/mutation_with_custom_scalar.go
+++ b/codegen/testserver/singlefile/mutation_with_custom_scalar.go
@@ -11,7 +11,7 @@ var re = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-
 
 type Email string
 
-func (value *Email) UnmarshalGQL(v interface{}) error {
+func (value *Email) UnmarshalGQL(v any) error {
 	input, ok := v.(string)
 	if !ok {
 		return fmt.Errorf("email expects a string value")

--- a/codegen/testserver/singlefile/mutation_with_custom_scalar_test.go
+++ b/codegen/testserver/singlefile/mutation_with_custom_scalar_test.go
@@ -19,9 +19,9 @@ func TestErrorInsideMutationArgument(t *testing.T) {
 	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
 
 	t.Run("mutation with correct input doesn't return error", func(t *testing.T) {
-		var resp map[string]interface{}
-		input := map[string]interface{}{
-			"nesting": map[string]interface{}{
+		var resp map[string]any
+		input := map[string]any{
+			"nesting": map[string]any{
 				"field": "email@example.com",
 			},
 		}
@@ -35,9 +35,9 @@ func TestErrorInsideMutationArgument(t *testing.T) {
 	})
 
 	t.Run("mutation with incorrect input returns full path", func(t *testing.T) {
-		var resp map[string]interface{}
-		input := map[string]interface{}{
-			"nesting": map[string]interface{}{
+		var resp map[string]any
+		input := map[string]any{
+			"nesting": map[string]any{
 				"field": "not-an-email",
 			},
 		}

--- a/codegen/testserver/singlefile/nulls_test.go
+++ b/codegen/testserver/singlefile/nulls_test.go
@@ -119,7 +119,7 @@ func TestNullBubbling(t *testing.T) {
 	})
 
 	t.Run("concurrent null detection", func(t *testing.T) {
-		var resp interface{}
+		var resp any
 		resolvers.ErrorsResolver.A = func(ctx context.Context, obj *Errors) (i *Error, e error) { return nil, nil }
 		resolvers.ErrorsResolver.B = func(ctx context.Context, obj *Errors) (i *Error, e error) { return nil, nil }
 		resolvers.ErrorsResolver.C = func(ctx context.Context, obj *Errors) (i *Error, e error) { return nil, nil }

--- a/codegen/testserver/singlefile/panics_test.go
+++ b/codegen/testserver/singlefile/panics_test.go
@@ -26,7 +26,7 @@ func TestPanics(t *testing.T) {
 	}
 
 	srv := handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers}))
-	srv.SetRecoverFunc(func(ctx context.Context, err interface{}) (userMessage error) {
+	srv.SetRecoverFunc(func(ctx context.Context, err any) (userMessage error) {
 		return fmt.Errorf("panic: %v", err)
 	})
 
@@ -40,28 +40,28 @@ func TestPanics(t *testing.T) {
 	c := client.New(srv)
 
 	t.Run("panics in marshallers will not kill server", func(t *testing.T) {
-		var resp interface{}
+		var resp any
 		err := c.Post(`query { panics { fieldScalarMarshal } }`, &resp)
 
 		require.EqualError(t, err, "http 422: {\"errors\":[{\"message\":\"presented: panic: BOOM\"}],\"data\":null}")
 	})
 
 	t.Run("panics in unmarshalers will not kill server", func(t *testing.T) {
-		var resp interface{}
+		var resp any
 		err := c.Post(`query { panics { argUnmarshal(u: ["aa", "bb"]) } }`, &resp)
 
 		require.EqualError(t, err, "[{\"message\":\"presented: input: panics.argUnmarshal panic: BOOM\",\"path\":[\"panics\",\"argUnmarshal\"]}]")
 	})
 
 	t.Run("panics in funcs unmarshal return errors", func(t *testing.T) {
-		var resp interface{}
+		var resp any
 		err := c.Post(`query { panics { fieldFuncMarshal(u: ["aa", "bb"]) } }`, &resp)
 
 		require.EqualError(t, err, "[{\"message\":\"presented: input: panics.fieldFuncMarshal panic: BOOM\",\"path\":[\"panics\",\"fieldFuncMarshal\"]}]")
 	})
 
 	t.Run("panics in funcs marshal return errors", func(t *testing.T) {
-		var resp interface{}
+		var resp any
 		err := c.Post(`query { panics { fieldFuncMarshal(u: []) } }`, &resp)
 
 		require.EqualError(t, err, "http 422: {\"errors\":[{\"message\":\"presented: panic: BOOM\"}],\"data\":null}")

--- a/codegen/testserver/singlefile/scalar_context.go
+++ b/codegen/testserver/singlefile/scalar_context.go
@@ -22,7 +22,7 @@ func (StringFromContextInterface) MarshalGQLContext(ctx context.Context, w io.Wr
 	return nil
 }
 
-func (i *StringFromContextInterface) UnmarshalGQLContext(ctx context.Context, v interface{}) error {
+func (i *StringFromContextInterface) UnmarshalGQLContext(ctx context.Context, v any) error {
 	i.OperationName = graphql.GetFieldContext(ctx).Field.Name
 	return nil
 }
@@ -34,6 +34,6 @@ func MarshalStringFromContextFunction(v string) graphql.ContextMarshaler {
 	})
 }
 
-func UnmarshalStringFromContextFunction(ctx context.Context, v interface{}) (string, error) {
+func UnmarshalStringFromContextFunction(ctx context.Context, v any) (string, error) {
 	return graphql.GetFieldContext(ctx).Field.Name, nil
 }

--- a/codegen/testserver/singlefile/subscription_test.go
+++ b/codegen/testserver/singlefile/subscription_test.go
@@ -89,12 +89,12 @@ func TestSubscriptions(t *testing.T) {
 	srv := handler.NewDefaultServer(
 		NewExecutableSchema(Config{Resolvers: resolvers}),
 	)
-	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		path, _ := ctx.Value(ckey("path")).([]int)
 		return next(context.WithValue(ctx, ckey("path"), append(path, 1)))
 	})
 
-	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		path, _ := ctx.Value(ckey("path")).([]int)
 		return next(context.WithValue(ctx, ckey("path"), append(path, 2)))
 	})
@@ -133,7 +133,7 @@ func TestSubscriptions(t *testing.T) {
 		runtime.GC() // ensure no go-routines left from preceding tests
 		initialGoroutineCount := runtime.NumGoroutine()
 
-		sub := c.WebsocketWithPayload(`subscription { initPayload }`, map[string]interface{}{
+		sub := c.WebsocketWithPayload(`subscription { initPayload }`, map[string]any{
 			"Authorization": "Bearer of the curse",
 			"number":        32,
 			"strings":       []string{"hello", "world"},

--- a/codegen/testserver/singlefile/thirdparty.go
+++ b/codegen/testserver/singlefile/thirdparty.go
@@ -21,7 +21,7 @@ func MarshalThirdParty(tp ThirdParty) graphql.Marshaler {
 	})
 }
 
-func UnmarshalThirdParty(input interface{}) (ThirdParty, error) {
+func UnmarshalThirdParty(input any) (ThirdParty, error) {
 	switch input := input.(type) {
 	case string:
 		return ThirdParty{str: input}, nil

--- a/complexity/complexity.go
+++ b/complexity/complexity.go
@@ -6,7 +6,7 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 )
 
-func Calculate(es graphql.ExecutableSchema, op *ast.OperationDefinition, vars map[string]interface{}) int {
+func Calculate(es graphql.ExecutableSchema, op *ast.OperationDefinition, vars map[string]any) int {
 	walker := complexityWalker{
 		es:     es,
 		schema: es.Schema(),
@@ -18,7 +18,7 @@ func Calculate(es graphql.ExecutableSchema, op *ast.OperationDefinition, vars ma
 type complexityWalker struct {
 	es     graphql.ExecutableSchema
 	schema *ast.Schema
-	vars   map[string]interface{}
+	vars   map[string]any
 }
 
 func (cw complexityWalker) selectionSetComplexity(selectionSet ast.SelectionSet) int {
@@ -57,7 +57,7 @@ func (cw complexityWalker) selectionSetComplexity(selectionSet ast.SelectionSet)
 	return complexity
 }
 
-func (cw complexityWalker) interfaceFieldComplexity(def *ast.Definition, field string, childComplexity int, args map[string]interface{}) int {
+func (cw complexityWalker) interfaceFieldComplexity(def *ast.Definition, field string, childComplexity int, args map[string]any) int {
 	// Interfaces don't have their own separate field costs, so they have to assume the worst case.
 	// We iterate over all implementors and choose the most expensive one.
 	maxComplexity := 0
@@ -71,7 +71,7 @@ func (cw complexityWalker) interfaceFieldComplexity(def *ast.Definition, field s
 	return maxComplexity
 }
 
-func (cw complexityWalker) fieldComplexity(object, field string, childComplexity int, args map[string]interface{}) int {
+func (cw complexityWalker) fieldComplexity(object, field string, childComplexity int, args map[string]any) int {
 	if customComplexity, ok := cw.es.Complexity(object, field, childComplexity, args); ok && customComplexity >= childComplexity {
 		return customComplexity
 	}

--- a/complexity/complexity_test.go
+++ b/complexity/complexity_test.go
@@ -52,7 +52,7 @@ func requireComplexity(t *testing.T, source string, complexity int) {
 	query := gqlparser.MustLoadQuery(schema, source)
 
 	es := &graphql.ExecutableSchemaMock{
-		ComplexityFunc: func(typeName, field string, childComplexity int, args map[string]interface{}) (int, bool) {
+		ComplexityFunc: func(typeName, field string, childComplexity int, args map[string]any) (int, bool) {
 			switch typeName + "." + field {
 			case "ExpensiveItem.name":
 				return 5, true

--- a/graphql/any.go
+++ b/graphql/any.go
@@ -5,7 +5,7 @@ import (
 	"io"
 )
 
-func MarshalAny(v interface{}) Marshaler {
+func MarshalAny(v any) Marshaler {
 	return WriterFunc(func(w io.Writer) {
 		err := json.NewEncoder(w).Encode(v)
 		if err != nil {
@@ -14,6 +14,6 @@ func MarshalAny(v interface{}) Marshaler {
 	})
 }
 
-func UnmarshalAny(v interface{}) (interface{}, error) {
+func UnmarshalAny(v any) (any, error) {
 	return v, nil
 }

--- a/graphql/bool.go
+++ b/graphql/bool.go
@@ -13,7 +13,7 @@ func MarshalBoolean(b bool) Marshaler {
 	return WriterFunc(func(w io.Writer) { w.Write(falseLit) })
 }
 
-func UnmarshalBoolean(v interface{}) (bool, error) {
+func UnmarshalBoolean(v any) (bool, error) {
 	switch v := v.(type) {
 	case string:
 		return strings.ToLower(v) == "true", nil

--- a/graphql/cache.go
+++ b/graphql/cache.go
@@ -5,25 +5,25 @@ import "context"
 // Cache is a shared store for APQ and query AST caching
 type Cache interface {
 	// Get looks up a key's value from the cache.
-	Get(ctx context.Context, key string) (value interface{}, ok bool)
+	Get(ctx context.Context, key string) (value any, ok bool)
 
 	// Add adds a value to the cache.
-	Add(ctx context.Context, key string, value interface{})
+	Add(ctx context.Context, key string, value any)
 }
 
 // MapCache is the simplest implementation of a cache, because it can not evict it should only be used in tests
-type MapCache map[string]interface{}
+type MapCache map[string]any
 
 // Get looks up a key's value from the cache.
-func (m MapCache) Get(_ context.Context, key string) (value interface{}, ok bool) {
+func (m MapCache) Get(_ context.Context, key string) (value any, ok bool) {
 	v, ok := m[key]
 	return v, ok
 }
 
 // Add adds a value to the cache.
-func (m MapCache) Add(_ context.Context, key string, value interface{}) { m[key] = value }
+func (m MapCache) Add(_ context.Context, key string, value any) { m[key] = value }
 
 type NoCache struct{}
 
-func (n NoCache) Get(_ context.Context, _ string) (value interface{}, ok bool) { return nil, false }
-func (n NoCache) Add(_ context.Context, _ string, _ interface{})               {}
+func (n NoCache) Get(_ context.Context, _ string) (value any, ok bool) { return nil, false }
+func (n NoCache) Add(_ context.Context, _ string, _ any)               {}

--- a/graphql/cache_test.go
+++ b/graphql/cache_test.go
@@ -161,7 +161,7 @@ func TestNoCacheEdgeCases(t *testing.T) {
 		key       string
 		value     string
 		wantOk    bool
-		wantValue interface{}
+		wantValue any
 	}
 
 	tests := []testCase{

--- a/graphql/coercion.go
+++ b/graphql/coercion.go
@@ -5,51 +5,51 @@ import (
 )
 
 // CoerceList applies coercion from a single value to a list.
-func CoerceList(v interface{}) []interface{} {
-	var vSlice []interface{}
+func CoerceList(v any) []any {
+	var vSlice []any
 	if v != nil {
 		switch v := v.(type) {
-		case []interface{}:
+		case []any:
 			// already a slice no coercion required
 			vSlice = v
 		case []string:
 			if len(v) > 0 {
-				vSlice = []interface{}{v[0]}
+				vSlice = []any{v[0]}
 			}
 		case []json.Number:
 			if len(v) > 0 {
-				vSlice = []interface{}{v[0]}
+				vSlice = []any{v[0]}
 			}
 		case []bool:
 			if len(v) > 0 {
-				vSlice = []interface{}{v[0]}
+				vSlice = []any{v[0]}
 			}
-		case []map[string]interface{}:
+		case []map[string]any:
 			if len(v) > 0 {
-				vSlice = []interface{}{v[0]}
+				vSlice = []any{v[0]}
 			}
 		case []float64:
 			if len(v) > 0 {
-				vSlice = []interface{}{v[0]}
+				vSlice = []any{v[0]}
 			}
 		case []float32:
 			if len(v) > 0 {
-				vSlice = []interface{}{v[0]}
+				vSlice = []any{v[0]}
 			}
 		case []int:
 			if len(v) > 0 {
-				vSlice = []interface{}{v[0]}
+				vSlice = []any{v[0]}
 			}
 		case []int32:
 			if len(v) > 0 {
-				vSlice = []interface{}{v[0]}
+				vSlice = []any{v[0]}
 			}
 		case []int64:
 			if len(v) > 0 {
-				vSlice = []interface{}{v[0]}
+				vSlice = []any{v[0]}
 			}
 		default:
-			vSlice = []interface{}{v}
+			vSlice = []any{v}
 		}
 	}
 	return vSlice

--- a/graphql/coercion_test.go
+++ b/graphql/coercion_test.go
@@ -8,29 +8,29 @@ import (
 )
 
 func TestCoerceList(t *testing.T) {
-	mapInput := map[string]interface{}{
+	mapInput := map[string]any{
 		"test": "value",
-		"nested": map[string]interface{}{
+		"nested": map[string]any{
 			"nested": true,
 		},
 	}
 
 	jsonNumber := json.Number("12")
 
-	assert.Equal(t, []interface{}{"test", "values"}, CoerceList([]interface{}{"test", "values"}))
-	assert.Equal(t, []interface{}{"test"}, CoerceList("test"))
-	assert.Equal(t, []interface{}{"test"}, CoerceList([]string{"test"}))
-	assert.Equal(t, []interface{}{3}, CoerceList([]int{3}))
-	assert.Equal(t, []interface{}{3}, CoerceList(3))
-	assert.Equal(t, []interface{}{int32(3)}, CoerceList([]int32{3}))
-	assert.Equal(t, []interface{}{int64(2)}, CoerceList([]int64{2}))
-	assert.Equal(t, []interface{}{float32(3.14)}, CoerceList([]float32{3.14}))
-	assert.Equal(t, []interface{}{3.14}, CoerceList([]float64{3.14}))
-	assert.Equal(t, []interface{}{jsonNumber}, CoerceList([]json.Number{jsonNumber}))
-	assert.Equal(t, []interface{}{jsonNumber}, CoerceList(jsonNumber))
-	assert.Equal(t, []interface{}{true}, CoerceList([]bool{true}))
-	assert.Equal(t, []interface{}{mapInput}, CoerceList(mapInput))
-	assert.Equal(t, []interface{}{mapInput}, CoerceList([]interface{}{mapInput}))
-	assert.Equal(t, []interface{}{mapInput}, CoerceList([]map[string]interface{}{mapInput}))
+	assert.Equal(t, []any{"test", "values"}, CoerceList([]any{"test", "values"}))
+	assert.Equal(t, []any{"test"}, CoerceList("test"))
+	assert.Equal(t, []any{"test"}, CoerceList([]string{"test"}))
+	assert.Equal(t, []any{3}, CoerceList([]int{3}))
+	assert.Equal(t, []any{3}, CoerceList(3))
+	assert.Equal(t, []any{int32(3)}, CoerceList([]int32{3}))
+	assert.Equal(t, []any{int64(2)}, CoerceList([]int64{2}))
+	assert.Equal(t, []any{float32(3.14)}, CoerceList([]float32{3.14}))
+	assert.Equal(t, []any{3.14}, CoerceList([]float64{3.14}))
+	assert.Equal(t, []any{jsonNumber}, CoerceList([]json.Number{jsonNumber}))
+	assert.Equal(t, []any{jsonNumber}, CoerceList(jsonNumber))
+	assert.Equal(t, []any{true}, CoerceList([]bool{true}))
+	assert.Equal(t, []any{mapInput}, CoerceList(mapInput))
+	assert.Equal(t, []any{mapInput}, CoerceList([]any{mapInput}))
+	assert.Equal(t, []any{mapInput}, CoerceList([]map[string]any{mapInput}))
 	assert.Empty(t, CoerceList(nil))
 }

--- a/graphql/context_field.go
+++ b/graphql/context_field.go
@@ -19,13 +19,13 @@ type FieldContext struct {
 	// The name of the type this field belongs to
 	Object string
 	// These are the args after processing, they can be mutated in middleware to change what the resolver will get.
-	Args map[string]interface{}
+	Args map[string]any
 	// The raw field
 	Field CollectedField
 	// The index of array in path.
 	Index *int
 	// The result object of resolver
-	Result interface{}
+	Result any
 	// IsMethod indicates if the resolver is a method
 	IsMethod bool
 	// IsResolver indicates if the field has a user-specified resolver

--- a/graphql/context_operation.go
+++ b/graphql/context_operation.go
@@ -14,7 +14,7 @@ type RequestContext = OperationContext
 
 type OperationContext struct {
 	RawQuery      string
-	Variables     map[string]interface{}
+	Variables     map[string]any
 	OperationName string
 	Doc           *ast.QueryDocument
 	Headers       http.Header
@@ -36,7 +36,7 @@ func (c *OperationContext) Validate(ctx context.Context) error {
 		return errors.New("field 'RawQuery' is required")
 	}
 	if c.Variables == nil {
-		c.Variables = make(map[string]interface{})
+		c.Variables = make(map[string]any)
 	}
 	if c.ResolverMiddleware == nil {
 		return errors.New("field 'ResolverMiddleware' is required")
@@ -103,7 +103,7 @@ Next:
 
 // Errorf sends an error string to the client, passing it through the formatter.
 // Deprecated: use graphql.AddErrorf(ctx, err) instead
-func (c *OperationContext) Errorf(ctx context.Context, format string, args ...interface{}) {
+func (c *OperationContext) Errorf(ctx context.Context, format string, args ...any) {
 	AddErrorf(ctx, format, args...)
 }
 
@@ -120,6 +120,6 @@ func (c *OperationContext) Error(ctx context.Context, err error) {
 	AddError(ctx, err)
 }
 
-func (c *OperationContext) Recover(ctx context.Context, err interface{}) error {
+func (c *OperationContext) Recover(ctx context.Context, err any) error {
 	return ErrorOnPath(ctx, c.RecoverFunc(ctx, err))
 }

--- a/graphql/context_operation_test.go
+++ b/graphql/context_operation_test.go
@@ -26,7 +26,7 @@ func (t *testGraphRequestContext) Err() error {
 	return nil
 }
 
-func (t *testGraphRequestContext) Value(key interface{}) interface{} {
+func (t *testGraphRequestContext) Value(key any) any {
 	return t.opContext
 }
 

--- a/graphql/context_response.go
+++ b/graphql/context_response.go
@@ -15,7 +15,7 @@ type responseContext struct {
 	errors   gqlerror.List
 	errorsMu sync.Mutex
 
-	extensions   map[string]interface{}
+	extensions   map[string]any
 	extensionsMu sync.Mutex
 }
 
@@ -45,7 +45,7 @@ func WithFreshResponseContext(ctx context.Context) context.Context {
 }
 
 // AddErrorf writes a formatted error to the client, first passing it through the error presenter.
-func AddErrorf(ctx context.Context, format string, args ...interface{}) {
+func AddErrorf(ctx context.Context, format string, args ...any) {
 	AddError(ctx, fmt.Errorf(format, args...))
 }
 
@@ -60,7 +60,7 @@ func AddError(ctx context.Context, err error) {
 	c.errors = append(c.errors, presentedError)
 }
 
-func Recover(ctx context.Context, err interface{}) (userMessage error) {
+func Recover(ctx context.Context, err any) (userMessage error) {
 	c := getResponseContext(ctx)
 	return ErrorOnPath(ctx, c.recover(ctx, err))
 }
@@ -125,13 +125,13 @@ func GetErrors(ctx context.Context) gqlerror.List {
 }
 
 // RegisterExtension allows you to add a new extension into the graphql response
-func RegisterExtension(ctx context.Context, key string, value interface{}) {
+func RegisterExtension(ctx context.Context, key string, value any) {
 	c := getResponseContext(ctx)
 	c.extensionsMu.Lock()
 	defer c.extensionsMu.Unlock()
 
 	if c.extensions == nil {
-		c.extensions = make(map[string]interface{})
+		c.extensions = make(map[string]any)
 	}
 
 	if _, ok := c.extensions[key]; ok {
@@ -142,16 +142,16 @@ func RegisterExtension(ctx context.Context, key string, value interface{}) {
 }
 
 // GetExtensions returns any extensions registered in the current result context
-func GetExtensions(ctx context.Context) map[string]interface{} {
+func GetExtensions(ctx context.Context) map[string]any {
 	ext := getResponseContext(ctx).extensions
 	if ext == nil {
-		return map[string]interface{}{}
+		return map[string]any{}
 	}
 
 	return ext
 }
 
-func GetExtension(ctx context.Context, name string) interface{} {
+func GetExtension(ctx context.Context, name string) any {
 	ext := getResponseContext(ctx).extensions
 	if ext == nil {
 		return nil

--- a/graphql/duration.go
+++ b/graphql/duration.go
@@ -8,7 +8,7 @@ import (
 )
 
 // UnmarshalDuration returns the duration from a string in ISO8601 format
-func UnmarshalDuration(v interface{}) (time.Duration, error) {
+func UnmarshalDuration(v any) (time.Duration, error) {
 	input, ok := v.(string)
 	if !ok {
 		return 0, fmt.Errorf("input must be a string")

--- a/graphql/errcode/codes.go
+++ b/graphql/errcode/codes.go
@@ -40,7 +40,7 @@ func Set(err error, value string) {
 	}
 
 	if gqlErr.Extensions == nil {
-		gqlErr.Extensions = map[string]interface{}{}
+		gqlErr.Extensions = map[string]any{}
 	}
 
 	gqlErr.Extensions["code"] = value

--- a/graphql/executable_schema.go
+++ b/graphql/executable_schema.go
@@ -12,7 +12,7 @@ import (
 type ExecutableSchema interface {
 	Schema() *ast.Schema
 
-	Complexity(typeName, fieldName string, childComplexity int, args map[string]interface{}) (int, bool)
+	Complexity(typeName, fieldName string, childComplexity int, args map[string]any) (int, bool)
 	Exec(ctx context.Context) ResponseHandler
 }
 
@@ -150,7 +150,7 @@ func getOrCreateAndAppendField(c *[]CollectedField, name string, alias string, o
 	return &(*c)[len(*c)-1]
 }
 
-func shouldIncludeNode(directives ast.DirectiveList, variables map[string]interface{}) bool {
+func shouldIncludeNode(directives ast.DirectiveList, variables map[string]any) bool {
 	if len(directives) == 0 {
 		return true
 	}
@@ -168,7 +168,7 @@ func shouldIncludeNode(directives ast.DirectiveList, variables map[string]interf
 	return !skip && include
 }
 
-func deferrable(directives ast.DirectiveList, variables map[string]interface{}) (shouldDefer bool, label string) {
+func deferrable(directives ast.DirectiveList, variables map[string]any) (shouldDefer bool, label string) {
 	d := directives.ForName("defer")
 	if d == nil {
 		return false, ""
@@ -194,7 +194,7 @@ func deferrable(directives ast.DirectiveList, variables map[string]interface{}) 
 	return shouldDefer, label
 }
 
-func resolveIfArgument(d *ast.Directive, variables map[string]interface{}) bool {
+func resolveIfArgument(d *ast.Directive, variables map[string]any) bool {
 	arg := d.Arguments.ForName("if")
 	if arg == nil {
 		panic(fmt.Sprintf("%s: argument 'if' not defined", d.Name))

--- a/graphql/executable_schema_mock.go
+++ b/graphql/executable_schema_mock.go
@@ -19,7 +19,7 @@ var _ ExecutableSchema = &ExecutableSchemaMock{}
 //
 //		// make and configure a mocked ExecutableSchema
 //		mockedExecutableSchema := &ExecutableSchemaMock{
-//			ComplexityFunc: func(typeName string, fieldName string, childComplexity int, args map[string]interface{}) (int, bool) {
+//			ComplexityFunc: func(typeName string, fieldName string, childComplexity int, args map[string]any) (int, bool) {
 //				panic("mock out the Complexity method")
 //			},
 //			ExecFunc: func(ctx context.Context) ResponseHandler {
@@ -36,7 +36,7 @@ var _ ExecutableSchema = &ExecutableSchemaMock{}
 //	}
 type ExecutableSchemaMock struct {
 	// ComplexityFunc mocks the Complexity method.
-	ComplexityFunc func(typeName string, fieldName string, childComplexity int, args map[string]interface{}) (int, bool)
+	ComplexityFunc func(typeName string, fieldName string, childComplexity int, args map[string]any) (int, bool)
 
 	// ExecFunc mocks the Exec method.
 	ExecFunc func(ctx context.Context) ResponseHandler
@@ -55,7 +55,7 @@ type ExecutableSchemaMock struct {
 			// ChildComplexity is the childComplexity argument value.
 			ChildComplexity int
 			// Args is the args argument value.
-			Args map[string]interface{}
+			Args map[string]any
 		}
 		// Exec holds details about calls to the Exec method.
 		Exec []struct {
@@ -72,7 +72,7 @@ type ExecutableSchemaMock struct {
 }
 
 // Complexity calls ComplexityFunc.
-func (mock *ExecutableSchemaMock) Complexity(typeName string, fieldName string, childComplexity int, args map[string]interface{}) (int, bool) {
+func (mock *ExecutableSchemaMock) Complexity(typeName string, fieldName string, childComplexity int, args map[string]any) (int, bool) {
 	if mock.ComplexityFunc == nil {
 		panic("ExecutableSchemaMock.ComplexityFunc: method is nil but ExecutableSchema.Complexity was just called")
 	}
@@ -80,7 +80,7 @@ func (mock *ExecutableSchemaMock) Complexity(typeName string, fieldName string, 
 		TypeName        string
 		FieldName       string
 		ChildComplexity int
-		Args            map[string]interface{}
+		Args            map[string]any
 	}{
 		TypeName:        typeName,
 		FieldName:       fieldName,
@@ -101,13 +101,13 @@ func (mock *ExecutableSchemaMock) ComplexityCalls() []struct {
 	TypeName        string
 	FieldName       string
 	ChildComplexity int
-	Args            map[string]interface{}
+	Args            map[string]any
 } {
 	var calls []struct {
 		TypeName        string
 		FieldName       string
 		ChildComplexity int
-		Args            map[string]interface{}
+		Args            map[string]any
 	}
 	mock.lockComplexity.RLock()
 	calls = mock.calls.Complexity

--- a/graphql/executor/executor.go
+++ b/graphql/executor/executor.go
@@ -153,7 +153,7 @@ func (e *Executor) DispatchError(ctx context.Context, list gqlerror.List) *graph
 	return resp
 }
 
-func (e *Executor) PresentRecoveredError(ctx context.Context, err interface{}) error {
+func (e *Executor) PresentRecoveredError(ctx context.Context, err any) error {
 	return e.errorPresenter(ctx, e.recoverFunc(ctx, err))
 }
 

--- a/graphql/executor/executor_test.go
+++ b/graphql/executor/executor_test.go
@@ -89,11 +89,11 @@ func TestExecutor(t *testing.T) {
 
 	t.Run("invokes field middleware in order", func(t *testing.T) {
 		var calls []string
-		exec.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+		exec.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 			calls = append(calls, "first")
 			return next(ctx)
 		})
-		exec.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+		exec.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 			calls = append(calls, "second")
 			return next(ctx)
 		})

--- a/graphql/executor/extensions.go
+++ b/graphql/executor/extensions.go
@@ -68,7 +68,7 @@ func processExtensions(exts []graphql.HandlerExtension) extensions {
 		rootFieldMiddleware: func(ctx context.Context, next graphql.RootResolver) graphql.Marshaler {
 			return next(ctx)
 		},
-		fieldMiddleware: func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+		fieldMiddleware: func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 			return next(ctx)
 		},
 	}
@@ -105,8 +105,8 @@ func processExtensions(exts []graphql.HandlerExtension) extensions {
 
 		if p, ok := p.(graphql.FieldInterceptor); ok {
 			previous := e.fieldMiddleware
-			e.fieldMiddleware = func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
-				return p.InterceptField(ctx, func(ctx context.Context) (res interface{}, err error) {
+			e.fieldMiddleware = func(ctx context.Context, next graphql.Resolver) (res any, err error) {
+				return p.InterceptField(ctx, func(ctx context.Context) (res any, err error) {
 					return previous(ctx, next)
 				})
 			}
@@ -160,7 +160,7 @@ func (r aroundRespFunc) InterceptResponse(ctx context.Context, next graphql.Resp
 	return r(ctx, next)
 }
 
-type aroundFieldFunc func(ctx context.Context, next graphql.Resolver) (res interface{}, err error)
+type aroundFieldFunc func(ctx context.Context, next graphql.Resolver) (res any, err error)
 
 func (f aroundFieldFunc) ExtensionName() string {
 	return "InlineFieldFunc"
@@ -173,7 +173,7 @@ func (f aroundFieldFunc) Validate(schema graphql.ExecutableSchema) error {
 	return nil
 }
 
-func (f aroundFieldFunc) InterceptField(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+func (f aroundFieldFunc) InterceptField(ctx context.Context, next graphql.Resolver) (res any, err error) {
 	return f(ctx, next)
 }
 

--- a/graphql/executor/testexecutor/testexecutor.go
+++ b/graphql/executor/testexecutor/testexecutor.go
@@ -19,7 +19,7 @@ type MockResponse struct {
 	Name string `json:"name"`
 }
 
-func (mr *MockResponse) UnmarshalGQL(v interface{}) error {
+func (mr *MockResponse) UnmarshalGQL(v any) error {
 	return nil
 }
 
@@ -80,7 +80,7 @@ func New() *TestExecutor {
 						},
 					})
 					data := graphql.GetOperationContext(ctx).RootResolverMiddleware(ctx, func(ctx context.Context) graphql.Marshaler {
-						res, err := graphql.GetOperationContext(ctx).ResolverMiddleware(ctx, func(ctx context.Context) (interface{}, error) {
+						res, err := graphql.GetOperationContext(ctx).ResolverMiddleware(ctx, func(ctx context.Context) (any, error) {
 							// return &graphql.Response{Data: []byte(`{"name":"test"}`)}, nil
 							return &MockResponse{Name: "test"}, nil
 						})
@@ -116,7 +116,7 @@ func New() *TestExecutor {
 		SchemaFunc: func() *ast.Schema {
 			return schema
 		},
-		ComplexityFunc: func(typeName string, fieldName string, childComplexity int, args map[string]interface{}) (i int, b bool) {
+		ComplexityFunc: func(typeName string, fieldName string, childComplexity int, args map[string]any) (i int, b bool) {
 			return exec.complexity, true
 		},
 	}
@@ -169,7 +169,7 @@ func NewError() *TestExecutor {
 		SchemaFunc: func() *ast.Schema {
 			return schema
 		},
-		ComplexityFunc: func(typeName string, fieldName string, childComplexity int, args map[string]interface{}) (i int, b bool) {
+		ComplexityFunc: func(typeName string, fieldName string, childComplexity int, args map[string]any) (i int, b bool) {
 			return exec.complexity, true
 		},
 	}

--- a/graphql/float.go
+++ b/graphql/float.go
@@ -15,7 +15,7 @@ func MarshalFloat(f float64) Marshaler {
 	})
 }
 
-func UnmarshalFloat(v interface{}) (float64, error) {
+func UnmarshalFloat(v any) (float64, error) {
 	switch v := v.(type) {
 	case string:
 		return strconv.ParseFloat(v, 64)
@@ -42,6 +42,6 @@ func MarshalFloatContext(f float64) ContextMarshaler {
 	})
 }
 
-func UnmarshalFloatContext(ctx context.Context, v interface{}) (float64, error) {
+func UnmarshalFloatContext(ctx context.Context, v any) (float64, error) {
 	return UnmarshalFloat(v)
 }

--- a/graphql/handler.go
+++ b/graphql/handler.go
@@ -16,18 +16,18 @@ type (
 	ResponseHandler    func(ctx context.Context) *Response
 	ResponseMiddleware func(ctx context.Context, next ResponseHandler) *Response
 
-	Resolver        func(ctx context.Context) (res interface{}, err error)
-	FieldMiddleware func(ctx context.Context, next Resolver) (res interface{}, err error)
+	Resolver        func(ctx context.Context) (res any, err error)
+	FieldMiddleware func(ctx context.Context, next Resolver) (res any, err error)
 
 	RootResolver        func(ctx context.Context) Marshaler
 	RootFieldMiddleware func(ctx context.Context, next RootResolver) Marshaler
 
 	RawParams struct {
-		Query         string                 `json:"query"`
-		OperationName string                 `json:"operationName"`
-		Variables     map[string]interface{} `json:"variables"`
-		Extensions    map[string]interface{} `json:"extensions"`
-		Headers       http.Header            `json:"headers"`
+		Query         string         `json:"query"`
+		OperationName string         `json:"operationName"`
+		Variables     map[string]any `json:"variables"`
+		Extensions    map[string]any `json:"extensions"`
+		Headers       http.Header    `json:"headers"`
 
 		ReadTime TraceTiming `json:"-"`
 	}
@@ -86,7 +86,7 @@ type (
 
 	// FieldInterceptor called around each field
 	FieldInterceptor interface {
-		InterceptField(ctx context.Context, next Resolver) (res interface{}, err error)
+		InterceptField(ctx context.Context, next Resolver) (res any, err error)
 	}
 
 	// Transport provides support for different wire level encodings of graphql requests, eg Form, Get, Post, Websocket
@@ -103,7 +103,7 @@ func (p *RawParams) AddUpload(upload Upload, key, path string) *gqlerror.Error {
 		return gqlerror.Errorf("invalid operations paths for key %s", key)
 	}
 
-	var ptr interface{} = p.Variables
+	var ptr any = p.Variables
 	parts := strings.Split(path, ".")
 
 	// skip the first part (variables) because we started there
@@ -114,15 +114,15 @@ func (p *RawParams) AddUpload(upload Upload, key, path string) *gqlerror.Error {
 		}
 		if index, parseNbrErr := strconv.Atoi(p); parseNbrErr == nil {
 			if last {
-				ptr.([]interface{})[index] = upload
+				ptr.([]any)[index] = upload
 			} else {
-				ptr = ptr.([]interface{})[index]
+				ptr = ptr.([]any)[index]
 			}
 		} else {
 			if last {
-				ptr.(map[string]interface{})[p] = upload
+				ptr.(map[string]any)[p] = upload
 			} else {
-				ptr = ptr.(map[string]interface{})[p]
+				ptr = ptr.(map[string]any)[p]
 			}
 		}
 	}

--- a/graphql/handler/apollofederatedtracingv1/tracing.go
+++ b/graphql/handler/apollofederatedtracingv1/tracing.go
@@ -67,7 +67,7 @@ func (t *Tracer) InterceptOperation(ctx context.Context, next graphql.OperationH
 
 // InterceptField is called on each field's resolution, including information about the path and parent node.
 // This information is then used to build the relevant Node Tree used in the FTV1 tracing format
-func (t *Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (interface{}, error) {
+func (t *Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (any, error) {
 	if !t.shouldTrace(ctx) {
 		return next(ctx)
 	}

--- a/graphql/handler/apollotracing/tracer.go
+++ b/graphql/handler/apollotracing/tracer.go
@@ -55,7 +55,7 @@ func (Tracer) Validate(graphql.ExecutableSchema) error {
 	return nil
 }
 
-func (Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (interface{}, error) {
+func (Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (any, error) {
 	td, ok := graphql.GetExtension(ctx, "tracing").(*TracingExtension)
 	if !ok {
 		return next(ctx)

--- a/graphql/handler/debug/tracer.go
+++ b/graphql/handler/debug/tracer.go
@@ -39,7 +39,7 @@ func (a *Tracer) Validate(schema graphql.ExecutableSchema) error {
 	return nil
 }
 
-func stringify(value interface{}) string {
+func stringify(value any) string {
 	valueJson, err := json.MarshalIndent(value, "  ", "  ")
 	if err == nil {
 		return string(valueJson)

--- a/graphql/handler/extension/apq_test.go
+++ b/graphql/handler/extension/apq_test.go
@@ -51,8 +51,8 @@ func TestAPQ(t *testing.T) {
 	t.Run("with hash miss and no query", func(t *testing.T) {
 		ctx := newOC()
 		params := &graphql.RawParams{
-			Extensions: map[string]interface{}{
-				"persistedQuery": map[string]interface{}{
+			Extensions: map[string]any{
+				"persistedQuery": map[string]any{
 					"sha256Hash": hash,
 					"version":    1,
 				},
@@ -67,8 +67,8 @@ func TestAPQ(t *testing.T) {
 		ctx := newOC()
 		params := &graphql.RawParams{
 			Query: query,
-			Extensions: map[string]interface{}{
-				"persistedQuery": map[string]interface{}{
+			Extensions: map[string]any{
+				"persistedQuery": map[string]any{
 					"sha256Hash": hash,
 					"version":    1,
 				},
@@ -86,8 +86,8 @@ func TestAPQ(t *testing.T) {
 		ctx := newOC()
 		params := &graphql.RawParams{
 			Query: query,
-			Extensions: map[string]interface{}{
-				"persistedQuery": map[string]interface{}{
+			Extensions: map[string]any{
+				"persistedQuery": map[string]any{
 					"sha256Hash": hash,
 					"version":    1,
 				},
@@ -104,8 +104,8 @@ func TestAPQ(t *testing.T) {
 	t.Run("with hash hit and no query", func(t *testing.T) {
 		ctx := newOC()
 		params := &graphql.RawParams{
-			Extensions: map[string]interface{}{
-				"persistedQuery": map[string]interface{}{
+			Extensions: map[string]any{
+				"persistedQuery": map[string]any{
 					"sha256Hash": hash,
 					"version":    1,
 				},
@@ -123,7 +123,7 @@ func TestAPQ(t *testing.T) {
 	t.Run("with malformed extension payload", func(t *testing.T) {
 		ctx := newOC()
 		params := &graphql.RawParams{
-			Extensions: map[string]interface{}{
+			Extensions: map[string]any{
 				"persistedQuery": "asdf",
 			},
 		}
@@ -135,8 +135,8 @@ func TestAPQ(t *testing.T) {
 	t.Run("with invalid extension version", func(t *testing.T) {
 		ctx := newOC()
 		params := &graphql.RawParams{
-			Extensions: map[string]interface{}{
-				"persistedQuery": map[string]interface{}{
+			Extensions: map[string]any{
+				"persistedQuery": map[string]any{
 					"version": 2,
 				},
 			},
@@ -149,8 +149,8 @@ func TestAPQ(t *testing.T) {
 		ctx := newOC()
 		params := &graphql.RawParams{
 			Query: query,
-			Extensions: map[string]interface{}{
-				"persistedQuery": map[string]interface{}{
+			Extensions: map[string]any{
+				"persistedQuery": map[string]any{
 					"sha256Hash": "badhash",
 					"version":    1,
 				},

--- a/graphql/handler/lru/lru.go
+++ b/graphql/handler/lru/lru.go
@@ -24,10 +24,10 @@ func New(size int) *LRU {
 	return &LRU{cache}
 }
 
-func (l LRU) Get(ctx context.Context, key string) (value interface{}, ok bool) {
+func (l LRU) Get(ctx context.Context, key string) (value any, ok bool) {
 	return l.lru.Get(key)
 }
 
-func (l LRU) Add(ctx context.Context, key string, value interface{}) {
+func (l LRU) Add(ctx context.Context, key string, value any) {
 	l.lru.Add(key, value)
 }

--- a/graphql/handler/server.go
+++ b/graphql/handler/server.go
@@ -131,7 +131,7 @@ func sendError(w http.ResponseWriter, code int, errors ...*gqlerror.Error) {
 	_, _ = w.Write(b)
 }
 
-func sendErrorf(w http.ResponseWriter, code int, format string, args ...interface{}) {
+func sendErrorf(w http.ResponseWriter, code int, format string, args ...any) {
 	sendError(w, code, &gqlerror.Error{Message: fmt.Sprintf(format, args...)})
 }
 
@@ -169,7 +169,7 @@ func (r ResponseFunc) InterceptResponse(ctx context.Context, next graphql.Respon
 	return r(ctx, next)
 }
 
-type FieldFunc func(ctx context.Context, next graphql.Resolver) (res interface{}, err error)
+type FieldFunc func(ctx context.Context, next graphql.Resolver) (res any, err error)
 
 func (f FieldFunc) ExtensionName() string {
 	return "InlineFieldFunc"
@@ -182,6 +182,6 @@ func (f FieldFunc) Validate(schema graphql.ExecutableSchema) error {
 	return nil
 }
 
-func (f FieldFunc) InterceptField(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+func (f FieldFunc) InterceptField(ctx context.Context, next graphql.Resolver) (res any, err error) {
 	return f(ctx, next)
 }

--- a/graphql/handler/server_test.go
+++ b/graphql/handler/server_test.go
@@ -81,11 +81,11 @@ func TestServer(t *testing.T) {
 
 	t.Run("invokes field middleware in order", func(t *testing.T) {
 		var calls []string
-		srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+		srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 			calls = append(calls, "first")
 			return next(ctx)
 		})
-		srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+		srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 			calls = append(calls, "second")
 			return next(ctx)
 		})

--- a/graphql/handler/testserver/testserver.go
+++ b/graphql/handler/testserver/testserver.go
@@ -58,7 +58,7 @@ func New() *TestServer {
 							},
 						},
 					})
-					res, err := graphql.GetOperationContext(ctx).ResolverMiddleware(ctx, func(ctx context.Context) (interface{}, error) {
+					res, err := graphql.GetOperationContext(ctx).ResolverMiddleware(ctx, func(ctx context.Context) (any, error) {
 						return &graphql.Response{Data: []byte(`{"name":"test"}`)}, nil
 					})
 					if err != nil {
@@ -88,7 +88,7 @@ func New() *TestServer {
 		SchemaFunc: func() *ast.Schema {
 			return schema
 		},
-		ComplexityFunc: func(typeName string, fieldName string, childComplexity int, args map[string]interface{}) (i int, b bool) {
+		ComplexityFunc: func(typeName string, fieldName string, childComplexity int, args map[string]any) (i int, b bool) {
 			return srv.complexity, true
 		},
 	})
@@ -139,7 +139,7 @@ func NewError() *TestServer {
 		SchemaFunc: func() *ast.Schema {
 			return schema
 		},
-		ComplexityFunc: func(typeName string, fieldName string, childComplexity int, args map[string]interface{}) (i int, b bool) {
+		ComplexityFunc: func(typeName string, fieldName string, childComplexity int, args map[string]any) (i int, b bool) {
 			return srv.complexity, true
 		},
 	})

--- a/graphql/handler/transport/error.go
+++ b/graphql/handler/transport/error.go
@@ -22,6 +22,6 @@ func SendError(w http.ResponseWriter, code int, errors ...*gqlerror.Error) {
 }
 
 // SendErrorf wraps SendError to add formatted messages
-func SendErrorf(w http.ResponseWriter, code int, format string, args ...interface{}) {
+func SendErrorf(w http.ResponseWriter, code int, format string, args ...any) {
 	SendError(w, code, &gqlerror.Error{Message: fmt.Sprintf(format, args...)})
 }

--- a/graphql/handler/transport/http_get.go
+++ b/graphql/handler/transport/http_get.go
@@ -84,7 +84,7 @@ func (h GET) Do(w http.ResponseWriter, r *http.Request, exec graphql.GraphExecut
 	writeJson(w, responses(ctx))
 }
 
-func jsonDecode(r io.Reader, val interface{}) error {
+func jsonDecode(r io.Reader, val any) error {
 	dec := json.NewDecoder(r)
 	dec.UseNumber()
 	return dec.Decode(val)

--- a/graphql/handler/transport/util.go
+++ b/graphql/handler/transport/util.go
@@ -22,7 +22,7 @@ func writeJsonError(w io.Writer, msg string) {
 	writeJson(w, &graphql.Response{Errors: gqlerror.List{{Message: msg}}})
 }
 
-func writeJsonErrorf(w io.Writer, format string, args ...interface{}) {
+func writeJsonErrorf(w io.Writer, format string, args ...any) {
 	writeJson(w, &graphql.Response{Errors: gqlerror.List{{Message: fmt.Sprintf(format, args...)}}})
 }
 

--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -480,7 +480,7 @@ func (c *wsConnection) sendError(id string, errors ...*gqlerror.Error) {
 	c.write(&message{t: errorMessageType, id: id, payload: b})
 }
 
-func (c *wsConnection) sendConnectionError(format string, args ...interface{}) {
+func (c *wsConnection) sendConnectionError(format string, args ...any) {
 	b, err := json.Marshal(&gqlerror.Error{Message: fmt.Sprintf(format, args...)})
 	if err != nil {
 		panic(err)

--- a/graphql/handler/transport/websocket_init.go
+++ b/graphql/handler/transport/websocket_init.go
@@ -10,7 +10,7 @@ const (
 
 // InitPayload is a structure that is parsed from the websocket init message payload. TO use
 // request headers for non-websocket, instead wrap the graphql handler in a middleware.
-type InitPayload map[string]interface{}
+type InitPayload map[string]any
 
 // GetString safely gets a string value from the payload. It returns an empty string if the
 // payload is nil or the value isn't set.

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -323,7 +323,7 @@ func TestWebsocketInitFunc(t *testing.T) {
 		connAck := readOp(c)
 		assert.Equal(t, connectionAckMsg, connAck.Type)
 
-		var payload map[string]interface{}
+		var payload map[string]any
 		err := json.Unmarshal(connAck.Payload, &payload)
 		if err != nil {
 			t.Fatal("Unexpected Error", err)
@@ -360,7 +360,7 @@ func TestWebSocketInitTimeout(t *testing.T) {
 		c := wsConnect(srv.URL)
 		defer c.Close()
 
-		done := make(chan interface{}, 1)
+		done := make(chan any, 1)
 		go func() {
 			var msg operationMessage
 			_ = c.ReadJSON(&msg)

--- a/graphql/handler_test.go
+++ b/graphql/handler_test.go
@@ -29,7 +29,7 @@ func TestAddUploadToOperations(t *testing.T) {
 	t.Run("valid variable", func(t *testing.T) {
 		file, _ := os.Open("path/to/file")
 		request := &RawParams{
-			Variables: map[string]interface{}{
+			Variables: map[string]any{
 				"file": nil,
 			},
 		}
@@ -42,7 +42,7 @@ func TestAddUploadToOperations(t *testing.T) {
 		}
 
 		expected := &RawParams{
-			Variables: map[string]interface{}{
+			Variables: map[string]any{
 				"file": upload,
 			},
 		}
@@ -57,9 +57,9 @@ func TestAddUploadToOperations(t *testing.T) {
 	t.Run("valid nested variable", func(t *testing.T) {
 		file, _ := os.Open("path/to/file")
 		request := &RawParams{
-			Variables: map[string]interface{}{
-				"req": []interface{}{
-					map[string]interface{}{
+			Variables: map[string]any{
+				"req": []any{
+					map[string]any{
 						"file": nil,
 					},
 				},
@@ -74,9 +74,9 @@ func TestAddUploadToOperations(t *testing.T) {
 		}
 
 		expected := &RawParams{
-			Variables: map[string]interface{}{
-				"req": []interface{}{
-					map[string]interface{}{
+			Variables: map[string]any{
+				"req": []any{
+					map[string]any{
 						"file": upload,
 					},
 				},

--- a/graphql/id.go
+++ b/graphql/id.go
@@ -11,7 +11,7 @@ func MarshalID(s string) Marshaler {
 	return MarshalString(s)
 }
 
-func UnmarshalID(v interface{}) (string, error) {
+func UnmarshalID(v any) (string, error) {
 	switch v := v.(type) {
 	case string:
 		return v, nil
@@ -42,7 +42,7 @@ func MarshalIntID(i int) Marshaler {
 	})
 }
 
-func UnmarshalIntID(v interface{}) (int, error) {
+func UnmarshalIntID(v any) (int, error) {
 	switch v := v.(type) {
 	case string:
 		return strconv.Atoi(v)
@@ -63,7 +63,7 @@ func MarshalUintID(i uint) Marshaler {
 	})
 }
 
-func UnmarshalUintID(v interface{}) (uint, error) {
+func UnmarshalUintID(v any) (uint, error) {
 	switch v := v.(type) {
 	case string:
 		result, err := strconv.ParseUint(v, 10, 64)

--- a/graphql/id_test.go
+++ b/graphql/id_test.go
@@ -30,7 +30,7 @@ func TestMarshalID(t *testing.T) {
 func TestUnmarshalID(t *testing.T) {
 	tests := []struct {
 		Name        string
-		Input       interface{}
+		Input       any
 		Expected    string
 		ShouldError bool
 	}{

--- a/graphql/input.go
+++ b/graphql/input.go
@@ -10,7 +10,7 @@ const unmarshalInputCtx key = "unmarshal_input_context"
 
 // BuildUnmarshalerMap returns a map of unmarshal functions of the ExecutableContext
 // to use with the WithUnmarshalerMap function.
-func BuildUnmarshalerMap(unmarshaler ...interface{}) map[reflect.Type]reflect.Value {
+func BuildUnmarshalerMap(unmarshaler ...any) map[reflect.Type]reflect.Value {
 	maps := make(map[reflect.Type]reflect.Value)
 	for _, v := range unmarshaler {
 		ft := reflect.TypeOf(v)
@@ -28,7 +28,7 @@ func WithUnmarshalerMap(ctx context.Context, maps map[reflect.Type]reflect.Value
 }
 
 // UnmarshalInputFromContext allows unmarshaling input object from a context.
-func UnmarshalInputFromContext(ctx context.Context, raw, v interface{}) error {
+func UnmarshalInputFromContext(ctx context.Context, raw, v any) error {
 	m, ok := ctx.Value(unmarshalInputCtx).(map[reflect.Type]reflect.Value)
 	if m == nil || !ok {
 		return errors.New("graphql: the input context is empty")

--- a/graphql/int.go
+++ b/graphql/int.go
@@ -13,7 +13,7 @@ func MarshalInt(i int) Marshaler {
 	})
 }
 
-func UnmarshalInt(v interface{}) (int, error) {
+func UnmarshalInt(v any) (int, error) {
 	switch v := v.(type) {
 	case string:
 		return strconv.Atoi(v)
@@ -34,7 +34,7 @@ func MarshalInt64(i int64) Marshaler {
 	})
 }
 
-func UnmarshalInt64(v interface{}) (int64, error) {
+func UnmarshalInt64(v any) (int64, error) {
 	switch v := v.(type) {
 	case string:
 		return strconv.ParseInt(v, 10, 64)
@@ -55,7 +55,7 @@ func MarshalInt32(i int32) Marshaler {
 	})
 }
 
-func UnmarshalInt32(v interface{}) (int32, error) {
+func UnmarshalInt32(v any) (int32, error) {
 	switch v := v.(type) {
 	case string:
 		iv, err := strconv.ParseInt(v, 10, 32)

--- a/graphql/int_test.go
+++ b/graphql/int_test.go
@@ -20,7 +20,7 @@ func TestInt(t *testing.T) {
 	})
 }
 
-func mustUnmarshalInt(v interface{}) int {
+func mustUnmarshalInt(v any) int {
 	res, err := UnmarshalInt(v)
 	if err != nil {
 		panic(err)
@@ -41,7 +41,7 @@ func TestInt32(t *testing.T) {
 	})
 }
 
-func mustUnmarshalInt32(v interface{}) int32 {
+func mustUnmarshalInt32(v any) int32 {
 	res, err := UnmarshalInt32(v)
 	if err != nil {
 		panic(err)
@@ -62,7 +62,7 @@ func TestInt64(t *testing.T) {
 	})
 }
 
-func mustUnmarshalInt64(v interface{}) int64 {
+func mustUnmarshalInt64(v any) int64 {
 	res, err := UnmarshalInt64(v)
 	if err != nil {
 		panic(err)

--- a/graphql/jsonw.go
+++ b/graphql/jsonw.go
@@ -28,7 +28,7 @@ type Marshaler interface {
 }
 
 type Unmarshaler interface {
-	UnmarshalGQL(v interface{}) error
+	UnmarshalGQL(v any) error
 }
 
 type ContextMarshaler interface {
@@ -36,7 +36,7 @@ type ContextMarshaler interface {
 }
 
 type ContextUnmarshaler interface {
-	UnmarshalGQLContext(ctx context.Context, v interface{}) error
+	UnmarshalGQLContext(ctx context.Context, v any) error
 }
 
 type contextMarshalerAdapter struct {

--- a/graphql/playground/altair_playground.go
+++ b/graphql/playground/altair_playground.go
@@ -66,7 +66,7 @@ var altairPage = template.Must(template.New("altair").Parse(`<!doctype html>
 // AltairHandler responsible for setting up the altair playground
 func AltairHandler(title, endpoint string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		err := altairPage.Execute(w, map[string]interface{}{
+		err := altairPage.Execute(w, map[string]any{
 			"title":                title,
 			"endpoint":             endpoint,
 			"endpointIsAbsolute":   endpointHasScheme(endpoint),

--- a/graphql/playground/apollo_sandbox_playground.go
+++ b/graphql/playground/apollo_sandbox_playground.go
@@ -64,7 +64,7 @@ func ApolloSandboxHandler(title, endpoint string, opts ...ApolloSandboxOption) h
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		err := apolloSandboxPage.Execute(w, map[string]interface{}{
+		err := apolloSandboxPage.Execute(w, map[string]any{
 			"title":              title,
 			"endpoint":           endpoint,
 			"endpointIsAbsolute": endpointHasScheme(endpoint),

--- a/graphql/playground/playground.go
+++ b/graphql/playground/playground.go
@@ -95,7 +95,7 @@ func Handler(title string, endpoint string) http.HandlerFunc {
 func HandlerWithHeaders(title string, endpoint string, fetcherHeaders map[string]string, uiHeaders map[string]string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "text/html; charset=UTF-8")
-		err := page.Execute(w, map[string]interface{}{
+		err := page.Execute(w, map[string]any{
 			"title":                title,
 			"endpoint":             endpoint,
 			"fetcherHeaders":       fetcherHeaders,

--- a/graphql/recovery.go
+++ b/graphql/recovery.go
@@ -9,9 +9,9 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
-type RecoverFunc func(ctx context.Context, err interface{}) (userMessage error)
+type RecoverFunc func(ctx context.Context, err any) (userMessage error)
 
-func DefaultRecover(ctx context.Context, err interface{}) error {
+func DefaultRecover(ctx context.Context, err any) error {
 	fmt.Fprintln(os.Stderr, err)
 	fmt.Fprintln(os.Stderr)
 	debug.PrintStack()

--- a/graphql/response.go
+++ b/graphql/response.go
@@ -13,15 +13,15 @@ import (
 // https://github.com/facebook/graphql/commit/7b40390d48680b15cb93e02d46ac5eb249689876#diff-757cea6edf0288677a9eea4cfc801d87R107
 // and https://github.com/facebook/graphql/pull/384
 type Response struct {
-	Errors     gqlerror.List          `json:"errors,omitempty"`
-	Data       json.RawMessage        `json:"data"`
-	Label      string                 `json:"label,omitempty"`
-	Path       ast.Path               `json:"path,omitempty"`
-	HasNext    *bool                  `json:"hasNext,omitempty"`
-	Extensions map[string]interface{} `json:"extensions,omitempty"`
+	Errors     gqlerror.List   `json:"errors,omitempty"`
+	Data       json.RawMessage `json:"data"`
+	Label      string          `json:"label,omitempty"`
+	Path       ast.Path        `json:"path,omitempty"`
+	HasNext    *bool           `json:"hasNext,omitempty"`
+	Extensions map[string]any  `json:"extensions,omitempty"`
 }
 
-func ErrorResponse(ctx context.Context, messagef string, args ...interface{}) *Response {
+func ErrorResponse(ctx context.Context, messagef string, args ...any) *Response {
 	return &Response{
 		Errors: gqlerror.List{{Message: fmt.Sprintf(messagef, args...)}},
 	}

--- a/graphql/stats.go
+++ b/graphql/stats.go
@@ -14,7 +14,7 @@ type Stats struct {
 
 	// Stats collected by handler extensions. Don't use directly, the extension should provide a type safe way to
 	// access this.
-	extension map[string]interface{}
+	extension map[string]any
 }
 
 type TraceTiming struct {
@@ -42,14 +42,14 @@ func GetStartTime(ctx context.Context) time.Time {
 	return t
 }
 
-func (c *Stats) SetExtension(name string, data interface{}) {
+func (c *Stats) SetExtension(name string, data any) {
 	if c.extension == nil {
-		c.extension = map[string]interface{}{}
+		c.extension = map[string]any{}
 	}
 	c.extension[name] = data
 }
 
-func (c *Stats) GetExtension(name string) interface{} {
+func (c *Stats) GetExtension(name string) any {
 	if c.extension == nil {
 		return nil
 	}

--- a/graphql/string.go
+++ b/graphql/string.go
@@ -47,7 +47,7 @@ func writeQuotedString(w io.Writer, s string) {
 	io.WriteString(w, `"`)
 }
 
-func UnmarshalString(v interface{}) (string, error) {
+func UnmarshalString(v any) (string, error) {
 	switch v := v.(type) {
 	case string:
 		return v, nil

--- a/graphql/string_test.go
+++ b/graphql/string_test.go
@@ -33,7 +33,7 @@ func TestString(t *testing.T) {
 	})
 }
 
-func mustUnmarshalString(v interface{}) string {
+func mustUnmarshalString(v any) string {
 	res, err := UnmarshalString(v)
 	if err != nil {
 		panic(err)

--- a/graphql/time.go
+++ b/graphql/time.go
@@ -17,7 +17,7 @@ func MarshalTime(t time.Time) Marshaler {
 	})
 }
 
-func UnmarshalTime(v interface{}) (time.Time, error) {
+func UnmarshalTime(v any) (time.Time, error) {
 	if tmpStr, ok := v.(string); ok {
 		return time.Parse(time.RFC3339Nano, tmpStr)
 	}

--- a/graphql/uint.go
+++ b/graphql/uint.go
@@ -14,7 +14,7 @@ func MarshalUint(i uint) Marshaler {
 	})
 }
 
-func UnmarshalUint(v interface{}) (uint, error) {
+func UnmarshalUint(v any) (uint, error) {
 	switch v := v.(type) {
 	case string:
 		u64, err := strconv.ParseUint(v, 10, 64)
@@ -45,7 +45,7 @@ func MarshalUint64(i uint64) Marshaler {
 	})
 }
 
-func UnmarshalUint64(v interface{}) (uint64, error) {
+func UnmarshalUint64(v any) (uint64, error) {
 	switch v := v.(type) {
 	case string:
 		return strconv.ParseUint(v, 10, 64)
@@ -74,7 +74,7 @@ func MarshalUint32(i uint32) Marshaler {
 	})
 }
 
-func UnmarshalUint32(v interface{}) (uint32, error) {
+func UnmarshalUint32(v any) (uint32, error) {
 	switch v := v.(type) {
 	case string:
 		iv, err := strconv.ParseUint(v, 10, 32)

--- a/graphql/uint_test.go
+++ b/graphql/uint_test.go
@@ -26,7 +26,7 @@ func TestUint(t *testing.T) {
 	})
 }
 
-func mustUnmarshalUint(v interface{}) uint {
+func mustUnmarshalUint(v any) uint {
 	res, err := UnmarshalUint(v)
 	if err != nil {
 		panic(err)
@@ -54,7 +54,7 @@ func TestUint32(t *testing.T) {
 	})
 }
 
-func mustUnmarshalUint32(v interface{}) uint32 {
+func mustUnmarshalUint32(v any) uint32 {
 	res, err := UnmarshalUint32(v)
 	if err != nil {
 		panic(err)
@@ -80,7 +80,7 @@ func TestUint64(t *testing.T) {
 	})
 }
 
-func mustUnmarshalUint64(v interface{}) uint64 {
+func mustUnmarshalUint64(v any) uint64 {
 	res, err := UnmarshalUint64(v)
 	if err != nil {
 		panic(err)

--- a/graphql/upload.go
+++ b/graphql/upload.go
@@ -18,7 +18,7 @@ func MarshalUpload(f Upload) Marshaler {
 	})
 }
 
-func UnmarshalUpload(v interface{}) (Upload, error) {
+func UnmarshalUpload(v any) (Upload, error) {
 	upload, ok := v.(Upload)
 	if !ok {
 		return Upload{}, fmt.Errorf("%T is not an Upload", v)

--- a/graphql/uuid_test.go
+++ b/graphql/uuid_test.go
@@ -27,7 +27,7 @@ func TestMarshalUUID(t *testing.T) {
 
 func TestUnmarshalUUID(t *testing.T) {
 	t.Run("Invalid Non-String Values", func(t *testing.T) {
-		values := []interface{}{123, 1.2345678901, 1.2e+20, 1.2e-20, true, false, nil}
+		values := []any{123, 1.2345678901, 1.2e+20, 1.2e-20, true, false, nil}
 		for _, v := range values {
 			result, err := UnmarshalUUID(v)
 			assert.Equal(t, uuid.Nil, result)

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -235,11 +235,11 @@ type apqAdapter struct {
 	PersistedQueryCache
 }
 
-func (a apqAdapter) Get(ctx context.Context, key string) (value interface{}, ok bool) {
+func (a apqAdapter) Get(ctx context.Context, key string) (value any, ok bool) {
 	return a.PersistedQueryCache.Get(ctx, key)
 }
 
-func (a apqAdapter) Add(ctx context.Context, key string, value interface{}) {
+func (a apqAdapter) Add(ctx context.Context, key string, value any) {
 	a.PersistedQueryCache.Add(ctx, key, value.(string))
 }
 

--- a/plugin/federation/federation_entityresolver_test.go
+++ b/plugin/federation/federation_entityresolver_test.go
@@ -23,7 +23,7 @@ func TestEntityResolver(t *testing.T) {
 	))
 
 	t.Run("Hello entities", func(t *testing.T) {
-		representations := []map[string]interface{}{
+		representations := []map[string]any{
 			{
 				"__typename": "Hello",
 				"name":       "first name - 1",
@@ -53,7 +53,7 @@ func TestEntityResolver(t *testing.T) {
 	})
 
 	t.Run("HelloWithError entities", func(t *testing.T) {
-		representations := []map[string]interface{}{
+		representations := []map[string]any{
 			{
 				"__typename": "HelloWithErrors",
 				"name":       "first name - 1",
@@ -107,16 +107,16 @@ func TestEntityResolver(t *testing.T) {
 	})
 
 	t.Run("World entities with nested key", func(t *testing.T) {
-		representations := []map[string]interface{}{
+		representations := []map[string]any{
 			{
 				"__typename": "World",
-				"hello": map[string]interface{}{
+				"hello": map[string]any{
 					"name": "world name - 1",
 				},
 				"foo": "foo 1",
 			}, {
 				"__typename": "World",
-				"hello": map[string]interface{}{
+				"hello": map[string]any{
 					"name": "world name - 2",
 				},
 				"foo": "foo 2",
@@ -148,10 +148,10 @@ func TestEntityResolver(t *testing.T) {
 	})
 
 	t.Run("World entities with multiple keys", func(t *testing.T) {
-		representations := []map[string]interface{}{
+		representations := []map[string]any{
 			{
 				"__typename": "WorldWithMultipleKeys",
-				"hello": map[string]interface{}{
+				"hello": map[string]any{
 					"name": "world name - 1",
 				},
 				"foo": "foo 1",
@@ -187,10 +187,10 @@ func TestEntityResolver(t *testing.T) {
 	})
 
 	t.Run("World entities with one single-key nil should hit resolver without nils", func(t *testing.T) {
-		representations := []map[string]interface{}{
+		representations := []map[string]any{
 			{
 				"__typename": "WorldWithMultipleKeys",
-				"hello": map[string]interface{}{
+				"hello": map[string]any{
 					"name": "world name - 1",
 				},
 				"foo": "foo 1",
@@ -229,17 +229,17 @@ func TestEntityResolver(t *testing.T) {
 		// __typename. So the tests here will interleve two different entity
 		// types so that we can test support for resolving different types and
 		// correctly handle ordering.
-		representations := []map[string]interface{}{}
+		representations := []map[string]any{}
 		count := 10
 
 		for i := 0; i < count; i++ {
 			if i%2 == 0 {
-				representations = append(representations, map[string]interface{}{
+				representations = append(representations, map[string]any{
 					"__typename": "Hello",
 					"name":       "hello - " + strconv.Itoa(i),
 				})
 			} else {
-				representations = append(representations, map[string]interface{}{
+				representations = append(representations, map[string]any{
 					"__typename": "WorldName",
 					"name":       "world name - " + strconv.Itoa(i),
 				})
@@ -274,7 +274,7 @@ func TestEntityResolver(t *testing.T) {
 	})
 
 	t.Run("PlanetRequires entities with requires directive", func(t *testing.T) {
-		representations := []map[string]interface{}{
+		representations := []map[string]any{
 			{
 				"__typename": "PlanetRequires",
 				"name":       "earth",
@@ -309,7 +309,7 @@ func TestEntityResolver(t *testing.T) {
 	})
 
 	t.Run("PlanetRequires entities with multiple required fields directive", func(t *testing.T) {
-		representations := []map[string]interface{}{
+		representations := []map[string]any{
 			{
 				"__typename": "PlanetMultipleRequires",
 				"name":       "earth",
@@ -349,17 +349,17 @@ func TestEntityResolver(t *testing.T) {
 	})
 
 	t.Run("PlanetRequiresNested entities with requires directive having nested field", func(t *testing.T) {
-		representations := []map[string]interface{}{
+		representations := []map[string]any{
 			{
 				"__typename": "PlanetRequiresNested",
 				"name":       "earth",
-				"world": map[string]interface{}{
+				"world": map[string]any{
 					"foo": "A",
 				},
 			}, {
 				"__typename": "PlanetRequiresNested",
 				"name":       "mars",
-				"world": map[string]interface{}{
+				"world": map[string]any{
 					"foo": "B",
 				},
 			},
@@ -399,10 +399,10 @@ func TestMultiEntityResolver(t *testing.T) {
 
 	t.Run("MultiHello entities", func(t *testing.T) {
 		itemCount := 10
-		representations := []map[string]interface{}{}
+		representations := []map[string]any{}
 
 		for i := 0; i < itemCount; i++ {
-			representations = append(representations, map[string]interface{}{
+			representations = append(representations, map[string]any{
 				"__typename": "MultiHello",
 				"name":       "world name - " + strconv.Itoa(i),
 			})
@@ -431,18 +431,18 @@ func TestMultiEntityResolver(t *testing.T) {
 
 	t.Run("MultiHello and Hello (heterogeneous) entities", func(t *testing.T) {
 		itemCount := 20
-		representations := []map[string]interface{}{}
+		representations := []map[string]any{}
 
 		for i := 0; i < itemCount; i++ {
 			// Let's interleve the representations to test ordering of the
 			// responses from the entity query
 			if i%2 == 0 {
-				representations = append(representations, map[string]interface{}{
+				representations = append(representations, map[string]any{
 					"__typename": "MultiHello",
 					"name":       "world name - " + strconv.Itoa(i),
 				})
 			} else {
-				representations = append(representations, map[string]interface{}{
+				representations = append(representations, map[string]any{
 					"__typename": "Hello",
 					"name":       "hello - " + strconv.Itoa(i),
 				})
@@ -477,10 +477,10 @@ func TestMultiEntityResolver(t *testing.T) {
 
 	t.Run("MultiHelloWithError entities", func(t *testing.T) {
 		itemCount := 10
-		representations := []map[string]interface{}{}
+		representations := []map[string]any{}
 
 		for i := 0; i < itemCount; i++ {
-			representations = append(representations, map[string]interface{}{
+			representations = append(representations, map[string]any{
 				"__typename": "MultiHelloWithError",
 				"name":       "world name - " + strconv.Itoa(i),
 			})
@@ -508,7 +508,7 @@ func TestMultiEntityResolver(t *testing.T) {
 	})
 
 	t.Run("MultiHelloRequires entities with requires directive", func(t *testing.T) {
-		representations := []map[string]interface{}{
+		representations := []map[string]any{
 			{
 				"__typename": "MultiHelloRequires",
 				"name":       "first name - 1",
@@ -543,7 +543,7 @@ func TestMultiEntityResolver(t *testing.T) {
 	})
 
 	t.Run("MultiHelloMultipleRequires entities with multiple required fields", func(t *testing.T) {
-		representations := []map[string]interface{}{
+		representations := []map[string]any{
 			{
 				"__typename": "MultiHelloMultipleRequires",
 				"name":       "first name - 1",
@@ -583,17 +583,17 @@ func TestMultiEntityResolver(t *testing.T) {
 	})
 
 	t.Run("MultiPlanetRequiresNested entities with requires directive having nested field", func(t *testing.T) {
-		representations := []map[string]interface{}{
+		representations := []map[string]any{
 			{
 				"__typename": "MultiPlanetRequiresNested",
 				"name":       "earth",
-				"world": map[string]interface{}{
+				"world": map[string]any{
 					"foo": "A",
 				},
 			}, {
 				"__typename": "MultiPlanetRequiresNested",
 				"name":       "mars",
-				"world": map[string]interface{}{
+				"world": map[string]any{
 					"foo": "B",
 				},
 			},

--- a/plugin/federation/federation_explicitrequires_test.go
+++ b/plugin/federation/federation_explicitrequires_test.go
@@ -20,7 +20,7 @@ func TestExplicitRequires(t *testing.T) {
 	))
 
 	t.Run("PlanetRequires entities with requires directive", func(t *testing.T) {
-		representations := []map[string]interface{}{
+		representations := []map[string]any{
 			{
 				"__typename": "PlanetRequires",
 				"name":       "earth",
@@ -55,7 +55,7 @@ func TestExplicitRequires(t *testing.T) {
 	})
 
 	t.Run("PlanetRequires entities with multiple required fields directive", func(t *testing.T) {
-		representations := []map[string]interface{}{
+		representations := []map[string]any{
 			{
 				"__typename": "PlanetMultipleRequires",
 				"name":       "earth",
@@ -95,17 +95,17 @@ func TestExplicitRequires(t *testing.T) {
 	})
 
 	t.Run("PlanetRequiresNested entities with requires directive having nested field", func(t *testing.T) {
-		representations := []map[string]interface{}{
+		representations := []map[string]any{
 			{
 				"__typename": "PlanetRequiresNested",
 				"name":       "earth",
-				"world": map[string]interface{}{
+				"world": map[string]any{
 					"foo": "A",
 				},
 			}, {
 				"__typename": "PlanetRequiresNested",
 				"name":       "mars",
-				"world": map[string]interface{}{
+				"world": map[string]any{
 					"foo": "B",
 				},
 			},
@@ -144,7 +144,7 @@ func TestMultiExplicitRequires(t *testing.T) {
 	))
 
 	t.Run("MultiHelloRequires entities with requires directive", func(t *testing.T) {
-		representations := []map[string]interface{}{
+		representations := []map[string]any{
 			{
 				"__typename": "MultiHelloRequires",
 				"name":       "first name - 1",
@@ -179,7 +179,7 @@ func TestMultiExplicitRequires(t *testing.T) {
 	})
 
 	t.Run("MultiHelloMultipleRequires entities with multiple required fields", func(t *testing.T) {
-		representations := []map[string]interface{}{
+		representations := []map[string]any{
 			{
 				"__typename": "MultiHelloMultipleRequires",
 				"name":       "first name - 1",
@@ -219,17 +219,17 @@ func TestMultiExplicitRequires(t *testing.T) {
 	})
 
 	t.Run("MultiPlanetRequiresNested entities with requires directive having nested field", func(t *testing.T) {
-		representations := []map[string]interface{}{
+		representations := []map[string]any{
 			{
 				"__typename": "MultiPlanetRequiresNested",
 				"name":       "earth",
-				"world": map[string]interface{}{
+				"world": map[string]any{
 					"foo": "A",
 				},
 			}, {
 				"__typename": "MultiPlanetRequiresNested",
 				"name":       "mars",
-				"world": map[string]interface{}{
+				"world": map[string]any{
 					"foo": "B",
 				},
 			},

--- a/plugin/federation/fedruntime/runtime.go
+++ b/plugin/federation/fedruntime/runtime.go
@@ -13,4 +13,4 @@ type Entity interface {
 }
 
 // Used for the Link directive
-type Link interface{}
+type Link any


### PR DESCRIPTION
The PR replaces `interface{}` with `any` in all codebase except generated files.
Additionally, enables `revive.use-any` to ensure consistency in the future.