### PR TITLE
refactor: use fmt.Sprintf for better readability

### DIFF
--- a/codegen/directive.go
+++ b/codegen/directive.go
@@ -2,7 +2,6 @@ package codegen
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/vektah/gqlparser/v2/ast"
@@ -143,7 +142,7 @@ func (d *Directive) CallArgs() string {
 	args := []string{"ctx", "obj", "n"}
 
 	for _, arg := range d.Args {
-		args = append(args, "args["+strconv.Quote(arg.Name)+"].("+templates.CurrentImports.LookupType(arg.TypeReference.GO)+")")
+		args = append(args, fmt.Sprintf("args[%q].(%s)", arg.Name, templates.CurrentImports.LookupType(arg.TypeReference.GO)))
 	}
 
 	return strings.Join(args, ", ")

--- a/codegen/directive_test.go
+++ b/codegen/directive_test.go
@@ -1,0 +1,38 @@
+package codegen
+
+import (
+	"go/types"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vektah/gqlparser/v2/ast"
+
+	"github.com/99designs/gqlgen/codegen/config"
+)
+
+func TestDirectiveCallArgs(t *testing.T) {
+	d := &Directive{
+		Args: []*FieldArgument{
+			{
+				ArgumentDefinition: &ast.ArgumentDefinition{
+					Name: "def1",
+				},
+				TypeReference: &config.TypeReference{
+					GO: types.Default(types.NewNamed(types.NewTypeName(0, nil, "string", nil), types.Typ[types.String], nil)),
+				},
+			},
+			{
+				ArgumentDefinition: &ast.ArgumentDefinition{
+					Name: "def2",
+				},
+				TypeReference: &config.TypeReference{
+					GO: types.Default(types.NewStruct(nil, nil)),
+				},
+			},
+		},
+	}
+
+	got := d.CallArgs()
+
+	assert.Equal(t, `ctx, obj, n, args["def1"].(string), args["def2"].(struct{})`, got)
+}


### PR DESCRIPTION
The PR refactors `Directive.CallArgs` implementation by using `fmt.Sprintf` instead of strings concatenation.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
