### PR TITLE
#3089 generate populateMany method for explicit_requires

### DIFF
--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -136,7 +136,7 @@ func (f *federation) InjectSourceEarly() *ast.Source {
 	directive @interfaceObject on OBJECT
 	directive @link(import: [String!], url: String!) repeatable on SCHEMA
 	directive @override(from: String!, label: String) on FIELD_DEFINITION
-	directive @policy(policies: [[federation__Policy!]!]!) on 
+	directive @policy(policies: [[federation__Policy!]!]!) on
 	  | FIELD_DEFINITION
 	  | OBJECT
 	  | INTERFACE
@@ -144,7 +144,7 @@ func (f *federation) InjectSourceEarly() *ast.Source {
 	  | ENUM
 	directive @provides(fields: FieldSet!) on FIELD_DEFINITION
 	directive @requires(fields: FieldSet!) on FIELD_DEFINITION
-	directive @requiresScopes(scopes: [[federation__Scope!]!]!) on 
+	directive @requiresScopes(scopes: [[federation__Scope!]!]!) on
 	  | FIELD_DEFINITION
 	  | OBJECT
 	  | INTERFACE
@@ -366,8 +366,12 @@ func (f *federation) GenerateCode(data *codegen.Data) error {
 
 		for name, entity := range requiresEntities {
 			populator := Populator{
-				FuncName: fmt.Sprintf("Populate%sRequires", name),
-				Entity:   entity,
+				Entity: entity,
+			}
+			if entity.Multi {
+				populator.FuncName = fmt.Sprintf("PopulateMany%sRequires", name)
+			} else {
+				populator.FuncName = fmt.Sprintf("Populate%sRequires", name)
 			}
 
 			populator.Comment = strings.TrimSpace(strings.TrimLeft(rewriter.GetMethodComment("executionContext", populator.FuncName), `\`))

--- a/plugin/federation/federation.gotpl
+++ b/plugin/federation/federation.gotpl
@@ -170,13 +170,22 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 							return err
 						}
 
+						{{ if and (index $options "explicit_requires") $entity.Requires }}
+							err = ec.PopulateMany{{$entity.Def.Name}}Requires(ctx, {{- if (not $usePointers) -}}&{{- end -}}entities, reps)
+							if err != nil {
+								return fmt.Errorf(`populating requires for Entity "{{$entity.Def.Name}}": %w`, err)
+							}
+						{{- end }}
+
 						for i, entity := range entities {
+							{{ if not (and (index $options "explicit_requires") $entity.Requires) }}
 							{{- range $entity.Requires }}
 									entity.{{.Field.JoinGo `.`}}, err = ec.{{.Type.UnmarshalFunc}}(ctx, reps[i]["{{.Field.Join `"].(map[string]interface{})["`}}"])
 									if err != nil {
 										return err
 									}
 							{{- end}}
+							{{- end }}
 							list[idx[i]] = entity
 						}
 						return nil

--- a/plugin/federation/requires.gotpl
+++ b/plugin/federation/requires.gotpl
@@ -12,7 +12,11 @@
 {{- else -}}
 // {{.FuncName}} is the requires populator for the {{.Entity.Def.Name}} entity.
 {{- end }}
+{{- if .Entity.Multi -}}
+func (ec *executionContext) {{.FuncName}}(ctx context.Context, entities []*{{.Entity.GetTypeInfo}}, reps []map[string]interface{}) error {
+{{- else }}
 func (ec *executionContext) {{.FuncName}}(ctx context.Context, entity *{{.Entity.GetTypeInfo}}, reps map[string]interface{}) error {
+{{- end }}
 	{{.Implementation}}
 }
 {{ end }}


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

Closes #3089 

continuation of #2884 

In this Pull Request, I've added generation of `PopulateMany...` methods for slice of entities -  if the `explicit_requires` option enabled, and an `@entityResolver(multi: true)`.

Right now, it generates stub federation.requires.go, that does nothing.

@jesse-apollo, I will be very glad to receive your suggestions for this task :)

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
