### PR TITLE
refactor: rename local variables to match Go codestyle

### DIFF
--- a/api/generate.go
+++ b/api/generate.go
@@ -90,11 +90,11 @@ func Generate(cfg *config.Config, option ...Option) error {
 		}
 	}
 	// Merge again now that the generated models have been injected into the typemap
-	data_plugins := make([]any, len(plugins))
+	dataPlugins := make([]any, len(plugins))
 	for index := range plugins {
-		data_plugins[index] = plugins[index]
+		dataPlugins[index] = plugins[index]
 	}
-	data, err := codegen.BuildData(cfg, data_plugins...)
+	data, err := codegen.BuildData(cfg, dataPlugins...)
 	if err != nil {
 		return fmt.Errorf("merging type systems failed: %w", err)
 	}

--- a/graphql/handler/transport/http_form_urlencoded.go
+++ b/graphql/handler/transport/http_form_urlencoded.go
@@ -63,10 +63,10 @@ func (h UrlEncodedForm) Do(w http.ResponseWriter, r *http.Request, exec graphql.
 		return
 	}
 
-	rc, OpErr := exec.CreateOperationContext(ctx, params)
-	if OpErr != nil {
-		w.WriteHeader(statusFor(OpErr))
-		resp := exec.DispatchError(graphql.WithOperationContext(ctx, rc), OpErr)
+	rc, opErr := exec.CreateOperationContext(ctx, params)
+	if opErr != nil {
+		w.WriteHeader(statusFor(opErr))
+		resp := exec.DispatchError(graphql.WithOperationContext(ctx, rc), opErr)
 		writeJson(w, resp)
 		return
 	}

--- a/graphql/handler/transport/http_graphql.go
+++ b/graphql/handler/transport/http_graphql.go
@@ -64,10 +64,10 @@ func (h GRAPHQL) Do(w http.ResponseWriter, r *http.Request, exec graphql.GraphEx
 		return
 	}
 
-	rc, OpErr := exec.CreateOperationContext(ctx, params)
-	if OpErr != nil {
-		w.WriteHeader(statusFor(OpErr))
-		resp := exec.DispatchError(graphql.WithOperationContext(ctx, rc), OpErr)
+	rc, opErr := exec.CreateOperationContext(ctx, params)
+	if opErr != nil {
+		w.WriteHeader(statusFor(opErr))
+		resp := exec.DispatchError(graphql.WithOperationContext(ctx, rc), opErr)
 		writeJson(w, resp)
 		return
 	}

--- a/graphql/handler/transport/http_post.go
+++ b/graphql/handler/transport/http_post.go
@@ -78,10 +78,10 @@ func (h POST) Do(w http.ResponseWriter, r *http.Request, exec graphql.GraphExecu
 		return
 	}
 
-	rc, OpErr := exec.CreateOperationContext(ctx, params)
-	if OpErr != nil {
-		w.WriteHeader(statusFor(OpErr))
-		resp := exec.DispatchError(graphql.WithOperationContext(ctx, rc), OpErr)
+	rc, opErr := exec.CreateOperationContext(ctx, params)
+	if opErr != nil {
+		w.WriteHeader(statusFor(opErr))
+		resp := exec.DispatchError(graphql.WithOperationContext(ctx, rc), opErr)
 		writeJson(w, resp)
 		return
 	}


### PR DESCRIPTION
The PR renames local variables to match common Go style.

From the [Effective Go](https://go.dev/doc/effective_go#mixed-caps):

> Finally, the convention in Go is to use MixedCaps or mixedCaps rather than underscores to write multiword names.

