### PR TITLE
feat: Embed template for root file generation

### DIFF
--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -4,9 +4,7 @@ import (
 	"embed"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/vektah/gqlparser/v2/ast"
@@ -129,24 +127,18 @@ func addBuild(filename string, p *ast.Position, data *Data, builds *map[string]*
 	}
 }
 
+// go:embed root_.gotpl
+var rootTemplate string
+
 // Root file contains top-level definitions that should not be duplicated across the generated
 // files for each schema file.
 func generateRootFile(data *Data) error {
 	dir := data.Config.Exec.DirName
 	path := filepath.Join(dir, "root_.generated.go")
 
-	_, thisFile, _, _ := runtime.Caller(0)
-	rootDir := filepath.Dir(thisFile)
-	templatePath := filepath.Join(rootDir, "root_.gotpl")
-	templateBytes, err := os.ReadFile(templatePath)
-	if err != nil {
-		return err
-	}
-	template := string(templateBytes)
-
 	return templates.Render(templates.Options{
 		PackageName:     data.Config.Exec.Package,
-		Template:        template,
+		Template:        rootTemplate,
 		Filename:        path,
 		Data:            data,
 		RegionTags:      false,

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -127,7 +127,7 @@ func addBuild(filename string, p *ast.Position, data *Data, builds *map[string]*
 	}
 }
 
-// go:embed root_.gotpl
+//go:embed root_.gotpl
 var rootTemplate string
 
 // Root file contains top-level definitions that should not be duplicated across the generated


### PR DESCRIPTION
This PR embeds the `root_.gotpl` file used for generating the rootFile rather than searching for that template at runtime. This change will allow codegen to be packaged as part of a binary without relying on root_.gotpl existing within the user's local file structure.

This PR will resolve this issue: https://github.com/99designs/gqlgen/issues/3168

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
