### PR TITLE
#3118 Add token limit option to fix CVE-2023-49559

### DIFF
--- a/graphql/executor/executor.go
+++ b/graphql/executor/executor.go
@@ -12,6 +12,8 @@ import (
 	"github.com/99designs/gqlgen/graphql/errcode"
 )
 
+const parserTokenNoLimit = 0
+
 // Executor executes graphql queries against a schema.
 type Executor struct {
 	es         graphql.ExecutableSchema
@@ -36,7 +38,7 @@ func New(es graphql.ExecutableSchema) *Executor {
 		recoverFunc:      graphql.DefaultRecover,
 		queryCache:       graphql.NoCache{},
 		ext:              processExtensions(nil),
-		parserTokenLimit: 0, // 0 means unlimited
+		parserTokenLimit: parserTokenNoLimit,
 	}
 	return e
 }

--- a/graphql/executor/executor.go
+++ b/graphql/executor/executor.go
@@ -21,6 +21,8 @@ type Executor struct {
 	errorPresenter graphql.ErrorPresenterFunc
 	recoverFunc    graphql.RecoverFunc
 	queryCache     graphql.Cache
+
+	parserTokenLimit int
 }
 
 var _ graphql.GraphExecutor = &Executor{}
@@ -29,11 +31,12 @@ var _ graphql.GraphExecutor = &Executor{}
 // recovery callbacks, and no query cache or extensions.
 func New(es graphql.ExecutableSchema) *Executor {
 	e := &Executor{
-		es:             es,
-		errorPresenter: graphql.DefaultErrorPresenter,
-		recoverFunc:    graphql.DefaultRecover,
-		queryCache:     graphql.NoCache{},
-		ext:            processExtensions(nil),
+		es:               es,
+		errorPresenter:   graphql.DefaultErrorPresenter,
+		recoverFunc:      graphql.DefaultRecover,
+		queryCache:       graphql.NoCache{},
+		ext:              processExtensions(nil),
+		parserTokenLimit: 0, // 0 means unlimited
 	}
 	return e
 }
@@ -169,6 +172,10 @@ func (e *Executor) SetRecoverFunc(f graphql.RecoverFunc) {
 	e.recoverFunc = f
 }
 
+func (e *Executor) SetParserTokenLimit(limit int) {
+	e.parserTokenLimit = limit
+}
+
 // parseQuery decodes the incoming query and validates it, pulling from cache if present.
 //
 // NOTE: This should NOT look at variables, they will change per request. It should only parse and
@@ -189,7 +196,7 @@ func (e *Executor) parseQuery(
 		return doc.(*ast.QueryDocument), nil
 	}
 
-	doc, err := parser.ParseQuery(&ast.Source{Input: query})
+	doc, err := parser.ParseQueryWithTokenLimit(&ast.Source{Input: query}, e.parserTokenLimit)
 	if err != nil {
 		gqlErr, ok := err.(*gqlerror.Error)
 		if ok {

--- a/graphql/handler/server.go
+++ b/graphql/handler/server.go
@@ -67,6 +67,10 @@ func (s *Server) SetQueryCache(cache graphql.Cache) {
 	s.exec.SetQueryCache(cache)
 }
 
+func (s *Server) SetParserTokenLimit(limit int) {
+	s.exec.SetParserTokenLimit(limit)
+}
+
 func (s *Server) Use(extension graphql.HandlerExtension) {
 	s.exec.Use(extension)
 }

--- a/graphql/handler/server_test.go
+++ b/graphql/handler/server_test.go
@@ -141,24 +141,6 @@ func TestServer(t *testing.T) {
 			require.Equal(t, "Bar", cacheDoc.(*ast.QueryDocument).Operations[0].Name)
 		})
 	})
-
-	t.Run("parser token limit", func(t *testing.T) {
-		qry := `query Foo {   __typename @a }`
-
-		t.Run("parser does not reaches token limit", func(t *testing.T) {
-			srv.SetParserTokenLimit(0)
-			resp := get(srv, "/foo?query="+url.QueryEscape(qry))
-			assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
-			assert.Equal(t, `{"errors":[{"message":"Unknown directive \"@a\".","locations":[{"line":1,"column":27}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
-		})
-
-		t.Run("parser reaches token limit", func(t *testing.T) {
-			srv.SetParserTokenLimit(2)
-			resp := get(srv, "/foo?query="+url.QueryEscape(qry))
-			assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
-			assert.Equal(t, `{"errors":[{"message":"exceeded token limit of 2.","extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
-		})
-	})
 }
 
 func TestErrorServer(t *testing.T) {


### PR DESCRIPTION
Related to #3118 

This PR allows setting a maximum token limit to the **gqlparser**.

The limit can be configured using a dedicated method on the server instance:
```golang
srv := handler.NewDefaultServer(generated.NewExecutableSchema(config))

srv.SetParserTokenLimit(15000)
```

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
