### PR TITLE
Accept event-stream for POST for urql-graphql

### DIFF
--- a/graphql/handler/transport/http_post.go
+++ b/graphql/handler/transport/http_post.go
@@ -27,10 +27,6 @@ func (h POST) Supports(r *http.Request) bool {
 		return false
 	}
 
-	if strings.Contains(r.Header.Get("Accept"), "text/event-stream") {
-		return false
-	}
-
 	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
 	if err != nil {
 		return false

--- a/graphql/handler/transport/http_post_test.go
+++ b/graphql/handler/transport/http_post_test.go
@@ -109,8 +109,8 @@ func TestPOST(t *testing.T) {
 		}
 
 		resp := doReq(h, "POST", "/graphql", `{"query":"{ name }"}`)
-		assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
-		assert.Equal(t, `{"errors":[{"message":"transport not supported"}],"data":null}`, resp.Body.String())
+		assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+		assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
 	})
 }
 


### PR DESCRIPTION
Fix #3275

There was an attempt to support SSE, but it broke HTTP POST.

#3153 added the following to the HTTP POST transport:

https://github.com/99designs/gqlgen/blob/4157ef997ff03647fe4ff9ede27b505fc098932f/graphql/handler/transport/http_post.go#L30-L32

From a general HTTP point of view though, the `Accept` header is there to communicate which content types the client _can_ understand, and indeed clients like javascript's `urql` advertise that they can understand SSE, even when the server is only set up to support POST.   The presence of `text/event-stream` in the client's accept header shouldn't mean that the request _can't_ be served by HTTP POST.

For instance, the javascript client `urql`, has this header hardcoded for every request:

https://github.com/urql-graphql/urql/blob/b9f34fd19ee5f9022db4d2f9eb610943c787dac1/packages/core/src/internal/fetchOptions.ts#L149-L154

```ts
const headers: HeadersInit = {
    accept:
      operation.kind === 'subscription'
        ? 'text/event-stream, multipart/mixed'
        : 'application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed',
  };
```


Signed-off-by: Steve Coffman <steve@khanacademy.org>
