### PR TITLE
[resolvergen] make single file with rewrite the default state and update type_system_extensions example

### DIFF
--- a/_examples/type-system-extension/gqlgen.yml
+++ b/_examples/type-system-extension/gqlgen.yml
@@ -10,6 +10,3 @@ exec:
   filename: generated.go
 model:
   filename: models_gen.go
-resolver:
-  filename: resolver.go
-  type: Resolver

--- a/plugin/resolvergen/resolver.go
+++ b/plugin/resolvergen/resolver.go
@@ -53,24 +53,38 @@ func (m *Plugin) GenerateCode(data *codegen.Data) error {
 
 func (m *Plugin) generateSingleFile(data *codegen.Data) error {
 	file := File{}
-
-	if _, err := os.Stat(data.Config.Resolver.Filename); err == nil {
-		// file already exists and we do not support updating resolvers with layout = single so just return
-		return nil
+	rewriter, err := rewrite.New(data.Config.Resolver.Dir())
+	if err != nil {
+		return err
 	}
 
 	for _, o := range data.Objects {
 		if o.HasResolvers() {
+			caser := cases.Title(language.English, cases.NoLower)
+			rewriter.MarkStructCopied(templates.LcFirst(o.Name) + templates.UcFirst(data.Config.Resolver.Type))
+			rewriter.GetMethodBody(data.Config.Resolver.Type, caser.String(o.Name))
+
 			file.Objects = append(file.Objects, o)
 		}
+
 		for _, f := range o.Fields {
 			if !f.IsResolver {
 				continue
 			}
 
-			resolver := Resolver{o, f, nil, "", `panic("not implemented")`, nil}
+			structName := templates.LcFirst(o.Name) + templates.UcFirst(data.Config.Resolver.Type)
+			comment := strings.TrimSpace(strings.TrimLeft(rewriter.GetMethodComment(structName, f.GoFieldName), `\`))
+			implementation := strings.TrimSpace(rewriter.GetMethodBody(structName, f.GoFieldName))
+
+			resolver := Resolver{o, f, rewriter.GetPrevDecl(structName, f.GoFieldName), comment, implementation, nil}
 			file.Resolvers = append(file.Resolvers, &resolver)
 		}
+	}
+
+	if _, err := os.Stat(data.Config.Resolver.Filename); err == nil {
+		file.name = data.Config.Resolver.Filename
+		file.imports = rewriter.ExistingImports(file.name)
+		file.RemainingSource = rewriter.RemainingSource(file.name)
 	}
 
 	resolverBuild := &ResolverBuild{
@@ -88,7 +102,7 @@ func (m *Plugin) generateSingleFile(data *codegen.Data) error {
 
 	return templates.Render(templates.Options{
 		PackageName: data.Config.Resolver.Package,
-		FileNotice:  `// THIS CODE IS A STARTING POINT ONLY. IT WILL NOT BE UPDATED WITH SCHEMA CHANGES.`,
+		FileNotice:  `// THIS CODE WILL BE UPDATED WITH SCHEMA CHANGES. PREVIOUS IMPLEMENTATION FOR SCHEMA CHANGES WILL BE KEPT IN THE COMMENT SECTION. IMPLEMENTATION FOR UNCHANGED SCHEMA WILL BE KEPT.`,
 		Filename:    data.Config.Resolver.Filename,
 		Data:        resolverBuild,
 		Packages:    data.Config.Packages,

--- a/plugin/resolvergen/resolver.gotpl
+++ b/plugin/resolvergen/resolver.gotpl
@@ -48,5 +48,7 @@
 	//  - When renaming or deleting a resolver the old code will be put in here. You can safely delete
 	//    it when you're done.
 	//  - You have helper methods in this file. Move them out to keep these resolver files clean.
+	/*
 	{{ .RemainingSource }}
+	*/
 {{ end }}

--- a/plugin/resolvergen/testdata/singlefile/out/resolver.go
+++ b/plugin/resolvergen/testdata/singlefile/out/resolver.go
@@ -1,21 +1,22 @@
 package customresolver
 
-// THIS CODE IS A STARTING POINT ONLY. IT WILL NOT BE UPDATED WITH SCHEMA CHANGES.
+// THIS CODE WILL BE UPDATED WITH SCHEMA CHANGES. PREVIOUS IMPLEMENTATION FOR SCHEMA CHANGES WILL BE KEPT IN THE COMMENT SECTION. IMPLEMENTATION FOR UNCHANGED SCHEMA WILL BE KEPT.
 
 import (
 	"context"
+	"fmt"
 )
 
 type CustomResolverType struct{}
 
 // Resolver is the resolver for the resolver field.
 func (r *queryCustomResolverType) Resolver(ctx context.Context) (*Resolver, error) {
-	panic("not implemented")
+	panic(fmt.Errorf("not implemented: Resolver - resolver"))
 }
 
 // Name is the resolver for the name field.
 func (r *resolverCustomResolverType) Name(ctx context.Context, obj *Resolver) (string, error) {
-	panic("not implemented")
+	panic(fmt.Errorf("not implemented: Name - name"))
 }
 
 // Query returns QueryResolver implementation.


### PR DESCRIPTION
As discussed in [this pull request](https://github.com/99designs/gqlgen/pull/3243), we eventually want to update single-file mode with rewrite feature since no one relies on single files not supporting rewrite. Using the existing rewrite functionality should remain backward-compatible, eliminating the need for a new `enable_rewrite_for_single_file` flag.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
