### PR TITLE
add option to omit panic handlers during development

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	OmitGQLGenVersionInFileNotice bool                       `yaml:"omit_gqlgen_version_in_file_notice,omitempty"`
 	OmitRootModels                bool                       `yaml:"omit_root_models,omitempty"`
 	OmitResolverFields            bool                       `yaml:"omit_resolver_fields,omitempty"`
+	OmitPanicHandler              bool                       `yaml:"omit_panic_handler,omitempty"`
 	StructFieldsAlwaysPointers    bool                       `yaml:"struct_fields_always_pointers,omitempty"`
 	ReturnPointersInUmarshalInput bool                       `yaml:"return_pointers_in_unmarshalinput,omitempty"`
 	ResolversAlwaysReturnPointers bool                       `yaml:"resolvers_always_return_pointers,omitempty"`

--- a/codegen/field.gotpl
+++ b/codegen/field.gotpl
@@ -10,12 +10,14 @@ func (ec *executionContext) _{{$object.Name}}_{{$field.Name}}(ctx context.Contex
 		return {{ $null }}
 	}
 	ctx = graphql.WithFieldContext(ctx, fc)
+	{{- if not $.Config.OmitPanicHandler }}
 	defer func () {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
 			ret = {{ $null }}
 		}
 	}()
+	{{- end }}
 	{{- if $field.TypeReference.IsRoot }}
 		{{- if $field.TypeReference.IsPtr }}
 			res := &{{ $field.TypeReference.Elem.GO | ref }}{}
@@ -95,12 +97,14 @@ func (ec *executionContext) {{ $field.FieldContextFunc }}({{ if not $field.Args 
 		},
 	}
 	{{- if $field.Args }}
+		{{- if not $.Config.OmitPanicHandler }}
 		defer func () {
 			if r := recover(); r != nil {
 				err = ec.Recover(ctx, r)
 				ec.Error(ctx, err)
 			}
 		}()
+		{{- end }}
 		ctx = graphql.WithFieldContext(ctx, fc)
 		if fc.Args, err = ec.{{ $field.ArgsFunc }}(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 			ec.Error(ctx, err)

--- a/codegen/object.gotpl
+++ b/codegen/object.gotpl
@@ -49,11 +49,13 @@ func (ec *executionContext) _{{$object.Name}}(ctx context.Context, sel ast.Selec
 				field := field
 
 				innerFunc := func(ctx context.Context, {{ if $field.TypeReference.GQL.NonNull }}fs{{ else }}_{{ end }} *graphql.FieldSet) (res graphql.Marshaler) {
+					{{- if not $.Config.OmitPanicHandler }}
 					defer func() {
 						if r := recover(); r != nil {
 							ec.Error(ctx, ec.Recover(ctx, r))
 						}
 					}()
+					{{- end }}
 					res = ec._{{$object.Name}}_{{$field.Name}}(ctx, field{{if not $object.Root}}, obj{{end}})
 					{{- if $field.TypeReference.GQL.NonNull }}
 						if res == graphql.Null {

--- a/codegen/type.gotpl
+++ b/codegen/type.gotpl
@@ -115,12 +115,14 @@
 						}
 						ctx := graphql.WithFieldContext(ctx, fc)
 						f := func(i int) {
+							{{- if not $.Config.OmitPanicHandler }}
 							defer func() {
 								if r := recover(); r != nil {
 									ec.Error(ctx, ec.Recover(ctx, r))
 									ret = nil
 								}
 							}()
+							{{- end }}
 							if !isLen1 {
 								defer wg.Done()
 							}

--- a/docs/content/reference/errors.md
+++ b/docs/content/reference/errors.md
@@ -80,7 +80,7 @@ var errSomethingWrong = errors.New("some validation failed")
 // DoThingsReturnMultipleErrors collect errors and returns it if any.
 func (r Query) DoThingsReturnMultipleErrors(ctx context.Context) (bool, error) {
 	errList := gqlerror.List{}
-		
+
 	// Add existing error
 	errList = append(errList, gqlerror.Wrap(errSomethingWrong))
 
@@ -95,7 +95,7 @@ func (r Query) DoThingsReturnMultipleErrors(ctx context.Context) (bool, error) {
 			"code": "10-4",
 		},
 	})
-	
+
 	return false, errList
 }
 ```
@@ -172,3 +172,10 @@ server.SetRecoverFunc(func(ctx context.Context, err interface{}) error {
 })
 ```
 
+While these handlers are useful in production to make sure the program does not crash, even if a user finds an issue that causes a crash-condition. During development, it can sometimes be more useful to properly crash, potentially generating a coredump to [enable further debugging](https://go.dev/wiki/CoreDumpDebugging).
+
+To allow your program to crash on a panic, add this to your config file:
+
+```yaml
+omit_panic_handler: true
+```


### PR DESCRIPTION
While panic recovery handlers are useful in production to make sure the program does not crash, even if a user finds an issue that causes a crash condition. During development, it can sometimes be more useful to properly crash, potentially generating a coredump to [enable further debugging](https://go.dev/wiki/CoreDumpDebugging).

To allow your program to crash on a panic, add this to your config file:

```yaml
omit_panic_handler: true
```

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
   - honestly, not sure on how to test a new config field. I have tried it out and verified that it works, though.
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
