### PR TITLE
refactor: fix testifylint.require-error lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters-settings:
       - error-nil
       - expected-actual
       - nil-compare
+      - require-error
 
 linters:
   disable-all: true

--- a/api/generate_test.go
+++ b/api/generate_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/codegen/config"
@@ -47,7 +46,7 @@ func TestGenerate(t *testing.T) {
 			cfg, err := config.LoadConfigFromDefaultLocations()
 			require.NoError(t, err, "failed to load config")
 			err = Generate(cfg)
-			assert.NoError(t, err, "failed to generate code")
+			require.NoError(t, err, "failed to generate code")
 		})
 	}
 }

--- a/graphql/duration_test.go
+++ b/graphql/duration_test.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDurationMarshaling(t *testing.T) {
 	t.Run("UnmarshalDuration", func(t *testing.T) {
 		d, err := UnmarshalDuration("P2Y")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, float64(365*24*2), d.Hours())
 	})

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -347,8 +347,7 @@ func TestWebSocketInitTimeout(t *testing.T) {
 
 		var msg operationMessage
 		err := c.ReadJSON(&msg)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "timeout")
+		require.ErrorContains(t, err, "timeout")
 	})
 
 	t.Run("keeps waiting for an init message if no time out is configured", func(t *testing.T) {

--- a/graphql/id_test.go
+++ b/graphql/id_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMarshalID(t *testing.T) {
@@ -126,12 +127,12 @@ func TestUnmarshalID(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			id, err := UnmarshalID(tt.Input)
 
-			assert.Equal(t, tt.Expected, id)
 			if tt.ShouldError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
+			assert.Equal(t, tt.Expected, id)
 		})
 	}
 }
@@ -142,30 +143,30 @@ func TestMarshalUintID(t *testing.T) {
 
 func TestUnMarshalUintID(t *testing.T) {
 	result, err := UnmarshalUintID("12")
+	require.NoError(t, err)
 	assert.Equal(t, uint(12), result)
-	assert.NoError(t, err)
 
 	result, err = UnmarshalUintID(12)
+	require.NoError(t, err)
 	assert.Equal(t, uint(12), result)
-	assert.NoError(t, err)
 
 	result, err = UnmarshalUintID(int64(12))
+	require.NoError(t, err)
 	assert.Equal(t, uint(12), result)
-	assert.NoError(t, err)
 
 	result, err = UnmarshalUintID(int32(12))
+	require.NoError(t, err)
 	assert.Equal(t, uint(12), result)
-	assert.NoError(t, err)
 
 	result, err = UnmarshalUintID(int(12))
+	require.NoError(t, err)
 	assert.Equal(t, uint(12), result)
-	assert.NoError(t, err)
 
 	result, err = UnmarshalUintID(uint32(12))
+	require.NoError(t, err)
 	assert.Equal(t, uint(12), result)
-	assert.NoError(t, err)
 
 	result, err = UnmarshalUintID(uint64(12))
+	require.NoError(t, err)
 	assert.Equal(t, uint(12), result)
-	assert.NoError(t, err)
 }

--- a/graphql/playground/helper_test.go
+++ b/graphql/playground/helper_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func testResourceIntegrity(t *testing.T, handler func(title, endpoint string) http.HandlerFunc) {
@@ -19,14 +20,14 @@ func testResourceIntegrity(t *testing.T, handler func(title, endpoint string) ht
 	handler("example.org API", "/query").ServeHTTP(recorder, request)
 
 	res := recorder.Result()
-	defer assert.NoError(t, res.Body.Close())
+	t.Cleanup(func() { _ = res.Body.Close() })
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 	assert.True(t, strings.HasPrefix(res.Header.Get("Content-Type"), "text/html"))
 
 	doc, err := goquery.NewDocumentFromReader(res.Body)
-	assert.NoError(t, err)
-	assert.NotNil(t, doc)
+	require.NoError(t, err)
+	require.NotNil(t, doc)
 
 	var baseUrl string
 	if base := doc.Find("base"); len(base.Nodes) != 0 {
@@ -58,11 +59,11 @@ func assertNodesIntegrity(t *testing.T, baseUrl string, doc *goquery.Document, s
 
 		if len(url) != 0 && len(integrity) != 0 {
 			resp, err := http.Get(baseUrl + url)
-			assert.NoError(t, err)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = resp.Body.Close() })
 			hasher := sha256.New()
 			_, err = io.Copy(hasher, resp.Body)
-			assert.NoError(t, err)
-			assert.NoError(t, resp.Body.Close())
+			require.NoError(t, err)
 			actual := "sha256-" + base64.StdEncoding.EncodeToString(hasher.Sum(nil))
 			assert.Equal(t, integrity, actual)
 		}


### PR DESCRIPTION
The PR fixes all `require-error` issues from the `testifylint` and enables this check to prevent future regressions.