### PR TITLE
fix bug: POST transport Insufficient rigorous judgment leads to invalid SSE transport

### DIFF
--- a/graphql/handler/transport/http_post.go
+++ b/graphql/handler/transport/http_post.go
@@ -27,6 +27,10 @@ func (h POST) Supports(r *http.Request) bool {
 		return false
 	}
 
+	if strings.Contains(r.Header.Get("Accept"), "text/event-stream") {
+		return false
+	}
+
 	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
 	if err != nil {
 		return false

--- a/graphql/handler/transport/http_post_test.go
+++ b/graphql/handler/transport/http_post_test.go
@@ -96,6 +96,22 @@ func TestPOST(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("validate SSE", func(t *testing.T) {
+		doReq := func(handler http.Handler, method string, target string, body string) *httptest.ResponseRecorder {
+			r := httptest.NewRequest(method, target, strings.NewReader(body))
+			r.Header.Set("Content-Type", "application/json")
+			r.Header.Set("Accept", "text/event-stream")
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, r)
+			return w
+		}
+
+		resp := doReq(h, "POST", "/graphql", `{"query":"{ name }"}`)
+		assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
+		assert.Equal(t, `{"errors":[{"message":"transport not supported"}],"data":null}`, resp.Body.String())
+	})
 }
 
 func doRequest(handler http.Handler, method, target, body, contentType string) *httptest.ResponseRecorder {


### PR DESCRIPTION
fix bug: POST transfer judgment was not strict enough, resulting in SSE transport never will be invoked

For example, the following POST based SSE request will be automatically taken over by POST transport and will not enter the SSE process

```
curl -N --request POST --url http://localhost:8080/query \
--data '{"query":"subscription { currentTime { unixTime timeStamp } }"}' \
-H "accept: text/event-stream" -H 'content-type: application/json' \
--verbose
```

Easy bug fixes, without updating documentation

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))