### PR TITLE
only close websocket once

### DIFF
--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -239,7 +239,6 @@ func (c *wsConnection) run() {
 	ctx, cancel := context.WithCancel(c.ctx)
 	defer func() {
 		cancel()
-		c.close(websocket.CloseAbnormalClosure, "unexpected closure")
 	}()
 
 	// If we're running in graphql-ws mode, create a timer that will trigger a


### PR DESCRIPTION
Fixes https://github.com/99designs/gqlgen/issues/2604

I have:
 - Removed the defer `c.close(websocket.CloseAbnormalClosure, "unexpected closure")` since `c.close()` is also triggered via `go c.closeOnCancel(ctx)` on line 281. This seems to have fixed the dual firing of a supplied closefunction for me, where the exit of the for loop on line 291 would fire the close function twice (via the defer directly, but also via `go c.closeOnCancel(ctx)` indirectly triggered by the defer). I will however point to line 305 and line 317, where the loop is also exited with explicit closures. I have not run into those lines in the debugger, but i would actually have expected those places to fire `c.close()` three times before, and now instead two times (probably still too many).
Let me know if i can add this expected behavior to existing tests.
