### PR TITLE
chore: fix typos in comments, tests and unexported vars

### DIFF
--- a/codegen/config/initialisms.go
+++ b/codegen/config/initialisms.go
@@ -14,7 +14,7 @@ type GoInitialismsConfig struct {
 	Initialisms []string `yaml:"initialisms"`
 }
 
-// setInitialisms adjustes GetInitialisms based on its settings.
+// setInitialisms adjusts GetInitialisms based on its settings.
 func (i GoInitialismsConfig) setInitialisms() {
 	toUse := i.determineGoInitialisms()
 	templates.GetInitialisms = func() map[string]bool {
@@ -22,7 +22,7 @@ func (i GoInitialismsConfig) setInitialisms() {
 	}
 }
 
-// determineGoInitialisms returns the Go initialims to be used, based on its settings.
+// determineGoInitialisms returns the Go initialisms to be used, based on its settings.
 func (i GoInitialismsConfig) determineGoInitialisms() (initialismsToUse map[string]bool) {
 	if i.ReplaceDefaults {
 		initialismsToUse = make(map[string]bool, len(i.Initialisms))

--- a/codegen/config/initialisms_test.go
+++ b/codegen/config/initialisms_test.go
@@ -33,7 +33,7 @@ func TestGoInitialismsConfig(t *testing.T) {
 		assert.Len(t, result, 1)
 		assert.True(t, result["ASDF"])
 	})
-	t.Run("initialism config uppercases the initialsms", func(t *testing.T) {
+	t.Run("initialism config uppercases the initialisms", func(t *testing.T) {
 		tt := GoInitialismsConfig{Initialisms: []string{"asdf"}}
 		result := tt.determineGoInitialisms()
 		assert.True(t, result["ASDF"])

--- a/codegen/field.go
+++ b/codegen/field.go
@@ -229,7 +229,7 @@ func (b *builder) bindField(obj *Object, f *Field) (errret error) {
 }
 
 // findBindTarget attempts to match the name to a field or method on a Type
-// with the following priorites:
+// with the following priorities:
 // 1. Any Fields with a struct tag (see config.StructTag). Errors if more than one match is found
 // 2. Any method or field with a matching name. Errors if more than one match is found
 // 3. Same logic again for embedded fields

--- a/codegen/templates/import_test.go
+++ b/codegen/templates/import_test.go
@@ -41,7 +41,7 @@ func TestImports(t *testing.T) {
 		require.Equal(t, "bar", a.Lookup(aBar))
 		require.Equal(t, "bar1", a.Lookup(bBar))
 
-		t.Run("additionial calls get decollisioned name", func(t *testing.T) {
+		t.Run("additional calls get decollisioned name", func(t *testing.T) {
 			require.Equal(t, "bar1", a.Lookup(bBar))
 		})
 	})

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -675,7 +675,7 @@ func TestWebsocketWithPingPongInterval(t *testing.T) {
 		h := testserver.New()
 		closeFuncCalled := make(chan bool, 1)
 		h.AddTransport(transport.Websocket{
-			MissingPongOk:    false, // default value but beign explicit for test clarity.
+			MissingPongOk:    false, // default value but being explicit for test clarity.
 			PingPongInterval: 5 * time.Millisecond,
 			CloseFunc: func(_ context.Context, _closeCode int) {
 				closeFuncCalled <- true

--- a/graphql/introspection/type_test.go
+++ b/graphql/introspection/type_test.go
@@ -37,7 +37,7 @@ func TestType(t *testing.T) {
 		require.Equal(t, "test", fields[0].Name)
 	})
 
-	t.Run("fields includeDepricated", func(t *testing.T) {
+	t.Run("fields includeDeprecated", func(t *testing.T) {
 		fields := schemaType.Fields(true)
 		require.Len(t, fields, 2)
 		require.Equal(t, "test", fields[0].Name)

--- a/plugin/federation/entity.go
+++ b/plugin/federation/entity.go
@@ -60,7 +60,7 @@ func (e *Entity) isFieldImplicitlyExternal(field *ast.FieldDefinition, federatio
 	if federationVersion != 2 {
 		return false
 	}
-	// TODO: From the spec, it seems like if an entity is not resolvable then it should not only not have a resolver, but should not appear in the _Entitiy union.
+	// TODO: From the spec, it seems like if an entity is not resolvable then it should not only not have a resolver, but should not appear in the _Entity union.
 	// The current implementation is a less drastic departure from the previous behavior, but should probably be reviewed.
 	// See https://www.apollographql.com/docs/federation/subgraph-spec/
 	if e.isResolvable() {

--- a/plugin/federation/readme.md
+++ b/plugin/federation/readme.md
@@ -18,7 +18,7 @@ TODO(miguel): add details.
 
 # Entity resolvers - GetMany entities
 
-The federation plugin implements `GetMany` semantics in which entity resolvers get the entire list of representations that need to be resolved. This functionality is currently optin tho, and to enable it you need to specify the directive `@entityResolver` in the federated entity you want this feature for.  E.g.
+The federation plugin implements `GetMany` semantics in which entity resolvers get the entire list of representations that need to be resolved. This functionality is currently option tho, and to enable it you need to specify the directive `@entityResolver` in the federated entity you want this feature for.  E.g.
 
 ```
 directive @entityResolver(multi: Boolean) on OBJECT

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -389,8 +389,8 @@ func (m *Plugin) generateFields(cfg *config.Config, schemaType *ast.Definition) 
 		}
 
 		name := templates.ToGo(field.Name)
-		if nameOveride := cfg.Models[schemaType.Name].Fields[field.Name].FieldName; nameOveride != "" {
-			name = nameOveride
+		if nameOverride := cfg.Models[schemaType.Name].Fields[field.Name].FieldName; nameOverride != "" {
+			name = nameOverride
 		}
 
 		typ = binder.CopyModifiersFromAst(field.Type, typ)

--- a/plugin/modelgen/testdata/schema.graphql
+++ b/plugin/modelgen/testdata/schema.graphql
@@ -10,15 +10,15 @@ directive @goField(
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION | INTERFACE
 
 type Query {
-    thisShoudlntGetGenerated: Boolean
+    thisShouldntGetGenerated: Boolean
 }
 
 type Mutation {
-    thisShoudlntGetGenerated: Boolean
+    thisShouldntGetGenerated: Boolean
 }
 
 type Subscription {
-    thisShoudlntGetGenerated: Boolean
+    thisShouldntGetGenerated: Boolean
 }
 
 type MissingTypeNotNull implements MissingInterface & ExistingInterface {


### PR DESCRIPTION
The PR corrects spelling mistakes.