### PR TITLE
feat: add possibility to configure client target

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -17,9 +17,10 @@ import (
 type (
 	// Client used for testing GraphQL servers. Not for production use.
 	Client struct {
-		h    http.Handler
-		dc   *mapstructure.DecoderConfig
-		opts []Option
+		h      http.Handler
+		dc     *mapstructure.DecoderConfig
+		opts   []Option
+		target string
 	}
 
 	// Option implements a visitor that mutates an outgoing GraphQL request
@@ -48,8 +49,9 @@ type (
 // Options can be set that should be applied to all requests made with this client
 func New(h http.Handler, opts ...Option) *Client {
 	p := &Client{
-		h:    h,
-		opts: opts,
+		h:      h,
+		opts:   opts,
+		target: "/",
 	}
 
 	return p
@@ -111,7 +113,7 @@ var boundaryRegex = regexp.MustCompile(`multipart/form-data; ?boundary=.*`)
 func (p *Client) newRequest(query string, options ...Option) (*http.Request, error) {
 	bd := &Request{
 		Query: query,
-		HTTP:  httptest.NewRequest(http.MethodPost, "/", http.NoBody),
+		HTTP:  httptest.NewRequest(http.MethodPost, p.target, http.NoBody),
 	}
 	bd.HTTP.Header.Set("Content-Type", "application/json")
 
@@ -144,6 +146,11 @@ func (p *Client) newRequest(query string, options ...Option) (*http.Request, err
 // SetCustomDecodeConfig sets a custom decode hook for the client
 func (p *Client) SetCustomDecodeConfig(dc *mapstructure.DecoderConfig) {
 	p.dc = dc
+}
+
+// SetCustomTarget sets a custom target path for the client
+func (p *Client) SetCustomTarget(target string) {
+	p.target = target
 }
 
 func unpack(data, into any, customDc *mapstructure.DecoderConfig) error {


### PR DESCRIPTION
The graphql client gqlgen provides for testing is hardcoded to use `/` as the target. 
The target is the [RFC 7230](https://rfc-editor.org/rfc/rfc7230.html) "request-target": it may be either a path or an absolute URL.
This PR retains`/` as the default target, but provides a customization option to pick an alternative target.

Describe your PR and link to any relevant issues:

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
