### PR TITLE
Nulls are now unmarshalled as zero values for primitive types

### DIFF
--- a/graphql/bool.go
+++ b/graphql/bool.go
@@ -20,6 +20,8 @@ func UnmarshalBoolean(v any) (bool, error) {
 		return v != 0, nil
 	case bool:
 		return v, nil
+	case nil:
+		return false, nil
 	default:
 		return false, fmt.Errorf("%T is not a bool", v)
 	}

--- a/graphql/executor/executor.go
+++ b/graphql/executor/executor.go
@@ -84,7 +84,6 @@ func (e *Executor) CreateOperationContext(
 
 	var err error
 	rc.Variables, err = validator.VariableValues(e.es.Schema(), rc.Operation, params.Variables)
-
 	if err != nil {
 		gqlErr, ok := err.(*gqlerror.Error)
 		if ok {

--- a/graphql/float.go
+++ b/graphql/float.go
@@ -28,6 +28,8 @@ func UnmarshalFloat(v any) (float64, error) {
 		return v, nil
 	case json.Number:
 		return strconv.ParseFloat(string(v), 64)
+	case nil:
+		return 0, nil
 	default:
 		return 0, fmt.Errorf("%T is not an float", v)
 	}

--- a/graphql/handler/transport/http_graphql.go
+++ b/graphql/handler/transport/http_graphql.go
@@ -88,7 +88,6 @@ func cleanupBody(body string) (out string, err error) {
 	// is where query starts. If it is, query is url encoded.
 	if strings.HasPrefix(body, "%7B") {
 		body, err = url.QueryUnescape(body)
-
 		if err != nil {
 			return body, err
 		}

--- a/graphql/int.go
+++ b/graphql/int.go
@@ -23,6 +23,8 @@ func UnmarshalInt(v any) (int, error) {
 		return int(v), nil
 	case json.Number:
 		return strconv.Atoi(string(v))
+	case nil:
+		return 0, nil
 	default:
 		return 0, fmt.Errorf("%T is not an int", v)
 	}
@@ -44,6 +46,8 @@ func UnmarshalInt64(v any) (int64, error) {
 		return v, nil
 	case json.Number:
 		return strconv.ParseInt(string(v), 10, 64)
+	case nil:
+		return 0, nil
 	default:
 		return 0, fmt.Errorf("%T is not an int", v)
 	}
@@ -73,6 +77,8 @@ func UnmarshalInt32(v any) (int32, error) {
 			return 0, err
 		}
 		return int32(iv), nil
+	case nil:
+		return 0, nil
 	default:
 		return 0, fmt.Errorf("%T is not an int", v)
 	}

--- a/graphql/int_test.go
+++ b/graphql/int_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInt(t *testing.T) {
@@ -13,18 +14,17 @@ func TestInt(t *testing.T) {
 	})
 
 	t.Run("unmarshal", func(t *testing.T) {
-		assert.Equal(t, 123, mustUnmarshalInt(123))
-		assert.Equal(t, 123, mustUnmarshalInt(int64(123)))
-		assert.Equal(t, 123, mustUnmarshalInt(json.Number("123")))
-		assert.Equal(t, 123, mustUnmarshalInt("123"))
+		assert.Equal(t, 123, mustUnmarshalInt(t, 123))
+		assert.Equal(t, 123, mustUnmarshalInt(t, int64(123)))
+		assert.Equal(t, 123, mustUnmarshalInt(t, json.Number("123")))
+		assert.Equal(t, 123, mustUnmarshalInt(t, "123"))
+		assert.Equal(t, 0, mustUnmarshalInt(t, nil))
 	})
 }
 
-func mustUnmarshalInt(v any) int {
+func mustUnmarshalInt(t *testing.T, v any) int {
 	res, err := UnmarshalInt(v)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	return res
 }
 
@@ -34,18 +34,17 @@ func TestInt32(t *testing.T) {
 	})
 
 	t.Run("unmarshal", func(t *testing.T) {
-		assert.Equal(t, int32(123), mustUnmarshalInt32(123))
-		assert.Equal(t, int32(123), mustUnmarshalInt32(int64(123)))
-		assert.Equal(t, int32(123), mustUnmarshalInt32(json.Number("123")))
-		assert.Equal(t, int32(123), mustUnmarshalInt32("123"))
+		assert.Equal(t, int32(123), mustUnmarshalInt32(t, 123))
+		assert.Equal(t, int32(123), mustUnmarshalInt32(t, int64(123)))
+		assert.Equal(t, int32(123), mustUnmarshalInt32(t, json.Number("123")))
+		assert.Equal(t, int32(123), mustUnmarshalInt32(t, "123"))
+		assert.Equal(t, int32(0), mustUnmarshalInt32(t, nil))
 	})
 }
 
-func mustUnmarshalInt32(v any) int32 {
+func mustUnmarshalInt32(t *testing.T, v any) int32 {
 	res, err := UnmarshalInt32(v)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	return res
 }
 
@@ -55,17 +54,16 @@ func TestInt64(t *testing.T) {
 	})
 
 	t.Run("unmarshal", func(t *testing.T) {
-		assert.Equal(t, int64(123), mustUnmarshalInt64(123))
-		assert.Equal(t, int64(123), mustUnmarshalInt64(int64(123)))
-		assert.Equal(t, int64(123), mustUnmarshalInt64(json.Number("123")))
-		assert.Equal(t, int64(123), mustUnmarshalInt64("123"))
+		assert.Equal(t, int64(123), mustUnmarshalInt64(t, 123))
+		assert.Equal(t, int64(123), mustUnmarshalInt64(t, int64(123)))
+		assert.Equal(t, int64(123), mustUnmarshalInt64(t, json.Number("123")))
+		assert.Equal(t, int64(123), mustUnmarshalInt64(t, "123"))
+		assert.Equal(t, int64(0), mustUnmarshalInt64(t, nil))
 	})
 }
 
-func mustUnmarshalInt64(v any) int64 {
+func mustUnmarshalInt64(t *testing.T, v any) int64 {
 	res, err := UnmarshalInt64(v)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	return res
 }

--- a/graphql/string.go
+++ b/graphql/string.go
@@ -62,7 +62,7 @@ func UnmarshalString(v any) (string, error) {
 	case bool:
 		return strconv.FormatBool(v), nil
 	case nil:
-		return "null", nil
+		return "", nil
 	default:
 		return "", fmt.Errorf("%T is not a string", v)
 	}

--- a/graphql/string_test.go
+++ b/graphql/string_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestString(t *testing.T) {
@@ -22,21 +23,19 @@ func TestString(t *testing.T) {
 	})
 
 	t.Run("unmarshal", func(t *testing.T) {
-		assert.Equal(t, "123", mustUnmarshalString("123"))
-		assert.Equal(t, "123", mustUnmarshalString(123))
-		assert.Equal(t, "123", mustUnmarshalString(int64(123)))
-		assert.Equal(t, "123", mustUnmarshalString(float64(123)))
-		assert.Equal(t, "123", mustUnmarshalString(json.Number("123")))
-		assert.Equal(t, "true", mustUnmarshalString(true))
-		assert.Equal(t, "false", mustUnmarshalString(false))
-		assert.Equal(t, "null", mustUnmarshalString(nil))
+		assert.Equal(t, "123", mustUnmarshalString(t, "123"))
+		assert.Equal(t, "123", mustUnmarshalString(t, 123))
+		assert.Equal(t, "123", mustUnmarshalString(t, int64(123)))
+		assert.Equal(t, "123", mustUnmarshalString(t, float64(123)))
+		assert.Equal(t, "123", mustUnmarshalString(t, json.Number("123")))
+		assert.Equal(t, "true", mustUnmarshalString(t, true))
+		assert.Equal(t, "false", mustUnmarshalString(t, false))
+		assert.Equal(t, "", mustUnmarshalString(t, nil))
 	})
 }
 
-func mustUnmarshalString(v any) string {
+func mustUnmarshalString(t *testing.T, v any) string {
 	res, err := UnmarshalString(v)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	return res
 }

--- a/graphql/uint.go
+++ b/graphql/uint.go
@@ -34,6 +34,8 @@ func UnmarshalUint(v any) (uint, error) {
 	case json.Number:
 		u64, err := strconv.ParseUint(string(v), 10, 64)
 		return uint(u64), err
+	case nil:
+		return 0, nil
 	default:
 		return 0, fmt.Errorf("%T is not an uint", v)
 	}
@@ -63,6 +65,8 @@ func UnmarshalUint64(v any) (uint64, error) {
 		return uint64(v), nil
 	case json.Number:
 		return strconv.ParseUint(string(v), 10, 64)
+	case nil:
+		return 0, nil
 	default:
 		return 0, fmt.Errorf("%T is not an uint", v)
 	}
@@ -100,6 +104,8 @@ func UnmarshalUint32(v any) (uint32, error) {
 			return 0, err
 		}
 		return uint32(iv), nil
+	case nil:
+		return 0, nil
 	default:
 		return 0, fmt.Errorf("%T is not an uint", v)
 	}


### PR DESCRIPTION
## Description

The current implementation of Unmarshal to primitives in gqlgen does not handle null values consistently. Specifically, when input types are mapped to Go structs, optional fields defined as primitives fields in the Go struct can lead to errors or unexpected behaviors.

#### Example

Consider the following GraphQL input type:

```graphql
input ExampleInput @goModel(model: "example.ExampleInput") {
  name: String
  age: Int
}
```

This maps to the following Go struct:

```go
type ExampleInput struct {
  Name string `json:"name,omitempty"`
  Age  int    `json:"age,omitempty"`
}
```

When unmarshalling the following JSON input:

```json
{
  "name": null,
  "age": null
}
```

The resulting `Name` field in the Go struct is assigned the string value `"null"`, and the `Age` field causes an error. This behavior is inconsistent with the Go standard JSON library, which leaves the field untouched.

#### Proposed Solution

To align with the Go standard library's behavior, null values should be mapped to the zero-value of the corresponding Go type. This approach is more idiomatic to Go and reduces the potential for errors.


I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
