### PR TITLE
feat: support graphiql playground defaultQuery property

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Our [discord](https://discord.gg/DYEq3EMs4U) server is the best place to ask que
 
 ## Reporting Bugs and Issues
 
- We use [GitHub Issues](https://github.com/99designs/gqlgen/issues) to track bugs, so please do a search before submitting to ensure your problem isn't already tracked.
+We use [GitHub Issues](https://github.com/99designs/gqlgen/issues) to track bugs, so please do a search before submitting to ensure your problem isn't already tracked.
 
 ### New Issues
 
@@ -16,11 +16,11 @@ Please provide the expected and observed behaviours in your issue. A minimal Gra
 
 ## Proposing a Change
 
-If you intend to implement a feature for gqlgen, or make a non-trivial change to the current implementation, we recommend [first filing an issue](https://github.com/99designs/gqlgen/issues/new) marked with the `proposal` tag, so that the engineering team can provide guidance and feedback on the direction of an implementation.  This also help ensure that other people aren't also working on the same thing.
+If you intend to implement a feature for gqlgen, or make a non-trivial change to the current implementation, we recommend [first filing an issue](https://github.com/99designs/gqlgen/issues/new) marked with the `proposal` tag, so that the engineering team can provide guidance and feedback on the direction of an implementation. This also help ensure that other people aren't also working on the same thing.
 
 Bug fixes are welcome and should come with appropriate test coverage.
 
-New features should be made against the `next` branch.
+New features should be made against the `master` branch.
 
 ### License
 

--- a/graphql/playground/altair_playground.go
+++ b/graphql/playground/altair_playground.go
@@ -64,7 +64,7 @@ var altairPage = template.Must(template.New("altair").Parse(`<!doctype html>
 </html>`))
 
 // AltairHandler responsible for setting up the altair playground
-func AltairHandler(title, endpoint string) http.HandlerFunc {
+func AltairHandler(title, endpoint string, options ...func(*PlaygroundOpts)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		err := altairPage.Execute(w, map[string]any{
 			"title":                title,

--- a/graphql/playground/apollo_sandbox_playground_test.go
+++ b/graphql/playground/apollo_sandbox_playground_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestApolloSandboxHandler_Integrity(t *testing.T) {
-	testResourceIntegrity(t, func(title, endpoint string) http.HandlerFunc {
+	testResourceIntegrity(t, func(title, endpoint string, options ...func(*PlaygroundOpts)) http.HandlerFunc {
 		return ApolloSandboxHandler(title, endpoint)
 	})
 }

--- a/graphql/playground/helper_test.go
+++ b/graphql/playground/helper_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testResourceIntegrity(t *testing.T, handler func(title, endpoint string) http.HandlerFunc) {
+func testResourceIntegrity(t *testing.T, handler func(title, endpoint string, options ...func(*PlaygroundOpts)) http.HandlerFunc) {
 	recorder := httptest.NewRecorder()
 	request := httptest.NewRequest(http.MethodGet, "http://localhost:8080/", http.NoBody)
 	handler("example.org API", "/query").ServeHTTP(recorder, request)


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

I've added the option to add customQuery to the GraphiQL playground, to allow override of the default message.


- Preserved backward compatibility
- Added Opts for additional features
- Fixed CONTRIBUTION.md (`next` branch doesn't exist)


![Screenshot 2024-09-11 at 20 17 44](https://github.com/user-attachments/assets/03b2d457-cdab-4140-92f6-effaffd7799c)


I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
