### PR TITLE
SSE Transport must be inserted before POST, so add convenience for using the DefaultServer

### DIFF
--- a/graphql/handler.go
+++ b/graphql/handler.go
@@ -93,6 +93,7 @@ type (
 	Transport interface {
 		Supports(r *http.Request) bool
 		Do(w http.ResponseWriter, r *http.Request, exec GraphExecutor)
+		String() string
 	}
 )
 

--- a/graphql/handler/server_test.go
+++ b/graphql/handler/server_test.go
@@ -166,6 +166,12 @@ func TestErrorServer(t *testing.T) {
 
 type panicTransport struct{}
 
+var _ graphql.Transport = panicTransport{}
+
+func (t panicTransport) String() string {
+	return "panicTransport"
+}
+
 func (t panicTransport) Supports(r *http.Request) bool {
 	return true
 }

--- a/graphql/handler/transport/http_form_multipart.go
+++ b/graphql/handler/transport/http_form_multipart.go
@@ -28,6 +28,10 @@ type MultipartForm struct {
 
 var _ graphql.Transport = MultipartForm{}
 
+func (f MultipartForm) String() string {
+	return "MultipartForm"
+}
+
 func (f MultipartForm) Supports(r *http.Request) bool {
 	if r.Header.Get("Upgrade") != "" {
 		return false

--- a/graphql/handler/transport/http_form_urlencoded.go
+++ b/graphql/handler/transport/http_form_urlencoded.go
@@ -21,6 +21,10 @@ type UrlEncodedForm struct {
 
 var _ graphql.Transport = UrlEncodedForm{}
 
+func (h UrlEncodedForm) String() string {
+	return "UrlEncodedForm"
+}
+
 func (h UrlEncodedForm) Supports(r *http.Request) bool {
 	if r.Header.Get("Upgrade") != "" {
 		return false

--- a/graphql/handler/transport/http_get.go
+++ b/graphql/handler/transport/http_get.go
@@ -24,6 +24,10 @@ type GET struct {
 
 var _ graphql.Transport = GET{}
 
+func (h GET) String() string {
+	return "GET"
+}
+
 func (h GET) Supports(r *http.Request) bool {
 	if r.Header.Get("Upgrade") != "" {
 		return false

--- a/graphql/handler/transport/http_graphql.go
+++ b/graphql/handler/transport/http_graphql.go
@@ -23,6 +23,10 @@ type GRAPHQL struct {
 
 var _ graphql.Transport = GRAPHQL{}
 
+func (h GRAPHQL) String() string {
+	return "GRAPHQL"
+}
+
 func (h GRAPHQL) Supports(r *http.Request) bool {
 	if r.Header.Get("Upgrade") != "" {
 		return false

--- a/graphql/handler/transport/http_post.go
+++ b/graphql/handler/transport/http_post.go
@@ -22,6 +22,10 @@ type POST struct {
 
 var _ graphql.Transport = POST{}
 
+func (h POST) String() string {
+	return "POST"
+}
+
 func (h POST) Supports(r *http.Request) bool {
 	if r.Header.Get("Upgrade") != "" {
 		return false

--- a/graphql/handler/transport/options.go
+++ b/graphql/handler/transport/options.go
@@ -15,6 +15,10 @@ type Options struct {
 
 var _ graphql.Transport = Options{}
 
+func (o Options) String() string {
+	return "Options"
+}
+
 func (o Options) Supports(r *http.Request) bool {
 	return r.Method == "HEAD" || r.Method == "OPTIONS"
 }

--- a/graphql/handler/transport/sse.go
+++ b/graphql/handler/transport/sse.go
@@ -18,6 +18,10 @@ type SSE struct{}
 
 var _ graphql.Transport = SSE{}
 
+func (t SSE) String() string {
+	return "SSE"
+}
+
 func (t SSE) Supports(r *http.Request) bool {
 	if !strings.Contains(r.Header.Get("Accept"), "text/event-stream") {
 		return false

--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -86,6 +86,10 @@ var (
 	_ error             = WebsocketError{}
 )
 
+func (t Websocket) String() string {
+	return "Websocket"
+}
+
 func (t Websocket) Supports(r *http.Request) bool {
 	return r.Header.Get("Upgrade") != ""
 }


### PR DESCRIPTION
Replacement for #3153 to allow upgrade from POST request to SSE transport response

In order to enable the experimental Server-Sent Events (SSE) transport, you need to have the precedence before the POST transport, but many folks use the DefaultServer which only allows Adding (appending) transports.

This adds convenience methods to the server to both prepend (which is NOT appropriate for SSE) and a special one for inserting right before POST (which is ideal for SSE).

Signed-off-by: Steve Coffman <steve@khanacademy.org>
