### PR TITLE
Go template function to split string into array of strings.

### DIFF
--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -206,7 +206,7 @@ func Funcs() template.FuncMap {
 		"call":               Call,
 		"prefixLines":        prefixLines,
 		"notNil":             notNil,
-		"stringsSplit":       stringsSplit,
+		"strSplit":           StrSplit,
 		"reserveImport":      CurrentImports.Reserve,
 		"lookupImport":       CurrentImports.Lookup,
 		"go":                 ToGo,
@@ -582,7 +582,7 @@ func notNil(field string, data any) bool {
 	return val.IsValid() && !val.IsNil()
 }
 
-func stringsSplit(s, sep string) []string {
+func StrSplit(s, sep string) []string {
 	return strings.Split(s, sep)
 }
 

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -206,6 +206,7 @@ func Funcs() template.FuncMap {
 		"call":               Call,
 		"prefixLines":        prefixLines,
 		"notNil":             notNil,
+		"stringsSplit":       stringsSplit,
 		"reserveImport":      CurrentImports.Reserve,
 		"lookupImport":       CurrentImports.Lookup,
 		"go":                 ToGo,
@@ -579,6 +580,10 @@ func notNil(field string, data any) bool {
 	val := v.FieldByName(field)
 
 	return val.IsValid() && !val.IsNil()
+}
+
+func stringsSplit(s, sep string) []string {
+	return strings.Split(s, sep)
 }
 
 func Dump(val any) string {


### PR DESCRIPTION
This adds new template function `strSplit` which splits string into array of strings.
This function gives more flexibility for custom custom .gotpl templating for resolvers in codegen templates. This function is intended to help developers who wants to write own .gotpl.
