### PR TITLE
Adding entity resolver fix for entityResolver(multi: true) directive

### DIFF
--- a/codegen/directives.gotpl
+++ b/codegen/directives.gotpl
@@ -18,8 +18,11 @@
 					{{- end }}
 			{{- end }}
 			if ec.directives.{{$directive.Name|ucFirst}} == nil {
-				var zeroVal {{$zeroVal}}
-				return zeroVal, errors.New("directive {{$directive.Name}} is not implemented")
+				{{- if ne $directive.Name "entityResolver" }}
+					return nil, errors.New("directive {{$directive.Name}} is not implemented")
+				{{- else }}
+					return directive{{ $i }}(ctx)
+				{{- end }}
 			}
 			return ec.directives.{{$directive.Name|ucFirst}}({{$directive.ResolveArgs $in $i }})
 		}

--- a/codegen/directives.gotpl
+++ b/codegen/directives.gotpl
@@ -19,7 +19,8 @@
 			{{- end }}
 			if ec.directives.{{$directive.Name|ucFirst}} == nil {
 				{{- if ne $directive.Name "entityResolver" }}
-					return nil, errors.New("directive {{$directive.Name}} is not implemented")
+					var zeroVal {{$zeroVal}}
+					return zeroVal, errors.New("directive {{$directive.Name}} is not implemented")
 				{{- else }}
 					return directive{{ $i }}(ctx)
 				{{- end }}

--- a/codegen/directives.gotpl
+++ b/codegen/directives.gotpl
@@ -18,12 +18,8 @@
 					{{- end }}
 			{{- end }}
 			if ec.directives.{{$directive.Name|ucFirst}} == nil {
-				{{- if ne $directive.Name "entityResolver" }}
-					var zeroVal {{$zeroVal}}
-					return zeroVal, errors.New("directive {{$directive.Name}} is not implemented")
-				{{- else }}
-					return directive{{ $i }}(ctx)
-				{{- end }}
+				var zeroVal {{$zeroVal}}
+				return zeroVal, errors.New("directive {{$directive.Name}} is not implemented")
 			}
 			return ec.directives.{{$directive.Name|ucFirst}}({{$directive.ResolveArgs $in $i }})
 		}

--- a/integration/src/generated/fragment-masking.ts
+++ b/integration/src/generated/fragment-masking.ts
@@ -19,7 +19,17 @@ export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: FragmentType<DocumentTypeDecoration<TType, any>>
 ): TType;
+// return nullable if `fragmentType` is undefined
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | undefined
+): TType | undefined;
 // return nullable if `fragmentType` is nullable
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null
+): TType | null;
+// return nullable if `fragmentType` is nullable or undefined
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null | undefined
@@ -27,17 +37,27 @@ export function useFragment<TType>(
 // return array of non-nullable if `fragmentType` is array of non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>>
+): Array<TType>;
+// return array of nullable if `fragmentType` is array of nullable
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+): Array<TType> | null | undefined;
+// return readonly array of non-nullable if `fragmentType` is array of non-nullable
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>
 ): ReadonlyArray<TType>;
-// return array of nullable if `fragmentType` is array of nullable
+// return readonly array of nullable if `fragmentType` is array of nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
 ): ReadonlyArray<TType> | null | undefined;
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
-): TType | ReadonlyArray<TType> | null | undefined {
+  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | Array<FragmentType<DocumentTypeDecoration<TType, any>>> | ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+): TType | Array<TType> | ReadonlyArray<TType> | null | undefined {
   return fragmentType as any;
 }
 

--- a/integration/src/generated/graphql.ts
+++ b/integration/src/generated/graphql.ts
@@ -9,7 +9,7 @@ export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> =
 export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string | number; output: string; }
+  ID: { input: string; output: string; }
   String: { input: string; output: string; }
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
@@ -142,10 +142,10 @@ export type PathQuery = { __typename?: 'Query', path?: Array<{ __typename?: 'Ele
 export type ViewerQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ViewerQuery = { __typename?: 'Query', viewer?: { __typename?: 'Viewer', user?: ( { __typename?: 'User', name: string, phoneNumber?: string | null, query: { __typename?: 'Query', jsonEncoding: string } } & (
+export type ViewerQuery = { __typename?: 'Query', viewer?: { __typename?: 'Viewer', user?: { __typename?: 'User', name: string, phoneNumber?: string | null, query: { __typename?: 'Query', jsonEncoding: string } } & (
       { __typename?: 'User' }
       & { ' $fragmentRefs'?: { 'UserFragmentFragment': Incremental<UserFragmentFragment> } }
-    ) ) | null } | null };
+    ) | null } | null };
 
 export type UserFragmentFragment = { __typename?: 'User', likes: Array<string> } & { ' $fragmentName'?: 'UserFragmentFragment' };
 

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -83,6 +83,7 @@ func (f *federation) MutateConfig(cfg *config.Config) error {
 	cfg.Directives["provides"] = config.DirectiveConfig{SkipRuntime: true}
 	cfg.Directives["key"] = config.DirectiveConfig{SkipRuntime: true}
 	cfg.Directives["extends"] = config.DirectiveConfig{SkipRuntime: true}
+	cfg.Directives["entityResolver"] = config.DirectiveConfig{SkipRuntime: true}
 
 	// Federation 2 specific directives
 	if f.Version == 2 {

--- a/plugin/federation/testdata/entityresolver/generated/exec.go
+++ b/plugin/federation/testdata/entityresolver/generated/exec.go
@@ -1804,8 +1804,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloByNames(ctx context.Contex
 				return zeroVal, err
 			}
 			if ec.directives.EntityResolver == nil {
-				var zeroVal []*model.MultiHello
-				return zeroVal, errors.New("directive entityResolver is not implemented")
+				return directive0(ctx)
 			}
 			return ec.directives.EntityResolver(ctx, nil, directive0, multi)
 		}
@@ -1887,8 +1886,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloMultipleRequiresByNames(ct
 				return zeroVal, err
 			}
 			if ec.directives.EntityResolver == nil {
-				var zeroVal []*model.MultiHelloMultipleRequires
-				return zeroVal, errors.New("directive entityResolver is not implemented")
+				return directive0(ctx)
 			}
 			return ec.directives.EntityResolver(ctx, nil, directive0, multi)
 		}
@@ -1976,8 +1974,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloRequiresByNames(ctx contex
 				return zeroVal, err
 			}
 			if ec.directives.EntityResolver == nil {
-				var zeroVal []*model.MultiHelloRequires
-				return zeroVal, errors.New("directive entityResolver is not implemented")
+				return directive0(ctx)
 			}
 			return ec.directives.EntityResolver(ctx, nil, directive0, multi)
 		}
@@ -2063,8 +2060,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloWithErrorByNames(ctx conte
 				return zeroVal, err
 			}
 			if ec.directives.EntityResolver == nil {
-				var zeroVal []*model.MultiHelloWithError
-				return zeroVal, errors.New("directive entityResolver is not implemented")
+				return directive0(ctx)
 			}
 			return ec.directives.EntityResolver(ctx, nil, directive0, multi)
 		}
@@ -2146,8 +2142,7 @@ func (ec *executionContext) _Entity_findManyMultiPlanetRequiresNestedByNames(ctx
 				return zeroVal, err
 			}
 			if ec.directives.EntityResolver == nil {
-				var zeroVal []*model.MultiPlanetRequiresNested
-				return zeroVal, errors.New("directive entityResolver is not implemented")
+				return directive0(ctx)
 			}
 			return ec.directives.EntityResolver(ctx, nil, directive0, multi)
 		}

--- a/plugin/federation/testdata/explicitrequires/generated/exec.go
+++ b/plugin/federation/testdata/explicitrequires/generated/exec.go
@@ -1257,8 +1257,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloByNames(ctx context.Contex
 				return zeroVal, err
 			}
 			if ec.directives.EntityResolver == nil {
-				var zeroVal []*MultiHello
-				return zeroVal, errors.New("directive entityResolver is not implemented")
+				return directive0(ctx)
 			}
 			return ec.directives.EntityResolver(ctx, nil, directive0, multi)
 		}
@@ -1340,8 +1339,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloMultipleRequiresByNames(ct
 				return zeroVal, err
 			}
 			if ec.directives.EntityResolver == nil {
-				var zeroVal []*MultiHelloMultipleRequires
-				return zeroVal, errors.New("directive entityResolver is not implemented")
+				return directive0(ctx)
 			}
 			return ec.directives.EntityResolver(ctx, nil, directive0, multi)
 		}
@@ -1429,8 +1427,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloRequiresByNames(ctx contex
 				return zeroVal, err
 			}
 			if ec.directives.EntityResolver == nil {
-				var zeroVal []*MultiHelloRequires
-				return zeroVal, errors.New("directive entityResolver is not implemented")
+				return directive0(ctx)
 			}
 			return ec.directives.EntityResolver(ctx, nil, directive0, multi)
 		}
@@ -1516,8 +1513,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloWithErrorByNames(ctx conte
 				return zeroVal, err
 			}
 			if ec.directives.EntityResolver == nil {
-				var zeroVal []*MultiHelloWithError
-				return zeroVal, errors.New("directive entityResolver is not implemented")
+				return directive0(ctx)
 			}
 			return ec.directives.EntityResolver(ctx, nil, directive0, multi)
 		}
@@ -1599,8 +1595,7 @@ func (ec *executionContext) _Entity_findManyMultiPlanetRequiresNestedByNames(ctx
 				return zeroVal, err
 			}
 			if ec.directives.EntityResolver == nil {
-				var zeroVal []*MultiPlanetRequiresNested
-				return zeroVal, errors.New("directive entityResolver is not implemented")
+				return directive0(ctx)
 			}
 			return ec.directives.EntityResolver(ctx, nil, directive0, multi)
 		}


### PR DESCRIPTION
A fix for the issue described in [issue 3160](https://github.com/99designs/gqlgen/issues/3160). If the multi entity is used in any other resolver the error would always be thrown, now it is just skipped. The multi entity resolver has the directive set and runs it, the other resolvers don't have it set so it gets skipped and works as expected.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
