### PR TITLE
Ignore gorilla/websocket 1.5.1 in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "github.com/gorilla/websocket"
+        # For websocket, v1.5.1 has serious bugs
+        versions: ["v1.5.1"]
   - package-ecosystem: "gomod" # See documentation for possible values
     directory: "/_examples" # Location of package manifests
     schedule:


### PR DESCRIPTION
After #3095 we need to instruct dependabot to ignore websocket v1.5.1 or it will continually try to "help" us.

Signed-off-by: Steve Coffman <steve@khanacademy.org>
