### PR TITLE
fix: tests failure, testifylint issues, pin golangci-lint version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,8 @@ concurrency:
   cancel-in-progress: true
 jobs:
   golangci-lint:
+    env:
+      GOLANGCI_LINT_VERSION: v1.59.0
     strategy:
       matrix:
         go: ["1.21", "1.22"]
@@ -24,11 +26,9 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6.0.1
         with:
-          version: latest
-          args: '--timeout 5m'
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
       - name: golangci-lint examples
         uses: golangci/golangci-lint-action@v6.0.1
         with:
-          version: latest
-          args: '--timeout 5m'
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: _examples

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 run:
   tests: true
+  timeout: 5m
 
 linters-settings:
   errcheck:

--- a/graphql/handler/extension/apq_test.go
+++ b/graphql/handler/extension/apq_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler/extension"
@@ -43,7 +44,7 @@ func TestAPQ(t *testing.T) {
 			Query: "original query",
 		}
 		err := extension.AutomaticPersistedQuery{graphql.MapCache{}}.MutateOperationParameters(ctx, params)
-		require.Nil(t, err)
+		require.Equal(t, (*gqlerror.Error)(nil), err)
 
 		require.Equal(t, "original query", params.Query)
 	})
@@ -76,7 +77,7 @@ func TestAPQ(t *testing.T) {
 		}
 		cache := graphql.MapCache{}
 		err := extension.AutomaticPersistedQuery{cache}.MutateOperationParameters(ctx, params)
-		require.Nil(t, err)
+		require.Equal(t, (*gqlerror.Error)(nil), err)
 
 		require.Equal(t, "{ me { name } }", params.Query)
 		require.Equal(t, "{ me { name } }", cache[hash])
@@ -95,7 +96,7 @@ func TestAPQ(t *testing.T) {
 		}
 		cache := graphql.MapCache{}
 		err := extension.AutomaticPersistedQuery{cache}.MutateOperationParameters(ctx, params)
-		require.Nil(t, err)
+		require.Equal(t, (*gqlerror.Error)(nil), err)
 
 		require.Equal(t, "{ me { name } }", params.Query)
 		require.Equal(t, "{ me { name } }", cache[hash])
@@ -115,7 +116,7 @@ func TestAPQ(t *testing.T) {
 			hash: query,
 		}
 		err := extension.AutomaticPersistedQuery{cache}.MutateOperationParameters(ctx, params)
-		require.Nil(t, err)
+		require.Equal(t, (*gqlerror.Error)(nil), err)
 
 		require.Equal(t, "{ me { name } }", params.Query)
 	})

--- a/graphql/handler/extension/introspection_test.go
+++ b/graphql/handler/extension/introspection_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 
 	"github.com/99designs/gqlgen/graphql"
 )
@@ -13,6 +14,7 @@ func TestIntrospection(t *testing.T) {
 	rc := &graphql.OperationContext{
 		DisableIntrospection: true,
 	}
-	require.NoError(t, Introspection{}.MutateOperationContext(context.Background(), rc))
+	err := Introspection{}.MutateOperationContext(context.Background(), rc)
+	require.Equal(t, (*gqlerror.Error)(nil), err)
 	require.False(t, rc.DisableIntrospection)
 }

--- a/graphql/handler_test.go
+++ b/graphql/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 func TestAddUploadToOperations(t *testing.T) {
@@ -22,8 +23,7 @@ func TestAddUploadToOperations(t *testing.T) {
 		}
 		path := "variables.req.0.file"
 		err := params.AddUpload(upload, key, path)
-		require.NoError(t, err)
-		require.Equal(t, "input: path is missing \"variables.\" prefix, key: 0, path: variables.req.0.file", err.Error())
+		require.EqualError(t, err, "input: path is missing \"variables.\" prefix, key: 0, path: variables.req.0.file")
 	})
 
 	t.Run("valid variable", func(t *testing.T) {
@@ -49,7 +49,7 @@ func TestAddUploadToOperations(t *testing.T) {
 
 		path := "variables.file"
 		err := request.AddUpload(upload, key, path)
-		require.NoError(t, err)
+		require.Equal(t, (*gqlerror.Error)(nil), err)
 
 		require.Equal(t, expected, request)
 	})
@@ -85,7 +85,7 @@ func TestAddUploadToOperations(t *testing.T) {
 
 		path := "variables.req.0.file"
 		err := request.AddUpload(upload, key, path)
-		require.Nil(t, err)
+		require.Equal(t, (*gqlerror.Error)(nil), err)
 
 		require.Equal(t, expected, request)
 	})

--- a/internal/code/packages_test.go
+++ b/internal/code/packages_test.go
@@ -56,7 +56,7 @@ func initialState(t *testing.T, opts ...Option) *Packages {
 		"github.com/99designs/gqlgen/internal/code/testdata/a",
 		"github.com/99designs/gqlgen/internal/code/testdata/b",
 	)
-	require.Nil(t, p.Errors())
+	require.Empty(t, p.Errors())
 
 	require.Equal(t, 1, p.numLoadCalls)
 	require.Equal(t, 0, p.numNameCalls)


### PR DESCRIPTION
The PR fixes failing tests and explicitly sets the golangci-lint's version to prevent new lint issues from being introduced during an upgrade.

Also, the PR correctly fixes `testifylint.error-nil` issues (that were mistakenly added in the #3102):

- `require.Nil` -> `require.NoError`.
- `require.NotNil` -> `require.Error`.
- `require.Nil` -> `require.Equal(t, (*gqlerror.Error)(nil), err)` for `AddUpload` and `.MutateOperationParameters` (see explanation below).

### Explanation

The functions `AddUpload` and `MutateOperationParameters` returns `*gqlerror.Error` instead of `error`:

```go
func (p *RawParams) AddUpload(upload Upload, key, path string) *gqlerror.Error

MutateOperationParameters(ctx context.Context, rawParams *graphql.RawParams) *gqlerror.Error
```

In the event of no error, these functions return `nil`, which transforms to `nil` of the type `*gqlerror.Error`. That's why we need to assert with `require.Equal(t, (*gqlerror.Error)(nil), err)`.

The proper fix would involve changing the return parameter from `*gqlerror.Error` to `error`. However, this could break backward compatibility.

### References
 
- https://yourbasic.org/golang/gotcha-why-nil-error-not-equal-nil/
- https://stackoverflow.com/questions/53892508/golang-returning-nil-does-not-return-nil