### PR TITLE
Call `Unalias()` in `IsNilable()` to support `gotypesalias=1`

### DIFF
--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -520,7 +520,10 @@ func (b *Binder) CopyModifiersFromAst(t *ast.Type, base types.Type) types.Type {
 }
 
 func IsNilable(t types.Type) bool {
-	t = code.Unalias(t)
+	// Note that we use types.Unalias rather than code.Unalias here
+	// because we want to always check the underlying type.
+	// code.Unalias only unwraps aliases in Go 1.23
+	t = types.Unalias(t)
 	if namedType, isNamed := t.(*types.Named); isNamed {
 		return IsNilable(namedType.Underlying())
 	}

--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -520,6 +520,7 @@ func (b *Binder) CopyModifiersFromAst(t *ast.Type, base types.Type) types.Type {
 }
 
 func IsNilable(t types.Type) bool {
+	t = code.Unalias(t)
 	if namedType, isNamed := t.(*types.Named); isNamed {
 		return IsNilable(namedType.Underlying())
 	}

--- a/codegen/config/binder_test.go
+++ b/codegen/config/binder_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"go/token"
 	"go/types"
 	"testing"
 
@@ -266,6 +267,11 @@ func TestEnumBinding(t *testing.T) {
 	require.Equal(t, cf.Schema.Types["Baz"].EnumValues[1], baz.EnumValues[1].Definition)
 }
 
+func createTypeAlias(name string, t types.Type) *types.Alias {
+	var nopos token.Pos
+	return types.NewAlias(types.NewTypeName(nopos, nil, name, nil), t)
+}
+
 func TestIsNilable(t *testing.T) {
 	type aTest struct {
 		input    types.Type
@@ -285,6 +291,10 @@ func TestIsNilable(t *testing.T) {
 		{types.NewMap(types.Typ[types.Int], types.Typ[types.Int]), true},
 		{types.NewSlice(types.Typ[types.Int]), true},
 		{types.NewInterfaceType(nil, nil), true},
+		{createTypeAlias("interfaceAlias", types.NewInterfaceType(nil, nil)), true},
+		{createTypeAlias("interfaceNestedAlias", createTypeAlias("interfaceAlias", types.NewInterfaceType(nil, nil))), true},
+		{createTypeAlias("intAlias", types.Typ[types.Int]), false},
+		{createTypeAlias("intNestedAlias", createTypeAlias("intAlias", types.Typ[types.Int])), false},
 	}
 
 	for _, at := range theTests {


### PR DESCRIPTION
Fixed false `IsNilable()` value for any (or any other aliased type) when `gotypesalias=1` (default since Go 1.23.0)
Fixes #3301

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
