### PR TITLE
refactor graphql.NoCache. use string type keys

### DIFF
--- a/graphql/cache.go
+++ b/graphql/cache.go
@@ -23,9 +23,13 @@ func (m MapCache[T]) Get(_ context.Context, key string) (value T, ok bool) {
 // Add adds a value to the cache.
 func (m MapCache[T]) Add(_ context.Context, key string, value T) { m[key] = value }
 
-type NoCache[T any, T2 *T] struct{}
+type NoCache[T any] struct{}
 
-var _ Cache[*string] = (*NoCache[string, *string])(nil)
+var _ Cache[string] = (*NoCache[string])(nil)
 
-func (n NoCache[T, T2]) Get(_ context.Context, _ string) (value T2, ok bool) { return nil, false }
-func (n NoCache[T, T2]) Add(_ context.Context, _ string, _ T2)               {}
+func (n NoCache[T]) Get(_ context.Context, _ string) (value T, ok bool) {
+	var val T
+	return val, false
+}
+
+func (n NoCache[T]) Add(_ context.Context, _ string, _ T) {}

--- a/graphql/cache_test.go
+++ b/graphql/cache_test.go
@@ -114,7 +114,7 @@ func TestMapCacheEdgeCases(t *testing.T) {
 
 func TestNoCache(t *testing.T) {
 	t.Run("Add and Get", func(t *testing.T) {
-		cache := NoCache[string, *string]{}
+		cache := NoCache[*string]{}
 		ctx := context.Background()
 		key := "testKey"
 		value := "testValue"
@@ -131,7 +131,7 @@ func TestNoCache(t *testing.T) {
 
 func TestNoCacheMultipleEntries(t *testing.T) {
 	t.Run("Multiple Add and Get", func(t *testing.T) {
-		cache := NoCache[string, *string]{}
+		cache := NoCache[*string]{}
 		ctx := context.Background()
 
 		// Define multiple key-value pairs
@@ -190,7 +190,7 @@ func TestNoCacheEdgeCases(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cache := NoCache[string, *string]{}
+			cache := NoCache[*string]{}
 			ctx := context.Background()
 
 			// Test Add

--- a/graphql/executor/executor.go
+++ b/graphql/executor/executor.go
@@ -36,7 +36,7 @@ func New(es graphql.ExecutableSchema) *Executor {
 		es:               es,
 		errorPresenter:   graphql.DefaultErrorPresenter,
 		recoverFunc:      graphql.DefaultRecover,
-		queryCache:       graphql.NoCache[ast.QueryDocument, *ast.QueryDocument]{},
+		queryCache:       graphql.NoCache[*ast.QueryDocument]{},
 		ext:              processExtensions(nil),
 		parserTokenLimit: parserTokenNoLimit,
 	}


### PR DESCRIPTION
Fixes: https://github.com/99designs/gqlgen/issues/3331

All internal uses of cache use string type keys and leaves out the value type as generic parameter. The new generic `NoCache` implementation only allows specifying the key type and the value type is a pointer of the key type. Meaning if I specify the key type `string` the value type is `*string`. This implementation cannot be assigned in place of `graphql.Cache[any]`

I propose to fix this by updating the `NoCache` definition by dropping the key type and allowing to use only string as key, any as value

See #3179