### PR TITLE
chore: Refactor federation.go to make it easier to read

### DIFF
--- a/_examples/federation/accounts/graph/generated.go
+++ b/_examples/federation/accounts/graph/generated.go
@@ -318,9 +318,8 @@ union _Entity = EmailHost | User
 
 # fake type to build resolver interfaces for users to implement
 type Entity {
-		findEmailHostByID(id: String!,): EmailHost!
+	findEmailHostByID(id: String!,): EmailHost!
 	findUserByID(id: ID!,): User!
-
 }
 
 type _Service {

--- a/_examples/federation/products/graph/generated.go
+++ b/_examples/federation/products/graph/generated.go
@@ -345,10 +345,9 @@ union _Entity = Manufacturer | Product
 
 # fake type to build resolver interfaces for users to implement
 type Entity {
-		findManufacturerByID(id: String!,): Manufacturer!
+	findManufacturerByID(id: String!,): Manufacturer!
 	findProductByManufacturerIDAndID(manufacturerID: String!,id: String!,): Product!
 	findProductByUpc(upc: String!,): Product!
-
 }
 
 type _Service {

--- a/_examples/federation/reviews/graph/generated.go
+++ b/_examples/federation/reviews/graph/generated.go
@@ -376,9 +376,8 @@ union _Entity = EmailHost | Manufacturer | Product | User
 
 # fake type to build resolver interfaces for users to implement
 type Entity {
-		findProductByManufacturerIDAndID(manufacturerID: String!,id: String!,): Product!
+	findProductByManufacturerIDAndID(manufacturerID: String!,id: String!,): Product!
 	findUserByID(id: ID!,): User!
-
 }
 
 type _Service {

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -179,7 +179,7 @@ func (f *federation) InjectSourcesEarly() ([]*ast.Source, error) {
 // InjectSourceLate creates a GraphQL Entity type with all
 // the fields that had the @key directive
 func (f *federation) InjectSourcesLate(schema *ast.Schema) ([]*ast.Source, error) {
-	f.setEntities(schema)
+	f.Entities = buildEntities(schema, f.Version)
 
 	var entities, resolvers, entityResolverInputDefinitions string
 	for _, e := range f.Entities {
@@ -430,126 +430,166 @@ func (f *federation) GenerateCode(data *codegen.Data) error {
 	})
 }
 
-func (f *federation) setEntities(schema *ast.Schema) {
+func buildEntities(schema *ast.Schema, version int) []*Entity {
+	entities := make([]*Entity, 0)
 	for _, schemaType := range schema.Types {
-		keys, ok := isFederatedEntity(schemaType)
-		if !ok {
-			continue
+		entity := buildEntity(schemaType, schema, version)
+		if entity != nil {
+			entities = append(entities, entity)
 		}
-
-		if (schemaType.Kind == ast.Interface) && (len(schema.GetPossibleTypes(schemaType)) == 0) {
-			fmt.Printf("@key directive found on unused \"interface %s\". Will be ignored.\n", schemaType.Name)
-			continue
-		}
-
-		e := &Entity{
-			Name:      schemaType.Name,
-			Def:       schemaType,
-			Resolvers: nil,
-			Requires:  nil,
-		}
-
-		// Let's process custom entity resolver settings.
-		dir := schemaType.Directives.ForName("entityResolver")
-		if dir != nil {
-			if dirArg := dir.Arguments.ForName("multi"); dirArg != nil {
-				if dirVal, err := dirArg.Value.Value(nil); err == nil {
-					e.Multi = dirVal.(bool)
-				}
-			}
-		}
-
-		// If our schema has a field with a type defined in
-		// another service, then we need to define an "empty
-		// extend" of that type in this service, so this service
-		// knows what the type is like.  But the graphql-server
-		// will never ask us to actually resolve this "empty
-		// extend", so we don't require a resolver function for
-		// it.  (Well, it will never ask in practice; it's
-		// unclear whether the spec guarantees this.  See
-		// https://github.com/apollographql/apollo-server/issues/3852
-		// ).  Example:
-		//    type MyType {
-		//       myvar: TypeDefinedInOtherService
-		//    }
-		//    // Federation needs this type, but
-		//    // it doesn't need a resolver for it!
-		//    extend TypeDefinedInOtherService @key(fields: "id") {
-		//       id: ID @external
-		//    }
-		if !e.allFieldsAreExternal(f.Version) {
-			for _, dir := range keys {
-				if len(dir.Arguments) > 2 {
-					panic("More than two arguments provided for @key declaration.")
-				}
-				var arg *ast.Argument
-
-				// since keys are able to now have multiple arguments, we need to check both possible for a possible @key(fields="" fields="")
-				for _, a := range dir.Arguments {
-					if a.Name == "fields" {
-						if arg != nil {
-							panic("More than one `fields` provided for @key declaration.")
-						}
-						arg = a
-					}
-				}
-
-				keyFieldSet := fieldset.New(arg.Value.Raw, nil)
-
-				keyFields := make([]*KeyField, len(keyFieldSet))
-				resolverFields := []string{}
-				for i, field := range keyFieldSet {
-					def := field.FieldDefinition(schemaType, schema)
-
-					if def == nil {
-						panic(fmt.Sprintf("no field for %v", field))
-					}
-
-					keyFields[i] = &KeyField{Definition: def, Field: field}
-					resolverFields = append(resolverFields, keyFields[i].Field.ToGo())
-				}
-
-				resolverFieldsToGo := schemaType.Name + "By" + strings.Join(resolverFields, "And")
-				var resolverName string
-				if e.Multi {
-					resolverFieldsToGo += "s" // Pluralize for better API readability
-					resolverName = fmt.Sprintf("findMany%s", resolverFieldsToGo)
-				} else {
-					resolverName = fmt.Sprintf("find%s", resolverFieldsToGo)
-				}
-
-				e.Resolvers = append(e.Resolvers, &EntityResolver{
-					ResolverName:  resolverName,
-					KeyFields:     keyFields,
-					InputTypeName: resolverFieldsToGo + "Input",
-				})
-			}
-
-			e.Requires = []*Requires{}
-			for _, f := range schemaType.Fields {
-				dir := f.Directives.ForName("requires")
-				if dir == nil {
-					continue
-				}
-				if len(dir.Arguments) != 1 || dir.Arguments[0].Name != "fields" {
-					panic("Exactly one `fields` argument needed for @requires declaration.")
-				}
-				requiresFieldSet := fieldset.New(dir.Arguments[0].Value.Raw, nil)
-				for _, field := range requiresFieldSet {
-					e.Requires = append(e.Requires, &Requires{
-						Name:  field.ToGoPrivate(),
-						Field: field,
-					})
-				}
-			}
-		}
-		f.Entities = append(f.Entities, e)
 	}
 
 	// make sure order remains stable across multiple builds
-	sort.Slice(f.Entities, func(i, j int) bool {
-		return f.Entities[i].Name < f.Entities[j].Name
+	sort.Slice(entities, func(i, j int) bool {
+		return entities[i].Name < entities[j].Name
 	})
+
+	return entities
+}
+
+func buildEntity(
+	schemaType *ast.Definition,
+	schema *ast.Schema,
+	version int,
+) *Entity {
+	keys, ok := isFederatedEntity(schemaType)
+	if !ok {
+		return nil
+	}
+
+	if (schemaType.Kind == ast.Interface) && (len(schema.GetPossibleTypes(schemaType)) == 0) {
+		fmt.Printf("@key directive found on unused \"interface %s\". Will be ignored.\n", schemaType.Name)
+		return nil
+	}
+
+	entity := &Entity{
+		Name:      schemaType.Name,
+		Def:       schemaType,
+		Resolvers: nil,
+		Requires:  nil,
+		Multi:     isMultiEntity(schemaType),
+	}
+
+	// If our schema has a field with a type defined in
+	// another service, then we need to define an "empty
+	// extend" of that type in this service, so this service
+	// knows what the type is like.  But the graphql-server
+	// will never ask us to actually resolve this "empty
+	// extend", so we don't require a resolver function for
+	// it.  (Well, it will never ask in practice; it's
+	// unclear whether the spec guarantees this.  See
+	// https://github.com/apollographql/apollo-server/issues/3852
+	// ).  Example:
+	//    type MyType {
+	//       myvar: TypeDefinedInOtherService
+	//    }
+	//    // Federation needs this type, but
+	//    // it doesn't need a resolver for it!
+	//    extend TypeDefinedInOtherService @key(fields: "id") {
+	//       id: ID @external
+	//    }
+	if entity.allFieldsAreExternal(version) {
+		return entity
+	}
+
+	entity.Resolvers = buildResolvers(schemaType, schema, keys, entity.Multi)
+	entity.Requires = buildRequires(schemaType)
+
+	return entity
+}
+
+func isMultiEntity(schemaType *ast.Definition) bool {
+	dir := schemaType.Directives.ForName("entityResolver")
+	if dir == nil {
+		return false
+	}
+
+	if dirArg := dir.Arguments.ForName("multi"); dirArg != nil {
+		if dirVal, err := dirArg.Value.Value(nil); err == nil {
+			return dirVal.(bool)
+		}
+	}
+
+	return false
+}
+
+func buildResolvers(
+	schemaType *ast.Definition,
+	schema *ast.Schema,
+	keys []*ast.Directive,
+	multi bool,
+) []*EntityResolver {
+	resolvers := make([]*EntityResolver, 0)
+	for _, dir := range keys {
+		if len(dir.Arguments) > 2 {
+			panic("More than two arguments provided for @key declaration.")
+		}
+		var arg *ast.Argument
+
+		// since keys are able to now have multiple arguments, we need to check both possible for a possible @key(fields="" fields="")
+		for _, a := range dir.Arguments {
+			if a.Name == "fields" {
+				if arg != nil {
+					panic("More than one `fields` provided for @key declaration.")
+				}
+				arg = a
+			}
+		}
+
+		keyFieldSet := fieldset.New(arg.Value.Raw, nil)
+
+		keyFields := make([]*KeyField, len(keyFieldSet))
+		resolverFields := []string{}
+		for i, field := range keyFieldSet {
+			def := field.FieldDefinition(schemaType, schema)
+
+			if def == nil {
+				panic(fmt.Sprintf("no field for %v", field))
+			}
+
+			keyFields[i] = &KeyField{Definition: def, Field: field}
+			resolverFields = append(resolverFields, keyFields[i].Field.ToGo())
+		}
+
+		resolverFieldsToGo := schemaType.Name + "By" + strings.Join(resolverFields, "And")
+		var resolverName string
+		if multi {
+			resolverFieldsToGo += "s" // Pluralize for better API readability
+			resolverName = fmt.Sprintf("findMany%s", resolverFieldsToGo)
+		} else {
+			resolverName = fmt.Sprintf("find%s", resolverFieldsToGo)
+		}
+
+		resolvers = append(resolvers, &EntityResolver{
+			ResolverName:  resolverName,
+			KeyFields:     keyFields,
+			InputTypeName: resolverFieldsToGo + "Input",
+		})
+	}
+
+	return resolvers
+}
+
+func buildRequires(schemaType *ast.Definition) []*Requires {
+	requires := make([]*Requires, 0)
+	for _, f := range schemaType.Fields {
+		dir := f.Directives.ForName("requires")
+		if dir == nil {
+			continue
+		}
+		if len(dir.Arguments) != 1 || dir.Arguments[0].Name != "fields" {
+			panic("Exactly one `fields` argument needed for @requires declaration.")
+		}
+		requiresFieldSet := fieldset.New(dir.Arguments[0].Value.Raw, nil)
+		for _, field := range requiresFieldSet {
+			requires = append(requires, &Requires{
+				Name:  field.ToGoPrivate(),
+				Field: field,
+			})
+		}
+	}
+
+	return requires
 }
 
 func isFederatedEntity(schemaType *ast.Definition) ([]*ast.Directive, bool) {

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -228,7 +228,7 @@ union _Entity = ` + strings.Join(entities, " | ")
 		}
 		resolversSDL := `# fake type to build resolver interfaces for users to implement
 type Entity {
-	` + strings.Join(resolvers, "\n") + `
+` + strings.Join(resolvers, "\n") + `
 }`
 		blocks = append(blocks, resolversSDL)
 	}

--- a/plugin/federation/testdata/entityresolver/generated/exec.go
+++ b/plugin/federation/testdata/entityresolver/generated/exec.go
@@ -821,26 +821,22 @@ union _Entity = Hello | HelloMultiSingleKeys | HelloWithErrors | MultiHello | Mu
 input MultiHelloByNamesInput {
 	Name: String!
 }
-
 input MultiHelloMultipleRequiresByNamesInput {
 	Name: String!
 }
-
 input MultiHelloRequiresByNamesInput {
 	Name: String!
 }
-
 input MultiHelloWithErrorByNamesInput {
 	Name: String!
 }
-
 input MultiPlanetRequiresNestedByNamesInput {
 	Name: String!
 }
 
 # fake type to build resolver interfaces for users to implement
 type Entity {
-		findHelloByName(name: String!,): Hello!
+	findHelloByName(name: String!,): Hello!
 	findHelloMultiSingleKeysByKey1AndKey2(key1: String!,key2: String!,): HelloMultiSingleKeys!
 	findHelloWithErrorsByName(name: String!,): HelloWithErrors!
 	findManyMultiHelloByNames(reps: [MultiHelloByNamesInput]!): [MultiHello]
@@ -855,7 +851,6 @@ type Entity {
 	findWorldNameByName(name: String!,): WorldName!
 	findWorldWithMultipleKeysByHelloNameAndFoo(helloName: String!,foo: String!,): WorldWithMultipleKeys!
 	findWorldWithMultipleKeysByBar(bar: Int!,): WorldWithMultipleKeys!
-
 }
 
 type _Service {

--- a/plugin/federation/testdata/explicitrequires/generated/exec.go
+++ b/plugin/federation/testdata/explicitrequires/generated/exec.go
@@ -838,26 +838,22 @@ union _Entity = Hello | HelloMultiSingleKeys | HelloWithErrors | MultiHello | Mu
 input MultiHelloByNamesInput {
 	Name: String!
 }
-
 input MultiHelloMultipleRequiresByNamesInput {
 	Name: String!
 }
-
 input MultiHelloRequiresByNamesInput {
 	Name: String!
 }
-
 input MultiHelloWithErrorByNamesInput {
 	Name: String!
 }
-
 input MultiPlanetRequiresNestedByNamesInput {
 	Name: String!
 }
 
 # fake type to build resolver interfaces for users to implement
 type Entity {
-		findHelloByName(name: String!,): Hello!
+	findHelloByName(name: String!,): Hello!
 	findHelloMultiSingleKeysByKey1AndKey2(key1: String!,key2: String!,): HelloMultiSingleKeys!
 	findHelloWithErrorsByName(name: String!,): HelloWithErrors!
 	findManyMultiHelloByNames(reps: [MultiHelloByNamesInput]!): [MultiHello]
@@ -872,7 +868,6 @@ type Entity {
 	findWorldNameByName(name: String!,): WorldName!
 	findWorldWithMultipleKeysByHelloNameAndFoo(helloName: String!,foo: String!,): WorldWithMultipleKeys!
 	findWorldWithMultipleKeysByBar(bar: Int!,): WorldWithMultipleKeys!
-
 }
 
 type _Service {


### PR DESCRIPTION
- Cut functions into smaller functions
- Remove mutation in several locations

This is setting up to make it easier to introduce improvements for #2991.

There are no behavior changes in this PR. There's one small change in how we output the Federation SDL into the generated code that is formatted more accurately than before.