### PR TITLE
refactor: decrease indentation in api.ReplacePlugin

### DIFF
--- a/api/option.go
+++ b/api/option.go
@@ -29,19 +29,20 @@ func PrependPlugin(p plugin.Plugin) Option {
 // ReplacePlugin replaces any existing plugin with a matching plugin name
 func ReplacePlugin(p plugin.Plugin) Option {
 	return func(cfg *config.Config, plugins *[]plugin.Plugin) {
-		if plugins != nil {
-			found := false
-			ps := *plugins
-			for i, o := range ps {
-				if p.Name() == o.Name() {
-					ps[i] = p
-					found = true
-				}
-			}
-			if !found {
-				ps = append(ps, p)
-			}
-			*plugins = ps
+		if plugins == nil {
+			return
 		}
+		found := false
+		ps := *plugins
+		for i, o := range ps {
+			if p.Name() == o.Name() {
+				ps[i] = p
+				found = true
+			}
+		}
+		if !found {
+			ps = append(ps, p)
+		}
+		*plugins = ps
 	}
 }

--- a/api/option_test.go
+++ b/api/option_test.go
@@ -53,6 +53,10 @@ func TestReplacePlugin(t *testing.T) {
 		require.EqualValues(t, resolvergen.New(), pg[1])
 		require.EqualValues(t, expectedPlugin, pg[2])
 	})
+
+	t.Run("do nothing if plugins is nil", func(t *testing.T) {
+		ReplacePlugin(&testPlugin{})(config.DefaultConfig(), nil)
+	})
 }
 
 func TestPrependPlugin(t *testing.T) {


### PR DESCRIPTION
The PR refactors `api.ReplacePlugin` to return early when `plugins` is `nil`. This reduces indentation.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
