### PR TITLE
refactor: avoid panic in tests

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -21,9 +21,7 @@ import (
 func TestClient(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b, err := io.ReadAll(r.Body)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 		require.Equal(t, `{"query":"user(id:$id){name}","variables":{"id":1}}`, string(b))
 
 		err = json.NewEncoder(w).Encode(map[string]any{
@@ -31,9 +29,7 @@ func TestClient(t *testing.T) {
 				"name": "bob",
 			},
 		})
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 	})
 
 	c := client.New(h)
@@ -151,18 +147,14 @@ func TestAddCookie(t *testing.T) {
 func TestAddExtensions(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b, err := io.ReadAll(r.Body)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 		require.Equal(t, `{"query":"user(id:1){name}","extensions":{"persistedQuery":{"sha256Hash":"ceec2897e2da519612279e63f24658c3e91194cbb2974744fa9007a7e1e9f9e7","version":1}}}`, string(b))
 		err = json.NewEncoder(w).Encode(map[string]any{
 			"data": map[string]any{
 				"Name": "Bob",
 			},
 		})
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 	})
 
 	c := client.New(h)

--- a/codegen/config/binder_test.go
+++ b/codegen/config/binder_test.go
@@ -24,9 +24,7 @@ func TestSlicePointerBinding(t *testing.T) {
 		})
 
 		ta, err := binder.TypeReference(schema.Query.Fields.ForName("messages").Type, nil)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		require.Equal(t, "[]*github.com/99designs/gqlgen/codegen/config/testdata/autobinding/chat.Message", ta.GO.String())
 	})
@@ -37,9 +35,7 @@ func TestSlicePointerBinding(t *testing.T) {
 		})
 
 		ta, err := binder.TypeReference(schema.Query.Fields.ForName("messages").Type, nil)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		require.Equal(t, "[]github.com/99designs/gqlgen/codegen/config/testdata/autobinding/chat.Message", ta.GO.String())
 	})
@@ -50,19 +46,13 @@ func TestOmittableBinding(t *testing.T) {
 		binder, schema := createBinder(Config{})
 
 		ot, err := binder.FindType("github.com/99designs/gqlgen/graphql", "Omittable")
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		it, err := binder.InstantiateType(ot, []types.Type{types.Universe.Lookup("string").Type()})
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		ta, err := binder.TypeReference(schema.Types["FooInput"].Fields.ForName("nullableString").Type, it)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		require.True(t, ta.IsOmittable)
 	})
@@ -71,19 +61,13 @@ func TestOmittableBinding(t *testing.T) {
 		binder, schema := createBinder(Config{})
 
 		ot, err := binder.FindType("github.com/99designs/gqlgen/graphql", "Omittable")
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		it, err := binder.InstantiateType(ot, []types.Type{types.NewPointer(types.Universe.Lookup("string").Type())})
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		ta, err := binder.TypeReference(schema.Types["FooInput"].Fields.ForName("nullableString").Type, it)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		require.True(t, ta.IsOmittable)
 	})
@@ -92,14 +76,10 @@ func TestOmittableBinding(t *testing.T) {
 		binder, schema := createBinder(Config{})
 
 		ot, err := binder.FindType("github.com/99designs/gqlgen/graphql", "Omittable")
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		it, err := binder.InstantiateType(ot, []types.Type{types.Universe.Lookup("string").Type()})
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		_, err = binder.TypeReference(schema.Types["FooInput"].Fields.ForName("nonNullableString").Type, it)
 		require.Error(t, err)
@@ -109,14 +89,10 @@ func TestOmittableBinding(t *testing.T) {
 		binder, schema := createBinder(Config{})
 
 		ot, err := binder.FindType("github.com/99designs/gqlgen/graphql", "Omittable")
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		it, err := binder.InstantiateType(ot, []types.Type{types.NewPointer(types.Universe.Lookup("string").Type())})
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		_, err = binder.TypeReference(schema.Types["FooInput"].Fields.ForName("nonNullableString").Type, it)
 		require.Error(t, err)
@@ -126,24 +102,16 @@ func TestOmittableBinding(t *testing.T) {
 		binder, schema := createBinder(Config{})
 
 		typ, err := binder.FindType("github.com/99designs/gqlgen/codegen/config/testdata/autobinding/chat", "Message")
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		ot, err := binder.FindType("github.com/99designs/gqlgen/graphql", "Omittable")
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		it, err := binder.InstantiateType(ot, []types.Type{typ})
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		ta, err := binder.TypeReference(schema.Types["FooInput"].Fields.ForName("nullableObject").Type, it)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		require.True(t, ta.IsOmittable)
 	})
@@ -152,24 +120,16 @@ func TestOmittableBinding(t *testing.T) {
 		binder, schema := createBinder(Config{})
 
 		typ, err := binder.FindType("github.com/99designs/gqlgen/codegen/config/testdata/autobinding/chat", "Message")
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		ot, err := binder.FindType("github.com/99designs/gqlgen/graphql", "Omittable")
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		it, err := binder.InstantiateType(ot, []types.Type{types.NewPointer(typ)})
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		ta, err := binder.TypeReference(schema.Types["FooInput"].Fields.ForName("nullableObject").Type, it)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		require.True(t, ta.IsOmittable)
 	})

--- a/codegen/testserver/followschema/interfaces_test.go
+++ b/codegen/testserver/followschema/interfaces_test.go
@@ -81,7 +81,8 @@ func TestInterfaces(t *testing.T) {
 	t.Run("interfaces can be typed nil", func(t *testing.T) {
 		resolvers := &Stub{}
 		resolvers.QueryResolver.NoShapeTypedNil = func(ctx context.Context) (shapes Shape, e error) {
-			panic("should not be called")
+			t.Fatal("should not be called")
+			return
 		}
 
 		srv := handler.NewDefaultServer(
@@ -105,7 +106,8 @@ func TestInterfaces(t *testing.T) {
 	t.Run("interfaces can be nil (test with code-generated resolver)", func(t *testing.T) {
 		resolvers := &Stub{}
 		resolvers.QueryResolver.Animal = func(ctx context.Context) (animal Animal, e error) {
-			panic("should not be called")
+			t.Fatal("should not be called")
+			return
 		}
 
 		srv := handler.NewDefaultServer(

--- a/codegen/testserver/generated_test.go
+++ b/codegen/testserver/generated_test.go
@@ -16,10 +16,10 @@ import (
 
 func TestLayouts(t *testing.T) {
 	singlefileFSet := token.NewFileSet()
-	singlefilePkg := loadPackage("singlefile", singlefileFSet)
+	singlefilePkg := loadPackage(t, "singlefile", singlefileFSet)
 
 	followschemaFSet := token.NewFileSet()
-	followschemaPkg := loadPackage("followschema", followschemaFSet)
+	followschemaPkg := loadPackage(t, "followschema", followschemaFSet)
 
 	eq, msg := eqgo.PackagesEquivalent(singlefilePkg, singlefileFSet, followschemaPkg, followschemaFSet, nil)
 	if !eq {
@@ -30,15 +30,13 @@ func TestLayouts(t *testing.T) {
 	}
 }
 
-func loadPackage(name string, fset *token.FileSet) *ast.Package {
+func loadPackage(t *testing.T, name string, fset *token.FileSet) *ast.Package {
+	t.Helper()
+
 	path, err := filepath.Abs(name)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	files, err := os.ReadDir(path)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	pkg := ast.Package{
 		Name:  name,
@@ -53,9 +51,7 @@ func loadPackage(name string, fset *token.FileSet) *ast.Package {
 			f.Name() == "models-gen.go" {
 			filename := filepath.Join(path, f.Name())
 			src, err := parser.ParseFile(fset, filename, nil, parser.AllErrors)
-			if err != nil {
-				panic(err)
-			}
+			require.NoError(t, err)
 			pkg.Files[filename] = src
 		}
 	}

--- a/codegen/testserver/singlefile/interfaces_test.go
+++ b/codegen/testserver/singlefile/interfaces_test.go
@@ -81,7 +81,8 @@ func TestInterfaces(t *testing.T) {
 	t.Run("interfaces can be typed nil", func(t *testing.T) {
 		resolvers := &Stub{}
 		resolvers.QueryResolver.NoShapeTypedNil = func(ctx context.Context) (shapes Shape, e error) {
-			panic("should not be called")
+			t.Fatal("should not be called")
+			return
 		}
 
 		srv := handler.NewDefaultServer(
@@ -105,7 +106,8 @@ func TestInterfaces(t *testing.T) {
 	t.Run("interfaces can be nil (test with code-generated resolver)", func(t *testing.T) {
 		resolvers := &Stub{}
 		resolvers.QueryResolver.Animal = func(ctx context.Context) (animal Animal, e error) {
-			panic("should not be called")
+			t.Fatal("should not be called")
+			return
 		}
 
 		srv := handler.NewDefaultServer(

--- a/graphql/playground/playground_test.go
+++ b/graphql/playground/playground_test.go
@@ -1,7 +1,6 @@
 package playground
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -23,7 +22,7 @@ func TestHandler_createsAbsoluteURLs(t *testing.T) {
 
 	b, err := io.ReadAll(res.Body)
 	if err != nil {
-		panic(fmt.Errorf("reading res.Body: %w", err))
+		t.Fatalf("reading res.Body: %v", err)
 	}
 
 	want := regexp.MustCompile(`(?m)^.*url\s*=\s*['"]https:\/\/example\.org\/query["'].*$`)
@@ -59,7 +58,7 @@ func TestHandler_createsRelativeURLs(t *testing.T) {
 
 	b, err := io.ReadAll(res.Body)
 	if err != nil {
-		panic(fmt.Errorf("reading res.Body: %w", err))
+		t.Fatalf("reading res.Body: %v", err)
 	}
 
 	wantURL := regexp.MustCompile(`(?m)^.*url\s*=\s*location\.protocol.*$`)

--- a/plugin/federation/federation_test.go
+++ b/plugin/federation/federation_test.go
@@ -143,9 +143,7 @@ func TestCodeGeneration(t *testing.T) {
 	require.NoError(t, f.MutateConfig(cfg))
 
 	data, err := codegen.BuildData(cfg)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	require.NoError(t, f.GenerateCode(data))
 }
 
@@ -162,9 +160,7 @@ func TestCodeGenerationFederation2(t *testing.T) {
 	require.Empty(t, f.Entities[2].Resolvers)
 
 	data, err := codegen.BuildData(cfg)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	require.NoError(t, f.GenerateCode(data))
 }
 

--- a/plugin/resolvergen/resolver_test.go
+++ b/plugin/resolvergen/resolver_test.go
@@ -23,9 +23,7 @@ func TestLayoutSingleFile(t *testing.T) {
 	require.NoError(t, cfg.Init())
 
 	data, err := codegen.BuildData(cfg)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	require.NoError(t, p.GenerateCode(data))
 	assertNoErrors(t, "github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out")
@@ -76,9 +74,7 @@ func TestOmitTemplateComment(t *testing.T) {
 	require.NoError(t, cfg.Init())
 
 	data, err := codegen.BuildData(cfg)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	require.NoError(t, p.GenerateCode(data))
 	assertNoErrors(t, "github.com/99designs/gqlgen/plugin/resolvergen/testdata/omit_template_comment/out")
@@ -94,9 +90,7 @@ func TestResolver_Implementation(t *testing.T) {
 	require.NoError(t, cfg.Init())
 
 	data, err := codegen.BuildData(cfg, &implementorTest{})
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	require.NoError(t, p.GenerateCode(data))
 	assertNoErrors(t, "github.com/99designs/gqlgen/plugin/resolvergen/testdata/resolver_implementor/out")
@@ -111,9 +105,7 @@ func TestCustomResolverTemplate(t *testing.T) {
 	require.NoError(t, cfg.Init())
 
 	data, err := codegen.BuildData(cfg)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	require.NoError(t, p.GenerateCode(data))
 }
@@ -128,9 +120,7 @@ func testFollowSchemaPersistence(t *testing.T, dir string) {
 	require.NoError(t, cfg.Init())
 
 	data, err := codegen.BuildData(cfg)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	require.NoError(t, p.GenerateCode(data))
 	assertNoErrors(t, "github.com/99designs/gqlgen/plugin/resolvergen/"+dir+"/out")
@@ -146,7 +136,7 @@ func assertNoErrors(t *testing.T, pkg string) {
 			packages.NeedTypesSizes,
 	}, pkg)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	hasErrors := false


### PR DESCRIPTION
The PR removes panics from tests.

Changes:
- use `require.NoError(t, err)` instead of `if err != nil { panic(err) }`;
- use `t.Fatal("should not be called"); return` instead of `panic("should not be called")`;
- use `t.Fatal` instead of `panic(fmt.Errorf`.