### PR TITLE
print response.Data before panicking when invalid

### DIFF
--- a/graphql/handler/transport/util.go
+++ b/graphql/handler/transport/util.go
@@ -13,7 +13,7 @@ import (
 func writeJson(w io.Writer, response *graphql.Response) {
 	b, err := json.Marshal(response)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("unable to marshal %s: %w", string(response.Data), err))
 	}
 	w.Write(b)
 }


### PR DESCRIPTION
This helped me to identify an issue otherwise hard to debug, where the code for some reason returns invalid JSON.