### PR TITLE
Fix go install gqlgen binary

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/PuerkitoBio/goquery v1.9.2
 	github.com/google/uuid v1.6.0
-	github.com/gorilla/websocket v1.5.0
+	github.com/gorilla/websocket v1.5.0 // do not upgrade to v1.5.1 as it has serious bugs
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/kevinmbeaulieu/eq-go v1.0.0
 	github.com/logrusorgru/aurora/v3 v3.0.0
@@ -36,6 +36,3 @@ require (
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 )
-
-// skip 1.5.1 as it has serious bugs
-replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.5.0


### PR DESCRIPTION
This PR fixes installation of `gqlgen` binary. The command for installation is `go install github.com/99designs/gqlgen@latest`.

The `go.mod` file doesn't require a `replace` directive because the version of `github.com/gorilla/websocket` is pinned to `v1.5.0`. It must be explicitly upgraded by someone to v1.5.1 and this will be seen during PR code review.

Fixes #3083
