### PR TITLE
fix: Ensure that nil http responses don't cause issues

### DIFF
--- a/graphql/handler/debug/tracer.go
+++ b/graphql/handler/debug/tracer.go
@@ -61,9 +61,12 @@ func (a Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 	resp := next(ctx)
 
 	_, _ = fmt.Fprintln(a.out, "  resp:", aurora.Green(stringify(resp)))
-	for _, err := range resp.Errors {
-		_, _ = fmt.Fprintln(a.out, "  error:", aurora.Bold(err.Path.String()+":"), aurora.Red(err.Message))
+	if resp != nil {
+		for _, err := range resp.Errors {
+			_, _ = fmt.Fprintln(a.out, "  error:", aurora.Bold(err.Path.String()+":"), aurora.Red(err.Message))
+		}
 	}
+
 	_, _ = fmt.Fprintln(a.out, "}")
 	_, _ = fmt.Fprintln(a.out)
 	return resp


### PR DESCRIPTION
In https://github.com/99designs/gqlgen/issues/3328, I investigated a debug error which had stopped local subscription development. This PR adds a simple `nil` guard around the problematic statement. 

I tested this PR  with our local setup and it solved our issues

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

Fixes #3328
