### PR TITLE
Fix typo in config field names

### DIFF
--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -193,19 +193,19 @@ func (b *Binder) PointerTo(ref *TypeReference) *TypeReference {
 
 // TypeReference is used by args and field types. The Definition can refer to both input and output types.
 type TypeReference struct {
-	Definition              *ast.Definition
-	GQL                     *ast.Type
-	GO                      types.Type  // Type of the field being bound. Could be a pointer or a value type of Target.
-	Target                  types.Type  // The actual type that we know how to bind to. May require pointer juggling when traversing to fields.
-	CastType                types.Type  // Before calling marshalling functions cast from/to this base type
-	Marshaler               *types.Func // When using external marshalling functions this will point to the Marshal function
-	Unmarshaler             *types.Func // When using external marshalling functions this will point to the Unmarshal function
-	IsMarshaler             bool        // Does the type implement graphql.Marshaler and graphql.Unmarshaler
-	IsOmittable             bool        // Is the type wrapped with Omittable
-	IsContext               bool        // Is the Marshaler/Unmarshaller the context version; applies to either the method or interface variety.
-	PointersInUmarshalInput bool        // Inverse values and pointers in return.
-	IsRoot                  bool        // Is the type a root level definition such as Query, Mutation or Subscription
-	EnumValues              []EnumValueReference
+	Definition               *ast.Definition
+	GQL                      *ast.Type
+	GO                       types.Type  // Type of the field being bound. Could be a pointer or a value type of Target.
+	Target                   types.Type  // The actual type that we know how to bind to. May require pointer juggling when traversing to fields.
+	CastType                 types.Type  // Before calling marshalling functions cast from/to this base type
+	Marshaler                *types.Func // When using external marshalling functions this will point to the Marshal function
+	Unmarshaler              *types.Func // When using external marshalling functions this will point to the Unmarshal function
+	IsMarshaler              bool        // Does the type implement graphql.Marshaler and graphql.Unmarshaler
+	IsOmittable              bool        // Is the type wrapped with Omittable
+	IsContext                bool        // Is the Marshaler/Unmarshaller the context version; applies to either the method or interface variety.
+	PointersInUnmarshalInput bool        // Inverse values and pointers in return.
+	IsRoot                   bool        // Is the type a root level definition such as Query, Mutation or Subscription
+	EnumValues               []EnumValueReference
 }
 
 func (ref *TypeReference) Elem() *TypeReference {
@@ -478,7 +478,7 @@ func (b *Binder) TypeReference(schemaType *ast.Type, bindTarget types.Type) (ret
 			ref.GO = bindTarget
 		}
 
-		ref.PointersInUmarshalInput = b.cfg.ReturnPointersInUmarshalInput
+		ref.PointersInUnmarshalInput = b.cfg.ReturnPointersInUnmarshalInput
 
 		return ref, nil
 	}

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -22,36 +22,36 @@ import (
 )
 
 type Config struct {
-	SchemaFilename                StringList                 `yaml:"schema,omitempty"`
-	Exec                          ExecConfig                 `yaml:"exec"`
-	Model                         PackageConfig              `yaml:"model,omitempty"`
-	Federation                    PackageConfig              `yaml:"federation,omitempty"`
-	Resolver                      ResolverConfig             `yaml:"resolver,omitempty"`
-	AutoBind                      []string                   `yaml:"autobind"`
-	Models                        TypeMap                    `yaml:"models,omitempty"`
-	StructTag                     string                     `yaml:"struct_tag,omitempty"`
-	Directives                    map[string]DirectiveConfig `yaml:"directives,omitempty"`
-	GoBuildTags                   StringList                 `yaml:"go_build_tags,omitempty"`
-	GoInitialisms                 GoInitialismsConfig        `yaml:"go_initialisms,omitempty"`
-	OmitSliceElementPointers      bool                       `yaml:"omit_slice_element_pointers,omitempty"`
-	OmitGetters                   bool                       `yaml:"omit_getters,omitempty"`
-	OmitInterfaceChecks           bool                       `yaml:"omit_interface_checks,omitempty"`
-	OmitComplexity                bool                       `yaml:"omit_complexity,omitempty"`
-	OmitGQLGenFileNotice          bool                       `yaml:"omit_gqlgen_file_notice,omitempty"`
-	OmitGQLGenVersionInFileNotice bool                       `yaml:"omit_gqlgen_version_in_file_notice,omitempty"`
-	OmitRootModels                bool                       `yaml:"omit_root_models,omitempty"`
-	OmitResolverFields            bool                       `yaml:"omit_resolver_fields,omitempty"`
-	OmitPanicHandler              bool                       `yaml:"omit_panic_handler,omitempty"`
-	StructFieldsAlwaysPointers    bool                       `yaml:"struct_fields_always_pointers,omitempty"`
-	ReturnPointersInUmarshalInput bool                       `yaml:"return_pointers_in_unmarshalinput,omitempty"`
-	ResolversAlwaysReturnPointers bool                       `yaml:"resolvers_always_return_pointers,omitempty"`
-	NullableInputOmittable        bool                       `yaml:"nullable_input_omittable,omitempty"`
-	EnableModelJsonOmitemptyTag   *bool                      `yaml:"enable_model_json_omitempty_tag,omitempty"`
-	SkipValidation                bool                       `yaml:"skip_validation,omitempty"`
-	SkipModTidy                   bool                       `yaml:"skip_mod_tidy,omitempty"`
-	Sources                       []*ast.Source              `yaml:"-"`
-	Packages                      *code.Packages             `yaml:"-"`
-	Schema                        *ast.Schema                `yaml:"-"`
+	SchemaFilename                 StringList                 `yaml:"schema,omitempty"`
+	Exec                           ExecConfig                 `yaml:"exec"`
+	Model                          PackageConfig              `yaml:"model,omitempty"`
+	Federation                     PackageConfig              `yaml:"federation,omitempty"`
+	Resolver                       ResolverConfig             `yaml:"resolver,omitempty"`
+	AutoBind                       []string                   `yaml:"autobind"`
+	Models                         TypeMap                    `yaml:"models,omitempty"`
+	StructTag                      string                     `yaml:"struct_tag,omitempty"`
+	Directives                     map[string]DirectiveConfig `yaml:"directives,omitempty"`
+	GoBuildTags                    StringList                 `yaml:"go_build_tags,omitempty"`
+	GoInitialisms                  GoInitialismsConfig        `yaml:"go_initialisms,omitempty"`
+	OmitSliceElementPointers       bool                       `yaml:"omit_slice_element_pointers,omitempty"`
+	OmitGetters                    bool                       `yaml:"omit_getters,omitempty"`
+	OmitInterfaceChecks            bool                       `yaml:"omit_interface_checks,omitempty"`
+	OmitComplexity                 bool                       `yaml:"omit_complexity,omitempty"`
+	OmitGQLGenFileNotice           bool                       `yaml:"omit_gqlgen_file_notice,omitempty"`
+	OmitGQLGenVersionInFileNotice  bool                       `yaml:"omit_gqlgen_version_in_file_notice,omitempty"`
+	OmitRootModels                 bool                       `yaml:"omit_root_models,omitempty"`
+	OmitResolverFields             bool                       `yaml:"omit_resolver_fields,omitempty"`
+	OmitPanicHandler               bool                       `yaml:"omit_panic_handler,omitempty"`
+	StructFieldsAlwaysPointers     bool                       `yaml:"struct_fields_always_pointers,omitempty"`
+	ReturnPointersInUnmarshalInput bool                       `yaml:"return_pointers_in_unmarshalinput,omitempty"`
+	ResolversAlwaysReturnPointers  bool                       `yaml:"resolvers_always_return_pointers,omitempty"`
+	NullableInputOmittable         bool                       `yaml:"nullable_input_omittable,omitempty"`
+	EnableModelJsonOmitemptyTag    *bool                      `yaml:"enable_model_json_omitempty_tag,omitempty"`
+	SkipValidation                 bool                       `yaml:"skip_validation,omitempty"`
+	SkipModTidy                    bool                       `yaml:"skip_mod_tidy,omitempty"`
+	Sources                        []*ast.Source              `yaml:"-"`
+	Packages                       *code.Packages             `yaml:"-"`
+	Schema                         *ast.Schema                `yaml:"-"`
 
 	// Deprecated: use Federation instead. Will be removed next release
 	Federated bool `yaml:"federated,omitempty"`
@@ -62,15 +62,15 @@ var cfgFilenames = []string{".gqlgen.yml", "gqlgen.yml", "gqlgen.yaml"}
 // DefaultConfig creates a copy of the default config
 func DefaultConfig() *Config {
 	return &Config{
-		SchemaFilename:                StringList{"schema.graphql"},
-		Model:                         PackageConfig{Filename: "models_gen.go"},
-		Exec:                          ExecConfig{Filename: "generated.go"},
-		Directives:                    map[string]DirectiveConfig{},
-		Models:                        TypeMap{},
-		StructFieldsAlwaysPointers:    true,
-		ReturnPointersInUmarshalInput: false,
-		ResolversAlwaysReturnPointers: true,
-		NullableInputOmittable:        false,
+		SchemaFilename:                 StringList{"schema.graphql"},
+		Model:                          PackageConfig{Filename: "models_gen.go"},
+		Exec:                           ExecConfig{Filename: "generated.go"},
+		Directives:                     map[string]DirectiveConfig{},
+		Models:                         TypeMap{},
+		StructFieldsAlwaysPointers:     true,
+		ReturnPointersInUnmarshalInput: false,
+		ResolversAlwaysReturnPointers:  true,
+		NullableInputOmittable:         false,
 	}
 }
 

--- a/codegen/input.gotpl
+++ b/codegen/input.gotpl
@@ -1,10 +1,10 @@
 {{- range $input := .Inputs }}
 	{{- if not .HasUnmarshal }}
 	{{- $it := "it" }}
-	{{- if .PointersInUmarshalInput }}
+	{{- if .PointersInUnmarshalInput }}
 	  {{- $it = "&it" }}
 	{{- end }}
-	func (ec *executionContext) unmarshalInput{{ .Name }}(ctx context.Context, obj interface{}) ({{ if .PointersInUmarshalInput }}*{{ end }}{{.Type | ref}}, error) {
+	func (ec *executionContext) unmarshalInput{{ .Name }}(ctx context.Context, obj interface{}) ({{ if .PointersInUnmarshalInput }}*{{ end }}{{.Type | ref}}, error) {
 		{{- if $input.IsMap }}
 			it := make(map[string]interface{}, len(obj.(map[string]interface{})))
 		{{- else }}

--- a/codegen/object.go
+++ b/codegen/object.go
@@ -26,15 +26,15 @@ const (
 type Object struct {
 	*ast.Definition
 
-	Type                    types.Type
-	ResolverInterface       types.Type
-	Root                    bool
-	Fields                  []*Field
-	Implements              []*ast.Definition
-	DisableConcurrency      bool
-	Stream                  bool
-	Directives              []*Directive
-	PointersInUmarshalInput bool
+	Type                     types.Type
+	ResolverInterface        types.Type
+	Root                     bool
+	Fields                   []*Field
+	Implements               []*ast.Definition
+	DisableConcurrency       bool
+	Stream                   bool
+	Directives               []*Directive
+	PointersInUnmarshalInput bool
 }
 
 func (b *builder) buildObject(typ *ast.Definition) (*Object, error) {
@@ -44,12 +44,12 @@ func (b *builder) buildObject(typ *ast.Definition) (*Object, error) {
 	}
 	caser := cases.Title(language.English, cases.NoLower)
 	obj := &Object{
-		Definition:              typ,
-		Root:                    b.Config.IsRoot(typ),
-		DisableConcurrency:      typ == b.Schema.Mutation,
-		Stream:                  typ == b.Schema.Subscription,
-		Directives:              dirs,
-		PointersInUmarshalInput: b.Config.ReturnPointersInUmarshalInput,
+		Definition:               typ,
+		Root:                     b.Config.IsRoot(typ),
+		DisableConcurrency:       typ == b.Schema.Mutation,
+		Stream:                   typ == b.Schema.Subscription,
+		Directives:               dirs,
+		PointersInUnmarshalInput: b.Config.ReturnPointersInUnmarshalInput,
 		ResolverInterface: types.NewNamed(
 			types.NewTypeName(0, b.Config.Exec.Pkg(), caser.String(typ.Name)+"Resolver", nil),
 			nil,

--- a/codegen/type.gotpl
+++ b/codegen/type.gotpl
@@ -76,9 +76,9 @@
 					return res, graphql.ErrorOnPath(ctx, err)
 				{{- else }}
 					res, err := ec.unmarshalInput{{ $type.GQL.Name }}(ctx, v)
-					{{- if and $type.IsNilable (not $type.IsMap) (not $type.PointersInUmarshalInput) }}
+					{{- if and $type.IsNilable (not $type.IsMap) (not $type.PointersInUnmarshalInput) }}
 						return &res, graphql.ErrorOnPath(ctx, err)
-					{{- else if and (not $type.IsNilable) $type.PointersInUmarshalInput }}
+					{{- else if and (not $type.IsNilable) $type.PointersInUnmarshalInput }}
 						return *res, graphql.ErrorOnPath(ctx, err)
 					{{- else }}
 						return res, graphql.ErrorOnPath(ctx, err)


### PR DESCRIPTION
The PR fixes the typo in the `Unmarshal` word.