### PR TITLE
refactor: simplify with strconv.FormatBool

### DIFF
--- a/graphql/bool.go
+++ b/graphql/bool.go
@@ -3,14 +3,13 @@ package graphql
 import (
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 )
 
 func MarshalBoolean(b bool) Marshaler {
-	if b {
-		return WriterFunc(func(w io.Writer) { w.Write(trueLit) })
-	}
-	return WriterFunc(func(w io.Writer) { w.Write(falseLit) })
+	str := strconv.FormatBool(b)
+	return WriterFunc(func(w io.Writer) { w.Write([]byte(str)) })
 }
 
 func UnmarshalBoolean(v any) (bool, error) {

--- a/graphql/string.go
+++ b/graphql/string.go
@@ -60,11 +60,7 @@ func UnmarshalString(v any) (string, error) {
 	case json.Number:
 		return string(v), nil
 	case bool:
-		if v {
-			return "true", nil
-		} else {
-			return "false", nil
-		}
+		return strconv.FormatBool(v), nil
 	case nil:
 		return "null", nil
 	default:


### PR DESCRIPTION
The PR refactors implementation of `graphql.MarshalBoolean` and `graphql.UnmarshalString` with `strconv.FormatBool` to slightly simplify code.