### PR TITLE
refactor: fix testifylint lint issues in examples

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,12 +16,20 @@ linters-settings:
   testifylint:
     disable-all: true
     enable:
+      - blank-import
       - bool-compare
       - compares
+      - empty
       - error-is-as
       - error-nil
       - expected-actual
+      - float-compare
+      - go-require
+      - len
+      - negative-positive
       - nil-compare
+      - require-error
+      - useless-assert
 
 linters:
   disable-all: true

--- a/_examples/chat/chat_test.go
+++ b/_examples/chat/chat_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -38,9 +39,11 @@ func TestChatSubscriptions(t *testing.T) {
 			}
 
 			msg.err = sub.Next(&msg.resp)
-			require.NoError(t, msg.err, "sub.Next")
-			require.Equal(t, "You've joined the room", msg.resp.MessageAdded.Text)
-			require.Equal(t, "system", msg.resp.MessageAdded.CreatedBy)
+			if !assert.NoError(t, msg.err, "sub.Next") {
+				return
+			}
+			assert.Equal(t, "You've joined the room", msg.resp.MessageAdded.Text)
+			assert.Equal(t, "system", msg.resp.MessageAdded.CreatedBy)
 
 			go func() {
 				var resp any
@@ -49,18 +52,22 @@ func TestChatSubscriptions(t *testing.T) {
 					b:post(text:"Hello Vektah!", roomName:"#gophers%d", username:"andrey") { id }
 					c:post(text:"Whats up?", roomName:"#gophers%d", username:"vektah") { id }
 				}`, i, i, i), &resp)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			}()
 
 			msg.err = sub.Next(&msg.resp)
-			require.NoError(t, msg.err, "sub.Next")
-			require.Equal(t, "Hello!", msg.resp.MessageAdded.Text)
-			require.Equal(t, "vektah", msg.resp.MessageAdded.CreatedBy)
+			if !assert.NoError(t, msg.err, "sub.Next") {
+				return
+			}
+			assert.Equal(t, "Hello!", msg.resp.MessageAdded.Text)
+			assert.Equal(t, "vektah", msg.resp.MessageAdded.CreatedBy)
 
 			msg.err = sub.Next(&msg.resp)
-			require.NoError(t, msg.err, "sub.Next")
-			require.Equal(t, "Whats up?", msg.resp.MessageAdded.Text)
-			require.Equal(t, "vektah", msg.resp.MessageAdded.CreatedBy)
+			if !assert.NoError(t, msg.err, "sub.Next") {
+				return
+			}
+			assert.Equal(t, "Whats up?", msg.resp.MessageAdded.Text)
+			assert.Equal(t, "vektah", msg.resp.MessageAdded.CreatedBy)
 		}(i)
 		// wait for goroutines to finish every N tests to not starve on CPU
 		if (i+1)%batchSize == 0 {

--- a/_examples/starwars/starwars_test.go
+++ b/_examples/starwars/starwars_test.go
@@ -67,10 +67,10 @@ func TestStarwars(t *testing.T) {
 		c.MustPost(`{ human(id:"1000") { starships { name length(unit:FOOT) } } }`, &resp)
 
 		require.Equal(t, "X-Wing", resp.Human.Starships[0].Name)
-		require.Equal(t, 41.0105, resp.Human.Starships[0].Length)
+		require.InDelta(t, 41.0105, resp.Human.Starships[0].Length, 0.0001)
 
 		require.Equal(t, "Imperial shuttle", resp.Human.Starships[1].Name)
-		require.Equal(t, 65.6168, resp.Human.Starships[1].Length)
+		require.InDelta(t, 65.6168, resp.Human.Starships[1].Length, 0.0001)
 	})
 
 	t.Run("hero height", func(t *testing.T) {
@@ -81,7 +81,7 @@ func TestStarwars(t *testing.T) {
 		}
 		c.MustPost(`{ hero(episode:EMPIRE) { ... on Human { height(unit:METER) } } }`, &resp)
 
-		require.Equal(t, 1.72, resp.Hero.Height)
+		require.InDelta(t, 1.72, resp.Hero.Height, 0.001)
 	})
 
 	t.Run("default hero episode", func(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -21,15 +22,16 @@ import (
 func TestClient(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		require.Equal(t, `{"query":"user(id:$id){name}","variables":{"id":1}}`, string(b))
+		if assert.NoError(t, err) {
+			assert.Equal(t, `{"query":"user(id:$id){name}","variables":{"id":1}}`, string(b))
 
-		err = json.NewEncoder(w).Encode(map[string]any{
-			"data": map[string]any{
-				"name": "bob",
-			},
-		})
-		require.NoError(t, err)
+			err = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"name": "bob",
+				},
+			})
+			assert.NoError(t, err)
+		}
 	})
 
 	c := client.New(h)
@@ -46,14 +48,17 @@ func TestClient(t *testing.T) {
 func TestClientMultipartFormData(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		bodyBytes, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		require.Contains(t, string(bodyBytes), `Content-Disposition: form-data; name="operations"`)
-		require.Contains(t, string(bodyBytes), `{"query":"mutation ($input: Input!) {}","variables":{"file":{}}`)
-		require.Contains(t, string(bodyBytes), `Content-Disposition: form-data; name="map"`)
-		require.Contains(t, string(bodyBytes), `{"0":["variables.file"]}`)
-		require.Contains(t, string(bodyBytes), `Content-Disposition: form-data; name="0"; filename="example.txt"`)
-		require.Contains(t, string(bodyBytes), `Content-Type: text/plain`)
-		require.Contains(t, string(bodyBytes), `Hello World`)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		assert.Contains(t, string(bodyBytes), `Content-Disposition: form-data; name="operations"`)
+		assert.Contains(t, string(bodyBytes), `{"query":"mutation ($input: Input!) {}","variables":{"file":{}}`)
+		assert.Contains(t, string(bodyBytes), `Content-Disposition: form-data; name="map"`)
+		assert.Contains(t, string(bodyBytes), `{"0":["variables.file"]}`)
+		assert.Contains(t, string(bodyBytes), `Content-Disposition: form-data; name="0"; filename="example.txt"`)
+		assert.Contains(t, string(bodyBytes), `Content-Type: text/plain`)
+		assert.Contains(t, string(bodyBytes), `Hello World`)
 
 		w.Write([]byte(`{}`))
 	})
@@ -83,7 +88,7 @@ func TestClientMultipartFormData(t *testing.T) {
 
 func TestAddHeader(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "ASDF", r.Header.Get("Test-Key"))
+		assert.Equal(t, "ASDF", r.Header.Get("Test-Key"))
 
 		w.Write([]byte(`{}`))
 	})
@@ -98,7 +103,7 @@ func TestAddHeader(t *testing.T) {
 
 func TestAddClientHeader(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "ASDF", r.Header.Get("Test-Key"))
+		assert.Equal(t, "ASDF", r.Header.Get("Test-Key"))
 
 		w.Write([]byte(`{}`))
 	})
@@ -112,9 +117,9 @@ func TestAddClientHeader(t *testing.T) {
 func TestBasicAuth(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		user, pass, ok := r.BasicAuth()
-		require.True(t, ok)
-		require.Equal(t, "user", user)
-		require.Equal(t, "pass", pass)
+		assert.True(t, ok)
+		assert.Equal(t, "user", user)
+		assert.Equal(t, "pass", pass)
 
 		w.Write([]byte(`{}`))
 	})
@@ -130,8 +135,10 @@ func TestBasicAuth(t *testing.T) {
 func TestAddCookie(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c, err := r.Cookie("foo")
-		require.NoError(t, err)
-		require.Equal(t, "value", c.Value)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, "value", c.Value)
 
 		w.Write([]byte(`{}`))
 	})
@@ -147,14 +154,16 @@ func TestAddCookie(t *testing.T) {
 func TestAddExtensions(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		require.Equal(t, `{"query":"user(id:1){name}","extensions":{"persistedQuery":{"sha256Hash":"ceec2897e2da519612279e63f24658c3e91194cbb2974744fa9007a7e1e9f9e7","version":1}}}`, string(b))
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, `{"query":"user(id:1){name}","extensions":{"persistedQuery":{"sha256Hash":"ceec2897e2da519612279e63f24658c3e91194cbb2974744fa9007a7e1e9f9e7","version":1}}}`, string(b))
 		err = json.NewEncoder(w).Encode(map[string]any{
 			"data": map[string]any{
 				"Name": "Bob",
 			},
 		})
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	})
 
 	c := client.New(h)

--- a/client/withfilesoption_test.go
+++ b/client/withfilesoption_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/99designs/gqlgen/client"
 )
@@ -29,8 +29,10 @@ func TestWithFiles(t *testing.T) {
 	t.Run("with one file", func(t *testing.T) {
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
-			require.NoError(t, err)
-			require.True(t, strings.HasPrefix(mediaType, "multipart/"))
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.True(t, strings.HasPrefix(mediaType, "multipart/"))
 
 			mr := multipart.NewReader(r.Body, params["boundary"])
 			for {
@@ -38,22 +40,26 @@ func TestWithFiles(t *testing.T) {
 				if err == io.EOF {
 					break
 				}
-				require.NoError(t, err)
+				if !assert.NoError(t, err) {
+					return
+				}
 
 				slurp, err := io.ReadAll(p)
-				require.NoError(t, err)
+				if !assert.NoError(t, err) {
+					return
+				}
 
 				contentDisposition := p.Header.Get("Content-Disposition")
 
 				if contentDisposition == `form-data; name="operations"` {
-					require.EqualValues(t, `{"query":"{ id }","variables":{"file":{}}}`, slurp)
+					assert.EqualValues(t, `{"query":"{ id }","variables":{"file":{}}}`, slurp)
 				}
 				if contentDisposition == `form-data; name="map"` {
-					require.EqualValues(t, `{"0":["variables.file"]}`, slurp)
+					assert.EqualValues(t, `{"0":["variables.file"]}`, slurp)
 				}
 				if regexp.MustCompile(`form-data; name="0"; filename=.*`).MatchString(contentDisposition) {
-					require.Equal(t, `text/plain; charset=utf-8`, p.Header.Get("Content-Type"))
-					require.EqualValues(t, `The quick brown fox jumps over the lazy dog`, slurp)
+					assert.Equal(t, `text/plain; charset=utf-8`, p.Header.Get("Content-Type"))
+					assert.EqualValues(t, `The quick brown fox jumps over the lazy dog`, slurp)
 				}
 			}
 			w.Write([]byte(`{}`))
@@ -71,8 +77,10 @@ func TestWithFiles(t *testing.T) {
 	t.Run("with multiple files", func(t *testing.T) {
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
-			require.NoError(t, err)
-			require.True(t, strings.HasPrefix(mediaType, "multipart/"))
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.True(t, strings.HasPrefix(mediaType, "multipart/"))
 
 			mr := multipart.NewReader(r.Body, params["boundary"])
 			for {
@@ -80,28 +88,32 @@ func TestWithFiles(t *testing.T) {
 				if err == io.EOF {
 					break
 				}
-				require.NoError(t, err)
+				if !assert.NoError(t, err) {
+					return
+				}
 
 				slurp, err := io.ReadAll(p)
-				require.NoError(t, err)
+				if !assert.NoError(t, err) {
+					return
+				}
 
 				contentDisposition := p.Header.Get("Content-Disposition")
 
 				if contentDisposition == `form-data; name="operations"` {
-					require.EqualValues(t, `{"query":"{ id }","variables":{"input":{"files":[{},{}]}}}`, slurp)
+					assert.EqualValues(t, `{"query":"{ id }","variables":{"input":{"files":[{},{}]}}}`, slurp)
 				}
 				if contentDisposition == `form-data; name="map"` {
 					// returns `{"0":["variables.input.files.0"],"1":["variables.input.files.1"]}`
 					// but the order of file inputs is unpredictable between different OS systems
-					require.Contains(t, string(slurp), `{"0":`)
-					require.Contains(t, string(slurp), `["variables.input.files.0"]`)
-					require.Contains(t, string(slurp), `,"1":`)
-					require.Contains(t, string(slurp), `["variables.input.files.1"]`)
-					require.Contains(t, string(slurp), `}`)
+					assert.Contains(t, string(slurp), `{"0":`)
+					assert.Contains(t, string(slurp), `["variables.input.files.0"]`)
+					assert.Contains(t, string(slurp), `,"1":`)
+					assert.Contains(t, string(slurp), `["variables.input.files.1"]`)
+					assert.Contains(t, string(slurp), `}`)
 				}
 				if regexp.MustCompile(`form-data; name="[0,1]"; filename=.*`).MatchString(contentDisposition) {
-					require.Equal(t, `text/plain; charset=utf-8`, p.Header.Get("Content-Type"))
-					require.Contains(t, []string{
+					assert.Equal(t, `text/plain; charset=utf-8`, p.Header.Get("Content-Type"))
+					assert.Contains(t, []string{
 						`The quick brown fox jumps over the lazy dog`,
 						`hello world`,
 					}, string(slurp))
@@ -124,8 +136,10 @@ func TestWithFiles(t *testing.T) {
 	t.Run("with multiple files across multiple variables", func(t *testing.T) {
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
-			require.NoError(t, err)
-			require.True(t, strings.HasPrefix(mediaType, "multipart/"))
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.True(t, strings.HasPrefix(mediaType, "multipart/"))
 
 			mr := multipart.NewReader(r.Body, params["boundary"])
 			for {
@@ -133,30 +147,34 @@ func TestWithFiles(t *testing.T) {
 				if err == io.EOF {
 					break
 				}
-				require.NoError(t, err)
+				if !assert.NoError(t, err) {
+					return
+				}
 
 				slurp, err := io.ReadAll(p)
-				require.NoError(t, err)
+				if !assert.NoError(t, err) {
+					return
+				}
 
 				contentDisposition := p.Header.Get("Content-Disposition")
 
 				if contentDisposition == `form-data; name="operations"` {
-					require.EqualValues(t, `{"query":"{ id }","variables":{"req":{"files":[{},{}],"foo":{"bar":{}}}}}`, slurp)
+					assert.EqualValues(t, `{"query":"{ id }","variables":{"req":{"files":[{},{}],"foo":{"bar":{}}}}}`, slurp)
 				}
 				if contentDisposition == `form-data; name="map"` {
 					// returns `{"0":["variables.req.files.0"],"1":["variables.req.files.1"],"2":["variables.req.foo.bar"]}`
 					// but the order of file inputs is unpredictable between different OS systems
-					require.Contains(t, string(slurp), `{"0":`)
-					require.Contains(t, string(slurp), `["variables.req.files.0"]`)
-					require.Contains(t, string(slurp), `,"1":`)
-					require.Contains(t, string(slurp), `["variables.req.files.1"]`)
-					require.Contains(t, string(slurp), `,"2":`)
-					require.Contains(t, string(slurp), `["variables.req.foo.bar"]`)
-					require.Contains(t, string(slurp), `}`)
+					assert.Contains(t, string(slurp), `{"0":`)
+					assert.Contains(t, string(slurp), `["variables.req.files.0"]`)
+					assert.Contains(t, string(slurp), `,"1":`)
+					assert.Contains(t, string(slurp), `["variables.req.files.1"]`)
+					assert.Contains(t, string(slurp), `,"2":`)
+					assert.Contains(t, string(slurp), `["variables.req.foo.bar"]`)
+					assert.Contains(t, string(slurp), `}`)
 				}
 				if regexp.MustCompile(`form-data; name="[0,1,2]"; filename=.*`).MatchString(contentDisposition) {
-					require.Equal(t, `text/plain; charset=utf-8`, p.Header.Get("Content-Type"))
-					require.Contains(t, []string{
+					assert.Equal(t, `text/plain; charset=utf-8`, p.Header.Get("Content-Type"))
+					assert.Contains(t, []string{
 						`The quick brown fox jumps over the lazy dog`,
 						`La-Li-Lu-Le-Lo`,
 						`hello world`,
@@ -183,8 +201,10 @@ func TestWithFiles(t *testing.T) {
 	t.Run("with multiple files and file reuse", func(t *testing.T) {
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
-			require.NoError(t, err)
-			require.True(t, strings.HasPrefix(mediaType, "multipart/"))
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.True(t, strings.HasPrefix(mediaType, "multipart/"))
 
 			mr := multipart.NewReader(r.Body, params["boundary"])
 			for {
@@ -192,36 +212,40 @@ func TestWithFiles(t *testing.T) {
 				if err == io.EOF {
 					break
 				}
-				require.NoError(t, err)
+				if !assert.NoError(t, err) {
+					return
+				}
 
 				slurp, err := io.ReadAll(p)
-				require.NoError(t, err)
+				if !assert.NoError(t, err) {
+					return
+				}
 
 				contentDisposition := p.Header.Get("Content-Disposition")
 
 				if contentDisposition == `form-data; name="operations"` {
-					require.EqualValues(t, `{"query":"{ id }","variables":{"files":[{},{},{}]}}`, slurp)
+					assert.EqualValues(t, `{"query":"{ id }","variables":{"files":[{},{},{}]}}`, slurp)
 				}
 				if contentDisposition == `form-data; name="map"` {
-					require.EqualValues(t, `{"0":["variables.files.0","variables.files.2"],"1":["variables.files.1"]}`, slurp)
+					assert.EqualValues(t, `{"0":["variables.files.0","variables.files.2"],"1":["variables.files.1"]}`, slurp)
 					// returns `{"0":["variables.files.0","variables.files.2"],"1":["variables.files.1"]}`
 					// but the order of file inputs is unpredictable between different OS systems
-					require.Contains(t, string(slurp), `{"0":`)
-					require.Contains(t, string(slurp), `["variables.files.0"`)
-					require.Contains(t, string(slurp), `,"1":`)
-					require.Contains(t, string(slurp), `"variables.files.1"]`)
-					require.Contains(t, string(slurp), `"variables.files.2"]`)
-					require.NotContains(t, string(slurp), `,"2":`)
-					require.Contains(t, string(slurp), `}`)
+					assert.Contains(t, string(slurp), `{"0":`)
+					assert.Contains(t, string(slurp), `["variables.files.0"`)
+					assert.Contains(t, string(slurp), `,"1":`)
+					assert.Contains(t, string(slurp), `"variables.files.1"]`)
+					assert.Contains(t, string(slurp), `"variables.files.2"]`)
+					assert.NotContains(t, string(slurp), `,"2":`)
+					assert.Contains(t, string(slurp), `}`)
 				}
 				if regexp.MustCompile(`form-data; name="[0,1]"; filename=.*`).MatchString(contentDisposition) {
-					require.Equal(t, `text/plain; charset=utf-8`, p.Header.Get("Content-Type"))
-					require.Contains(t, []string{
+					assert.Equal(t, `text/plain; charset=utf-8`, p.Header.Get("Content-Type"))
+					assert.Contains(t, []string{
 						`The quick brown fox jumps over the lazy dog`,
 						`hello world`,
 					}, string(slurp))
 				}
-				require.False(t, regexp.MustCompile(`form-data; name="2"; filename=.*`).MatchString(contentDisposition))
+				assert.False(t, regexp.MustCompile(`form-data; name="2"; filename=.*`).MatchString(contentDisposition))
 			}
 			w.Write([]byte(`{}`))
 		})

--- a/graphql/handler/apollofederatedtracingv1/tracing_test.go
+++ b/graphql/handler/apollofederatedtracingv1/tracing_test.go
@@ -77,16 +77,23 @@ func TestApolloTracing_Concurrent(t *testing.T) {
 					FTV1 string `json:"ftv1"`
 				} `json:"extensions"`
 			}
-			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &respData))
+
+			err := json.Unmarshal(resp.Body.Bytes(), &respData)
+			if !assert.NoError(t, err) {
+				return
+			}
 
 			tracing := respData.Extensions.FTV1
 			pbuf, err := base64.StdEncoding.DecodeString(tracing)
-			require.NoError(t, err)
+			if !assert.NoError(t, err) {
+				return
+			}
 
 			ftv1 := &generated.Trace{}
 			err = proto.Unmarshal(pbuf, ftv1)
-			require.NoError(t, err)
-			require.NotZero(t, ftv1.StartTime.Nanos)
+			if assert.NoError(t, err) {
+				assert.NotZero(t, ftv1.StartTime.Nanos)
+			}
 		}()
 	}
 }


### PR DESCRIPTION
The PR enables all `testifylint` rules in the golangci-lint' config and fixes all lint issues in gqlgen and examples.

Follows #3103

Fixes #3106