### PR TITLE
docs: missing 'repeatable' in @goExtraField directive

### DIFF
--- a/docs/content/recipes/extra_fields.md
+++ b/docs/content/recipes/extra_fields.md
@@ -58,7 +58,7 @@ directive @goExtraField(
 	type: String!
 	overrideTags: String
 	description: String
-) on OBJECT | INPUT_OBJECT
+) repeatable on OBJECT | INPUT_OBJECT
 ```
 
 Now you can use these directive when defining types in your schema:


### PR DESCRIPTION
According to the GraphQL [spec](https://spec.graphql.org/draft/#sec-Directives-Are-Unique-per-Location), directives that are used more than once must be defined as `repeatable`:

> GraphQL allows directives that are defined as `repeatable` to be used more than once on the definition they apply to, possibly with different arguments. In contrast, if a directive is not `repeatable`, then only one occurrence of it is allowed per location.

Fixes #3145

I have:
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
