### PR TITLE
[resolvergen] enable rewrite features for single-file mode

### DIFF
--- a/internal/rewrite/rewriter.go
+++ b/internal/rewrite/rewriter.go
@@ -188,7 +188,7 @@ func (r *Rewriter) RemainingSource(filename string) string {
 				continue
 			}
 
-			if d, isGen := d.(*ast.GenDecl); isGen && d.Tok == token.IMPORT {
+			if d, isGen := d.(*ast.GenDecl); isGen && (d.Tok == token.IMPORT || d.Tok == token.VAR || d.Tok == token.TYPE) {
 				continue
 			}
 

--- a/plugin/resolvergen/resolver.go
+++ b/plugin/resolvergen/resolver.go
@@ -53,24 +53,38 @@ func (m *Plugin) GenerateCode(data *codegen.Data) error {
 
 func (m *Plugin) generateSingleFile(data *codegen.Data) error {
 	file := File{}
-
-	if _, err := os.Stat(data.Config.Resolver.Filename); err == nil {
-		// file already exists and we do not support updating resolvers with layout = single so just return
-		return nil
+	rewriter, err := rewrite.New(data.Config.Resolver.Dir())
+	if err != nil {
+		return err
 	}
 
 	for _, o := range data.Objects {
 		if o.HasResolvers() {
+			caser := cases.Title(language.English, cases.NoLower)
+			rewriter.MarkStructCopied(templates.UcFirst(o.Name) + templates.UcFirst(data.Config.Resolver.Type))
+			rewriter.GetMethodBody(data.Config.Resolver.Type, caser.String(o.Name))
+
 			file.Objects = append(file.Objects, o)
 		}
+
 		for _, f := range o.Fields {
 			if !f.IsResolver {
 				continue
 			}
 
-			resolver := Resolver{o, f, nil, "", `panic("not implemented")`, nil}
+			structName := templates.LcFirst(o.Name) + templates.UcFirst(data.Config.Resolver.Type)
+			comment := strings.TrimSpace(strings.TrimLeft(rewriter.GetMethodComment(structName, f.GoFieldName), `\`))
+			implementation := strings.TrimSpace(rewriter.GetMethodBody(structName, f.GoFieldName))
+
+			resolver := Resolver{o, f, rewriter.GetPrevDecl(structName, f.GoFieldName), comment, implementation, nil}
 			file.Resolvers = append(file.Resolvers, &resolver)
 		}
+	}
+
+	if _, err := os.Stat(data.Config.Resolver.Filename); err == nil {
+		file.name = data.Config.Resolver.Filename
+		file.imports = rewriter.ExistingImports(file.name)
+		file.RemainingSource = rewriter.RemainingSource(file.name)
 	}
 
 	resolverBuild := &ResolverBuild{
@@ -88,7 +102,7 @@ func (m *Plugin) generateSingleFile(data *codegen.Data) error {
 
 	return templates.Render(templates.Options{
 		PackageName: data.Config.Resolver.Package,
-		FileNotice:  `// THIS CODE IS A STARTING POINT ONLY. IT WILL NOT BE UPDATED WITH SCHEMA CHANGES.`,
+		FileNotice:  `// THIS CODE WILL BE UPDATED WITH SCHEMA CHANGES. PREVIOUS IMPLEMENTATION FOR SCHEMA CHANGES WILL BE KEPT IN THE COMMENT SECTION. IMPLEMENTATION FOR UNCHANGED SCHEMA WILL BE KEPT.`,
 		Filename:    data.Config.Resolver.Filename,
 		Data:        resolverBuild,
 		Packages:    data.Config.Packages,

--- a/plugin/resolvergen/resolver_test.go
+++ b/plugin/resolvergen/resolver_test.go
@@ -29,6 +29,28 @@ func TestLayoutSingleFile(t *testing.T) {
 	assertNoErrors(t, "github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out")
 }
 
+func TestLayoutSingleFileWhenResolverExists(t *testing.T) {
+	// Ensure the resolver file exists before running the test
+	resolverFilePath := "testdata/singlefile/out/resolver.go"
+	_, err := os.Stat(resolverFilePath)
+	if os.IsNotExist(err) {
+		t.Fatalf("Expected resolver file does not exist: %s", resolverFilePath)
+	}
+	require.NoError(t, err)
+
+	cfg, err := config.LoadConfig("testdata/singlefile/gqlgen.yml")
+	require.NoError(t, err)
+	p := Plugin{}
+
+	require.NoError(t, cfg.Init())
+
+	data, err := codegen.BuildData(cfg)
+	require.NoError(t, err)
+
+	require.NoError(t, p.GenerateCode(data))
+	assertNoErrors(t, "github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out")
+}
+
 func TestLayoutFollowSchema(t *testing.T) {
 	testFollowSchemaPersistence(t, "testdata/followschema")
 

--- a/plugin/resolvergen/testdata/singlefile/out/resolver.go
+++ b/plugin/resolvergen/testdata/singlefile/out/resolver.go
@@ -1,21 +1,22 @@
 package customresolver
 
-// THIS CODE IS A STARTING POINT ONLY. IT WILL NOT BE UPDATED WITH SCHEMA CHANGES.
+// THIS CODE WILL BE UPDATED WITH SCHEMA CHANGES. PREVIOUS IMPLEMENTATION FOR SCHEMA CHANGES WILL BE KEPT IN THE COMMENT SECTION. IMPLEMENTATION FOR UNCHANGED SCHEMA WILL BE KEPT.
 
 import (
 	"context"
+	"fmt"
 )
 
 type CustomResolverType struct{}
 
 // Resolver is the resolver for the resolver field.
 func (r *queryCustomResolverType) Resolver(ctx context.Context) (*Resolver, error) {
-	panic("not implemented")
+	panic(fmt.Errorf("not implemented: Resolver - resolver"))
 }
 
 // Name is the resolver for the name field.
 func (r *resolverCustomResolverType) Name(ctx context.Context, obj *Resolver) (string, error) {
-	panic("not implemented")
+	panic(fmt.Errorf("not implemented: Name - name"))
 }
 
 // Query returns QueryResolver implementation.


### PR DESCRIPTION
Enable rewrite in `single-file` mode, rewrite behaviors are as below:
* When there’s no change on the schema, re-run resolver generators should not move the old code that conforms the resolver interface to the comment.
* When there’s change on a single field, the rest of the resolver.go code that conforms to the resolver interface should not be moved to the comment.
* Only when the functions are no longer valid per the schema change, or functions that do not conform to the resolver.go should be moved to the comment.
* When checking which components to move to the comment, we fix `rewrite.go` to skip `token.VAR` and `token.TYPE` to avoid redeclare errors.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
