### PR TITLE
testifylint v1.3.0 fixes

### DIFF
--- a/_examples/chat/chat_test.go
+++ b/_examples/chat/chat_test.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -50,7 +49,7 @@ func TestChatSubscriptions(t *testing.T) {
 					b:post(text:"Hello Vektah!", roomName:"#gophers%d", username:"andrey") { id }
 					c:post(text:"Whats up?", roomName:"#gophers%d", username:"vektah") { id }
 				}`, i, i, i), &resp)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}()
 
 			msg.err = sub.Next(&msg.resp)

--- a/api/generate_test.go
+++ b/api/generate_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/codegen/config"
@@ -47,7 +46,7 @@ func TestGenerate(t *testing.T) {
 			cfg, err := config.LoadConfigFromDefaultLocations()
 			require.NoError(t, err, "failed to load config")
 			err = Generate(cfg)
-			assert.NoError(t, err, "failed to generate code")
+			require.NoError(t, err, "failed to generate code")
 		})
 	}
 }

--- a/codegen/config/initialisms_test.go
+++ b/codegen/config/initialisms_test.go
@@ -24,13 +24,13 @@ func TestGoInitialismsConfig(t *testing.T) {
 	t.Run("initialism config appends if desired", func(t *testing.T) {
 		tt := GoInitialismsConfig{ReplaceDefaults: false, Initialisms: []string{"ASDF"}}
 		result := tt.determineGoInitialisms()
-		assert.Equal(t, len(templates.CommonInitialisms)+1, len(result))
+		assert.Len(t, result, len(templates.CommonInitialisms)+1)
 		assert.True(t, result["ASDF"])
 	})
 	t.Run("initialism config replaces if desired", func(t *testing.T) {
 		tt := GoInitialismsConfig{ReplaceDefaults: true, Initialisms: []string{"ASDF"}}
 		result := tt.determineGoInitialisms()
-		assert.Equal(t, 1, len(result))
+		assert.Len(t, result, 1)
 		assert.True(t, result["ASDF"])
 	})
 	t.Run("initialism config uppercases the initialsms", func(t *testing.T) {

--- a/codegen/testserver/followschema/interfaces_test.go
+++ b/codegen/testserver/followschema/interfaces_test.go
@@ -251,10 +251,10 @@ func TestInterfaces(t *testing.T) {
 		`, &resp)
 
 		require.Len(t, resp.Shapes, 2)
-		require.Equal(t, float64(-1), resp.Shapes[0].Coordinates.X)
-		require.Equal(t, float64(0), resp.Shapes[0].Coordinates.Y)
-		require.Equal(t, float64(1), resp.Shapes[1].Coordinates.X)
-		require.Equal(t, float64(1), resp.Shapes[1].Coordinates.Y)
+		require.InEpsilon(t, float64(-1), resp.Shapes[0].Coordinates.X, 0.02)
+		require.InEpsilon(t, float64(0), resp.Shapes[0].Coordinates.Y, 0.02)
+		require.InEpsilon(t, float64(1), resp.Shapes[1].Coordinates.X, 0.02)
+		require.InEpsilon(t, float64(1), resp.Shapes[1].Coordinates.Y, 0.02)
 	})
 
 	t.Run("fragment on interface must return merged fields", func(t *testing.T) {

--- a/codegen/testserver/followschema/interfaces_test.go
+++ b/codegen/testserver/followschema/interfaces_test.go
@@ -250,7 +250,7 @@ func TestInterfaces(t *testing.T) {
 			}
 		`, &resp)
 
-		require.Equal(t, 2, len(resp.Shapes))
+		require.Len(t, resp.Shapes, 2)
 		require.Equal(t, float64(-1), resp.Shapes[0].Coordinates.X)
 		require.Equal(t, float64(0), resp.Shapes[0].Coordinates.Y)
 		require.Equal(t, float64(1), resp.Shapes[1].Coordinates.X)

--- a/codegen/testserver/followschema/interfaces_test.go
+++ b/codegen/testserver/followschema/interfaces_test.go
@@ -251,10 +251,10 @@ func TestInterfaces(t *testing.T) {
 		`, &resp)
 
 		require.Len(t, resp.Shapes, 2)
-		require.InEpsilon(t, float64(-1), resp.Shapes[0].Coordinates.X, 0.02)
-		require.InEpsilon(t, float64(0), resp.Shapes[0].Coordinates.Y, 0.02)
-		require.InEpsilon(t, float64(1), resp.Shapes[1].Coordinates.X, 0.02)
-		require.InEpsilon(t, float64(1), resp.Shapes[1].Coordinates.Y, 0.02)
+		require.InDelta(t, float64(-1), resp.Shapes[0].Coordinates.X, 0.02)
+		require.InDelta(t, float64(0), resp.Shapes[0].Coordinates.Y, 0.02)
+		require.InDelta(t, float64(1), resp.Shapes[1].Coordinates.X, 0.02)
+		require.InDelta(t, float64(1), resp.Shapes[1].Coordinates.Y, 0.02)
 	})
 
 	t.Run("fragment on interface must return merged fields", func(t *testing.T) {

--- a/codegen/testserver/followschema/nulls_test.go
+++ b/codegen/testserver/followschema/nulls_test.go
@@ -86,7 +86,7 @@ func TestNullBubbling(t *testing.T) {
 		err := c.Post(`query { valid, errorList { id } }`, &resp)
 
 		require.NoError(t, err)
-		require.Equal(t, 1, len(resp.ErrorList))
+		require.Len(t, resp.ErrorList, 1)
 		require.Nil(t, resp.ErrorList[0])
 		require.Equal(t, "Ok", resp.Valid)
 	})

--- a/codegen/testserver/singlefile/interfaces_test.go
+++ b/codegen/testserver/singlefile/interfaces_test.go
@@ -251,10 +251,10 @@ func TestInterfaces(t *testing.T) {
 		`, &resp)
 
 		require.Len(t, resp.Shapes, 2)
-		require.Equal(t, float64(-1), resp.Shapes[0].Coordinates.X)
-		require.Equal(t, float64(0), resp.Shapes[0].Coordinates.Y)
-		require.Equal(t, float64(1), resp.Shapes[1].Coordinates.X)
-		require.Equal(t, float64(1), resp.Shapes[1].Coordinates.Y)
+		require.InEpsilon(t, float64(-1), resp.Shapes[0].Coordinates.X, 0.02)
+		require.InEpsilon(t, float64(0), resp.Shapes[0].Coordinates.Y, 0.02)
+		require.InEpsilon(t, float64(1), resp.Shapes[1].Coordinates.X, 0.02)
+		require.InEpsilon(t, float64(1), resp.Shapes[1].Coordinates.Y, 0.02)
 	})
 
 	t.Run("fragment on interface must return merged fields", func(t *testing.T) {

--- a/codegen/testserver/singlefile/interfaces_test.go
+++ b/codegen/testserver/singlefile/interfaces_test.go
@@ -250,7 +250,7 @@ func TestInterfaces(t *testing.T) {
 			}
 		`, &resp)
 
-		require.Equal(t, 2, len(resp.Shapes))
+		require.Len(t, resp.Shapes, 2)
 		require.Equal(t, float64(-1), resp.Shapes[0].Coordinates.X)
 		require.Equal(t, float64(0), resp.Shapes[0].Coordinates.Y)
 		require.Equal(t, float64(1), resp.Shapes[1].Coordinates.X)

--- a/codegen/testserver/singlefile/interfaces_test.go
+++ b/codegen/testserver/singlefile/interfaces_test.go
@@ -251,10 +251,10 @@ func TestInterfaces(t *testing.T) {
 		`, &resp)
 
 		require.Len(t, resp.Shapes, 2)
-		require.InEpsilon(t, float64(-1), resp.Shapes[0].Coordinates.X, 0.02)
-		require.InEpsilon(t, float64(0), resp.Shapes[0].Coordinates.Y, 0.02)
-		require.InEpsilon(t, float64(1), resp.Shapes[1].Coordinates.X, 0.02)
-		require.InEpsilon(t, float64(1), resp.Shapes[1].Coordinates.Y, 0.02)
+		require.InDelta(t, float64(-1), resp.Shapes[0].Coordinates.X, 0.02)
+		require.InDelta(t, float64(0), resp.Shapes[0].Coordinates.Y, 0.02)
+		require.InDelta(t, float64(1), resp.Shapes[1].Coordinates.X, 0.02)
+		require.InDelta(t, float64(1), resp.Shapes[1].Coordinates.Y, 0.02)
 	})
 
 	t.Run("fragment on interface must return merged fields", func(t *testing.T) {

--- a/codegen/testserver/singlefile/nulls_test.go
+++ b/codegen/testserver/singlefile/nulls_test.go
@@ -86,7 +86,7 @@ func TestNullBubbling(t *testing.T) {
 		err := c.Post(`query { valid, errorList { id } }`, &resp)
 
 		require.NoError(t, err)
-		require.Equal(t, 1, len(resp.ErrorList))
+		require.Len(t, resp.ErrorList, 1)
 		require.Nil(t, resp.ErrorList[0])
 		require.Equal(t, "Ok", resp.Valid)
 	})

--- a/graphql/context_response_test.go
+++ b/graphql/context_response_test.go
@@ -85,7 +85,7 @@ func TestGetErrorFromPresenter(t *testing.T) {
 		errs := GetErrors(ctx)
 
 		// because we are still presenting the error it is not expected to be returned, but this should not deadlock.
-		require.Len(t, errs, 0)
+		require.Empty(t, errs)
 		return DefaultErrorPresenter(ctx, err)
 	}, nil)
 

--- a/graphql/duration_test.go
+++ b/graphql/duration_test.go
@@ -6,14 +6,15 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDurationMarshaling(t *testing.T) {
 	t.Run("UnmarshalDuration", func(t *testing.T) {
 		d, err := UnmarshalDuration("P2Y")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
-		assert.Equal(t, float64(365*24*2), d.Hours())
+		assert.InEpsilon(t, float64(365*24*2), d.Hours(), 0.02)
 	})
 	t.Run("MarshalDuration", func(t *testing.T) {
 		m := MarshalDuration(time.Hour * 365 * 24 * 2)

--- a/graphql/executor/executor_test.go
+++ b/graphql/executor/executor_test.go
@@ -27,14 +27,14 @@ func TestExecutor(t *testing.T) {
 		t.Run("no operation", func(t *testing.T) {
 			resp := query(exec, "", "")
 			assert.Equal(t, "", string(resp.Data))
-			assert.Equal(t, 1, len(resp.Errors))
+			assert.Len(t, resp.Errors, 1)
 			assert.Equal(t, errcode.ValidationFailed, resp.Errors[0].Extensions["code"])
 		})
 
 		t.Run("bad operation", func(t *testing.T) {
 			resp := query(exec, "badOp", "query test { name }")
 			assert.Equal(t, "", string(resp.Data))
-			assert.Equal(t, 1, len(resp.Errors))
+			assert.Len(t, resp.Errors, 1)
 			assert.Equal(t, errcode.ValidationFailed, resp.Errors[0].Extensions["code"])
 		})
 	})
@@ -134,9 +134,9 @@ func TestExecutor(t *testing.T) {
 
 		resp := query(exec, "", "invalid")
 		assert.Equal(t, "", string(resp.Data))
-		assert.Equal(t, 1, len(resp.Errors))
-		assert.Equal(t, 1, len(errors1))
-		assert.Equal(t, 1, len(errors2))
+		assert.Len(t, resp.Errors, 1)
+		assert.Len(t, errors1, 1)
+		assert.Len(t, errors2, 1)
 	})
 
 	t.Run("query caching", func(t *testing.T) {
@@ -216,8 +216,8 @@ func TestErrorServer(t *testing.T) {
 
 		resp := query(exec, "", "{name}")
 		assert.Equal(t, "null", string(resp.Data))
-		assert.Equal(t, 1, len(errors1))
-		assert.Equal(t, 1, len(errors2))
+		assert.Len(t, errors1, 1)
+		assert.Len(t, errors2, 1)
 	})
 }
 

--- a/graphql/handler/extension/apq_test.go
+++ b/graphql/handler/extension/apq_test.go
@@ -43,9 +43,10 @@ func TestAPQ(t *testing.T) {
 		params := &graphql.RawParams{
 			Query: "original query",
 		}
-		err := extension.AutomaticPersistedQuery{graphql.MapCache{}}.MutateOperationParameters(ctx, params)
-		require.Equal(t, (*gqlerror.Error)(nil), err)
 
+		err := extension.AutomaticPersistedQuery{Cache: graphql.MapCache{}}.MutateOperationParameters(ctx, params)
+
+		require.Equal(t, (*gqlerror.Error)(nil), err)
 		require.Equal(t, "original query", params.Query)
 	})
 
@@ -60,7 +61,7 @@ func TestAPQ(t *testing.T) {
 			},
 		}
 
-		err := extension.AutomaticPersistedQuery{graphql.MapCache{}}.MutateOperationParameters(ctx, params)
+		err := extension.AutomaticPersistedQuery{Cache: graphql.MapCache{}}.MutateOperationParameters(ctx, params)
 		require.Equal(t, "PersistedQueryNotFound", err.Message)
 	})
 
@@ -76,9 +77,9 @@ func TestAPQ(t *testing.T) {
 			},
 		}
 		cache := graphql.MapCache{}
-		err := extension.AutomaticPersistedQuery{cache}.MutateOperationParameters(ctx, params)
-		require.Equal(t, (*gqlerror.Error)(nil), err)
+		err := extension.AutomaticPersistedQuery{Cache: cache}.MutateOperationParameters(ctx, params)
 
+		require.Equal(t, (*gqlerror.Error)(nil), err)
 		require.Equal(t, "{ me { name } }", params.Query)
 		require.Equal(t, "{ me { name } }", cache[hash])
 	})
@@ -116,8 +117,8 @@ func TestAPQ(t *testing.T) {
 			hash: query,
 		}
 		err := extension.AutomaticPersistedQuery{cache}.MutateOperationParameters(ctx, params)
-		require.Equal(t, (*gqlerror.Error)(nil), err)
 
+		require.Equal(t, (*gqlerror.Error)(nil), err)
 		require.Equal(t, "{ me { name } }", params.Query)
 	})
 

--- a/graphql/handler/server_test.go
+++ b/graphql/handler/server_test.go
@@ -107,8 +107,8 @@ func TestServer(t *testing.T) {
 
 		resp := get(srv, "/foo?query=invalid")
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
-		assert.Equal(t, 1, len(errors1))
-		assert.Equal(t, 1, len(errors2))
+		assert.Len(t, errors1, 1)
+		assert.Len(t, errors2, 1)
 	})
 
 	t.Run("query caching", func(t *testing.T) {
@@ -159,8 +159,8 @@ func TestErrorServer(t *testing.T) {
 
 		resp := get(srv, "/foo?query={name}")
 		assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-		assert.Equal(t, 1, len(errors1))
-		assert.Equal(t, 1, len(errors2))
+		assert.Len(t, errors1, 1)
+		assert.Len(t, errors2, 1)
 	})
 }
 

--- a/graphql/handler/transport/headers_test.go
+++ b/graphql/handler/transport/headers_test.go
@@ -24,7 +24,7 @@ func TestHeadersWithPOST(t *testing.T) {
 
 		resp := doRequest(h, "POST", "/graphql", `{"query":"{ name }"}`, "application/json")
 		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, 1, len(resp.Header()))
+		assert.Len(t, resp.Header(), 1)
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 	})
 
@@ -39,7 +39,7 @@ func TestHeadersWithPOST(t *testing.T) {
 
 		resp := doRequest(h, "POST", "/graphql", `{"query":"{ name }"}`, "application/json")
 		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, 2, len(resp.Header()))
+		assert.Len(t, resp.Header(), 2)
 		assert.Equal(t, "application/json; charset: utf8", resp.Header().Get("Content-Type"))
 		assert.Equal(t, "dummy-post", resp.Header().Get("Other-Header"))
 		assert.Equal(t, "another-one", resp.Header().Values("Other-Header")[1])
@@ -53,7 +53,7 @@ func TestHeadersWithGET(t *testing.T) {
 
 		resp := doRequest(h, "GET", "/graphql?query={name}", "", "application/json")
 		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, 1, len(resp.Header()))
+		assert.Len(t, resp.Header(), 1)
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 	})
 
@@ -68,7 +68,7 @@ func TestHeadersWithGET(t *testing.T) {
 
 		resp := doRequest(h, "GET", "/graphql?query={name}", "", "application/json")
 		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, 2, len(resp.Header()))
+		assert.Len(t, resp.Header(), 2)
 		assert.Equal(t, "application/json; charset: utf8", resp.Header().Get("Content-Type"))
 		assert.Equal(t, "dummy-get", resp.Header().Get("Other-Header"))
 	})
@@ -81,7 +81,7 @@ func TestHeadersWithGRAPHQL(t *testing.T) {
 
 		resp := doRequest(h, "POST", "/graphql", `{ name }`, "application/graphql")
 		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, 1, len(resp.Header()))
+		assert.Len(t, resp.Header(), 1)
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 	})
 
@@ -96,7 +96,7 @@ func TestHeadersWithGRAPHQL(t *testing.T) {
 
 		resp := doRequest(h, "POST", "/graphql", `{ name }`, "application/graphql")
 		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, 2, len(resp.Header()))
+		assert.Len(t, resp.Header(), 2)
 		assert.Equal(t, "application/json; charset: utf8", resp.Header().Get("Content-Type"))
 		assert.Equal(t, "dummy-get-qraphql", resp.Header().Get("Other-Header"))
 	})
@@ -109,7 +109,7 @@ func TestHeadersWithFormUrlEncoded(t *testing.T) {
 
 		resp := doRequest(h, "POST", "/graphql", `{ name }`, "application/x-www-form-urlencoded")
 		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, 1, len(resp.Header()))
+		assert.Len(t, resp.Header(), 1)
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 	})
 
@@ -124,7 +124,7 @@ func TestHeadersWithFormUrlEncoded(t *testing.T) {
 
 		resp := doRequest(h, "POST", "/graphql", `{ name }`, "application/x-www-form-urlencoded")
 		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, 2, len(resp.Header()))
+		assert.Len(t, resp.Header(), 2)
 		assert.Equal(t, "application/json; charset: utf8", resp.Header().Get("Content-Type"))
 		assert.Equal(t, "dummy-get-urlencoded-form", resp.Header().Get("Other-Header"))
 	})
@@ -168,7 +168,7 @@ func TestHeadersWithMULTIPART(t *testing.T) {
 		resp := httptest.NewRecorder()
 		h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-		assert.Equal(t, 1, len(resp.Header()))
+		assert.Len(t, resp.Header(), 1)
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 	})
 
@@ -213,7 +213,7 @@ func TestHeadersWithMULTIPART(t *testing.T) {
 		resp := httptest.NewRecorder()
 		h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-		assert.Equal(t, 2, len(resp.Header()))
+		assert.Len(t, resp.Header(), 2)
 		assert.Equal(t, "application/json; charset: utf8", resp.Header().Get("Content-Type"))
 		assert.Equal(t, "dummy-multipart", resp.Header().Get("Other-Header"))
 	})

--- a/graphql/handler/transport/http_form_multipart_test.go
+++ b/graphql/handler/transport/http_form_multipart_test.go
@@ -46,7 +46,7 @@ func TestFileUpload(t *testing.T) {
 	t.Run("valid single file upload", func(t *testing.T) {
 		es.ExecFunc = func(ctx context.Context) graphql.ResponseHandler {
 			op := graphql.GetOperationContext(ctx).Operation
-			require.Equal(t, 1, len(op.VariableDefinitions))
+			require.Len(t, op.VariableDefinitions, 1)
 			require.Equal(t, "file", op.VariableDefinitions[0].Variable)
 			return graphql.OneShot(&graphql.Response{Data: []byte(`{"singleUpload":"test"}`)})
 		}
@@ -72,7 +72,7 @@ func TestFileUpload(t *testing.T) {
 	t.Run("valid single file upload with payload", func(t *testing.T) {
 		es.ExecFunc = func(ctx context.Context) graphql.ResponseHandler {
 			op := graphql.GetOperationContext(ctx).Operation
-			require.Equal(t, 1, len(op.VariableDefinitions))
+			require.Len(t, op.VariableDefinitions, 1)
 			require.Equal(t, "req", op.VariableDefinitions[0].Variable)
 			return graphql.OneShot(&graphql.Response{Data: []byte(`{"singleUploadWithPayload":"test"}`)})
 		}
@@ -98,7 +98,7 @@ func TestFileUpload(t *testing.T) {
 	t.Run("valid file list upload", func(t *testing.T) {
 		es.ExecFunc = func(ctx context.Context) graphql.ResponseHandler {
 			op := graphql.GetOperationContext(ctx).Operation
-			require.Equal(t, 1, len(op.VariableDefinitions))
+			require.Len(t, op.VariableDefinitions, 1)
 			require.Equal(t, "files", op.VariableDefinitions[0].Variable)
 			return graphql.OneShot(&graphql.Response{Data: []byte(`{"multipleUpload":[{"id":1},{"id":2}]}`)})
 		}
@@ -130,7 +130,7 @@ func TestFileUpload(t *testing.T) {
 	t.Run("valid file list upload with payload", func(t *testing.T) {
 		es.ExecFunc = func(ctx context.Context) graphql.ResponseHandler {
 			op := graphql.GetOperationContext(ctx).Operation
-			require.Equal(t, 1, len(op.VariableDefinitions))
+			require.Len(t, op.VariableDefinitions, 1)
 			require.Equal(t, "req", op.VariableDefinitions[0].Variable)
 			return graphql.OneShot(&graphql.Response{Data: []byte(`{"multipleUploadWithPayload":[{"id":1},{"id":2}]}`)})
 		}
@@ -163,7 +163,7 @@ func TestFileUpload(t *testing.T) {
 		test := func(uploadMaxMemory int64) {
 			es.ExecFunc = func(ctx context.Context) graphql.ResponseHandler {
 				op := graphql.GetOperationContext(ctx).Operation
-				require.Equal(t, 1, len(op.VariableDefinitions))
+				require.Len(t, op.VariableDefinitions, 1)
 				require.Equal(t, "req", op.VariableDefinitions[0].Variable)
 				return graphql.OneShot(&graphql.Response{Data: []byte(`{"multipleUploadWithPayload":[{"id":1},{"id":2}]}`)})
 			}

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -347,7 +347,7 @@ func TestWebSocketInitTimeout(t *testing.T) {
 
 		var msg operationMessage
 		err := c.ReadJSON(&msg)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "timeout")
 	})
 

--- a/graphql/handler_test.go
+++ b/graphql/handler_test.go
@@ -86,7 +86,6 @@ func TestAddUploadToOperations(t *testing.T) {
 		path := "variables.req.0.file"
 		err := request.AddUpload(upload, key, path)
 		require.Equal(t, (*gqlerror.Error)(nil), err)
-
 		require.Equal(t, expected, request)
 	})
 }

--- a/graphql/id_test.go
+++ b/graphql/id_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMarshalID(t *testing.T) {
@@ -130,7 +131,7 @@ func TestUnmarshalID(t *testing.T) {
 			if tt.ShouldError {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -143,29 +144,29 @@ func TestMarshalUintID(t *testing.T) {
 func TestUnMarshalUintID(t *testing.T) {
 	result, err := UnmarshalUintID("12")
 	assert.Equal(t, uint(12), result)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result, err = UnmarshalUintID(12)
 	assert.Equal(t, uint(12), result)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result, err = UnmarshalUintID(int64(12))
 	assert.Equal(t, uint(12), result)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result, err = UnmarshalUintID(int32(12))
 	assert.Equal(t, uint(12), result)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result, err = UnmarshalUintID(int(12))
 	assert.Equal(t, uint(12), result)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result, err = UnmarshalUintID(uint32(12))
 	assert.Equal(t, uint(12), result)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result, err = UnmarshalUintID(uint64(12))
 	assert.Equal(t, uint(12), result)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/graphql/playground/helper_test.go
+++ b/graphql/playground/helper_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func testResourceIntegrity(t *testing.T, handler func(title, endpoint string) http.HandlerFunc) {
@@ -19,13 +20,13 @@ func testResourceIntegrity(t *testing.T, handler func(title, endpoint string) ht
 	handler("example.org API", "/query").ServeHTTP(recorder, request)
 
 	res := recorder.Result()
-	defer assert.NoError(t, res.Body.Close())
+	defer require.NoError(t, res.Body.Close())
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 	assert.True(t, strings.HasPrefix(res.Header.Get("Content-Type"), "text/html"))
 
 	doc, err := goquery.NewDocumentFromReader(res.Body)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, doc)
 
 	var baseUrl string
@@ -58,11 +59,11 @@ func assertNodesIntegrity(t *testing.T, baseUrl string, doc *goquery.Document, s
 
 		if len(url) != 0 && len(integrity) != 0 {
 			resp, err := http.Get(baseUrl + url)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			hasher := sha256.New()
 			_, err = io.Copy(hasher, resp.Body)
-			assert.NoError(t, err)
-			assert.NoError(t, resp.Body.Close())
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
 			actual := "sha256-" + base64.StdEncoding.EncodeToString(hasher.Sum(nil))
 			assert.Equal(t, integrity, actual)
 		}

--- a/internal/code/packages_test.go
+++ b/internal/code/packages_test.go
@@ -56,8 +56,8 @@ func initialState(t *testing.T, opts ...Option) *Packages {
 		"github.com/99designs/gqlgen/internal/code/testdata/a",
 		"github.com/99designs/gqlgen/internal/code/testdata/b",
 	)
-	require.Empty(t, p.Errors())
 
+	require.Empty(t, p.Errors())
 	require.Equal(t, 1, p.numLoadCalls)
 	require.Equal(t, 0, p.numNameCalls)
 	require.Equal(t, "a", pkgs[0].Name)

--- a/plugin/federation/federation_test.go
+++ b/plugin/federation/federation_test.go
@@ -46,7 +46,7 @@ func TestWithEntities(t *testing.T) {
 	require.Equal(t, "String", f.Entities[1].Resolvers[0].KeyFields[0].Definition.Type.Name())
 
 	require.Equal(t, "MoreNesting", f.Entities[2].Name)
-	require.Len(t, f.Entities[2].Resolvers, 0)
+	require.Empty(t, f.Entities[2].Resolvers)
 
 	require.Equal(t, "MultiHelloMultiKey", f.Entities[3].Name)
 	require.Len(t, f.Entities[3].Resolvers, 2)
@@ -98,7 +98,7 @@ func TestNoEntities(t *testing.T) {
 
 	err := f.MutateConfig(cfg)
 	require.NoError(t, err)
-	require.Len(t, f.Entities, 0)
+	require.Empty(t, f.Entities)
 }
 
 func TestUnusedInterfaceKeyDirective(t *testing.T) {
@@ -106,7 +106,7 @@ func TestUnusedInterfaceKeyDirective(t *testing.T) {
 
 	err := f.MutateConfig(cfg)
 	require.NoError(t, err)
-	require.Len(t, f.Entities, 0)
+	require.Empty(t, f.Entities)
 }
 
 func TestInterfaceKeyDirective(t *testing.T) {
@@ -209,7 +209,7 @@ func TestMultiWithOmitSliceElemPointersCfg(t *testing.T) {
 
 func TestHandlesRequiresArgumentCorrectlyIfNoSpace(t *testing.T) {
 	requiresFieldSet := fieldset.New("foo bar baz(limit:4)", nil)
-	assert.Equal(t, 3, len(requiresFieldSet))
+	assert.Len(t, requiresFieldSet, 3)
 	assert.Equal(t, "Foo", requiresFieldSet[0].ToGo())
 	assert.Equal(t, "Bar", requiresFieldSet[1].ToGo())
 	assert.Equal(t, "Baz(limit:4)", requiresFieldSet[2].ToGo())

--- a/plugin/federation/fieldset/fieldset_test.go
+++ b/plugin/federation/fieldset/fieldset_test.go
@@ -3,9 +3,10 @@ package fieldset
 import (
 	"testing"
 
-	"github.com/99designs/gqlgen/codegen"
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/v2/ast"
+
+	"github.com/99designs/gqlgen/codegen"
 )
 
 func TestUnnestedWithoutPrefix(t *testing.T) {


### PR DESCRIPTION
Inspired by @alexandear , I took a stab at upgrading testifylint and enabling some more of it's linters

After upgrading testifylint to v1.3.0, running `testifylint --fix ./...`, I got some test failures. Running `testifylint ./...` there were still a number of other new issues, so I followed those recommendations, and there were even more test failures.

I'm imagining that these are either:
1. longstanding issues that we just weren't noticing before or 
2. incorrect adjustments to the existing tests.

However, even if we got all failures to pass, there are still a fair number of remaining lint issues around testify's `require.` being called inside handlers or goroutines.

These are problems that should also get fixed, but need some more work to address so I'm deferring that.


### Wait, tell me about the legit issues that we are not addressing
This checker is a radically improved analogue of `go vet`'s
[testinggoroutine](https://cs.opensource.google/go/x/tools/+/master:go/analysis/passes/testinggoroutine/doc.go) check.

The point of the check is that, according to the [documentation](https://pkg.go.dev/testing#T),
functions leading to `t.FailNow` (essentially to `runtime.GoExit`) must only be used in the goroutine that runs the test.
Otherwise, they will not work as declared, namely, finish the test function.

You can disable the `go-require` checker and continue to use `require` as the current goroutine finisher, but this could lead
1. to possible resource leaks in tests;
2. to increasing confusion, because functions will be not used as intended.

Typically, any assertions inside goroutines are a marker of poor test architecture.
Try to execute them in the main goroutine and distribute the data necessary for this into it
([example](https://github.com/ipfs/kubo/issues/2043#issuecomment-164136026)).

Also a bad solution would be to simply replace all `require` in goroutines with `assert`
(like [here](https://github.com/gravitational/teleport/pull/22567/files#diff-9f5fd20913c5fe80c85263153fa9a0b28dbd1407e53da4ab5d09e13d2774c5dbR7377))
– this will only mask the problem.

In addition, the checker warns about `require` in HTTP handlers (functions and methods whose signature matches 
[http.HandlerFunc](https://pkg.go.dev/net/http#HandlerFunc)), because handlers run in a separate 
[service goroutine](https://cs.opensource.google/go/go/+/refs/tags/go1.22.3:src/net/http/server.go;l=2782;drc=1d45a7ef560a76318ed59dfdb178cecd58caf948) that 
services the HTTP connection. Terminating these goroutines can lead to undefined behaviour and difficulty debugging tests.
You can turn off the check using the `--go-require.ignore-http-handlers` flag.

P.S. Look at [testify's issue](https://github.com/stretchr/testify/issues/772), related to assertions in the goroutines.


### List of remaining lint problems:
/gqlgen/client/client_test.go:24:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:25:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:32:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:49:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:50:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:51:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:52:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:53:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:54:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:55:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:56:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:86:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:101:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:115:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:116:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:117:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:133:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:134:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:150:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:151:3: go-require: do not use require in http handlers
/gqlgen/client/client_test.go:157:3: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:32:4: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:33:4: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:41:5: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:44:5: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:49:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:52:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:55:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:56:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:74:4: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:75:4: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:83:5: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:86:5: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:91:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:96:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:97:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:98:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:99:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:100:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:103:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:104:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:127:4: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:128:4: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:136:5: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:139:5: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:144:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:149:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:150:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:151:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:152:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:153:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:154:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:155:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:158:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:159:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:186:4: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:187:4: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:195:5: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:198:5: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:203:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:206:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:209:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:210:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:211:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:212:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:213:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:214:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:215:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:218:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:219:6: go-require: do not use require in http handlers
/gqlgen/client/withfilesoption_test.go:224:5: go-require: do not use require in http handlers
/gqlgen/graphql/handler/apollofederatedtracingv1/tracing_test.go:80:4: go-require: require must only be used in the goroutine running the test function
/gqlgen/graphql/handler/apollofederatedtracingv1/tracing_test.go:84:4: go-require: require must only be used in the goroutine running the test function
/gqlgen/graphql/handler/apollofederatedtracingv1/tracing_test.go:88:4: go-require: require must only be used in the goroutine running the test function
/gqlgen/graphql/handler/apollofederatedtracingv1/tracing_test.go:89:4: go-require: require must only be used in the goroutine running the test function


