### PR TITLE
refactor: use t.Log instead of fmt.Print

### DIFF
--- a/graphql/handler/apollofederatedtracingv1/tracing_test.go
+++ b/graphql/handler/apollofederatedtracingv1/tracing_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -59,7 +58,7 @@ func TestApolloTracing(t *testing.T) {
 	require.Less(t, ftv1.StartTime.Nanos, ftv1.EndTime.Nanos)
 	require.EqualValues(t, ftv1.EndTime.Nanos-ftv1.StartTime.Nanos, ftv1.DurationNs)
 
-	fmt.Printf("%#v\n", resp.Body.String())
+	t.Logf("%#v\n", resp.Body.String())
 	require.Equal(t, "Query", ftv1.Root.Child[0].ParentType)
 	require.Equal(t, "name", ftv1.Root.Child[0].GetResponseName())
 	require.Equal(t, "String!", ftv1.Root.Child[0].Type)

--- a/plugin/resolvergen/resolver_test.go
+++ b/plugin/resolvergen/resolver_test.go
@@ -1,7 +1,6 @@
 package resolvergen
 
 import (
-	"fmt"
 	"os"
 	"syscall"
 	"testing"
@@ -135,20 +134,13 @@ func assertNoErrors(t *testing.T, pkg string) {
 			packages.NeedTypes |
 			packages.NeedTypesSizes,
 	}, pkg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	hasErrors := false
+	var errors []packages.Error
 	for _, pkg := range pkgs {
-		for _, err := range pkg.Errors {
-			hasErrors = true
-			fmt.Println(err.Pos + ":" + err.Msg)
-		}
+		errors = append(errors, pkg.Errors...)
 	}
-	if hasErrors {
-		t.Fatal("see compilation errors above")
-	}
+	require.Emptyf(t, errors, "There are compilation errors")
 }
 
 type implementorTest struct{}

--- a/plugin/resolvergen/resolver_test.go
+++ b/plugin/resolvergen/resolver_test.go
@@ -2,6 +2,7 @@ package resolvergen
 
 import (
 	"os"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -136,11 +137,16 @@ func assertNoErrors(t *testing.T, pkg string) {
 	}, pkg)
 	require.NoError(t, err)
 
+	var errFilePos []string
 	var errors []packages.Error
 	for _, pkg := range pkgs {
 		errors = append(errors, pkg.Errors...)
+		for _, err := range pkg.Errors {
+			errFilePos = append(errFilePos, err.Pos+":"+err.Msg)
+		}
 	}
-	require.Emptyf(t, errors, "There are compilation errors")
+	require.Emptyf(t, errors, "There are compilation errors:\n"+
+		strings.Join(errFilePos, "\n"))
 }
 
 type implementorTest struct{}


### PR DESCRIPTION
This PR removes instances of `fmt.Print` in tests.

Changes:

- `fmt.Printf` is replaced with the superior alternative, [t.Log](https://pkg.go.dev/testing#T.Log), which is specifically designed for logging in tests.
- `fmt.Println` is replaced with the simpler `require.Empty` (see Details below).

<details>
<summary>Details</summary>

Let's simulate failure of `TestLayoutSingleFile`. The error message from `go test`:

- before:

```
=== RUN   TestLayoutSingleFile
:# github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out
/Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out/resolver.go:22:10: undefined: CustomResolverType
/Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out/resolver.go:25:10: undefined: CustomResolverType
/Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out/resolver.go:27:39: undefined: CustomResolverType
/Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out/resolver.go:28:42: undefined: CustomResolverType
/Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out/resolver.go:27:39:undefined: CustomResolverType
/Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out/resolver.go:28:42:undefined: CustomResolverType
/Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out/resolver.go:22:10:undefined: CustomResolverType
/Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out/resolver.go:25:10:undefined: CustomResolverType
    /Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/resolver_test.go:150: see compilation errors above
--- FAIL: TestLayoutSingleFile (0.36s)
```

- after:

```
=== RUN   TestLayoutSingleFile
    /Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/resolver_test.go:143:
        	Error Trace:	/Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/resolver_test.go:143
        	            				/Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/resolver_test.go:28
        	Error:      	Should be empty, but was [-: # github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out
        	            	/Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out/resolver.go:22:10: undefined: CustomResolverType
        	            	/Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out/resolver.go:25:10: undefined: CustomResolverType
        	            	/Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out/resolver.go:27:39: undefined: CustomResolverType
        	            	/Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out/resolver.go:28:42: undefined: CustomResolverType /Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out/resolver.go:27:39: undefined: CustomResolverType /Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out/resolver.go:28:42: undefined: CustomResolverType /Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out/resolver.go:22:10: undefined: CustomResolverType /Users/Oleksandr_Redko/src/github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out/resolver.go:25:10: undefined: CustomResolverType]
        	Test:       	TestLayoutSingleFile
        	Messages:   	There are compilation errors
--- FAIL: TestLayoutSingleFile (0.32s)
```

</details>

