### PR TITLE
refactor: add missed file.Close() and use t.TempDir()

### DIFF
--- a/_examples/fileupload/fileupload_test.go
+++ b/_examples/fileupload/fileupload_test.go
@@ -23,14 +23,17 @@ func TestFileUpload(t *testing.T) {
 	defer srv.Close()
 	gql := gqlclient.New(srv.Config.Handler, gqlclient.Path("/graphql"))
 
-	aTxtFile, _ := os.CreateTemp(os.TempDir(), "a.txt")
-	defer os.Remove(aTxtFile.Name())
+	aTxtFile, err := os.CreateTemp(t.TempDir(), "a.txt")
+	require.NoError(t, err)
+	defer aTxtFile.Close()
 	aTxtFile.WriteString(`test`)
 
-	a1TxtFile, _ := os.CreateTemp(os.TempDir(), "a.txt")
-	b1TxtFile, _ := os.CreateTemp(os.TempDir(), "b.txt")
-	defer os.Remove(a1TxtFile.Name())
-	defer os.Remove(b1TxtFile.Name())
+	a1TxtFile, err := os.CreateTemp(t.TempDir(), "a.txt")
+	require.NoError(t, err)
+	defer a1TxtFile.Close()
+	b1TxtFile, err := os.CreateTemp(t.TempDir(), "b.txt")
+	require.NoError(t, err)
+	defer b1TxtFile.Close()
 	a1TxtFile.WriteString(`test1`)
 	b1TxtFile.WriteString(`test2`)
 

--- a/client/withfilesoption_test.go
+++ b/client/withfilesoption_test.go
@@ -11,17 +11,21 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
 )
 
 func TestWithFiles(t *testing.T) {
-	tempFile1, _ := os.CreateTemp(os.TempDir(), "tempFile1")
-	tempFile2, _ := os.CreateTemp(os.TempDir(), "tempFile2")
-	tempFile3, _ := os.CreateTemp(os.TempDir(), "tempFile3")
-	defer os.Remove(tempFile1.Name())
-	defer os.Remove(tempFile2.Name())
-	defer os.Remove(tempFile3.Name())
+	tempFile1, err := os.CreateTemp(t.TempDir(), "tempFile1")
+	require.NoError(t, err)
+	tempFile2, err := os.CreateTemp(t.TempDir(), "tempFile2")
+	require.NoError(t, err)
+	tempFile3, err := os.CreateTemp(t.TempDir(), "tempFile3")
+	require.NoError(t, err)
+	defer tempFile1.Close()
+	defer tempFile2.Close()
+	defer tempFile3.Close()
 	tempFile1.WriteString(`The quick brown fox jumps over the lazy dog`)
 	tempFile2.WriteString(`hello world`)
 	tempFile3.WriteString(`La-Li-Lu-Le-Lo`)

--- a/codegen/templates/templates_test.go
+++ b/codegen/templates/templates_test.go
@@ -320,12 +320,11 @@ func TestCenter(t *testing.T) {
 }
 
 func TestTemplateOverride(t *testing.T) {
-	f, err := os.CreateTemp("", "gqlgen")
+	f, err := os.CreateTemp(t.TempDir(), "gqlgen")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer f.Close()
-	defer os.RemoveAll(f.Name())
 	err = Render(Options{Template: "hello", Filename: f.Name(), Packages: code.NewPackages()})
 	if err != nil {
 		t.Fatal(err)
@@ -344,7 +343,6 @@ func TestRenderFS(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer f.Close()
-	defer os.RemoveAll(f.Name())
 	err = Render(Options{TemplateFS: templateFS, Filename: f.Name(), Packages: code.NewPackages()})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The PR adds missing `file.Close()` calls and refactors to `t.TempDir()` instead of `os.TempDir()`.

[`t.TempDir`](https://pkg.go.dev/testing#T.TempDir) automatically removes the temporary directory after the test completes.


I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))

