### PR TITLE
Correct dataloader example

### DIFF
--- a/docs/content/reference/dataloaders.md
+++ b/docs/content/reference/dataloaders.md
@@ -115,11 +115,9 @@ func (u *userReader) getUsers(ctx context.Context, userIDs []string) ([]*model.U
 	errs := make([]error, 0, len(userIDs))
 	for rows.Next() {
 		var user model.User
-		if err := rows.Scan(&user.ID, &user.Name); err != nil {
-			errs = append(errs, err)
-			continue
-		}
+		err := rows.Scan(&user.ID, &user.Name)
 		users = append(users, &user)
+		errs = append(errs, err)
 	}
 	return users, errs
 }


### PR DESCRIPTION
Dataloader requires the value and error slice to be of equal length, in order to correctly return the values.

Link: https://github.com/vikstrous/dataloadgen/blob/7de6ebe3d882737607ce2ba646e8d6ec652b32e3/dataloadgen_test.go#L19-L20