### PR TITLE
support alias type in templates

### DIFF
--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -706,6 +706,8 @@ func TypeIdentifier(t types.Type) string {
 	res := ""
 	for {
 		switch it := code.Unalias(t).(type) {
+		case *types.Alias:
+			return TypeIdentifier(it.Underlying())
 		case *types.Pointer:
 			t.Underlying()
 			res += "ᚖ"

--- a/codegen/templates/templates_test.go
+++ b/codegen/templates/templates_test.go
@@ -381,3 +381,16 @@ func TestTypeName(t *testing.T) {
 		assert.Equal(t, test.expected, result)
 	}
 }
+
+func TestTypeIdentifierWithAlias(t *testing.T) {
+	pkg := types.NewPackage("example.com/pkg", "pkg")
+
+	basicType := types.Typ[types.String]
+	aliasType := types.NewAlias(types.NewTypeName(0, pkg, "MyAlias", nil), basicType)
+	namedType := types.NewNamed(types.NewTypeName(0, pkg, "MyType", nil), aliasType, nil)
+	result := TypeIdentifier(namedType)
+
+	expected := "exampleᚗcomᚋpkgᚐMyType"
+
+	assert.Equal(t, expected, result, "TypeIdentifier should handle alias types correctly")
+}


### PR DESCRIPTION
Solves the issue #3263 

Currently alias types are not supported as TypeIdentifiers. This PR adds a handler for the `types.Alias` type by recursively calling the `TypeIdentifier` function with the underlying type.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
