### PR TITLE
feat: add ability to unmarshal Upload from map[string]interface

### DIFF
--- a/graphql/upload.go
+++ b/graphql/upload.go
@@ -1,15 +1,20 @@
 package graphql
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 )
 
+var (
+	invalidUpload = "%T is not an Upload"
+)
+
 type Upload struct {
-	File        io.ReadSeeker
-	Filename    string
-	Size        int64
-	ContentType string
+	File        io.ReadSeeker `json:"file"`
+	Filename    string        `json:"filename"`
+	Size        int64         `json:"size"`
+	ContentType string        `json:"contentType"`
 }
 
 func MarshalUpload(f Upload) Marshaler {
@@ -18,10 +23,39 @@ func MarshalUpload(f Upload) Marshaler {
 	})
 }
 
+// UnmarshalUpload reads an Upload from a JSON-encoded value.
 func UnmarshalUpload(v any) (Upload, error) {
-	upload, ok := v.(Upload)
-	if !ok {
-		return Upload{}, fmt.Errorf("%T is not an Upload", v)
+	switch t := v.(type) {
+	case Upload:
+		return t, nil
+	case map[string]interface{}:
+		upload, err := unmarshalUploadMap(t)
+		if err != nil {
+			return Upload{}, fmt.Errorf(invalidUpload, v)
+		}
+
+		return upload, nil
+	default:
+		return Upload{}, fmt.Errorf(invalidUpload, v)
 	}
+}
+
+// unmarshalUploadMap reads an Upload from a map value and returns the struct if it's not empty
+func unmarshalUploadMap(m map[string]interface{}) (Upload, error) {
+	var upload Upload
+
+	out, err := json.Marshal(m)
+	if err != nil {
+		return upload, err
+	}
+
+	// Unmarshal the JSON-encoded value into the Upload struct
+	// ignoring the error because we want to return the Upload struct if it's not empty
+	json.Unmarshal(out, &upload) // nolint: errcheck
+
+	if (Upload{}) == upload {
+		return Upload{}, fmt.Errorf(invalidUpload, m)
+	}
+
 	return upload, nil
 }

--- a/graphql/upload_test.go
+++ b/graphql/upload_test.go
@@ -1,0 +1,81 @@
+package graphql
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshalUpload(t *testing.T) {
+	// Create a ReadSeeker with nil value to test the Upload struct
+	file := io.ReadSeeker(nil)
+
+	tests := []struct {
+		name    string
+		input   any
+		want    Upload
+		wantErr bool
+	}{
+		{
+			name: "valid Upload struct",
+			input: Upload{
+				File:        file,
+				Filename:    "test.txt",
+				Size:        1234,
+				ContentType: "text/plain",
+			},
+			want: Upload{
+				File:        file,
+				Filename:    "test.txt",
+				Size:        1234,
+				ContentType: "text/plain",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid type",
+			input:   "invalid",
+			want:    Upload{},
+			wantErr: true,
+		},
+		{
+			name: "valid JSON",
+			input: map[string]interface{}{
+				"file":        file,
+				"filename":    "test.txt",
+				"size":        1234,
+				"contentType": "text/plain",
+			},
+			want: Upload{
+				File:        file,
+				Filename:    "test.txt",
+				Size:        1234,
+				ContentType: "text/plain",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid JSON",
+			input: map[string]interface{}{
+				"hello": "invalid",
+			},
+			want:    Upload{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := UnmarshalUpload(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary:

When using the generated server client, the types come through as a `map[string]interface{}` rather than a `graphql.Upload`. This change allows the generic map to be unmarshalled into the `Upload` type:

example from `gen_server.go`, this currently fails because its coming through as a `map[string]interface{}` instead of a `graphql.Upload`

```
func (ec *executionContext) unmarshalNUpload2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUpload(ctx context.Context, v interface{}) (graphql.Upload, error) {
	res, err := graphql.UnmarshalUpload(v)
	return res, graphql.ErrorOnPath(ctx, err)
}
```

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
