### PR TITLE
Allow preserve_resolver config to work for layout follow schema

### DIFF
--- a/.github/workflows/check-coverage
+++ b/.github/workflows/check-coverage
@@ -7,4 +7,4 @@ go test -covermode atomic -coverprofile=/tmp/coverage.out.tmp -coverpkg=./... $(
 # ignore protobuf files
 cat /tmp/coverage.out.tmp | grep -v ".pb.go" > /tmp/coverage.out
 
-goveralls -coverprofile=/tmp/coverage.out -service=github -ignore='_examples/*/*,_examples/*/*/*,integration/*,integration/*/*,codegen/testserver/*/*,plugin/federation/testdata/*/*/*,*/generated.go,*/*/generated.go,*/*/*/generated.go,graphql/executable_schema_mock.go'
+goveralls -coverprofile=/tmp/coverage.out -service=github -ignore='_examples/*/*,_examples/*/*/*,integration/*,integration/*/*,codegen/testserver/*/*,plugin/resolvergen/testdata/*/*,plugin/modelgen/*/*,plugin/federation/testdata/*/*/*,*/generated.go,*/*/generated.go,*/*/*/generated.go,graphql/executable_schema_mock.go'

--- a/_examples/federation/subgraphs/subgraphs.go
+++ b/_examples/federation/subgraphs/subgraphs.go
@@ -7,11 +7,12 @@ import (
 	"log"
 	"net/http"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/debug"
 	"github.com/99designs/gqlgen/graphql/playground"
-	"golang.org/x/sync/errgroup"
 )
 
 type Config struct {

--- a/client/readme.md
+++ b/client/readme.md
@@ -1,5 +1,8 @@
 This client is used internally for testing. I wanted a simple graphql client sent user specified queries.
 
 You might want to look at:
- - https://github.com/shurcooL/graphql: Uses reflection to build queries from structs. 
+ - https://github.com/shurcooL/graphql: Uses reflection to build queries from structs.
  - https://github.com/machinebox/graphql: Probably would have been a perfect fit, but it uses form encoding instead of json...
+ - [Khan/genqlient](https://github.com/Khan/genqlient) - Generate go GraphQL client from GraphQL query
+ - [infiotinc/gqlgenc](https://github.com/infiotinc/gqlgenc) - Generate go GraphQL client from GraphQL query
+ - [Yamashou/gqlgenc](https://github.com/Yamashou/gqlgenc) - Generate go GraphQL client from GraphQL query

--- a/codegen/config/resolver.go
+++ b/codegen/config/resolver.go
@@ -56,9 +56,6 @@ func (r *ResolverConfig) Check() error {
 		} else {
 			r.Filename = abs(r.Filename)
 		}
-		if r.PreserveResolver {
-			return fmt.Errorf("preserve_resolver=true cannot be used with layout=%s", r.Layout)
-		}
 	default:
 		return fmt.Errorf("invalid layout %s. must be %s or %s", r.Layout, LayoutSingleFile, LayoutFollowSchema)
 	}

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -46,6 +46,8 @@ resolver:
   # omit_template_comment: false
   # Optional: Pass in a path to a new gotpl template to use for generating resolvers
   # resolver_template: [your/path/resolver.gotpl]
+	# Optional: turn on to avoid rewriting existing resolver(s) when generating
+	# preserve_resolver: false
 
 # Optional: turn on use ` + "`" + `gqlgen:"fieldName"` + "`" + ` tags in your models
 # struct_tag: json

--- a/plugin/federation/constants.go
+++ b/plugin/federation/constants.go
@@ -1,8 +1,9 @@
 package federation
 
 import (
-	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/vektah/gqlparser/v2/ast"
+
+	"github.com/99designs/gqlgen/codegen/config"
 )
 
 // The name of the field argument that is injected into the resolver to support @requires.

--- a/plugin/resolvergen/resolver_test.go
+++ b/plugin/resolvergen/resolver_test.go
@@ -157,7 +157,7 @@ func overWriteFile(t *testing.T, sourceFile, destinationFile string) {
 	input, err := os.ReadFile(sourceFile)
 	require.NoError(t, err)
 
-	err = os.WriteFile(destinationFile, input, 0644)
+	err = os.WriteFile(destinationFile, input, 0o644)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
Follow up to #3361 to enable `preserve_resolver:true` resolver config for `follow-schema` layout.

Signed-off-by: Steve Coffman <steve@khanacademy.org>
