### PR TITLE
proposal: allow the custom template for server code generation

### DIFF
--- a/api/generate_test.go
+++ b/api/generate_test.go
@@ -16,7 +16,10 @@ func cleanup(workDir string) {
 	_ = os.Remove(filepath.Join(workDir, "graph", "resolver.go"))
 	_ = os.Remove(filepath.Join(workDir, "graph", "federation.go"))
 	_ = os.Remove(filepath.Join(workDir, "graph", "schema.resolvers.go"))
+	_ = os.Remove(filepath.Join(workDir, "graph", "todo.resolvers.go"))
+	_ = os.Remove(filepath.Join(workDir, "graph", "user.resolvers.go"))
 	_ = os.Remove(filepath.Join(workDir, "graph", "model", "models_gen.go"))
+	_ = os.RemoveAll(filepath.Join(workDir, "graph", "generated"))
 }
 
 func TestGenerate(t *testing.T) {
@@ -33,6 +36,22 @@ func TestGenerate(t *testing.T) {
 		{
 			name:    "federation2",
 			workDir: filepath.Join(wd, "testdata", "federation2"),
+		},
+		{
+			name:    "single-file with multiple custom templates",
+			workDir: filepath.Join(wd, "testdata", "template", "single-file", "dir"),
+		},
+		{
+			name:    "single-file with a single custom template",
+			workDir: filepath.Join(wd, "testdata", "template", "single-file", "file"),
+		},
+		{
+			name:    "follow-schema with multiple custom templates",
+			workDir: filepath.Join(wd, "testdata", "template", "follow-schema", "dir"),
+		},
+		{
+			name:    "follow-schema with a single custom template",
+			workDir: filepath.Join(wd, "testdata", "template", "follow-schema", "file"),
 		},
 	}
 	for _, tt := range tests {

--- a/api/testdata/template/follow-schema/dir/gqlgen.yml
+++ b/api/testdata/template/follow-schema/dir/gqlgen.yml
@@ -1,0 +1,71 @@
+# Where are all the schema files located? globs are supported eg  src/**/*.graphqls
+schema:
+  - graph/*.graphqls
+
+# Where should the generated server code go?
+exec:
+  layout: follow-schema
+  dir: graph/generated
+  package: generated
+  exec_template_dir: graph/template
+
+# Uncomment to enable federation
+# federation:
+#   filename: graph/federation.go
+#   package: graph
+
+# Where should any generated models go?
+model:
+  filename: graph/model/models_gen.go
+  package: model
+
+# Where should the resolver implementations go?
+resolver:
+  layout: follow-schema
+  dir: graph
+  package: graph
+
+# Optional: turn on use `gqlgen:"fieldName"` tags in your models
+# struct_tag: json
+
+# Optional: turn on to use []Thing instead of []*Thing
+# omit_slice_element_pointers: false
+
+# Optional: turn off to make struct-type struct fields not use pointers
+# e.g. type Thing struct { FieldA OtherThing } instead of { FieldA *OtherThing }
+# struct_fields_always_pointers: true
+
+# Optional: turn off to make resolvers return values instead of pointers for structs
+# resolvers_always_return_pointers: true
+
+# Optional: turn on to return pointers instead of values in unmarshalInput
+# return_pointers_in_unmarshalinput: false
+
+# Optional: wrap nullable input fields with Omittable
+# nullable_input_omittable: true
+
+# Optional: set to speed up generation time by not performing a final validation pass.
+# skip_validation: true
+
+# gqlgen will search for any type names in the schema in these go packages
+# if they match it will use them, otherwise it will generate them.
+autobind:
+  - "github.com/99designs/gqlgen/api/testdata/default/graph/model"
+
+# This section declares type mapping between the GraphQL and go type systems
+#
+# The first line in each type will be used as defaults for resolver arguments and
+# modelgen, the others will be allowed when binding to fields. Configure them to
+# your liking
+models:
+  ID:
+    model:
+      - github.com/99designs/gqlgen/graphql.ID
+      - github.com/99designs/gqlgen/graphql.Int
+      - github.com/99designs/gqlgen/graphql.Int64
+      - github.com/99designs/gqlgen/graphql.Int32
+  Int:
+    model:
+      - github.com/99designs/gqlgen/graphql.Int
+      - github.com/99designs/gqlgen/graphql.Int64
+      - github.com/99designs/gqlgen/graphql.Int32

--- a/api/testdata/template/follow-schema/dir/graph/model/doc.go
+++ b/api/testdata/template/follow-schema/dir/graph/model/doc.go
@@ -1,0 +1,1 @@
+package model

--- a/api/testdata/template/follow-schema/dir/graph/template/args.gotpl
+++ b/api/testdata/template/follow-schema/dir/graph/template/args.gotpl
@@ -1,0 +1,68 @@
+{{ range $name, $args := .Args }}
+func (ec *executionContext) {{ $name }}(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+
+	{{- range $i, $arg := . }}
+		arg{{$i}}, err := ec.{{ $name }}{{$arg.Name | go}}(ctx, rawArgs)
+		if err != nil {
+			return nil, err
+		}
+		args[{{$arg.Name|quote}}] = arg{{$i}}
+	{{- end }}
+	return args, nil
+}
+
+	{{- range $i, $arg := . }}
+		func (ec *executionContext) {{ $name }}{{$arg.Name | go}}(
+			ctx context.Context,
+			rawArgs map[string]interface{},
+		) ({{ $arg.TypeReference.GO | ref}}, error) {
+			{{- if not .CallArgumentDirectivesWithNull}}
+				// We won't call the directive if the argument is null.
+				// Set call_argument_directives_with_null to true to call directives
+				// even if the argument is null.
+				_, ok := rawArgs[{{$arg.Name|quote}}]
+				if !ok {
+					var zeroVal {{ $arg.TypeReference.GO | ref}}
+					return zeroVal, nil
+				}
+			{{end}}
+			ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField({{$arg.Name|quote}}))
+			{{- if $arg.ImplDirectives }}
+				directive0 := func(ctx context.Context) (interface{}, error) {
+					tmp, ok := rawArgs[{{$arg.Name|quote}}]
+					if !ok {
+						var zeroVal {{ $arg.TypeReference.GO | ref}}
+						return zeroVal, nil
+					}
+					return ec.{{ $arg.TypeReference.UnmarshalFunc }}(ctx, tmp)
+				}
+				{{ template "implDirectives" $arg }}
+				tmp, err := directive{{$arg.ImplDirectives|len}}(ctx)
+				if err != nil {
+					var zeroVal {{ $arg.TypeReference.GO | ref}}
+					return zeroVal, graphql.ErrorOnPath(ctx, err)
+				}
+				if data, ok := tmp.({{ $arg.TypeReference.GO | ref }}) ; ok {
+					return data, nil
+				{{- if $arg.TypeReference.IsNilable }}
+					} else if tmp == nil {
+						var zeroVal {{ $arg.TypeReference.GO | ref}}
+						return zeroVal, nil
+				{{- end }}
+				} else {
+					var zeroVal {{ $arg.TypeReference.GO | ref}}
+					return zeroVal, graphql.ErrorOnPath(ctx, fmt.Errorf(`unexpected type %T from directive, should be {{ $arg.TypeReference.GO }}`, tmp))
+				}
+			{{- else }}
+				if tmp, ok := rawArgs[{{$arg.Name|quote}}]; ok {
+					return ec.{{ $arg.TypeReference.UnmarshalFunc }}(ctx, tmp)
+				}
+
+				var zeroVal {{ $arg.TypeReference.GO | ref}}
+				return zeroVal, nil
+			{{- end }}
+		}
+	{{end}}
+{{ end }}

--- a/api/testdata/template/follow-schema/dir/graph/template/directives.gotpl
+++ b/api/testdata/template/follow-schema/dir/graph/template/directives.gotpl
@@ -1,0 +1,155 @@
+{{ define "implDirectives" }}{{ $in := .DirectiveObjName }}
+	{{ $zeroVal := .TypeReference.GO | ref}}
+	{{- range $i, $directive := .ImplDirectives -}}
+		directive{{add $i 1}} := func(ctx context.Context) (interface{}, error) {
+			{{- range $arg := $directive.Args }}
+				{{- if notNil "Value" $arg }}
+						{{ $arg.VarName }}, err := ec.{{ $arg.TypeReference.UnmarshalFunc }}(ctx, {{ $arg.Value | dump }})
+						if err != nil{
+							var zeroVal {{$zeroVal}}
+							return zeroVal, err
+						}
+					{{- else if notNil "Default" $arg }}
+						{{ $arg.VarName }}, err := ec.{{ $arg.TypeReference.UnmarshalFunc }}(ctx, {{ $arg.Default | dump }})
+						if err != nil{
+							var zeroVal {{$zeroVal}}
+							return zeroVal, err
+						}
+					{{- end }}
+			{{- end }}
+			{{- if not $directive.IsBuiltIn}}
+				if {{$directive.CallPath}} == nil {
+					var zeroVal {{$zeroVal}}
+					return zeroVal, errors.New("directive {{$directive.Name}} is not implemented")
+				}
+			{{- end}}
+			return {{$directive.CallPath}}({{$directive.ResolveArgs $in $i }})
+		}
+	{{ end -}}
+{{ end }}
+
+{{define "queryDirectives"}}
+	for _, d := range obj.Directives {
+		switch d.Name {
+		{{- range $directive := . }}
+		case "{{$directive.Name}}":
+			{{- if $directive.Args }}
+				rawArgs := d.ArgumentMap(ec.Variables)
+				args, err := ec.{{ $directive.ArgsFunc }}(ctx,rawArgs)
+				if err != nil {
+					ec.Error(ctx, err)
+					return graphql.Null
+				}
+			{{- end }}
+			n := next
+			next = func(ctx context.Context) (interface{}, error) {
+				{{- template "callDirective" $directive -}}
+			}
+		{{- end }}
+		}
+	}
+	tmp, err := next(ctx)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if data, ok := tmp.(graphql.Marshaler); ok {
+		return data
+	}
+	ec.Errorf(ctx, `unexpected type %T from directive, should be graphql.Marshaler`, tmp)
+	return graphql.Null
+{{end}}
+
+{{define "callDirective"}}
+	{{- if not .IsBuiltIn}}
+		if {{.CallPath}} == nil {
+			return nil, errors.New("directive {{.Name}} is not implemented")
+		}
+	{{- end}}
+	return {{.CallPath}}({{.CallArgs}})
+{{end}}
+
+{{ if .Directives.LocationDirectives "QUERY" }}
+func (ec *executionContext) _queryMiddleware(ctx context.Context, obj *ast.OperationDefinition, next func(ctx context.Context) (interface{}, error)) graphql.Marshaler {
+	{{ template "queryDirectives" .Directives.LocationDirectives "QUERY" }}
+}
+{{ end }}
+
+{{ if .Directives.LocationDirectives "MUTATION" }}
+func (ec *executionContext) _mutationMiddleware(ctx context.Context, obj *ast.OperationDefinition, next func(ctx context.Context) (interface{}, error)) graphql.Marshaler {
+	{{ template "queryDirectives" .Directives.LocationDirectives "MUTATION" }}
+}
+{{ end }}
+
+{{ if .Directives.LocationDirectives "SUBSCRIPTION" }}
+func (ec *executionContext) _subscriptionMiddleware(ctx context.Context, obj *ast.OperationDefinition, next func(ctx context.Context) (interface{}, error)) func(ctx context.Context) graphql.Marshaler {
+	for _, d := range obj.Directives {
+		switch d.Name {
+		{{- range $directive := .Directives.LocationDirectives "SUBSCRIPTION" }}
+		case "{{$directive.Name}}":
+			{{- if $directive.Args }}
+				rawArgs := d.ArgumentMap(ec.Variables)
+				args, err := ec.{{ $directive.ArgsFunc }}(ctx,rawArgs)
+				if err != nil {
+					ec.Error(ctx, err)
+					return func(ctx context.Context) graphql.Marshaler {
+						return graphql.Null
+					}
+				}
+			{{- end }}
+			n := next
+			next = func(ctx context.Context) (interface{}, error) {
+				{{- template "callDirective" $directive -}}
+			}
+		{{- end }}
+		}
+	}
+	tmp, err := next(ctx)
+	if err != nil {
+		ec.Error(ctx, err)
+		return func(ctx context.Context) graphql.Marshaler {
+			return graphql.Null
+		}
+	}
+	if data, ok := tmp.(func(ctx context.Context) graphql.Marshaler); ok {
+		return data
+	}
+	ec.Errorf(ctx, `unexpected type %T from directive, should be graphql.Marshaler`, tmp)
+	return func(ctx context.Context) graphql.Marshaler {
+		return graphql.Null
+	}
+}
+{{ end }}
+
+{{ if .Directives.LocationDirectives "FIELD" }}
+	func (ec *executionContext) _fieldMiddleware(ctx context.Context, obj interface{}, next graphql.Resolver) interface{} {
+		{{- if .Directives.LocationDirectives "FIELD" }}
+		fc := graphql.GetFieldContext(ctx)
+		for _, d := range fc.Field.Directives {
+			switch d.Name {
+			{{- range $directive := .Directives.LocationDirectives "FIELD" }}
+			case "{{$directive.Name}}":
+				{{- if $directive.Args }}
+					rawArgs := d.ArgumentMap(ec.Variables)
+					args, err := ec.{{ $directive.ArgsFunc }}(ctx,rawArgs)
+					if err != nil {
+						ec.Error(ctx, err)
+						return nil
+					}
+				{{- end }}
+				n := next
+				next = func(ctx context.Context) (interface{}, error) {
+					{{- template "callDirective" $directive -}}
+				}
+			{{- end }}
+			}
+		}
+		{{- end }}
+		res, err := ec.ResolverMiddleware(ctx, next)
+		if err != nil {
+			ec.Error(ctx, err)
+			return nil
+		}
+		return res
+	}
+{{ end }}

--- a/api/testdata/template/follow-schema/dir/graph/template/field.gotpl
+++ b/api/testdata/template/follow-schema/dir/graph/template/field.gotpl
@@ -1,0 +1,172 @@
+{{- range $object := .Objects }}{{- range $field := $object.Fields }}
+
+func (ec *executionContext) _{{$object.Name}}_{{$field.Name}}(ctx context.Context, field graphql.CollectedField{{ if not $object.Root }}, obj {{$object.Reference | ref}}{{end}}) (ret {{ if $object.Stream }}func(ctx context.Context){{ end }}graphql.Marshaler) {
+	{{- $null := "graphql.Null" }}
+	{{- if $object.Stream }}
+		{{- $null = "nil" }}
+	{{- end }}
+	fc, err := ec.{{ $field.FieldContextFunc }}(ctx, field)
+	if err != nil {
+		return {{ $null }}
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	{{- if not $.Config.OmitPanicHandler }}
+	defer func () {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = {{ $null }}
+		}
+	}()
+	{{- end }}
+	{{- if $field.TypeReference.IsRoot }}
+		{{- if $field.TypeReference.IsPtr }}
+			res := &{{ $field.TypeReference.Elem.GO | ref }}{}
+		{{- else }}
+			res := {{ $field.TypeReference.GO | ref }}{}
+		{{- end }}
+		fc.Result = res
+		return ec.{{ $field.TypeReference.MarshalFunc }}(ctx, field.Selections, res)
+	{{- else}}
+		{{- if  $.AllDirectives.LocationDirectives "FIELD" }}
+			resTmp := ec._fieldMiddleware(ctx, {{if $object.Root}}nil{{else}}obj{{end}}, func(rctx context.Context) (interface{}, error) {
+				{{ template "field" $field }}
+			})
+		{{ else }}
+			resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+				{{ template "field" $field }}
+			})
+			if err != nil {
+				ec.Error(ctx, err)
+				return {{ $null }}
+			}
+		{{- end }}
+		if resTmp == nil {
+			{{- if $field.TypeReference.GQL.NonNull }}
+				if !graphql.HasFieldError(ctx, fc) {
+					ec.Errorf(ctx, "must not be null")
+				}
+			{{- end }}
+			return {{ $null }}
+		}
+		{{- if $object.Stream }}
+			return func(ctx context.Context) graphql.Marshaler {
+				select {
+				case res, ok := <-resTmp.(<-chan {{$field.TypeReference.GO | ref}}):
+					if !ok {
+						return nil
+					}
+					return graphql.WriterFunc(func(w io.Writer) {
+						w.Write([]byte{'{'})
+						graphql.MarshalString(field.Alias).MarshalGQL(w)
+						w.Write([]byte{':'})
+						ec.{{ $field.TypeReference.MarshalFunc }}(ctx, field.Selections, res).MarshalGQL(w)
+						w.Write([]byte{'}'})
+					})
+				case <-ctx.Done():
+					return nil
+				}
+			}
+		{{- else }}
+			res := resTmp.({{$field.TypeReference.GO | ref}})
+			fc.Result = res
+			return ec.{{ $field.TypeReference.MarshalFunc }}(ctx, field.Selections, res)
+		{{- end }}
+	{{- end }}
+}
+
+func (ec *executionContext) {{ $field.FieldContextFunc }}({{ if not $field.Args }}_{{ else }}ctx{{ end }} context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object: {{quote $field.Object.Name}},
+		Field: field,
+		IsMethod: {{or $field.IsMethod $field.IsResolver}},
+		IsResolver: {{ $field.IsResolver }},
+		Child: func (ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			{{- if not $field.TypeReference.Definition.Fields }}
+				return nil, errors.New("field of type {{ $field.TypeReference.Definition.Name }} does not have child fields")
+			{{- else if ne $field.TypeReference.Definition.Kind "OBJECT" }}
+				return nil, errors.New("FieldContext.Child cannot be called on type {{ $field.TypeReference.Definition.Kind }}")
+			{{- else }}
+				switch field.Name {
+					{{- range $f := $field.TypeReference.Definition.Fields }}
+						case "{{ $f.Name }}":
+							return ec.{{ $field.ChildFieldContextFunc $f.Name }}(ctx, field)
+					{{- end }}
+				}
+				return nil, fmt.Errorf("no field named %q was found under type {{ $field.TypeReference.Definition.Name }}", field.Name)
+			{{- end }}
+		},
+	}
+	{{- if $field.Args }}
+		{{- if not $.Config.OmitPanicHandler }}
+		defer func () {
+			if r := recover(); r != nil {
+				err = ec.Recover(ctx, r)
+				ec.Error(ctx, err)
+			}
+		}()
+		{{- end }}
+		ctx = graphql.WithFieldContext(ctx, fc)
+		if fc.Args, err = ec.{{ $field.ArgsFunc }}(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+			ec.Error(ctx, err)
+			return fc, err
+		}
+	{{- end }}
+	return fc, nil
+}
+
+{{- end }}{{- end}}
+
+{{ define "field" }}
+	{{- if .HasDirectives -}}
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx  // use context from middleware stack in children
+			{{ template "fieldDefinition" . }}
+		}
+		{{ template "implDirectives" . }}
+		tmp, err := directive{{.ImplDirectives|len}}(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+		    return nil, nil
+		}
+		if data, ok := tmp.({{if .Stream}}<-chan {{end}}{{ .TypeReference.GO | ref }}) ; ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be {{if .Stream}}<-chan {{end}}{{ .TypeReference.GO }}`, tmp)
+	{{- else -}}
+		ctx = rctx  // use context from middleware stack in children
+		{{ template "fieldDefinition" . }}
+	{{- end -}}
+{{ end }}
+
+{{ define "fieldDefinition" }}
+	{{- if .IsResolver -}}
+		return ec.resolvers.{{ .ShortInvocation }}
+	{{- else if .IsMap -}}
+		switch v := {{.GoReceiverName}}[{{.Name|quote}}].(type) {
+		case {{if .Stream}}<-chan {{end}}{{.TypeReference.GO | ref}}:
+			return v, nil
+		case {{if .Stream}}<-chan {{end}}{{.TypeReference.Elem.GO | ref}}:
+			return &v, nil
+		case nil:
+			return ({{.TypeReference.GO | ref}})(nil), nil
+		default:
+			return nil, fmt.Errorf("unexpected type %T for field %s", v, {{ .Name | quote}})
+		}
+	{{- else if .IsMethod -}}
+		{{- if .VOkFunc -}}
+			v, ok := {{.GoReceiverName}}.{{.GoFieldName}}({{ .CallArgs }})
+			if !ok {
+				return nil, nil
+			}
+			return v, nil
+		{{- else if .NoErr -}}
+			return {{.GoReceiverName}}.{{.GoFieldName}}({{ .CallArgs }}), nil
+		{{- else -}}
+			return {{.GoReceiverName}}.{{.GoFieldName}}({{ .CallArgs }})
+		{{- end -}}
+	{{- else if .IsVariable -}}
+		return {{.GoReceiverName}}.{{.GoFieldName}}, nil
+	{{- end }}
+{{- end }}

--- a/api/testdata/template/follow-schema/dir/graph/template/generated!.gotpl
+++ b/api/testdata/template/follow-schema/dir/graph/template/generated!.gotpl
@@ -1,0 +1,313 @@
+{{/* Context object: codegen.Data */}}
+{{ reserveImport "context"  }}
+{{ reserveImport "fmt"  }}
+{{ reserveImport "io"  }}
+{{ reserveImport "strconv"  }}
+{{ reserveImport "time"  }}
+{{ reserveImport "sync"  }}
+{{ reserveImport "sync/atomic" }}
+{{ reserveImport "errors"  }}
+{{ reserveImport "bytes"  }}
+{{ reserveImport "embed"  }}
+
+{{ reserveImport "github.com/vektah/gqlparser/v2" "gqlparser" }}
+{{ reserveImport "github.com/vektah/gqlparser/v2/ast" }}
+{{ reserveImport "github.com/99designs/gqlgen/graphql" }}
+{{ reserveImport "github.com/99designs/gqlgen/graphql/introspection" }}
+
+{{ if eq .Config.Exec.Layout "single-file" }}
+	// NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
+	func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
+		return &executableSchema{
+		 	schema: cfg.Schema,
+			resolvers: cfg.Resolvers,
+			directives: cfg.Directives,
+			complexity: cfg.Complexity,
+		}
+	}
+
+	type Config struct {
+		Schema    *ast.Schema
+		Resolvers  ResolverRoot
+		Directives DirectiveRoot
+		Complexity ComplexityRoot
+	}
+
+	type ResolverRoot interface {
+	{{- range $object := .Objects -}}
+		{{ if $object.HasResolvers -}}
+			{{ucFirst $object.Name}}() {{ucFirst $object.Name}}Resolver
+		{{ end }}
+	{{- end }}
+	{{- range $object := .Inputs -}}
+	{{ if $object.HasResolvers -}}
+		{{ucFirst $object.Name}}() {{ucFirst $object.Name}}Resolver
+	{{ end }}
+{{- end }}
+}
+
+	type DirectiveRoot struct {
+	{{ range $directive := .UserDirectives }}
+		{{- $directive.Declaration }}
+	{{ end }}
+	}
+
+	type ComplexityRoot struct {
+	{{- if not .Config.OmitComplexity }}
+	{{ range $object := .Objects }}
+		{{ if not $object.IsReserved -}}
+			{{ ucFirst $object.Name }} struct {
+			{{ range $_, $fields := $object.UniqueFields }}
+				{{- $field := index $fields 0 -}}
+				{{ if not $field.IsReserved -}}
+					{{ $field.GoFieldName }} {{ $field.ComplexitySignature }}
+				{{ end }}
+			{{- end }}
+			}
+		{{- end }}
+	{{ end }}
+	{{- end }}
+	}
+{{ end }}
+
+{{ range $object := .Objects -}}
+	{{ if $object.HasResolvers }}
+		type {{ucFirst $object.Name}}Resolver interface {
+		{{ range $field := $object.Fields -}}
+			{{- if $field.IsResolver }}
+				{{- $field.GoFieldName}}{{ $field.ShortResolverDeclaration }}
+			{{- end }}
+		{{ end }}
+		}
+	{{- end }}
+{{- end }}
+
+{{ range $object := .Inputs -}}
+	{{ if $object.HasResolvers }}
+		type {{$object.Name}}Resolver interface {
+		{{ range $field := $object.Fields -}}
+			{{- if $field.IsResolver }}
+				{{- $field.GoFieldName}}{{ $field.ShortResolverDeclaration }}
+			{{- end }}
+		{{ end }}
+		}
+	{{- end }}
+{{- end }}
+
+{{ range $directive := .BuiltInDirectives }}
+	var (
+		{{- $directive.FunctionImpl }}
+	)
+{{ end }}
+
+{{ if eq .Config.Exec.Layout "single-file" }}
+	type executableSchema struct {
+		schema    *ast.Schema
+		resolvers  ResolverRoot
+		directives DirectiveRoot
+		complexity ComplexityRoot
+	}
+
+	func (e *executableSchema) Schema() *ast.Schema {
+		if e.schema != nil {
+        		return e.schema
+		}
+		return parsedSchema
+	}
+
+	func (e *executableSchema) Complexity(typeName, field string, childComplexity int, rawArgs map[string]interface{}) (int, bool) {
+		ec := executionContext{nil, e, 0, 0, nil}
+		_ = ec
+		{{ if not .Config.OmitComplexity -}}
+		switch typeName + "." + field {
+		{{ range $object := .Objects }}
+			{{ if not $object.IsReserved }}
+				{{ range $_, $fields := $object.UniqueFields }}
+					{{- $len := len $fields }}
+					{{- range $i, $field := $fields }}
+						{{- $last := eq (add $i 1) $len }}
+						{{- if not $field.IsReserved }}
+							{{- if eq $i 0 }}case {{ end }}"{{$object.Name}}.{{$field.Name}}"{{ if not $last }},{{ else }}:
+								if e.complexity.{{ucFirst $object.Name}}.{{$field.GoFieldName}} == nil {
+									break
+								}
+								{{ if $field.Args }}
+									args, err := ec.{{ $field.ArgsFunc }}(context.TODO(),rawArgs)
+									if err != nil {
+										return 0, false
+									}
+								{{ end }}
+								return e.complexity.{{ucFirst $object.Name}}.{{$field.GoFieldName}}(childComplexity{{if $field.Args}}, {{$field.ComplexityArgs}} {{ end }}), true
+							{{ end }}
+						{{- end }}
+					{{- end }}
+				{{ end }}
+			{{ end }}
+		{{ end }}
+		}
+		{{- end }}
+		return 0, false
+	}
+
+	func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
+		opCtx := graphql.GetOperationContext(ctx)
+		ec := executionContext{opCtx, e, 0, 0, make(chan graphql.DeferredResult)}
+		inputUnmarshalMap := graphql.BuildUnmarshalerMap(
+			{{- range $input := .Inputs -}}
+				{{ if not $input.HasUnmarshal }}
+					ec.unmarshalInput{{ $input.Name }},
+				{{- end }}
+			{{- end }}
+		)
+		first := true
+
+		switch opCtx.Operation.Operation {
+		{{- if .QueryRoot }} case ast.Query:
+			return func(ctx context.Context) *graphql.Response {
+				var response graphql.Response
+				var data graphql.Marshaler
+				if first {
+					first = false
+					ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
+					{{ if .Directives.LocationDirectives "QUERY" -}}
+						data = ec._queryMiddleware(ctx, opCtx.Operation, func(ctx context.Context) (interface{}, error){
+							return ec._{{.QueryRoot.Name}}(ctx, opCtx.Operation.SelectionSet), nil
+						})
+					{{- else -}}
+						data = ec._{{.QueryRoot.Name}}(ctx, opCtx.Operation.SelectionSet)
+					{{- end }}
+				} else {
+					if atomic.LoadInt32(&ec.pendingDeferred) > 0 {
+						result := <-ec.deferredResults
+						atomic.AddInt32(&ec.pendingDeferred, -1)
+						data = result.Result
+						response.Path = result.Path
+						response.Label = result.Label
+						response.Errors = result.Errors
+					} else {
+						return nil
+					}
+				}
+				var buf bytes.Buffer
+				data.MarshalGQL(&buf)
+				response.Data = buf.Bytes()
+				if atomic.LoadInt32(&ec.deferred) > 0 {
+					hasNext := atomic.LoadInt32(&ec.pendingDeferred) > 0
+					response.HasNext = &hasNext
+				}
+
+				return &response
+			}
+		{{ end }}
+
+		{{- if .MutationRoot }} case ast.Mutation:
+			return func(ctx context.Context) *graphql.Response {
+				if !first { return nil }
+				first = false
+				ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
+				{{ if .Directives.LocationDirectives "MUTATION" -}}
+					data := ec._mutationMiddleware(ctx, opCtx.Operation, func(ctx context.Context) (interface{}, error){
+						return ec._{{.MutationRoot.Name}}(ctx, opCtx.Operation.SelectionSet), nil
+					})
+				{{- else -}}
+					data := ec._{{.MutationRoot.Name}}(ctx, opCtx.Operation.SelectionSet)
+				{{- end }}
+				var buf bytes.Buffer
+				data.MarshalGQL(&buf)
+
+				return &graphql.Response{
+					Data:       buf.Bytes(),
+				}
+			}
+		{{ end }}
+
+		{{- if .SubscriptionRoot }} case ast.Subscription:
+			{{ if .Directives.LocationDirectives "SUBSCRIPTION" -}}
+				next := ec._subscriptionMiddleware(ctx, opCtx.Operation, func(ctx context.Context) (interface{}, error){
+					return ec._{{.SubscriptionRoot.Name}}(ctx, opCtx.Operation.SelectionSet),nil
+				})
+			{{- else -}}
+				next := ec._{{.SubscriptionRoot.Name}}(ctx, opCtx.Operation.SelectionSet)
+			{{- end }}
+
+			var buf bytes.Buffer
+			return func(ctx context.Context) *graphql.Response {
+				buf.Reset()
+				data := next(ctx)
+
+				if data == nil {
+					return nil
+				}
+				data.MarshalGQL(&buf)
+
+				return &graphql.Response{
+					Data:       buf.Bytes(),
+				}
+			}
+		{{ end }}
+		default:
+			return graphql.OneShot(graphql.ErrorResponse(ctx, "unsupported GraphQL operation"))
+		}
+	}
+
+	type executionContext struct {
+		*graphql.OperationContext
+		*executableSchema
+		deferred        int32
+		pendingDeferred int32
+		deferredResults chan graphql.DeferredResult
+	}
+
+	func (ec *executionContext) processDeferredGroup(dg graphql.DeferredGroup) {
+		atomic.AddInt32(&ec.pendingDeferred, 1)
+		go func () {
+			ctx := graphql.WithFreshResponseContext(dg.Context)
+			dg.FieldSet.Dispatch(ctx)
+			ds := graphql.DeferredResult{
+				Path:   dg.Path,
+				Label:  dg.Label,
+				Result: dg.FieldSet,
+				Errors: graphql.GetErrors(ctx),
+			}
+			// null fields should bubble up
+			if dg.FieldSet.Invalids > 0 {
+				ds.Result = graphql.Null
+			}
+			ec.deferredResults <- ds
+		}()
+	}
+
+	func (ec *executionContext) introspectSchema() (*introspection.Schema, error) {
+		if ec.DisableIntrospection {
+			return nil, errors.New("introspection disabled")
+		}
+		return introspection.WrapSchema(ec.Schema()), nil
+	}
+
+	func (ec *executionContext) introspectType(name string) (*introspection.Type, error) {
+		if ec.DisableIntrospection {
+			return nil, errors.New("introspection disabled")
+		}
+		return introspection.WrapTypeFromDef(ec.Schema(), ec.Schema().Types[name]), nil
+	}
+
+	{{if .HasEmbeddableSources }}
+	//go:embed{{- range $source := .AugmentedSources }}{{if $source.Embeddable}} {{$source.RelativePath|quote}}{{end}}{{- end }}
+	var sourcesFS embed.FS
+
+	func sourceData(filename string) string {
+		data, err := sourcesFS.ReadFile(filename)
+		if err != nil {
+			panic(fmt.Sprintf("codegen problem: %s not available", filename))
+		}
+		return string(data)
+	}
+	{{- end }}
+
+	var sources = []*ast.Source{
+	{{- range $source := .AugmentedSources }}
+		{Name: {{$source.RelativePath|quote}}, Input: {{if (not $source.Embeddable)}}{{$source.Source|rawQuote}}{{else}}sourceData({{$source.RelativePath|quote}}){{end}}, BuiltIn: {{$source.BuiltIn}}},
+	{{- end }}
+	}
+	var parsedSchema = gqlparser.MustLoadSchema(sources...)
+{{ end }}

--- a/api/testdata/template/follow-schema/dir/graph/template/input.gotpl
+++ b/api/testdata/template/follow-schema/dir/graph/template/input.gotpl
@@ -1,0 +1,100 @@
+{{- range $input := .Inputs }}
+	{{- if not .HasUnmarshal }}
+	{{- $it := "it" }}
+	{{- if .PointersInUnmarshalInput }}
+	  {{- $it = "&it" }}
+	{{- end }}
+	func (ec *executionContext) unmarshalInput{{ .Name }}(ctx context.Context, obj interface{}) ({{ if .PointersInUnmarshalInput }}*{{ end }}{{.Type | ref}}, error) {
+		{{- if $input.IsMap }}
+			it := make(map[string]interface{}, len(obj.(map[string]interface{})))
+		{{- else }}
+			var it {{.Type | ref}}
+		{{- end }}
+		asMap := map[string]interface{}{}
+		for k, v := range obj.(map[string]interface{}) {
+			asMap[k] = v
+		}
+		{{ range $field := .Fields}}
+			{{- if notNil "Default" $field }}
+				if _, present := asMap[{{$field.Name|quote}}] ; !present {
+					asMap[{{$field.Name|quote}}] = {{ $field.Default | dump }}
+				}
+			{{- end}}
+		{{- end }}
+
+		fieldsInOrder := [...]string{ {{ range .Fields }}{{ quote .Name }},{{ end }} }
+		for _, k := range fieldsInOrder {
+			v, ok := asMap[k]
+			if !ok {
+				continue
+			}
+			switch k {
+			{{- range $field := .Fields }}
+			case {{$field.Name|quote}}:
+				{{- $lhs := (printf "it.%s" $field.GoFieldName) }}
+				{{- if $input.IsMap }}
+					{{- $lhs = (printf "it[%q]" $field.Name) }}
+				{{- end }}
+				ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField({{$field.Name|quote}}))
+				{{- if $field.ImplDirectives }}
+					directive0 := func(ctx context.Context) (interface{}, error) { return ec.{{ $field.TypeReference.UnmarshalFunc }}(ctx, v) }
+					{{ template "implDirectives" $field }}
+					tmp, err := directive{{$field.ImplDirectives|len}}(ctx)
+					if err != nil {
+						return {{$it}}, graphql.ErrorOnPath(ctx, err)
+					}
+					if data, ok := tmp.({{ $field.TypeReference.GO | ref }}) ; ok {
+						{{- if $field.IsResolver }}
+							if err = ec.resolvers.{{ $field.ShortInvocation }}; err != nil {
+								return {{$it}}, err
+							}
+						{{- else }}
+							{{- if $field.TypeReference.IsOmittable }}
+								{{ $lhs }} = graphql.OmittableOf(data)
+							{{- else }}
+								{{ $lhs }} = data
+							{{- end }}
+						{{- end }}
+					{{- if $field.TypeReference.IsNilable }}
+						{{- if not $field.IsResolver }}
+						} else if tmp == nil {
+							{{- if $field.TypeReference.IsOmittable }}
+								{{ $lhs }} = graphql.OmittableOf[{{ $field.TypeReference.GO | ref }}](nil)
+							{{- else }}
+								{{ $lhs }} = nil
+							{{- end }}
+						{{- end }}
+					{{- end }}
+					} else {
+						err := fmt.Errorf(`unexpected type %T from directive, should be {{ $field.TypeReference.GO }}`, tmp)
+						return {{$it}}, graphql.ErrorOnPath(ctx, err)
+					}
+				{{- else }}
+					{{- if $field.IsResolver }}
+						data, err := ec.{{ $field.TypeReference.UnmarshalFunc }}(ctx, v)
+						if err != nil {
+							return {{$it}}, err
+						}
+						if err = ec.resolvers.{{ $field.ShortInvocation }}; err != nil {
+							return {{$it}}, err
+						}
+					{{- else }}
+						data, err := ec.{{ $field.TypeReference.UnmarshalFunc }}(ctx, v)
+						if err != nil {
+							return {{$it}}, err
+						}
+						{{- if $field.TypeReference.IsOmittable }}
+							{{ $lhs }} = graphql.OmittableOf(data)
+						{{- else }}
+							{{ $lhs }} = data
+						{{- end }}
+					{{- end }}
+				{{- end }}
+			{{- end }}
+			}
+		}
+
+		return {{$it}}, nil
+	}
+	{{- end }}
+{{ end }}

--- a/api/testdata/template/follow-schema/dir/graph/template/interface.gotpl
+++ b/api/testdata/template/follow-schema/dir/graph/template/interface.gotpl
@@ -1,0 +1,21 @@
+{{- range $interface := .Interfaces }}
+
+func (ec *executionContext) _{{$interface.Name}}(ctx context.Context, sel ast.SelectionSet, obj {{$interface.Type | ref}}) graphql.Marshaler {
+	switch obj := (obj).(type) {
+	case nil:
+		return graphql.Null
+	{{- range $implementor := $interface.Implementors }}
+		case {{$implementor.Type | ref}}:
+			{{- if $implementor.CanBeNil }}
+				if obj == nil {
+					return graphql.Null
+				}
+			{{- end }}
+			return ec._{{$implementor.Name}}(ctx, sel, {{ if $implementor.TakeRef }}&{{ end }}obj)
+	{{- end }}
+	default:
+		panic(fmt.Errorf("unexpected type %T", obj))
+	}
+}
+
+{{- end }}

--- a/api/testdata/template/follow-schema/dir/graph/template/object.gotpl
+++ b/api/testdata/template/follow-schema/dir/graph/template/object.gotpl
@@ -1,0 +1,149 @@
+{{- range $object := .Objects }}
+
+var {{ $object.Name|lcFirst}}Implementors = {{$object.Implementors}}
+
+{{- if .Stream }}
+func (ec *executionContext) _{{$object.Name}}(ctx context.Context, sel ast.SelectionSet) func(ctx context.Context) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, {{$object.Name|lcFirst}}Implementors)
+	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+		Object: {{$object.Name|quote}},
+	})
+	if len(fields) != 1 {
+		ec.Errorf(ctx, "must subscribe to exactly one stream")
+		return nil
+	}
+
+	switch fields[0].Name {
+	{{- range $field := $object.Fields }}
+	case "{{$field.Name}}":
+		return ec._{{$object.Name}}_{{$field.Name}}(ctx, fields[0])
+	{{- end }}
+	default:
+		panic("unknown field " + strconv.Quote(fields[0].Name))
+	}
+}
+{{- else }}
+func (ec *executionContext) _{{$object.Name}}(ctx context.Context, sel ast.SelectionSet{{ if not $object.Root }},obj {{$object.Reference | ref }}{{ end }}) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, {{$object.Name|lcFirst}}Implementors)
+	{{- if $object.Root }}
+		ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+			Object: {{$object.Name|quote}},
+		})
+	{{end}}
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		{{- if $object.Root }}
+			innerCtx := graphql.WithRootFieldContext(ctx, &graphql.RootFieldContext{
+				Object: field.Name,
+				Field: field,
+			})
+		{{end}}
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString({{$object.Name|quote}})
+		{{- range $field := $object.Fields }}
+		case "{{$field.Name}}":
+			{{- if $field.IsConcurrent }}
+				field := field
+
+				innerFunc := func(ctx context.Context, {{ if $field.TypeReference.GQL.NonNull }}fs{{ else }}_{{ end }} *graphql.FieldSet) (res graphql.Marshaler) {
+					{{- if not $.Config.OmitPanicHandler }}
+					defer func() {
+						if r := recover(); r != nil {
+							ec.Error(ctx, ec.Recover(ctx, r))
+						}
+					}()
+					{{- end }}
+					res = ec._{{$object.Name}}_{{$field.Name}}(ctx, field{{if not $object.Root}}, obj{{end}})
+					{{- if $field.TypeReference.GQL.NonNull }}
+						if res == graphql.Null {
+							{{- if $object.IsConcurrent }}
+								atomic.AddUint32(&fs.Invalids, 1)
+							{{- else }}
+								fs.Invalids++
+							{{- end }}
+						}
+					{{- end }}
+					return res
+				}
+
+				{{if $object.Root}}
+					rrm := func(ctx context.Context) graphql.Marshaler {
+						return ec.OperationContext.RootResolverMiddleware(ctx,
+							func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+					}
+				{{end}}
+
+				{{if not $object.Root}}
+					if field.Deferrable != nil {
+						dfs, ok := deferred[field.Deferrable.Label]
+						di := 0
+						if ok {
+							dfs.AddField(field)
+							di = len(dfs.Values) - 1
+						} else {
+							dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+							deferred[field.Deferrable.Label] = dfs
+						}
+						dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+							return innerFunc(ctx, dfs)
+						})
+
+						// don't run the out.Concurrently() call below
+						out.Values[i] = graphql.Null
+						continue
+					}
+				{{end}}
+
+				out.Concurrently(i, func(ctx context.Context) graphql.Marshaler {
+					{{- if $object.Root -}}
+						return rrm(innerCtx)
+					{{- else -}}
+						return innerFunc(ctx, out)
+					{{- end -}}
+				})
+			{{- else }}
+				{{- if $object.Root -}}
+					out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+						return ec._{{$object.Name}}_{{$field.Name}}(ctx, field)
+					})
+				{{- else -}}
+					out.Values[i] = ec._{{$object.Name}}_{{$field.Name}}(ctx, field, obj)
+				{{- end -}}
+
+				{{- if $field.TypeReference.GQL.NonNull }}
+					if out.Values[i] == graphql.Null {
+						{{- if $object.IsConcurrent }}
+							atomic.AddUint32(&out.Invalids, 1)
+						{{- else }}
+							out.Invalids++
+						{{- end }}
+					}
+				{{- end }}
+			{{- end }}
+		{{- end }}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 { return graphql.Null }
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+{{- end }}
+
+{{- end }}

--- a/api/testdata/template/follow-schema/dir/graph/template/type.gotpl
+++ b/api/testdata/template/follow-schema/dir/graph/template/type.gotpl
@@ -1,0 +1,228 @@
+{{- range $type := .ReferencedTypes }}
+	{{ with $type.UnmarshalFunc }}
+		func (ec *executionContext) {{ . }}(ctx context.Context, v interface{}) ({{ $type.GO | ref }}, error) {
+			{{- if and $type.IsNilable (not $type.GQL.NonNull) (not $type.IsPtrToPtr) }}
+				if v == nil { return nil, nil }
+			{{- end }}
+			{{- if or $type.IsPtrToSlice $type.IsPtrToIntf }}
+				res, err := ec.{{ $type.Elem.UnmarshalFunc }}(ctx, v)
+				return &res, graphql.ErrorOnPath(ctx, err)
+			{{- else if $type.IsSlice }}
+				var vSlice []interface{}
+				if v != nil {
+					vSlice = graphql.CoerceList(v)
+				}
+				var err error
+				res := make([]{{$type.GO.Elem | ref}}, len(vSlice))
+				for i := range vSlice {
+					ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+					res[i], err = ec.{{ $type.Elem.UnmarshalFunc }}(ctx, vSlice[i])
+					if err != nil {
+						return nil, err
+					}
+				}
+				return res, nil
+			{{- else if and $type.IsPtrToPtr (not $type.Unmarshaler) (not $type.IsMarshaler) }}
+				var pres {{ $type.Elem.GO | ref }}
+				if v != nil {
+					res, err := ec.{{ $type.Elem.UnmarshalFunc }}(ctx, v)
+					if err != nil {
+						return nil, graphql.ErrorOnPath(ctx, err)
+					}
+					pres = res
+				}
+				return &pres, nil
+			{{- else }}
+				{{- if $type.Unmarshaler }}
+					{{- if $type.HasEnumValues }}
+						tmp, err := {{ $type.Unmarshaler | call }}(v)
+						res := {{ $type.UnmarshalFunc }}[tmp]
+					{{- else if $type.CastType }}
+						{{- if $type.IsContext }}
+							tmp, err := {{ $type.Unmarshaler | call }}(ctx, v)
+						{{- else }}
+							tmp, err := {{ $type.Unmarshaler | call }}(v)
+						{{- end }}
+						{{- if and $type.IsNilable $type.Elem }}
+							res := {{ $type.Elem.GO | ref }}(tmp)
+						{{- else}}
+							res := {{ $type.GO | ref }}(tmp)
+						{{- end }}
+					{{- else}}
+						{{- if $type.IsContext }}
+							res, err := {{ $type.Unmarshaler | call }}(ctx, v)
+						{{- else }}
+							res, err := {{ $type.Unmarshaler | call }}(v)
+						{{- end }}
+					{{- end }}
+					{{- if and $type.IsTargetNilable (not $type.IsNilable) }}
+						return *res, graphql.ErrorOnPath(ctx, err)
+					{{- else if and (not $type.IsTargetNilable) $type.IsNilable }}
+						return &res, graphql.ErrorOnPath(ctx, err)
+					{{- else}}
+						return res, graphql.ErrorOnPath(ctx, err)
+					{{- end }}
+				{{- else if $type.IsMarshaler }}
+					{{- if and $type.IsNilable $type.Elem }}
+						var res = new({{ $type.Elem.GO | ref }})
+					{{- else}}
+						var res {{ $type.GO | ref }}
+					{{- end }}
+					{{- if $type.IsContext }}
+						err := res.UnmarshalGQLContext(ctx, v)
+					{{- else }}
+						err := res.UnmarshalGQL(v)
+					{{- end }}
+					return res, graphql.ErrorOnPath(ctx, err)
+				{{- else }}
+					res, err := ec.unmarshalInput{{ $type.GQL.Name }}(ctx, v)
+					{{- if and $type.IsNilable (not $type.IsMap) (not $type.PointersInUnmarshalInput) }}
+						return &res, graphql.ErrorOnPath(ctx, err)
+					{{- else if and (not $type.IsNilable) $type.PointersInUnmarshalInput }}
+						return *res, graphql.ErrorOnPath(ctx, err)
+					{{- else }}
+						return res, graphql.ErrorOnPath(ctx, err)
+					{{- end }}
+				{{- end }}
+			{{- end }}
+		}
+	{{- end }}
+
+	{{ with $type.MarshalFunc }}
+		func (ec *executionContext) {{ . }}(ctx context.Context, sel ast.SelectionSet, v {{ $type.GO | ref }}) graphql.Marshaler {
+			{{- if or $type.IsPtrToSlice $type.IsPtrToIntf }}
+				return ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, *v)
+			{{- else if $type.IsSlice }}
+				{{- if not $type.GQL.NonNull }}
+					if v == nil {
+						return graphql.Null
+					}
+				{{- end }}
+				ret := make(graphql.Array, len(v))
+				{{- if not $type.IsScalar }}
+					var wg sync.WaitGroup
+					isLen1 := len(v) == 1
+					if !isLen1 {
+						wg.Add(len(v))
+					}
+				{{- end }}
+				for i := range v {
+					{{- if not $type.IsScalar }}
+						i := i
+						fc := &graphql.FieldContext{
+							Index: &i,
+							Result: &v[i],
+						}
+						ctx := graphql.WithFieldContext(ctx, fc)
+						f := func(i int) {
+							{{- if not $.Config.OmitPanicHandler }}
+							defer func() {
+								if r := recover(); r != nil {
+									ec.Error(ctx, ec.Recover(ctx, r))
+									ret = nil
+								}
+							}()
+							{{- end }}
+							if !isLen1 {
+								defer wg.Done()
+							}
+							ret[i] = ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, v[i])
+						}
+						if isLen1 {
+							f(i)
+						} else {
+							go f(i)
+						}
+					{{ else }}
+						ret[i] = ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, v[i])
+					{{- end }}
+				}
+				{{ if not $type.IsScalar }} wg.Wait() {{ end }}
+				{{ if $type.Elem.GQL.NonNull }}
+					for _, e := range ret {
+						if e == graphql.Null {
+							return graphql.Null
+						}
+					}
+				{{ end }}
+				return ret
+			{{- else if and $type.IsPtrToPtr (not $type.Unmarshaler) (not $type.IsMarshaler) }}
+				if v == nil {
+					return graphql.Null
+				}
+				return ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, *v)
+			{{- else }}
+				{{- if $type.IsNilable }}
+					if v == nil {
+						{{- if $type.GQL.NonNull }}
+							if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+								ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+							}
+						{{- end }}
+						return graphql.Null
+					}
+				{{- end }}
+				{{- if $type.IsMarshaler }}
+					{{- if $type.IsContext }}
+						return graphql.WrapContextMarshaler(ctx, v)
+					{{- else }}
+						return v
+					{{- end }}
+				{{- else if $type.Marshaler }}
+					{{- $v := "v" }}
+					{{- if and $type.IsTargetNilable (not $type.IsNilable) }}
+						{{- $v = "&v" }}
+					{{- else if and (not $type.IsTargetNilable) $type.IsNilable }}
+						{{- $v = "*v" }}
+					{{- end }}
+					{{- if $type.HasEnumValues }}
+						{{- $v = printf "%v[%v]" $type.MarshalFunc $v }}
+					{{- else if $type.CastType }}
+						{{- $v = printf "%v(%v)" ($type.CastType | ref) $v}}
+					{{- end }}
+					res := {{ $type.Marshaler | call }}({{ $v }})
+					{{- if $type.GQL.NonNull }}
+						if res == graphql.Null {
+							if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+								ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+							}
+						}
+					{{- end }}
+					{{- if $type.IsContext }}
+						return graphql.WrapContextMarshaler(ctx, res)
+					{{- else }}
+						return res
+					{{- end }}
+				{{- else if $type.IsRoot }}
+					{{- if eq $type.Definition.Name "Subscription" }}
+						res := ec._{{$type.Definition.Name}}(ctx, sel)
+						return res(ctx)
+					{{- else }}
+						return ec._{{$type.Definition.Name}}(ctx, sel)
+					{{- end }}
+				{{- else }}
+					return ec._{{$type.Definition.Name}}(ctx, sel, {{ if not $type.IsNilable}}&{{end}} v)
+				{{- end }}
+			{{- end }}
+		}
+	{{- end }}
+
+	{{- if $type.HasEnumValues }}
+	{{- $enum := $type.GO }}
+	{{- if $type.IsNilable }}
+		{{- $enum = $type.GO.Elem }}
+	{{- end }}
+	var (
+		{{ $type.UnmarshalFunc }} = map[string]{{ $enum | ref }}{
+		{{- range $value := $type.EnumValues }}
+			"{{ $value.Definition.Name }}": {{ $value.Object | obj }},
+		{{- end }}
+		}
+		{{ $type.MarshalFunc }} = map[{{ $enum | ref }}]string{
+		{{- range $value := $type.EnumValues }}
+			 {{ $value.Object | obj }}: "{{ $value.Definition.Name }}",
+		{{- end }}
+		}
+	 )
+	{{- end }}
+{{- end }}

--- a/api/testdata/template/follow-schema/dir/graph/todo.graphqls
+++ b/api/testdata/template/follow-schema/dir/graph/todo.graphqls
@@ -1,0 +1,23 @@
+# GraphQL schema example
+#
+# https://gqlgen.com/getting-started/
+
+type Todo {
+  id: ID!
+  text: String!
+  done: Boolean!
+  user: User!
+}
+
+type Query {
+  todos: [Todo!]!
+}
+
+input NewTodo {
+  text: String!
+  userId: String!
+}
+
+type Mutation {
+  createTodo(input: NewTodo!): Todo!
+}

--- a/api/testdata/template/follow-schema/dir/graph/user.graphqls
+++ b/api/testdata/template/follow-schema/dir/graph/user.graphqls
@@ -1,0 +1,22 @@
+# GraphQL schema example
+#
+# https://gqlgen.com/getting-started/
+
+type User {
+  id: ID!
+  name: String!
+}
+
+extend type Query {
+    user(id: ID!): User
+    users: [User!]!
+}
+
+input NewUser {
+  id: ID!
+  name: String!
+}
+
+extend type Mutation {
+  createUser(input: NewUser!): User!
+}

--- a/api/testdata/template/follow-schema/file/gqlgen.yml
+++ b/api/testdata/template/follow-schema/file/gqlgen.yml
@@ -1,0 +1,71 @@
+# Where are all the schema files located? globs are supported eg  src/**/*.graphqls
+schema:
+  - graph/*.graphqls
+
+# Where should the generated server code go?
+exec:
+  layout: follow-schema
+  dir: graph/generated
+  package: graph
+  exec_template: graph/template/exec.gotpl
+
+# Uncomment to enable federation
+# federation:
+#   filename: graph/federation.go
+#   package: graph
+
+# Where should any generated models go?
+model:
+  filename: graph/model/models_gen.go
+  package: model
+
+# Where should the resolver implementations go?
+resolver:
+  layout: follow-schema
+  dir: graph
+  package: graph
+
+# Optional: turn on use `gqlgen:"fieldName"` tags in your models
+# struct_tag: json
+
+# Optional: turn on to use []Thing instead of []*Thing
+# omit_slice_element_pointers: false
+
+# Optional: turn off to make struct-type struct fields not use pointers
+# e.g. type Thing struct { FieldA OtherThing } instead of { FieldA *OtherThing }
+# struct_fields_always_pointers: true
+
+# Optional: turn off to make resolvers return values instead of pointers for structs
+# resolvers_always_return_pointers: true
+
+# Optional: turn on to return pointers instead of values in unmarshalInput
+# return_pointers_in_unmarshalinput: false
+
+# Optional: wrap nullable input fields with Omittable
+# nullable_input_omittable: true
+
+# Optional: set to speed up generation time by not performing a final validation pass.
+# skip_validation: true
+
+# gqlgen will search for any type names in the schema in these go packages
+# if they match it will use them, otherwise it will generate them.
+autobind:
+  - "github.com/99designs/gqlgen/api/testdata/default/graph/model"
+
+# This section declares type mapping between the GraphQL and go type systems
+#
+# The first line in each type will be used as defaults for resolver arguments and
+# modelgen, the others will be allowed when binding to fields. Configure them to
+# your liking
+models:
+  ID:
+    model:
+      - github.com/99designs/gqlgen/graphql.ID
+      - github.com/99designs/gqlgen/graphql.Int
+      - github.com/99designs/gqlgen/graphql.Int64
+      - github.com/99designs/gqlgen/graphql.Int32
+  Int:
+    model:
+      - github.com/99designs/gqlgen/graphql.Int
+      - github.com/99designs/gqlgen/graphql.Int64
+      - github.com/99designs/gqlgen/graphql.Int32

--- a/api/testdata/template/follow-schema/file/graph/model/doc.go
+++ b/api/testdata/template/follow-schema/file/graph/model/doc.go
@@ -1,0 +1,1 @@
+package model

--- a/api/testdata/template/follow-schema/file/graph/schema.graphqls
+++ b/api/testdata/template/follow-schema/file/graph/schema.graphqls
@@ -1,0 +1,28 @@
+# GraphQL schema example
+#
+# https://gqlgen.com/getting-started/
+
+type Todo {
+  id: ID!
+  text: String!
+  done: Boolean!
+  user: User!
+}
+
+type User {
+  id: ID!
+  name: String!
+}
+
+type Query {
+  todos: [Todo!]!
+}
+
+input NewTodo {
+  text: String!
+  userId: String!
+}
+
+type Mutation {
+  createTodo(input: NewTodo!): Todo!
+}

--- a/api/testdata/template/follow-schema/file/graph/template/exec.gotpl
+++ b/api/testdata/template/follow-schema/file/graph/template/exec.gotpl
@@ -1,0 +1,1051 @@
+{{/* Context object: codegen.Data */}}
+{{ reserveImport "context"  }}
+{{ reserveImport "fmt"  }}
+{{ reserveImport "io"  }}
+{{ reserveImport "strconv"  }}
+{{ reserveImport "time"  }}
+{{ reserveImport "sync"  }}
+{{ reserveImport "sync/atomic" }}
+{{ reserveImport "errors"  }}
+{{ reserveImport "bytes"  }}
+{{ reserveImport "embed"  }}
+
+{{ reserveImport "github.com/vektah/gqlparser/v2" "gqlparser" }}
+{{ reserveImport "github.com/vektah/gqlparser/v2/ast" }}
+{{ reserveImport "github.com/99designs/gqlgen/graphql" }}
+{{ reserveImport "github.com/99designs/gqlgen/graphql/introspection" }}
+
+{{ if eq .Config.Exec.Layout "single-file" }}
+	// NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
+	func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
+		return &executableSchema{
+		 	schema: cfg.Schema,
+			resolvers: cfg.Resolvers,
+			directives: cfg.Directives,
+			complexity: cfg.Complexity,
+		}
+	}
+
+	type Config struct {
+		Schema    *ast.Schema
+		Resolvers  ResolverRoot
+		Directives DirectiveRoot
+		Complexity ComplexityRoot
+	}
+
+	type ResolverRoot interface {
+	{{- range $object := .Objects -}}
+		{{ if $object.HasResolvers -}}
+			{{ucFirst $object.Name}}() {{ucFirst $object.Name}}Resolver
+		{{ end }}
+	{{- end }}
+	{{- range $object := .Inputs -}}
+	{{ if $object.HasResolvers -}}
+		{{ucFirst $object.Name}}() {{ucFirst $object.Name}}Resolver
+	{{ end }}
+{{- end }}
+}
+
+	type DirectiveRoot struct {
+	{{ range $directive := .UserDirectives }}
+		{{- $directive.Declaration }}
+	{{ end }}
+	}
+
+	type ComplexityRoot struct {
+	{{- if not .Config.OmitComplexity }}
+	{{ range $object := .Objects }}
+		{{ if not $object.IsReserved -}}
+			{{ ucFirst $object.Name }} struct {
+			{{ range $_, $fields := $object.UniqueFields }}
+				{{- $field := index $fields 0 -}}
+				{{ if not $field.IsReserved -}}
+					{{ $field.GoFieldName }} {{ $field.ComplexitySignature }}
+				{{ end }}
+			{{- end }}
+			}
+		{{- end }}
+	{{ end }}
+	{{- end }}
+	}
+{{ end }}
+
+{{ range $object := .Objects -}}
+	{{ if $object.HasResolvers }}
+		type {{ucFirst $object.Name}}Resolver interface {
+		{{ range $field := $object.Fields -}}
+			{{- if $field.IsResolver }}
+				{{- $field.GoFieldName}}{{ $field.ShortResolverDeclaration }}
+			{{- end }}
+		{{ end }}
+		}
+	{{- end }}
+{{- end }}
+
+{{ range $object := .Inputs -}}
+	{{ if $object.HasResolvers }}
+		type {{$object.Name}}Resolver interface {
+		{{ range $field := $object.Fields -}}
+			{{- if $field.IsResolver }}
+				{{- $field.GoFieldName}}{{ $field.ShortResolverDeclaration }}
+			{{- end }}
+		{{ end }}
+		}
+	{{- end }}
+{{- end }}
+
+{{ range $directive := .BuiltInDirectives }}
+	var (
+		{{- $directive.FunctionImpl }}
+	)
+{{ end }}
+
+{{ if eq .Config.Exec.Layout "single-file" }}
+	type executableSchema struct {
+		schema    *ast.Schema
+		resolvers  ResolverRoot
+		directives DirectiveRoot
+		complexity ComplexityRoot
+	}
+
+	func (e *executableSchema) Schema() *ast.Schema {
+		if e.schema != nil {
+        		return e.schema
+		}
+		return parsedSchema
+	}
+
+	func (e *executableSchema) Complexity(typeName, field string, childComplexity int, rawArgs map[string]interface{}) (int, bool) {
+		ec := executionContext{nil, e, 0, 0, nil}
+		_ = ec
+		{{ if not .Config.OmitComplexity -}}
+		switch typeName + "." + field {
+		{{ range $object := .Objects }}
+			{{ if not $object.IsReserved }}
+				{{ range $_, $fields := $object.UniqueFields }}
+					{{- $len := len $fields }}
+					{{- range $i, $field := $fields }}
+						{{- $last := eq (add $i 1) $len }}
+						{{- if not $field.IsReserved }}
+							{{- if eq $i 0 }}case {{ end }}"{{$object.Name}}.{{$field.Name}}"{{ if not $last }},{{ else }}:
+								if e.complexity.{{ucFirst $object.Name}}.{{$field.GoFieldName}} == nil {
+									break
+								}
+								{{ if $field.Args }}
+									args, err := ec.{{ $field.ArgsFunc }}(context.TODO(),rawArgs)
+									if err != nil {
+										return 0, false
+									}
+								{{ end }}
+								return e.complexity.{{ucFirst $object.Name}}.{{$field.GoFieldName}}(childComplexity{{if $field.Args}}, {{$field.ComplexityArgs}} {{ end }}), true
+							{{ end }}
+						{{- end }}
+					{{- end }}
+				{{ end }}
+			{{ end }}
+		{{ end }}
+		}
+		{{- end }}
+		return 0, false
+	}
+
+	func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
+		rc := graphql.GetOperationContext(ctx)
+		ec := executionContext{rc, e, 0, 0, make(chan graphql.DeferredResult)}
+		inputUnmarshalMap := graphql.BuildUnmarshalerMap(
+			{{- range $input := .Inputs -}}
+				{{ if not $input.HasUnmarshal }}
+					ec.unmarshalInput{{ $input.Name }},
+				{{- end }}
+			{{- end }}
+		)
+		first := true
+
+		switch rc.Operation.Operation {
+		{{- if .QueryRoot }} case ast.Query:
+			return func(ctx context.Context) *graphql.Response {
+				var response graphql.Response
+				var data graphql.Marshaler
+				if first {
+					first = false
+					ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
+					{{ if .Directives.LocationDirectives "QUERY" -}}
+						data = ec._queryMiddleware(ctx, rc.Operation, func(ctx context.Context) (interface{}, error){
+							return ec._{{.QueryRoot.Name}}(ctx, rc.Operation.SelectionSet), nil
+						})
+					{{- else -}}
+						data = ec._{{.QueryRoot.Name}}(ctx, rc.Operation.SelectionSet)
+					{{- end }}
+				} else {
+					if atomic.LoadInt32(&ec.pendingDeferred) > 0 {
+						result := <-ec.deferredResults
+						atomic.AddInt32(&ec.pendingDeferred, -1)
+						data = result.Result
+						response.Path = result.Path
+						response.Label = result.Label
+						response.Errors = result.Errors
+					} else {
+						return nil
+					}
+				}
+				var buf bytes.Buffer
+				data.MarshalGQL(&buf)
+				response.Data = buf.Bytes()
+				if atomic.LoadInt32(&ec.deferred) > 0 {
+					hasNext := atomic.LoadInt32(&ec.pendingDeferred) > 0
+					response.HasNext = &hasNext
+				}
+
+				return &response
+			}
+		{{ end }}
+
+		{{- if .MutationRoot }} case ast.Mutation:
+			return func(ctx context.Context) *graphql.Response {
+				if !first { return nil }
+				first = false
+				ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
+				{{ if .Directives.LocationDirectives "MUTATION" -}}
+					data := ec._mutationMiddleware(ctx, rc.Operation, func(ctx context.Context) (interface{}, error){
+						return ec._{{.MutationRoot.Name}}(ctx, rc.Operation.SelectionSet), nil
+					})
+				{{- else -}}
+					data := ec._{{.MutationRoot.Name}}(ctx, rc.Operation.SelectionSet)
+				{{- end }}
+				var buf bytes.Buffer
+				data.MarshalGQL(&buf)
+
+				return &graphql.Response{
+					Data:       buf.Bytes(),
+				}
+			}
+		{{ end }}
+
+		{{- if .SubscriptionRoot }} case ast.Subscription:
+			{{ if .Directives.LocationDirectives "SUBSCRIPTION" -}}
+				next := ec._subscriptionMiddleware(ctx, rc.Operation, func(ctx context.Context) (interface{}, error){
+					return ec._{{.SubscriptionRoot.Name}}(ctx, rc.Operation.SelectionSet),nil
+				})
+			{{- else -}}
+				next := ec._{{.SubscriptionRoot.Name}}(ctx, rc.Operation.SelectionSet)
+			{{- end }}
+
+			var buf bytes.Buffer
+			return func(ctx context.Context) *graphql.Response {
+				buf.Reset()
+				data := next(ctx)
+
+				if data == nil {
+					return nil
+				}
+				data.MarshalGQL(&buf)
+
+				return &graphql.Response{
+					Data:       buf.Bytes(),
+				}
+			}
+		{{ end }}
+		default:
+			return graphql.OneShot(graphql.ErrorResponse(ctx, "unsupported GraphQL operation"))
+		}
+	}
+
+	type executionContext struct {
+		*graphql.OperationContext
+		*executableSchema
+		deferred        int32
+		pendingDeferred int32
+		deferredResults chan graphql.DeferredResult
+	}
+
+	func (ec *executionContext) processDeferredGroup(dg graphql.DeferredGroup) {
+		atomic.AddInt32(&ec.pendingDeferred, 1)
+		go func () {
+			ctx := graphql.WithFreshResponseContext(dg.Context)
+			dg.FieldSet.Dispatch(ctx)
+			ds := graphql.DeferredResult{
+				Path:   dg.Path,
+				Label:  dg.Label,
+				Result: dg.FieldSet,
+				Errors: graphql.GetErrors(ctx),
+			}
+			// null fields should bubble up
+			if dg.FieldSet.Invalids > 0 {
+				ds.Result = graphql.Null
+			}
+			ec.deferredResults <- ds
+		}()
+	}
+
+	func (ec *executionContext) introspectSchema() (*introspection.Schema, error) {
+		if ec.DisableIntrospection {
+			return nil, errors.New("introspection disabled")
+		}
+		return introspection.WrapSchema(ec.Schema()), nil
+	}
+
+	func (ec *executionContext) introspectType(name string) (*introspection.Type, error) {
+		if ec.DisableIntrospection {
+			return nil, errors.New("introspection disabled")
+		}
+		return introspection.WrapTypeFromDef(ec.Schema(), ec.Schema().Types[name]), nil
+	}
+
+	{{if .HasEmbeddableSources }}
+	//go:embed{{- range $source := .AugmentedSources }}{{if $source.Embeddable}} {{$source.RelativePath|quote}}{{end}}{{- end }}
+	var sourcesFS embed.FS
+
+	func sourceData(filename string) string {
+		data, err := sourcesFS.ReadFile(filename)
+		if err != nil {
+			panic(fmt.Sprintf("codegen problem: %s not available", filename))
+		}
+		return string(data)
+	}
+	{{- end }}
+
+	var sources = []*ast.Source{
+	{{- range $source := .AugmentedSources }}
+		{Name: {{$source.RelativePath|quote}}, Input: {{if (not $source.Embeddable)}}{{$source.Source|rawQuote}}{{else}}sourceData({{$source.RelativePath|quote}}){{end}}, BuiltIn: {{$source.BuiltIn}}},
+	{{- end }}
+	}
+	var parsedSchema = gqlparser.MustLoadSchema(sources...)
+{{ end }}
+{{ range $name, $args := .Args }}
+func (ec *executionContext) {{ $name }}(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+
+	{{- range $i, $arg := . }}
+		arg{{$i}}, err := ec.{{ $name }}{{$arg.Name | go}}(ctx, rawArgs)
+		if err != nil {
+			return nil, err
+		}
+		args[{{$arg.Name|quote}}] = arg{{$i}}
+	{{- end }}
+	return args, nil
+}
+
+	{{- range $i, $arg := . }}
+		func (ec *executionContext) {{ $name }}{{$arg.Name | go}}(
+			ctx context.Context,
+			rawArgs map[string]interface{},
+		) ({{ $arg.TypeReference.GO | ref}}, error) {
+			{{- if not .CallArgumentDirectivesWithNull}}
+				// We won't call the directive if the argument is null.
+				// Set call_argument_directives_with_null to true to call directives
+				// even if the argument is null.
+				_, ok := rawArgs[{{$arg.Name|quote}}]
+				if !ok {
+					var zeroVal {{ $arg.TypeReference.GO | ref}}
+					return zeroVal, nil
+				}
+			{{end}}
+			ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField({{$arg.Name|quote}}))
+			{{- if $arg.ImplDirectives }}
+				directive0 := func(ctx context.Context) (interface{}, error) {
+					tmp, ok := rawArgs[{{$arg.Name|quote}}]
+					if !ok {
+						var zeroVal {{ $arg.TypeReference.GO | ref}}
+						return zeroVal, nil
+					}
+					return ec.{{ $arg.TypeReference.UnmarshalFunc }}(ctx, tmp)
+				}
+				{{ template "implDirectives" $arg }}
+				tmp, err := directive{{$arg.ImplDirectives|len}}(ctx)
+				if err != nil {
+					var zeroVal {{ $arg.TypeReference.GO | ref}}
+					return zeroVal, graphql.ErrorOnPath(ctx, err)
+				}
+				if data, ok := tmp.({{ $arg.TypeReference.GO | ref }}) ; ok {
+					return data, nil
+				{{- if $arg.TypeReference.IsNilable }}
+					} else if tmp == nil {
+						var zeroVal {{ $arg.TypeReference.GO | ref}}
+						return zeroVal, nil
+				{{- end }}
+				} else {
+					var zeroVal {{ $arg.TypeReference.GO | ref}}
+					return zeroVal, graphql.ErrorOnPath(ctx, fmt.Errorf(`unexpected type %T from directive, should be {{ $arg.TypeReference.GO }}`, tmp))
+				}
+			{{- else }}
+				if tmp, ok := rawArgs[{{$arg.Name|quote}}]; ok {
+					return ec.{{ $arg.TypeReference.UnmarshalFunc }}(ctx, tmp)
+				}
+
+				var zeroVal {{ $arg.TypeReference.GO | ref}}
+				return zeroVal, nil
+			{{- end }}
+		}
+	{{end}}
+{{ end }}
+{{- range $object := .Objects }}{{- range $field := $object.Fields }}
+
+func (ec *executionContext) _{{$object.Name}}_{{$field.Name}}(ctx context.Context, field graphql.CollectedField{{ if not $object.Root }}, obj {{$object.Reference | ref}}{{end}}) (ret {{ if $object.Stream }}func(ctx context.Context){{ end }}graphql.Marshaler) {
+	{{- $null := "graphql.Null" }}
+	{{- if $object.Stream }}
+		{{- $null = "nil" }}
+	{{- end }}
+	fc, err := ec.{{ $field.FieldContextFunc }}(ctx, field)
+	if err != nil {
+		return {{ $null }}
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	{{- if not $.Config.OmitPanicHandler }}
+	defer func () {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = {{ $null }}
+		}
+	}()
+	{{- end }}
+	{{- if $field.TypeReference.IsRoot }}
+		{{- if $field.TypeReference.IsPtr }}
+			res := &{{ $field.TypeReference.Elem.GO | ref }}{}
+		{{- else }}
+			res := {{ $field.TypeReference.GO | ref }}{}
+		{{- end }}
+		fc.Result = res
+		return ec.{{ $field.TypeReference.MarshalFunc }}(ctx, field.Selections, res)
+	{{- else}}
+		{{- if  $.AllDirectives.LocationDirectives "FIELD" }}
+			resTmp := ec._fieldMiddleware(ctx, {{if $object.Root}}nil{{else}}obj{{end}}, func(rctx context.Context) (interface{}, error) {
+				{{ template "field" $field }}
+			})
+		{{ else }}
+			resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+				{{ template "field" $field }}
+			})
+			if err != nil {
+				ec.Error(ctx, err)
+				return {{ $null }}
+			}
+		{{- end }}
+		if resTmp == nil {
+			{{- if $field.TypeReference.GQL.NonNull }}
+				if !graphql.HasFieldError(ctx, fc) {
+					ec.Errorf(ctx, "must not be null")
+				}
+			{{- end }}
+			return {{ $null }}
+		}
+		{{- if $object.Stream }}
+			return func(ctx context.Context) graphql.Marshaler {
+				select {
+				case res, ok := <-resTmp.(<-chan {{$field.TypeReference.GO | ref}}):
+					if !ok {
+						return nil
+					}
+					return graphql.WriterFunc(func(w io.Writer) {
+						w.Write([]byte{'{'})
+						graphql.MarshalString(field.Alias).MarshalGQL(w)
+						w.Write([]byte{':'})
+						ec.{{ $field.TypeReference.MarshalFunc }}(ctx, field.Selections, res).MarshalGQL(w)
+						w.Write([]byte{'}'})
+					})
+				case <-ctx.Done():
+					return nil
+				}
+			}
+		{{- else }}
+			res := resTmp.({{$field.TypeReference.GO | ref}})
+			fc.Result = res
+			return ec.{{ $field.TypeReference.MarshalFunc }}(ctx, field.Selections, res)
+		{{- end }}
+	{{- end }}
+}
+
+func (ec *executionContext) {{ $field.FieldContextFunc }}({{ if not $field.Args }}_{{ else }}ctx{{ end }} context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object: {{quote $field.Object.Name}},
+		Field: field,
+		IsMethod: {{or $field.IsMethod $field.IsResolver}},
+		IsResolver: {{ $field.IsResolver }},
+		Child: func (ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			{{- if not $field.TypeReference.Definition.Fields }}
+				return nil, errors.New("field of type {{ $field.TypeReference.Definition.Name }} does not have child fields")
+			{{- else if ne $field.TypeReference.Definition.Kind "OBJECT" }}
+				return nil, errors.New("FieldContext.Child cannot be called on type {{ $field.TypeReference.Definition.Kind }}")
+			{{- else }}
+				switch field.Name {
+					{{- range $f := $field.TypeReference.Definition.Fields }}
+						case "{{ $f.Name }}":
+							return ec.{{ $field.ChildFieldContextFunc $f.Name }}(ctx, field)
+					{{- end }}
+				}
+				return nil, fmt.Errorf("no field named %q was found under type {{ $field.TypeReference.Definition.Name }}", field.Name)
+			{{- end }}
+		},
+	}
+	{{- if $field.Args }}
+		{{- if not $.Config.OmitPanicHandler }}
+		defer func () {
+			if r := recover(); r != nil {
+				err = ec.Recover(ctx, r)
+				ec.Error(ctx, err)
+			}
+		}()
+		{{- end }}
+		ctx = graphql.WithFieldContext(ctx, fc)
+		if fc.Args, err = ec.{{ $field.ArgsFunc }}(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+			ec.Error(ctx, err)
+			return fc, err
+		}
+	{{- end }}
+	return fc, nil
+}
+
+{{- end }}{{- end}}
+
+{{ define "field" }}
+	{{- if .HasDirectives -}}
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx  // use context from middleware stack in children
+			{{ template "fieldDefinition" . }}
+		}
+		{{ template "implDirectives" . }}
+		tmp, err := directive{{.ImplDirectives|len}}(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+		    return nil, nil
+		}
+		if data, ok := tmp.({{if .Stream}}<-chan {{end}}{{ .TypeReference.GO | ref }}) ; ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be {{if .Stream}}<-chan {{end}}{{ .TypeReference.GO }}`, tmp)
+	{{- else -}}
+		ctx = rctx  // use context from middleware stack in children
+		{{ template "fieldDefinition" . }}
+	{{- end -}}
+{{ end }}
+
+{{ define "fieldDefinition" }}
+	{{- if .IsResolver -}}
+		return ec.resolvers.{{ .ShortInvocation }}
+	{{- else if .IsMap -}}
+		switch v := {{.GoReceiverName}}[{{.Name|quote}}].(type) {
+		case {{if .Stream}}<-chan {{end}}{{.TypeReference.GO | ref}}:
+			return v, nil
+		case {{if .Stream}}<-chan {{end}}{{.TypeReference.Elem.GO | ref}}:
+			return &v, nil
+		case nil:
+			return ({{.TypeReference.GO | ref}})(nil), nil
+		default:
+			return nil, fmt.Errorf("unexpected type %T for field %s", v, {{ .Name | quote}})
+		}
+	{{- else if .IsMethod -}}
+		{{- if .VOkFunc -}}
+			v, ok := {{.GoReceiverName}}.{{.GoFieldName}}({{ .CallArgs }})
+			if !ok {
+				return nil, nil
+			}
+			return v, nil
+		{{- else if .NoErr -}}
+			return {{.GoReceiverName}}.{{.GoFieldName}}({{ .CallArgs }}), nil
+		{{- else -}}
+			return {{.GoReceiverName}}.{{.GoFieldName}}({{ .CallArgs }})
+		{{- end -}}
+	{{- else if .IsVariable -}}
+		return {{.GoReceiverName}}.{{.GoFieldName}}, nil
+	{{- end }}
+{{- end }}
+{{- range $input := .Inputs }}
+	{{- if not .HasUnmarshal }}
+	{{- $it := "it" }}
+	{{- if .PointersInUnmarshalInput }}
+	  {{- $it = "&it" }}
+	{{- end }}
+	func (ec *executionContext) unmarshalInput{{ .Name }}(ctx context.Context, obj interface{}) ({{ if .PointersInUnmarshalInput }}*{{ end }}{{.Type | ref}}, error) {
+		{{- if $input.IsMap }}
+			it := make(map[string]interface{}, len(obj.(map[string]interface{})))
+		{{- else }}
+			var it {{.Type | ref}}
+		{{- end }}
+		asMap := map[string]interface{}{}
+		for k, v := range obj.(map[string]interface{}) {
+			asMap[k] = v
+		}
+		{{ range $field := .Fields}}
+			{{- if notNil "Default" $field }}
+				if _, present := asMap[{{$field.Name|quote}}] ; !present {
+					asMap[{{$field.Name|quote}}] = {{ $field.Default | dump }}
+				}
+			{{- end}}
+		{{- end }}
+
+		fieldsInOrder := [...]string{ {{ range .Fields }}{{ quote .Name }},{{ end }} }
+		for _, k := range fieldsInOrder {
+			v, ok := asMap[k]
+			if !ok {
+				continue
+			}
+			switch k {
+			{{- range $field := .Fields }}
+			case {{$field.Name|quote}}:
+				{{- $lhs := (printf "it.%s" $field.GoFieldName) }}
+				{{- if $input.IsMap }}
+					{{- $lhs = (printf "it[%q]" $field.Name) }}
+				{{- end }}
+				ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField({{$field.Name|quote}}))
+				{{- if $field.ImplDirectives }}
+					directive0 := func(ctx context.Context) (interface{}, error) { return ec.{{ $field.TypeReference.UnmarshalFunc }}(ctx, v) }
+					{{ template "implDirectives" $field }}
+					tmp, err := directive{{$field.ImplDirectives|len}}(ctx)
+					if err != nil {
+						return {{$it}}, graphql.ErrorOnPath(ctx, err)
+					}
+					if data, ok := tmp.({{ $field.TypeReference.GO | ref }}) ; ok {
+						{{- if $field.IsResolver }}
+							if err = ec.resolvers.{{ $field.ShortInvocation }}; err != nil {
+								return {{$it}}, err
+							}
+						{{- else }}
+							{{- if $field.TypeReference.IsOmittable }}
+								{{ $lhs }} = graphql.OmittableOf(data)
+							{{- else }}
+								{{ $lhs }} = data
+							{{- end }}
+						{{- end }}
+					{{- if $field.TypeReference.IsNilable }}
+						{{- if not $field.IsResolver }}
+						} else if tmp == nil {
+							{{- if $field.TypeReference.IsOmittable }}
+								{{ $lhs }} = graphql.OmittableOf[{{ $field.TypeReference.GO | ref }}](nil)
+							{{- else }}
+								{{ $lhs }} = nil
+							{{- end }}
+						{{- end }}
+					{{- end }}
+					} else {
+						err := fmt.Errorf(`unexpected type %T from directive, should be {{ $field.TypeReference.GO }}`, tmp)
+						return {{$it}}, graphql.ErrorOnPath(ctx, err)
+					}
+				{{- else }}
+					{{- if $field.IsResolver }}
+						data, err := ec.{{ $field.TypeReference.UnmarshalFunc }}(ctx, v)
+						if err != nil {
+							return {{$it}}, err
+						}
+						if err = ec.resolvers.{{ $field.ShortInvocation }}; err != nil {
+							return {{$it}}, err
+						}
+					{{- else }}
+						data, err := ec.{{ $field.TypeReference.UnmarshalFunc }}(ctx, v)
+						if err != nil {
+							return {{$it}}, err
+						}
+						{{- if $field.TypeReference.IsOmittable }}
+							{{ $lhs }} = graphql.OmittableOf(data)
+						{{- else }}
+							{{ $lhs }} = data
+						{{- end }}
+					{{- end }}
+				{{- end }}
+			{{- end }}
+			}
+		}
+
+		return {{$it}}, nil
+	}
+	{{- end }}
+{{ end }}
+{{- range $interface := .Interfaces }}
+
+func (ec *executionContext) _{{$interface.Name}}(ctx context.Context, sel ast.SelectionSet, obj {{$interface.Type | ref}}) graphql.Marshaler {
+	switch obj := (obj).(type) {
+	case nil:
+		return graphql.Null
+	{{- range $implementor := $interface.Implementors }}
+		case {{$implementor.Type | ref}}:
+			{{- if $implementor.CanBeNil }}
+				if obj == nil {
+					return graphql.Null
+				}
+			{{- end }}
+			return ec._{{$implementor.Name}}(ctx, sel, {{ if $implementor.TakeRef }}&{{ end }}obj)
+	{{- end }}
+	default:
+		panic(fmt.Errorf("unexpected type %T", obj))
+	}
+}
+
+{{- end }}
+{{- range $object := .Objects }}
+
+var {{ $object.Name|lcFirst}}Implementors = {{$object.Implementors}}
+
+{{- if .Stream }}
+func (ec *executionContext) _{{$object.Name}}(ctx context.Context, sel ast.SelectionSet) func(ctx context.Context) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, {{$object.Name|lcFirst}}Implementors)
+	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+		Object: {{$object.Name|quote}},
+	})
+	if len(fields) != 1 {
+		ec.Errorf(ctx, "must subscribe to exactly one stream")
+		return nil
+	}
+
+	switch fields[0].Name {
+	{{- range $field := $object.Fields }}
+	case "{{$field.Name}}":
+		return ec._{{$object.Name}}_{{$field.Name}}(ctx, fields[0])
+	{{- end }}
+	default:
+		panic("unknown field " + strconv.Quote(fields[0].Name))
+	}
+}
+{{- else }}
+func (ec *executionContext) _{{$object.Name}}(ctx context.Context, sel ast.SelectionSet{{ if not $object.Root }},obj {{$object.Reference | ref }}{{ end }}) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, {{$object.Name|lcFirst}}Implementors)
+	{{- if $object.Root }}
+		ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+			Object: {{$object.Name|quote}},
+		})
+	{{end}}
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		{{- if $object.Root }}
+			innerCtx := graphql.WithRootFieldContext(ctx, &graphql.RootFieldContext{
+				Object: field.Name,
+				Field: field,
+			})
+		{{end}}
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString({{$object.Name|quote}})
+		{{- range $field := $object.Fields }}
+		case "{{$field.Name}}":
+			{{- if $field.IsConcurrent }}
+				field := field
+
+				innerFunc := func(ctx context.Context, {{ if $field.TypeReference.GQL.NonNull }}fs{{ else }}_{{ end }} *graphql.FieldSet) (res graphql.Marshaler) {
+					{{- if not $.Config.OmitPanicHandler }}
+					defer func() {
+						if r := recover(); r != nil {
+							ec.Error(ctx, ec.Recover(ctx, r))
+						}
+					}()
+					{{- end }}
+					res = ec._{{$object.Name}}_{{$field.Name}}(ctx, field{{if not $object.Root}}, obj{{end}})
+					{{- if $field.TypeReference.GQL.NonNull }}
+						if res == graphql.Null {
+							{{- if $object.IsConcurrent }}
+								atomic.AddUint32(&fs.Invalids, 1)
+							{{- else }}
+								fs.Invalids++
+							{{- end }}
+						}
+					{{- end }}
+					return res
+				}
+
+				{{if $object.Root}}
+					rrm := func(ctx context.Context) graphql.Marshaler {
+						return ec.OperationContext.RootResolverMiddleware(ctx,
+							func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+					}
+				{{end}}
+
+				{{if not $object.Root}}
+					if field.Deferrable != nil {
+						dfs, ok := deferred[field.Deferrable.Label]
+						di := 0
+						if ok {
+							dfs.AddField(field)
+							di = len(dfs.Values) - 1
+						} else {
+							dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+							deferred[field.Deferrable.Label] = dfs
+						}
+						dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+							return innerFunc(ctx, dfs)
+						})
+
+						// don't run the out.Concurrently() call below
+						out.Values[i] = graphql.Null
+						continue
+					}
+				{{end}}
+
+				out.Concurrently(i, func(ctx context.Context) graphql.Marshaler {
+					{{- if $object.Root -}}
+						return rrm(innerCtx)
+					{{- else -}}
+						return innerFunc(ctx, out)
+					{{- end -}}
+				})
+			{{- else }}
+				{{- if $object.Root -}}
+					out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+						return ec._{{$object.Name}}_{{$field.Name}}(ctx, field)
+					})
+				{{- else -}}
+					out.Values[i] = ec._{{$object.Name}}_{{$field.Name}}(ctx, field, obj)
+				{{- end -}}
+
+				{{- if $field.TypeReference.GQL.NonNull }}
+					if out.Values[i] == graphql.Null {
+						{{- if $object.IsConcurrent }}
+							atomic.AddUint32(&out.Invalids, 1)
+						{{- else }}
+							out.Invalids++
+						{{- end }}
+					}
+				{{- end }}
+			{{- end }}
+		{{- end }}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 { return graphql.Null }
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+{{- end }}
+
+{{- end }}
+{{- range $type := .ReferencedTypes }}
+	{{ with $type.UnmarshalFunc }}
+		func (ec *executionContext) {{ . }}(ctx context.Context, v interface{}) ({{ $type.GO | ref }}, error) {
+			{{- if and $type.IsNilable (not $type.GQL.NonNull) (not $type.IsPtrToPtr) }}
+				if v == nil { return nil, nil }
+			{{- end }}
+			{{- if or $type.IsPtrToSlice $type.IsPtrToIntf }}
+				res, err := ec.{{ $type.Elem.UnmarshalFunc }}(ctx, v)
+				return &res, graphql.ErrorOnPath(ctx, err)
+			{{- else if $type.IsSlice }}
+				var vSlice []interface{}
+				if v != nil {
+					vSlice = graphql.CoerceList(v)
+				}
+				var err error
+				res := make([]{{$type.GO.Elem | ref}}, len(vSlice))
+				for i := range vSlice {
+					ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+					res[i], err = ec.{{ $type.Elem.UnmarshalFunc }}(ctx, vSlice[i])
+					if err != nil {
+						return nil, err
+					}
+				}
+				return res, nil
+			{{- else if and $type.IsPtrToPtr (not $type.Unmarshaler) (not $type.IsMarshaler) }}
+				var pres {{ $type.Elem.GO | ref }}
+				if v != nil {
+					res, err := ec.{{ $type.Elem.UnmarshalFunc }}(ctx, v)
+					if err != nil {
+						return nil, graphql.ErrorOnPath(ctx, err)
+					}
+					pres = res
+				}
+				return &pres, nil
+			{{- else }}
+				{{- if $type.Unmarshaler }}
+					{{- if $type.HasEnumValues }}
+						tmp, err := {{ $type.Unmarshaler | call }}(v)
+						res := {{ $type.UnmarshalFunc }}[tmp]
+					{{- else if $type.CastType }}
+						{{- if $type.IsContext }}
+							tmp, err := {{ $type.Unmarshaler | call }}(ctx, v)
+						{{- else }}
+							tmp, err := {{ $type.Unmarshaler | call }}(v)
+						{{- end }}
+						{{- if and $type.IsNilable $type.Elem }}
+							res := {{ $type.Elem.GO | ref }}(tmp)
+						{{- else}}
+							res := {{ $type.GO | ref }}(tmp)
+						{{- end }}
+					{{- else}}
+						{{- if $type.IsContext }}
+							res, err := {{ $type.Unmarshaler | call }}(ctx, v)
+						{{- else }}
+							res, err := {{ $type.Unmarshaler | call }}(v)
+						{{- end }}
+					{{- end }}
+					{{- if and $type.IsTargetNilable (not $type.IsNilable) }}
+						return *res, graphql.ErrorOnPath(ctx, err)
+					{{- else if and (not $type.IsTargetNilable) $type.IsNilable }}
+						return &res, graphql.ErrorOnPath(ctx, err)
+					{{- else}}
+						return res, graphql.ErrorOnPath(ctx, err)
+					{{- end }}
+				{{- else if $type.IsMarshaler }}
+					{{- if and $type.IsNilable $type.Elem }}
+						var res = new({{ $type.Elem.GO | ref }})
+					{{- else}}
+						var res {{ $type.GO | ref }}
+					{{- end }}
+					{{- if $type.IsContext }}
+						err := res.UnmarshalGQLContext(ctx, v)
+					{{- else }}
+						err := res.UnmarshalGQL(v)
+					{{- end }}
+					return res, graphql.ErrorOnPath(ctx, err)
+				{{- else }}
+					res, err := ec.unmarshalInput{{ $type.GQL.Name }}(ctx, v)
+					{{- if and $type.IsNilable (not $type.IsMap) (not $type.PointersInUnmarshalInput) }}
+						return &res, graphql.ErrorOnPath(ctx, err)
+					{{- else if and (not $type.IsNilable) $type.PointersInUnmarshalInput }}
+						return *res, graphql.ErrorOnPath(ctx, err)
+					{{- else }}
+						return res, graphql.ErrorOnPath(ctx, err)
+					{{- end }}
+				{{- end }}
+			{{- end }}
+		}
+	{{- end }}
+
+	{{ with $type.MarshalFunc }}
+		func (ec *executionContext) {{ . }}(ctx context.Context, sel ast.SelectionSet, v {{ $type.GO | ref }}) graphql.Marshaler {
+			{{- if or $type.IsPtrToSlice $type.IsPtrToIntf }}
+				return ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, *v)
+			{{- else if $type.IsSlice }}
+				{{- if not $type.GQL.NonNull }}
+					if v == nil {
+						return graphql.Null
+					}
+				{{- end }}
+				ret := make(graphql.Array, len(v))
+				{{- if not $type.IsScalar }}
+					var wg sync.WaitGroup
+					isLen1 := len(v) == 1
+					if !isLen1 {
+						wg.Add(len(v))
+					}
+				{{- end }}
+				for i := range v {
+					{{- if not $type.IsScalar }}
+						i := i
+						fc := &graphql.FieldContext{
+							Index: &i,
+							Result: &v[i],
+						}
+						ctx := graphql.WithFieldContext(ctx, fc)
+						f := func(i int) {
+							{{- if not $.Config.OmitPanicHandler }}
+							defer func() {
+								if r := recover(); r != nil {
+									ec.Error(ctx, ec.Recover(ctx, r))
+									ret = nil
+								}
+							}()
+							{{- end }}
+							if !isLen1 {
+								defer wg.Done()
+							}
+							ret[i] = ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, v[i])
+						}
+						if isLen1 {
+							f(i)
+						} else {
+							go f(i)
+						}
+					{{ else }}
+						ret[i] = ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, v[i])
+					{{- end }}
+				}
+				{{ if not $type.IsScalar }} wg.Wait() {{ end }}
+				{{ if $type.Elem.GQL.NonNull }}
+					for _, e := range ret {
+						if e == graphql.Null {
+							return graphql.Null
+						}
+					}
+				{{ end }}
+				return ret
+			{{- else if and $type.IsPtrToPtr (not $type.Unmarshaler) (not $type.IsMarshaler) }}
+				if v == nil {
+					return graphql.Null
+				}
+				return ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, *v)
+			{{- else }}
+				{{- if $type.IsNilable }}
+					if v == nil {
+						{{- if $type.GQL.NonNull }}
+							if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+								ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+							}
+						{{- end }}
+						return graphql.Null
+					}
+				{{- end }}
+				{{- if $type.IsMarshaler }}
+					{{- if $type.IsContext }}
+						return graphql.WrapContextMarshaler(ctx, v)
+					{{- else }}
+						return v
+					{{- end }}
+				{{- else if $type.Marshaler }}
+					{{- $v := "v" }}
+					{{- if and $type.IsTargetNilable (not $type.IsNilable) }}
+						{{- $v = "&v" }}
+					{{- else if and (not $type.IsTargetNilable) $type.IsNilable }}
+						{{- $v = "*v" }}
+					{{- end }}
+					{{- if $type.HasEnumValues }}
+						{{- $v = printf "%v[%v]" $type.MarshalFunc $v }}
+					{{- else if $type.CastType }}
+						{{- $v = printf "%v(%v)" ($type.CastType | ref) $v}}
+					{{- end }}
+					res := {{ $type.Marshaler | call }}({{ $v }})
+					{{- if $type.GQL.NonNull }}
+						if res == graphql.Null {
+							if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+								ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+							}
+						}
+					{{- end }}
+					{{- if $type.IsContext }}
+						return graphql.WrapContextMarshaler(ctx, res)
+					{{- else }}
+						return res
+					{{- end }}
+				{{- else if $type.IsRoot }}
+					{{- if eq $type.Definition.Name "Subscription" }}
+						res := ec._{{$type.Definition.Name}}(ctx, sel)
+						return res(ctx)
+					{{- else }}
+						return ec._{{$type.Definition.Name}}(ctx, sel)
+					{{- end }}
+				{{- else }}
+					return ec._{{$type.Definition.Name}}(ctx, sel, {{ if not $type.IsNilable}}&{{end}} v)
+				{{- end }}
+			{{- end }}
+		}
+	{{- end }}
+
+	{{- if $type.HasEnumValues }}
+	{{- $enum := $type.GO }}
+	{{- if $type.IsNilable }}
+		{{- $enum = $type.GO.Elem }}
+	{{- end }}
+	var (
+		{{ $type.UnmarshalFunc }} = map[string]{{ $enum | ref }}{
+		{{- range $value := $type.EnumValues }}
+			"{{ $value.Definition.Name }}": {{ $value.Object | obj }},
+		{{- end }}
+		}
+		{{ $type.MarshalFunc }} = map[{{ $enum | ref }}]string{
+		{{- range $value := $type.EnumValues }}
+			 {{ $value.Object | obj }}: "{{ $value.Definition.Name }}",
+		{{- end }}
+		}
+	 )
+	{{- end }}
+{{- end }}

--- a/api/testdata/template/single-file/dir/gqlgen.yml
+++ b/api/testdata/template/single-file/dir/gqlgen.yml
@@ -1,0 +1,70 @@
+# Where are all the schema files located? globs are supported eg  src/**/*.graphqls
+schema:
+  - graph/*.graphqls
+
+# Where should the generated server code go?
+exec:
+  filename: graph/generated.go
+  package: graph
+  exec_template_dir: graph/template
+
+# Uncomment to enable federation
+# federation:
+#   filename: graph/federation.go
+#   package: graph
+
+# Where should any generated models go?
+model:
+  filename: graph/model/models_gen.go
+  package: model
+
+# Where should the resolver implementations go?
+resolver:
+  layout: follow-schema
+  dir: graph
+  package: graph
+
+# Optional: turn on use `gqlgen:"fieldName"` tags in your models
+# struct_tag: json
+
+# Optional: turn on to use []Thing instead of []*Thing
+# omit_slice_element_pointers: false
+
+# Optional: turn off to make struct-type struct fields not use pointers
+# e.g. type Thing struct { FieldA OtherThing } instead of { FieldA *OtherThing }
+# struct_fields_always_pointers: true
+
+# Optional: turn off to make resolvers return values instead of pointers for structs
+# resolvers_always_return_pointers: true
+
+# Optional: turn on to return pointers instead of values in unmarshalInput
+# return_pointers_in_unmarshalinput: false
+
+# Optional: wrap nullable input fields with Omittable
+# nullable_input_omittable: true
+
+# Optional: set to speed up generation time by not performing a final validation pass.
+# skip_validation: true
+
+# gqlgen will search for any type names in the schema in these go packages
+# if they match it will use them, otherwise it will generate them.
+autobind:
+  - "github.com/99designs/gqlgen/api/testdata/default/graph/model"
+
+# This section declares type mapping between the GraphQL and go type systems
+#
+# The first line in each type will be used as defaults for resolver arguments and
+# modelgen, the others will be allowed when binding to fields. Configure them to
+# your liking
+models:
+  ID:
+    model:
+      - github.com/99designs/gqlgen/graphql.ID
+      - github.com/99designs/gqlgen/graphql.Int
+      - github.com/99designs/gqlgen/graphql.Int64
+      - github.com/99designs/gqlgen/graphql.Int32
+  Int:
+    model:
+      - github.com/99designs/gqlgen/graphql.Int
+      - github.com/99designs/gqlgen/graphql.Int64
+      - github.com/99designs/gqlgen/graphql.Int32

--- a/api/testdata/template/single-file/dir/graph/model/doc.go
+++ b/api/testdata/template/single-file/dir/graph/model/doc.go
@@ -1,0 +1,1 @@
+package model

--- a/api/testdata/template/single-file/dir/graph/schema.graphqls
+++ b/api/testdata/template/single-file/dir/graph/schema.graphqls
@@ -1,0 +1,28 @@
+# GraphQL schema example
+#
+# https://gqlgen.com/getting-started/
+
+type Todo {
+  id: ID!
+  text: String!
+  done: Boolean!
+  user: User!
+}
+
+type User {
+  id: ID!
+  name: String!
+}
+
+type Query {
+  todos: [Todo!]!
+}
+
+input NewTodo {
+  text: String!
+  userId: String!
+}
+
+type Mutation {
+  createTodo(input: NewTodo!): Todo!
+}

--- a/api/testdata/template/single-file/dir/graph/template/args.gotpl
+++ b/api/testdata/template/single-file/dir/graph/template/args.gotpl
@@ -1,0 +1,68 @@
+{{ range $name, $args := .Args }}
+func (ec *executionContext) {{ $name }}(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+
+	{{- range $i, $arg := . }}
+		arg{{$i}}, err := ec.{{ $name }}{{$arg.Name | go}}(ctx, rawArgs)
+		if err != nil {
+			return nil, err
+		}
+		args[{{$arg.Name|quote}}] = arg{{$i}}
+	{{- end }}
+	return args, nil
+}
+
+	{{- range $i, $arg := . }}
+		func (ec *executionContext) {{ $name }}{{$arg.Name | go}}(
+			ctx context.Context,
+			rawArgs map[string]interface{},
+		) ({{ $arg.TypeReference.GO | ref}}, error) {
+			{{- if not .CallArgumentDirectivesWithNull}}
+				// We won't call the directive if the argument is null.
+				// Set call_argument_directives_with_null to true to call directives
+				// even if the argument is null.
+				_, ok := rawArgs[{{$arg.Name|quote}}]
+				if !ok {
+					var zeroVal {{ $arg.TypeReference.GO | ref}}
+					return zeroVal, nil
+				}
+			{{end}}
+			ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField({{$arg.Name|quote}}))
+			{{- if $arg.ImplDirectives }}
+				directive0 := func(ctx context.Context) (interface{}, error) {
+					tmp, ok := rawArgs[{{$arg.Name|quote}}]
+					if !ok {
+						var zeroVal {{ $arg.TypeReference.GO | ref}}
+						return zeroVal, nil
+					}
+					return ec.{{ $arg.TypeReference.UnmarshalFunc }}(ctx, tmp)
+				}
+				{{ template "implDirectives" $arg }}
+				tmp, err := directive{{$arg.ImplDirectives|len}}(ctx)
+				if err != nil {
+					var zeroVal {{ $arg.TypeReference.GO | ref}}
+					return zeroVal, graphql.ErrorOnPath(ctx, err)
+				}
+				if data, ok := tmp.({{ $arg.TypeReference.GO | ref }}) ; ok {
+					return data, nil
+				{{- if $arg.TypeReference.IsNilable }}
+					} else if tmp == nil {
+						var zeroVal {{ $arg.TypeReference.GO | ref}}
+						return zeroVal, nil
+				{{- end }}
+				} else {
+					var zeroVal {{ $arg.TypeReference.GO | ref}}
+					return zeroVal, graphql.ErrorOnPath(ctx, fmt.Errorf(`unexpected type %T from directive, should be {{ $arg.TypeReference.GO }}`, tmp))
+				}
+			{{- else }}
+				if tmp, ok := rawArgs[{{$arg.Name|quote}}]; ok {
+					return ec.{{ $arg.TypeReference.UnmarshalFunc }}(ctx, tmp)
+				}
+
+				var zeroVal {{ $arg.TypeReference.GO | ref}}
+				return zeroVal, nil
+			{{- end }}
+		}
+	{{end}}
+{{ end }}

--- a/api/testdata/template/single-file/dir/graph/template/directives.gotpl
+++ b/api/testdata/template/single-file/dir/graph/template/directives.gotpl
@@ -1,0 +1,155 @@
+{{ define "implDirectives" }}{{ $in := .DirectiveObjName }}
+	{{ $zeroVal := .TypeReference.GO | ref}}
+	{{- range $i, $directive := .ImplDirectives -}}
+		directive{{add $i 1}} := func(ctx context.Context) (interface{}, error) {
+			{{- range $arg := $directive.Args }}
+				{{- if notNil "Value" $arg }}
+						{{ $arg.VarName }}, err := ec.{{ $arg.TypeReference.UnmarshalFunc }}(ctx, {{ $arg.Value | dump }})
+						if err != nil{
+							var zeroVal {{$zeroVal}}
+							return zeroVal, err
+						}
+					{{- else if notNil "Default" $arg }}
+						{{ $arg.VarName }}, err := ec.{{ $arg.TypeReference.UnmarshalFunc }}(ctx, {{ $arg.Default | dump }})
+						if err != nil{
+							var zeroVal {{$zeroVal}}
+							return zeroVal, err
+						}
+					{{- end }}
+			{{- end }}
+			{{- if not $directive.IsBuiltIn}}
+				if {{$directive.CallPath}} == nil {
+					var zeroVal {{$zeroVal}}
+					return zeroVal, errors.New("directive {{$directive.Name}} is not implemented")
+				}
+			{{- end}}
+			return {{$directive.CallPath}}({{$directive.ResolveArgs $in $i }})
+		}
+	{{ end -}}
+{{ end }}
+
+{{define "queryDirectives"}}
+	for _, d := range obj.Directives {
+		switch d.Name {
+		{{- range $directive := . }}
+		case "{{$directive.Name}}":
+			{{- if $directive.Args }}
+				rawArgs := d.ArgumentMap(ec.Variables)
+				args, err := ec.{{ $directive.ArgsFunc }}(ctx,rawArgs)
+				if err != nil {
+					ec.Error(ctx, err)
+					return graphql.Null
+				}
+			{{- end }}
+			n := next
+			next = func(ctx context.Context) (interface{}, error) {
+				{{- template "callDirective" $directive -}}
+			}
+		{{- end }}
+		}
+	}
+	tmp, err := next(ctx)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if data, ok := tmp.(graphql.Marshaler); ok {
+		return data
+	}
+	ec.Errorf(ctx, `unexpected type %T from directive, should be graphql.Marshaler`, tmp)
+	return graphql.Null
+{{end}}
+
+{{define "callDirective"}}
+	{{- if not .IsBuiltIn}}
+		if {{.CallPath}} == nil {
+			return nil, errors.New("directive {{.Name}} is not implemented")
+		}
+	{{- end}}
+	return {{.CallPath}}({{.CallArgs}})
+{{end}}
+
+{{ if .Directives.LocationDirectives "QUERY" }}
+func (ec *executionContext) _queryMiddleware(ctx context.Context, obj *ast.OperationDefinition, next func(ctx context.Context) (interface{}, error)) graphql.Marshaler {
+	{{ template "queryDirectives" .Directives.LocationDirectives "QUERY" }}
+}
+{{ end }}
+
+{{ if .Directives.LocationDirectives "MUTATION" }}
+func (ec *executionContext) _mutationMiddleware(ctx context.Context, obj *ast.OperationDefinition, next func(ctx context.Context) (interface{}, error)) graphql.Marshaler {
+	{{ template "queryDirectives" .Directives.LocationDirectives "MUTATION" }}
+}
+{{ end }}
+
+{{ if .Directives.LocationDirectives "SUBSCRIPTION" }}
+func (ec *executionContext) _subscriptionMiddleware(ctx context.Context, obj *ast.OperationDefinition, next func(ctx context.Context) (interface{}, error)) func(ctx context.Context) graphql.Marshaler {
+	for _, d := range obj.Directives {
+		switch d.Name {
+		{{- range $directive := .Directives.LocationDirectives "SUBSCRIPTION" }}
+		case "{{$directive.Name}}":
+			{{- if $directive.Args }}
+				rawArgs := d.ArgumentMap(ec.Variables)
+				args, err := ec.{{ $directive.ArgsFunc }}(ctx,rawArgs)
+				if err != nil {
+					ec.Error(ctx, err)
+					return func(ctx context.Context) graphql.Marshaler {
+						return graphql.Null
+					}
+				}
+			{{- end }}
+			n := next
+			next = func(ctx context.Context) (interface{}, error) {
+				{{- template "callDirective" $directive -}}
+			}
+		{{- end }}
+		}
+	}
+	tmp, err := next(ctx)
+	if err != nil {
+		ec.Error(ctx, err)
+		return func(ctx context.Context) graphql.Marshaler {
+			return graphql.Null
+		}
+	}
+	if data, ok := tmp.(func(ctx context.Context) graphql.Marshaler); ok {
+		return data
+	}
+	ec.Errorf(ctx, `unexpected type %T from directive, should be graphql.Marshaler`, tmp)
+	return func(ctx context.Context) graphql.Marshaler {
+		return graphql.Null
+	}
+}
+{{ end }}
+
+{{ if .Directives.LocationDirectives "FIELD" }}
+	func (ec *executionContext) _fieldMiddleware(ctx context.Context, obj interface{}, next graphql.Resolver) interface{} {
+		{{- if .Directives.LocationDirectives "FIELD" }}
+		fc := graphql.GetFieldContext(ctx)
+		for _, d := range fc.Field.Directives {
+			switch d.Name {
+			{{- range $directive := .Directives.LocationDirectives "FIELD" }}
+			case "{{$directive.Name}}":
+				{{- if $directive.Args }}
+					rawArgs := d.ArgumentMap(ec.Variables)
+					args, err := ec.{{ $directive.ArgsFunc }}(ctx,rawArgs)
+					if err != nil {
+						ec.Error(ctx, err)
+						return nil
+					}
+				{{- end }}
+				n := next
+				next = func(ctx context.Context) (interface{}, error) {
+					{{- template "callDirective" $directive -}}
+				}
+			{{- end }}
+			}
+		}
+		{{- end }}
+		res, err := ec.ResolverMiddleware(ctx, next)
+		if err != nil {
+			ec.Error(ctx, err)
+			return nil
+		}
+		return res
+	}
+{{ end }}

--- a/api/testdata/template/single-file/dir/graph/template/field.gotpl
+++ b/api/testdata/template/single-file/dir/graph/template/field.gotpl
@@ -1,0 +1,172 @@
+{{- range $object := .Objects }}{{- range $field := $object.Fields }}
+
+func (ec *executionContext) _{{$object.Name}}_{{$field.Name}}(ctx context.Context, field graphql.CollectedField{{ if not $object.Root }}, obj {{$object.Reference | ref}}{{end}}) (ret {{ if $object.Stream }}func(ctx context.Context){{ end }}graphql.Marshaler) {
+	{{- $null := "graphql.Null" }}
+	{{- if $object.Stream }}
+		{{- $null = "nil" }}
+	{{- end }}
+	fc, err := ec.{{ $field.FieldContextFunc }}(ctx, field)
+	if err != nil {
+		return {{ $null }}
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	{{- if not $.Config.OmitPanicHandler }}
+	defer func () {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = {{ $null }}
+		}
+	}()
+	{{- end }}
+	{{- if $field.TypeReference.IsRoot }}
+		{{- if $field.TypeReference.IsPtr }}
+			res := &{{ $field.TypeReference.Elem.GO | ref }}{}
+		{{- else }}
+			res := {{ $field.TypeReference.GO | ref }}{}
+		{{- end }}
+		fc.Result = res
+		return ec.{{ $field.TypeReference.MarshalFunc }}(ctx, field.Selections, res)
+	{{- else}}
+		{{- if  $.AllDirectives.LocationDirectives "FIELD" }}
+			resTmp := ec._fieldMiddleware(ctx, {{if $object.Root}}nil{{else}}obj{{end}}, func(rctx context.Context) (interface{}, error) {
+				{{ template "field" $field }}
+			})
+		{{ else }}
+			resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+				{{ template "field" $field }}
+			})
+			if err != nil {
+				ec.Error(ctx, err)
+				return {{ $null }}
+			}
+		{{- end }}
+		if resTmp == nil {
+			{{- if $field.TypeReference.GQL.NonNull }}
+				if !graphql.HasFieldError(ctx, fc) {
+					ec.Errorf(ctx, "must not be null")
+				}
+			{{- end }}
+			return {{ $null }}
+		}
+		{{- if $object.Stream }}
+			return func(ctx context.Context) graphql.Marshaler {
+				select {
+				case res, ok := <-resTmp.(<-chan {{$field.TypeReference.GO | ref}}):
+					if !ok {
+						return nil
+					}
+					return graphql.WriterFunc(func(w io.Writer) {
+						w.Write([]byte{'{'})
+						graphql.MarshalString(field.Alias).MarshalGQL(w)
+						w.Write([]byte{':'})
+						ec.{{ $field.TypeReference.MarshalFunc }}(ctx, field.Selections, res).MarshalGQL(w)
+						w.Write([]byte{'}'})
+					})
+				case <-ctx.Done():
+					return nil
+				}
+			}
+		{{- else }}
+			res := resTmp.({{$field.TypeReference.GO | ref}})
+			fc.Result = res
+			return ec.{{ $field.TypeReference.MarshalFunc }}(ctx, field.Selections, res)
+		{{- end }}
+	{{- end }}
+}
+
+func (ec *executionContext) {{ $field.FieldContextFunc }}({{ if not $field.Args }}_{{ else }}ctx{{ end }} context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object: {{quote $field.Object.Name}},
+		Field: field,
+		IsMethod: {{or $field.IsMethod $field.IsResolver}},
+		IsResolver: {{ $field.IsResolver }},
+		Child: func (ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			{{- if not $field.TypeReference.Definition.Fields }}
+				return nil, errors.New("field of type {{ $field.TypeReference.Definition.Name }} does not have child fields")
+			{{- else if ne $field.TypeReference.Definition.Kind "OBJECT" }}
+				return nil, errors.New("FieldContext.Child cannot be called on type {{ $field.TypeReference.Definition.Kind }}")
+			{{- else }}
+				switch field.Name {
+					{{- range $f := $field.TypeReference.Definition.Fields }}
+						case "{{ $f.Name }}":
+							return ec.{{ $field.ChildFieldContextFunc $f.Name }}(ctx, field)
+					{{- end }}
+				}
+				return nil, fmt.Errorf("no field named %q was found under type {{ $field.TypeReference.Definition.Name }}", field.Name)
+			{{- end }}
+		},
+	}
+	{{- if $field.Args }}
+		{{- if not $.Config.OmitPanicHandler }}
+		defer func () {
+			if r := recover(); r != nil {
+				err = ec.Recover(ctx, r)
+				ec.Error(ctx, err)
+			}
+		}()
+		{{- end }}
+		ctx = graphql.WithFieldContext(ctx, fc)
+		if fc.Args, err = ec.{{ $field.ArgsFunc }}(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+			ec.Error(ctx, err)
+			return fc, err
+		}
+	{{- end }}
+	return fc, nil
+}
+
+{{- end }}{{- end}}
+
+{{ define "field" }}
+	{{- if .HasDirectives -}}
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx  // use context from middleware stack in children
+			{{ template "fieldDefinition" . }}
+		}
+		{{ template "implDirectives" . }}
+		tmp, err := directive{{.ImplDirectives|len}}(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+		    return nil, nil
+		}
+		if data, ok := tmp.({{if .Stream}}<-chan {{end}}{{ .TypeReference.GO | ref }}) ; ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be {{if .Stream}}<-chan {{end}}{{ .TypeReference.GO }}`, tmp)
+	{{- else -}}
+		ctx = rctx  // use context from middleware stack in children
+		{{ template "fieldDefinition" . }}
+	{{- end -}}
+{{ end }}
+
+{{ define "fieldDefinition" }}
+	{{- if .IsResolver -}}
+		return ec.resolvers.{{ .ShortInvocation }}
+	{{- else if .IsMap -}}
+		switch v := {{.GoReceiverName}}[{{.Name|quote}}].(type) {
+		case {{if .Stream}}<-chan {{end}}{{.TypeReference.GO | ref}}:
+			return v, nil
+		case {{if .Stream}}<-chan {{end}}{{.TypeReference.Elem.GO | ref}}:
+			return &v, nil
+		case nil:
+			return ({{.TypeReference.GO | ref}})(nil), nil
+		default:
+			return nil, fmt.Errorf("unexpected type %T for field %s", v, {{ .Name | quote}})
+		}
+	{{- else if .IsMethod -}}
+		{{- if .VOkFunc -}}
+			v, ok := {{.GoReceiverName}}.{{.GoFieldName}}({{ .CallArgs }})
+			if !ok {
+				return nil, nil
+			}
+			return v, nil
+		{{- else if .NoErr -}}
+			return {{.GoReceiverName}}.{{.GoFieldName}}({{ .CallArgs }}), nil
+		{{- else -}}
+			return {{.GoReceiverName}}.{{.GoFieldName}}({{ .CallArgs }})
+		{{- end -}}
+	{{- else if .IsVariable -}}
+		return {{.GoReceiverName}}.{{.GoFieldName}}, nil
+	{{- end }}
+{{- end }}

--- a/api/testdata/template/single-file/dir/graph/template/generated!.gotpl
+++ b/api/testdata/template/single-file/dir/graph/template/generated!.gotpl
@@ -1,0 +1,313 @@
+{{/* Context object: codegen.Data */}}
+{{ reserveImport "context"  }}
+{{ reserveImport "fmt"  }}
+{{ reserveImport "io"  }}
+{{ reserveImport "strconv"  }}
+{{ reserveImport "time"  }}
+{{ reserveImport "sync"  }}
+{{ reserveImport "sync/atomic" }}
+{{ reserveImport "errors"  }}
+{{ reserveImport "bytes"  }}
+{{ reserveImport "embed"  }}
+
+{{ reserveImport "github.com/vektah/gqlparser/v2" "gqlparser" }}
+{{ reserveImport "github.com/vektah/gqlparser/v2/ast" }}
+{{ reserveImport "github.com/99designs/gqlgen/graphql" }}
+{{ reserveImport "github.com/99designs/gqlgen/graphql/introspection" }}
+
+{{ if eq .Config.Exec.Layout "single-file" }}
+	// NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
+	func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
+		return &executableSchema{
+		 	schema: cfg.Schema,
+			resolvers: cfg.Resolvers,
+			directives: cfg.Directives,
+			complexity: cfg.Complexity,
+		}
+	}
+
+	type Config struct {
+		Schema    *ast.Schema
+		Resolvers  ResolverRoot
+		Directives DirectiveRoot
+		Complexity ComplexityRoot
+	}
+
+	type ResolverRoot interface {
+	{{- range $object := .Objects -}}
+		{{ if $object.HasResolvers -}}
+			{{ucFirst $object.Name}}() {{ucFirst $object.Name}}Resolver
+		{{ end }}
+	{{- end }}
+	{{- range $object := .Inputs -}}
+	{{ if $object.HasResolvers -}}
+		{{ucFirst $object.Name}}() {{ucFirst $object.Name}}Resolver
+	{{ end }}
+{{- end }}
+}
+
+	type DirectiveRoot struct {
+	{{ range $directive := .UserDirectives }}
+		{{- $directive.Declaration }}
+	{{ end }}
+	}
+
+	type ComplexityRoot struct {
+	{{- if not .Config.OmitComplexity }}
+	{{ range $object := .Objects }}
+		{{ if not $object.IsReserved -}}
+			{{ ucFirst $object.Name }} struct {
+			{{ range $_, $fields := $object.UniqueFields }}
+				{{- $field := index $fields 0 -}}
+				{{ if not $field.IsReserved -}}
+					{{ $field.GoFieldName }} {{ $field.ComplexitySignature }}
+				{{ end }}
+			{{- end }}
+			}
+		{{- end }}
+	{{ end }}
+	{{- end }}
+	}
+{{ end }}
+
+{{ range $object := .Objects -}}
+	{{ if $object.HasResolvers }}
+		type {{ucFirst $object.Name}}Resolver interface {
+		{{ range $field := $object.Fields -}}
+			{{- if $field.IsResolver }}
+				{{- $field.GoFieldName}}{{ $field.ShortResolverDeclaration }}
+			{{- end }}
+		{{ end }}
+		}
+	{{- end }}
+{{- end }}
+
+{{ range $object := .Inputs -}}
+	{{ if $object.HasResolvers }}
+		type {{$object.Name}}Resolver interface {
+		{{ range $field := $object.Fields -}}
+			{{- if $field.IsResolver }}
+				{{- $field.GoFieldName}}{{ $field.ShortResolverDeclaration }}
+			{{- end }}
+		{{ end }}
+		}
+	{{- end }}
+{{- end }}
+
+{{ range $directive := .BuiltInDirectives }}
+	var (
+		{{- $directive.FunctionImpl }}
+	)
+{{ end }}
+
+{{ if eq .Config.Exec.Layout "single-file" }}
+	type executableSchema struct {
+		schema    *ast.Schema
+		resolvers  ResolverRoot
+		directives DirectiveRoot
+		complexity ComplexityRoot
+	}
+
+	func (e *executableSchema) Schema() *ast.Schema {
+		if e.schema != nil {
+        		return e.schema
+		}
+		return parsedSchema
+	}
+
+	func (e *executableSchema) Complexity(typeName, field string, childComplexity int, rawArgs map[string]interface{}) (int, bool) {
+		ec := executionContext{nil, e, 0, 0, nil}
+		_ = ec
+		{{ if not .Config.OmitComplexity -}}
+		switch typeName + "." + field {
+		{{ range $object := .Objects }}
+			{{ if not $object.IsReserved }}
+				{{ range $_, $fields := $object.UniqueFields }}
+					{{- $len := len $fields }}
+					{{- range $i, $field := $fields }}
+						{{- $last := eq (add $i 1) $len }}
+						{{- if not $field.IsReserved }}
+							{{- if eq $i 0 }}case {{ end }}"{{$object.Name}}.{{$field.Name}}"{{ if not $last }},{{ else }}:
+								if e.complexity.{{ucFirst $object.Name}}.{{$field.GoFieldName}} == nil {
+									break
+								}
+								{{ if $field.Args }}
+									args, err := ec.{{ $field.ArgsFunc }}(context.TODO(),rawArgs)
+									if err != nil {
+										return 0, false
+									}
+								{{ end }}
+								return e.complexity.{{ucFirst $object.Name}}.{{$field.GoFieldName}}(childComplexity{{if $field.Args}}, {{$field.ComplexityArgs}} {{ end }}), true
+							{{ end }}
+						{{- end }}
+					{{- end }}
+				{{ end }}
+			{{ end }}
+		{{ end }}
+		}
+		{{- end }}
+		return 0, false
+	}
+
+	func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
+		opCtx := graphql.GetOperationContext(ctx)
+		ec := executionContext{opCtx, e, 0, 0, make(chan graphql.DeferredResult)}
+		inputUnmarshalMap := graphql.BuildUnmarshalerMap(
+			{{- range $input := .Inputs -}}
+				{{ if not $input.HasUnmarshal }}
+					ec.unmarshalInput{{ $input.Name }},
+				{{- end }}
+			{{- end }}
+		)
+		first := true
+
+		switch opCtx.Operation.Operation {
+		{{- if .QueryRoot }} case ast.Query:
+			return func(ctx context.Context) *graphql.Response {
+				var response graphql.Response
+				var data graphql.Marshaler
+				if first {
+					first = false
+					ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
+					{{ if .Directives.LocationDirectives "QUERY" -}}
+						data = ec._queryMiddleware(ctx, opCtx.Operation, func(ctx context.Context) (interface{}, error){
+							return ec._{{.QueryRoot.Name}}(ctx, opCtx.Operation.SelectionSet), nil
+						})
+					{{- else -}}
+						data = ec._{{.QueryRoot.Name}}(ctx, opCtx.Operation.SelectionSet)
+					{{- end }}
+				} else {
+					if atomic.LoadInt32(&ec.pendingDeferred) > 0 {
+						result := <-ec.deferredResults
+						atomic.AddInt32(&ec.pendingDeferred, -1)
+						data = result.Result
+						response.Path = result.Path
+						response.Label = result.Label
+						response.Errors = result.Errors
+					} else {
+						return nil
+					}
+				}
+				var buf bytes.Buffer
+				data.MarshalGQL(&buf)
+				response.Data = buf.Bytes()
+				if atomic.LoadInt32(&ec.deferred) > 0 {
+					hasNext := atomic.LoadInt32(&ec.pendingDeferred) > 0
+					response.HasNext = &hasNext
+				}
+
+				return &response
+			}
+		{{ end }}
+
+		{{- if .MutationRoot }} case ast.Mutation:
+			return func(ctx context.Context) *graphql.Response {
+				if !first { return nil }
+				first = false
+				ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
+				{{ if .Directives.LocationDirectives "MUTATION" -}}
+					data := ec._mutationMiddleware(ctx, opCtx.Operation, func(ctx context.Context) (interface{}, error){
+						return ec._{{.MutationRoot.Name}}(ctx, opCtx.Operation.SelectionSet), nil
+					})
+				{{- else -}}
+					data := ec._{{.MutationRoot.Name}}(ctx, opCtx.Operation.SelectionSet)
+				{{- end }}
+				var buf bytes.Buffer
+				data.MarshalGQL(&buf)
+
+				return &graphql.Response{
+					Data:       buf.Bytes(),
+				}
+			}
+		{{ end }}
+
+		{{- if .SubscriptionRoot }} case ast.Subscription:
+			{{ if .Directives.LocationDirectives "SUBSCRIPTION" -}}
+				next := ec._subscriptionMiddleware(ctx, opCtx.Operation, func(ctx context.Context) (interface{}, error){
+					return ec._{{.SubscriptionRoot.Name}}(ctx, opCtx.Operation.SelectionSet),nil
+				})
+			{{- else -}}
+				next := ec._{{.SubscriptionRoot.Name}}(ctx, opCtx.Operation.SelectionSet)
+			{{- end }}
+
+			var buf bytes.Buffer
+			return func(ctx context.Context) *graphql.Response {
+				buf.Reset()
+				data := next(ctx)
+
+				if data == nil {
+					return nil
+				}
+				data.MarshalGQL(&buf)
+
+				return &graphql.Response{
+					Data:       buf.Bytes(),
+				}
+			}
+		{{ end }}
+		default:
+			return graphql.OneShot(graphql.ErrorResponse(ctx, "unsupported GraphQL operation"))
+		}
+	}
+
+	type executionContext struct {
+		*graphql.OperationContext
+		*executableSchema
+		deferred        int32
+		pendingDeferred int32
+		deferredResults chan graphql.DeferredResult
+	}
+
+	func (ec *executionContext) processDeferredGroup(dg graphql.DeferredGroup) {
+		atomic.AddInt32(&ec.pendingDeferred, 1)
+		go func () {
+			ctx := graphql.WithFreshResponseContext(dg.Context)
+			dg.FieldSet.Dispatch(ctx)
+			ds := graphql.DeferredResult{
+				Path:   dg.Path,
+				Label:  dg.Label,
+				Result: dg.FieldSet,
+				Errors: graphql.GetErrors(ctx),
+			}
+			// null fields should bubble up
+			if dg.FieldSet.Invalids > 0 {
+				ds.Result = graphql.Null
+			}
+			ec.deferredResults <- ds
+		}()
+	}
+
+	func (ec *executionContext) introspectSchema() (*introspection.Schema, error) {
+		if ec.DisableIntrospection {
+			return nil, errors.New("introspection disabled")
+		}
+		return introspection.WrapSchema(ec.Schema()), nil
+	}
+
+	func (ec *executionContext) introspectType(name string) (*introspection.Type, error) {
+		if ec.DisableIntrospection {
+			return nil, errors.New("introspection disabled")
+		}
+		return introspection.WrapTypeFromDef(ec.Schema(), ec.Schema().Types[name]), nil
+	}
+
+	{{if .HasEmbeddableSources }}
+	//go:embed{{- range $source := .AugmentedSources }}{{if $source.Embeddable}} {{$source.RelativePath|quote}}{{end}}{{- end }}
+	var sourcesFS embed.FS
+
+	func sourceData(filename string) string {
+		data, err := sourcesFS.ReadFile(filename)
+		if err != nil {
+			panic(fmt.Sprintf("codegen problem: %s not available", filename))
+		}
+		return string(data)
+	}
+	{{- end }}
+
+	var sources = []*ast.Source{
+	{{- range $source := .AugmentedSources }}
+		{Name: {{$source.RelativePath|quote}}, Input: {{if (not $source.Embeddable)}}{{$source.Source|rawQuote}}{{else}}sourceData({{$source.RelativePath|quote}}){{end}}, BuiltIn: {{$source.BuiltIn}}},
+	{{- end }}
+	}
+	var parsedSchema = gqlparser.MustLoadSchema(sources...)
+{{ end }}

--- a/api/testdata/template/single-file/dir/graph/template/input.gotpl
+++ b/api/testdata/template/single-file/dir/graph/template/input.gotpl
@@ -1,0 +1,100 @@
+{{- range $input := .Inputs }}
+	{{- if not .HasUnmarshal }}
+	{{- $it := "it" }}
+	{{- if .PointersInUnmarshalInput }}
+	  {{- $it = "&it" }}
+	{{- end }}
+	func (ec *executionContext) unmarshalInput{{ .Name }}(ctx context.Context, obj interface{}) ({{ if .PointersInUnmarshalInput }}*{{ end }}{{.Type | ref}}, error) {
+		{{- if $input.IsMap }}
+			it := make(map[string]interface{}, len(obj.(map[string]interface{})))
+		{{- else }}
+			var it {{.Type | ref}}
+		{{- end }}
+		asMap := map[string]interface{}{}
+		for k, v := range obj.(map[string]interface{}) {
+			asMap[k] = v
+		}
+		{{ range $field := .Fields}}
+			{{- if notNil "Default" $field }}
+				if _, present := asMap[{{$field.Name|quote}}] ; !present {
+					asMap[{{$field.Name|quote}}] = {{ $field.Default | dump }}
+				}
+			{{- end}}
+		{{- end }}
+
+		fieldsInOrder := [...]string{ {{ range .Fields }}{{ quote .Name }},{{ end }} }
+		for _, k := range fieldsInOrder {
+			v, ok := asMap[k]
+			if !ok {
+				continue
+			}
+			switch k {
+			{{- range $field := .Fields }}
+			case {{$field.Name|quote}}:
+				{{- $lhs := (printf "it.%s" $field.GoFieldName) }}
+				{{- if $input.IsMap }}
+					{{- $lhs = (printf "it[%q]" $field.Name) }}
+				{{- end }}
+				ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField({{$field.Name|quote}}))
+				{{- if $field.ImplDirectives }}
+					directive0 := func(ctx context.Context) (interface{}, error) { return ec.{{ $field.TypeReference.UnmarshalFunc }}(ctx, v) }
+					{{ template "implDirectives" $field }}
+					tmp, err := directive{{$field.ImplDirectives|len}}(ctx)
+					if err != nil {
+						return {{$it}}, graphql.ErrorOnPath(ctx, err)
+					}
+					if data, ok := tmp.({{ $field.TypeReference.GO | ref }}) ; ok {
+						{{- if $field.IsResolver }}
+							if err = ec.resolvers.{{ $field.ShortInvocation }}; err != nil {
+								return {{$it}}, err
+							}
+						{{- else }}
+							{{- if $field.TypeReference.IsOmittable }}
+								{{ $lhs }} = graphql.OmittableOf(data)
+							{{- else }}
+								{{ $lhs }} = data
+							{{- end }}
+						{{- end }}
+					{{- if $field.TypeReference.IsNilable }}
+						{{- if not $field.IsResolver }}
+						} else if tmp == nil {
+							{{- if $field.TypeReference.IsOmittable }}
+								{{ $lhs }} = graphql.OmittableOf[{{ $field.TypeReference.GO | ref }}](nil)
+							{{- else }}
+								{{ $lhs }} = nil
+							{{- end }}
+						{{- end }}
+					{{- end }}
+					} else {
+						err := fmt.Errorf(`unexpected type %T from directive, should be {{ $field.TypeReference.GO }}`, tmp)
+						return {{$it}}, graphql.ErrorOnPath(ctx, err)
+					}
+				{{- else }}
+					{{- if $field.IsResolver }}
+						data, err := ec.{{ $field.TypeReference.UnmarshalFunc }}(ctx, v)
+						if err != nil {
+							return {{$it}}, err
+						}
+						if err = ec.resolvers.{{ $field.ShortInvocation }}; err != nil {
+							return {{$it}}, err
+						}
+					{{- else }}
+						data, err := ec.{{ $field.TypeReference.UnmarshalFunc }}(ctx, v)
+						if err != nil {
+							return {{$it}}, err
+						}
+						{{- if $field.TypeReference.IsOmittable }}
+							{{ $lhs }} = graphql.OmittableOf(data)
+						{{- else }}
+							{{ $lhs }} = data
+						{{- end }}
+					{{- end }}
+				{{- end }}
+			{{- end }}
+			}
+		}
+
+		return {{$it}}, nil
+	}
+	{{- end }}
+{{ end }}

--- a/api/testdata/template/single-file/dir/graph/template/interface.gotpl
+++ b/api/testdata/template/single-file/dir/graph/template/interface.gotpl
@@ -1,0 +1,21 @@
+{{- range $interface := .Interfaces }}
+
+func (ec *executionContext) _{{$interface.Name}}(ctx context.Context, sel ast.SelectionSet, obj {{$interface.Type | ref}}) graphql.Marshaler {
+	switch obj := (obj).(type) {
+	case nil:
+		return graphql.Null
+	{{- range $implementor := $interface.Implementors }}
+		case {{$implementor.Type | ref}}:
+			{{- if $implementor.CanBeNil }}
+				if obj == nil {
+					return graphql.Null
+				}
+			{{- end }}
+			return ec._{{$implementor.Name}}(ctx, sel, {{ if $implementor.TakeRef }}&{{ end }}obj)
+	{{- end }}
+	default:
+		panic(fmt.Errorf("unexpected type %T", obj))
+	}
+}
+
+{{- end }}

--- a/api/testdata/template/single-file/dir/graph/template/object.gotpl
+++ b/api/testdata/template/single-file/dir/graph/template/object.gotpl
@@ -1,0 +1,149 @@
+{{- range $object := .Objects }}
+
+var {{ $object.Name|lcFirst}}Implementors = {{$object.Implementors}}
+
+{{- if .Stream }}
+func (ec *executionContext) _{{$object.Name}}(ctx context.Context, sel ast.SelectionSet) func(ctx context.Context) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, {{$object.Name|lcFirst}}Implementors)
+	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+		Object: {{$object.Name|quote}},
+	})
+	if len(fields) != 1 {
+		ec.Errorf(ctx, "must subscribe to exactly one stream")
+		return nil
+	}
+
+	switch fields[0].Name {
+	{{- range $field := $object.Fields }}
+	case "{{$field.Name}}":
+		return ec._{{$object.Name}}_{{$field.Name}}(ctx, fields[0])
+	{{- end }}
+	default:
+		panic("unknown field " + strconv.Quote(fields[0].Name))
+	}
+}
+{{- else }}
+func (ec *executionContext) _{{$object.Name}}(ctx context.Context, sel ast.SelectionSet{{ if not $object.Root }},obj {{$object.Reference | ref }}{{ end }}) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, {{$object.Name|lcFirst}}Implementors)
+	{{- if $object.Root }}
+		ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+			Object: {{$object.Name|quote}},
+		})
+	{{end}}
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		{{- if $object.Root }}
+			innerCtx := graphql.WithRootFieldContext(ctx, &graphql.RootFieldContext{
+				Object: field.Name,
+				Field: field,
+			})
+		{{end}}
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString({{$object.Name|quote}})
+		{{- range $field := $object.Fields }}
+		case "{{$field.Name}}":
+			{{- if $field.IsConcurrent }}
+				field := field
+
+				innerFunc := func(ctx context.Context, {{ if $field.TypeReference.GQL.NonNull }}fs{{ else }}_{{ end }} *graphql.FieldSet) (res graphql.Marshaler) {
+					{{- if not $.Config.OmitPanicHandler }}
+					defer func() {
+						if r := recover(); r != nil {
+							ec.Error(ctx, ec.Recover(ctx, r))
+						}
+					}()
+					{{- end }}
+					res = ec._{{$object.Name}}_{{$field.Name}}(ctx, field{{if not $object.Root}}, obj{{end}})
+					{{- if $field.TypeReference.GQL.NonNull }}
+						if res == graphql.Null {
+							{{- if $object.IsConcurrent }}
+								atomic.AddUint32(&fs.Invalids, 1)
+							{{- else }}
+								fs.Invalids++
+							{{- end }}
+						}
+					{{- end }}
+					return res
+				}
+
+				{{if $object.Root}}
+					rrm := func(ctx context.Context) graphql.Marshaler {
+						return ec.OperationContext.RootResolverMiddleware(ctx,
+							func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+					}
+				{{end}}
+
+				{{if not $object.Root}}
+					if field.Deferrable != nil {
+						dfs, ok := deferred[field.Deferrable.Label]
+						di := 0
+						if ok {
+							dfs.AddField(field)
+							di = len(dfs.Values) - 1
+						} else {
+							dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+							deferred[field.Deferrable.Label] = dfs
+						}
+						dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+							return innerFunc(ctx, dfs)
+						})
+
+						// don't run the out.Concurrently() call below
+						out.Values[i] = graphql.Null
+						continue
+					}
+				{{end}}
+
+				out.Concurrently(i, func(ctx context.Context) graphql.Marshaler {
+					{{- if $object.Root -}}
+						return rrm(innerCtx)
+					{{- else -}}
+						return innerFunc(ctx, out)
+					{{- end -}}
+				})
+			{{- else }}
+				{{- if $object.Root -}}
+					out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+						return ec._{{$object.Name}}_{{$field.Name}}(ctx, field)
+					})
+				{{- else -}}
+					out.Values[i] = ec._{{$object.Name}}_{{$field.Name}}(ctx, field, obj)
+				{{- end -}}
+
+				{{- if $field.TypeReference.GQL.NonNull }}
+					if out.Values[i] == graphql.Null {
+						{{- if $object.IsConcurrent }}
+							atomic.AddUint32(&out.Invalids, 1)
+						{{- else }}
+							out.Invalids++
+						{{- end }}
+					}
+				{{- end }}
+			{{- end }}
+		{{- end }}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 { return graphql.Null }
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+{{- end }}
+
+{{- end }}

--- a/api/testdata/template/single-file/dir/graph/template/type.gotpl
+++ b/api/testdata/template/single-file/dir/graph/template/type.gotpl
@@ -1,0 +1,228 @@
+{{- range $type := .ReferencedTypes }}
+	{{ with $type.UnmarshalFunc }}
+		func (ec *executionContext) {{ . }}(ctx context.Context, v interface{}) ({{ $type.GO | ref }}, error) {
+			{{- if and $type.IsNilable (not $type.GQL.NonNull) (not $type.IsPtrToPtr) }}
+				if v == nil { return nil, nil }
+			{{- end }}
+			{{- if or $type.IsPtrToSlice $type.IsPtrToIntf }}
+				res, err := ec.{{ $type.Elem.UnmarshalFunc }}(ctx, v)
+				return &res, graphql.ErrorOnPath(ctx, err)
+			{{- else if $type.IsSlice }}
+				var vSlice []interface{}
+				if v != nil {
+					vSlice = graphql.CoerceList(v)
+				}
+				var err error
+				res := make([]{{$type.GO.Elem | ref}}, len(vSlice))
+				for i := range vSlice {
+					ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+					res[i], err = ec.{{ $type.Elem.UnmarshalFunc }}(ctx, vSlice[i])
+					if err != nil {
+						return nil, err
+					}
+				}
+				return res, nil
+			{{- else if and $type.IsPtrToPtr (not $type.Unmarshaler) (not $type.IsMarshaler) }}
+				var pres {{ $type.Elem.GO | ref }}
+				if v != nil {
+					res, err := ec.{{ $type.Elem.UnmarshalFunc }}(ctx, v)
+					if err != nil {
+						return nil, graphql.ErrorOnPath(ctx, err)
+					}
+					pres = res
+				}
+				return &pres, nil
+			{{- else }}
+				{{- if $type.Unmarshaler }}
+					{{- if $type.HasEnumValues }}
+						tmp, err := {{ $type.Unmarshaler | call }}(v)
+						res := {{ $type.UnmarshalFunc }}[tmp]
+					{{- else if $type.CastType }}
+						{{- if $type.IsContext }}
+							tmp, err := {{ $type.Unmarshaler | call }}(ctx, v)
+						{{- else }}
+							tmp, err := {{ $type.Unmarshaler | call }}(v)
+						{{- end }}
+						{{- if and $type.IsNilable $type.Elem }}
+							res := {{ $type.Elem.GO | ref }}(tmp)
+						{{- else}}
+							res := {{ $type.GO | ref }}(tmp)
+						{{- end }}
+					{{- else}}
+						{{- if $type.IsContext }}
+							res, err := {{ $type.Unmarshaler | call }}(ctx, v)
+						{{- else }}
+							res, err := {{ $type.Unmarshaler | call }}(v)
+						{{- end }}
+					{{- end }}
+					{{- if and $type.IsTargetNilable (not $type.IsNilable) }}
+						return *res, graphql.ErrorOnPath(ctx, err)
+					{{- else if and (not $type.IsTargetNilable) $type.IsNilable }}
+						return &res, graphql.ErrorOnPath(ctx, err)
+					{{- else}}
+						return res, graphql.ErrorOnPath(ctx, err)
+					{{- end }}
+				{{- else if $type.IsMarshaler }}
+					{{- if and $type.IsNilable $type.Elem }}
+						var res = new({{ $type.Elem.GO | ref }})
+					{{- else}}
+						var res {{ $type.GO | ref }}
+					{{- end }}
+					{{- if $type.IsContext }}
+						err := res.UnmarshalGQLContext(ctx, v)
+					{{- else }}
+						err := res.UnmarshalGQL(v)
+					{{- end }}
+					return res, graphql.ErrorOnPath(ctx, err)
+				{{- else }}
+					res, err := ec.unmarshalInput{{ $type.GQL.Name }}(ctx, v)
+					{{- if and $type.IsNilable (not $type.IsMap) (not $type.PointersInUnmarshalInput) }}
+						return &res, graphql.ErrorOnPath(ctx, err)
+					{{- else if and (not $type.IsNilable) $type.PointersInUnmarshalInput }}
+						return *res, graphql.ErrorOnPath(ctx, err)
+					{{- else }}
+						return res, graphql.ErrorOnPath(ctx, err)
+					{{- end }}
+				{{- end }}
+			{{- end }}
+		}
+	{{- end }}
+
+	{{ with $type.MarshalFunc }}
+		func (ec *executionContext) {{ . }}(ctx context.Context, sel ast.SelectionSet, v {{ $type.GO | ref }}) graphql.Marshaler {
+			{{- if or $type.IsPtrToSlice $type.IsPtrToIntf }}
+				return ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, *v)
+			{{- else if $type.IsSlice }}
+				{{- if not $type.GQL.NonNull }}
+					if v == nil {
+						return graphql.Null
+					}
+				{{- end }}
+				ret := make(graphql.Array, len(v))
+				{{- if not $type.IsScalar }}
+					var wg sync.WaitGroup
+					isLen1 := len(v) == 1
+					if !isLen1 {
+						wg.Add(len(v))
+					}
+				{{- end }}
+				for i := range v {
+					{{- if not $type.IsScalar }}
+						i := i
+						fc := &graphql.FieldContext{
+							Index: &i,
+							Result: &v[i],
+						}
+						ctx := graphql.WithFieldContext(ctx, fc)
+						f := func(i int) {
+							{{- if not $.Config.OmitPanicHandler }}
+							defer func() {
+								if r := recover(); r != nil {
+									ec.Error(ctx, ec.Recover(ctx, r))
+									ret = nil
+								}
+							}()
+							{{- end }}
+							if !isLen1 {
+								defer wg.Done()
+							}
+							ret[i] = ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, v[i])
+						}
+						if isLen1 {
+							f(i)
+						} else {
+							go f(i)
+						}
+					{{ else }}
+						ret[i] = ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, v[i])
+					{{- end }}
+				}
+				{{ if not $type.IsScalar }} wg.Wait() {{ end }}
+				{{ if $type.Elem.GQL.NonNull }}
+					for _, e := range ret {
+						if e == graphql.Null {
+							return graphql.Null
+						}
+					}
+				{{ end }}
+				return ret
+			{{- else if and $type.IsPtrToPtr (not $type.Unmarshaler) (not $type.IsMarshaler) }}
+				if v == nil {
+					return graphql.Null
+				}
+				return ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, *v)
+			{{- else }}
+				{{- if $type.IsNilable }}
+					if v == nil {
+						{{- if $type.GQL.NonNull }}
+							if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+								ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+							}
+						{{- end }}
+						return graphql.Null
+					}
+				{{- end }}
+				{{- if $type.IsMarshaler }}
+					{{- if $type.IsContext }}
+						return graphql.WrapContextMarshaler(ctx, v)
+					{{- else }}
+						return v
+					{{- end }}
+				{{- else if $type.Marshaler }}
+					{{- $v := "v" }}
+					{{- if and $type.IsTargetNilable (not $type.IsNilable) }}
+						{{- $v = "&v" }}
+					{{- else if and (not $type.IsTargetNilable) $type.IsNilable }}
+						{{- $v = "*v" }}
+					{{- end }}
+					{{- if $type.HasEnumValues }}
+						{{- $v = printf "%v[%v]" $type.MarshalFunc $v }}
+					{{- else if $type.CastType }}
+						{{- $v = printf "%v(%v)" ($type.CastType | ref) $v}}
+					{{- end }}
+					res := {{ $type.Marshaler | call }}({{ $v }})
+					{{- if $type.GQL.NonNull }}
+						if res == graphql.Null {
+							if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+								ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+							}
+						}
+					{{- end }}
+					{{- if $type.IsContext }}
+						return graphql.WrapContextMarshaler(ctx, res)
+					{{- else }}
+						return res
+					{{- end }}
+				{{- else if $type.IsRoot }}
+					{{- if eq $type.Definition.Name "Subscription" }}
+						res := ec._{{$type.Definition.Name}}(ctx, sel)
+						return res(ctx)
+					{{- else }}
+						return ec._{{$type.Definition.Name}}(ctx, sel)
+					{{- end }}
+				{{- else }}
+					return ec._{{$type.Definition.Name}}(ctx, sel, {{ if not $type.IsNilable}}&{{end}} v)
+				{{- end }}
+			{{- end }}
+		}
+	{{- end }}
+
+	{{- if $type.HasEnumValues }}
+	{{- $enum := $type.GO }}
+	{{- if $type.IsNilable }}
+		{{- $enum = $type.GO.Elem }}
+	{{- end }}
+	var (
+		{{ $type.UnmarshalFunc }} = map[string]{{ $enum | ref }}{
+		{{- range $value := $type.EnumValues }}
+			"{{ $value.Definition.Name }}": {{ $value.Object | obj }},
+		{{- end }}
+		}
+		{{ $type.MarshalFunc }} = map[{{ $enum | ref }}]string{
+		{{- range $value := $type.EnumValues }}
+			 {{ $value.Object | obj }}: "{{ $value.Definition.Name }}",
+		{{- end }}
+		}
+	 )
+	{{- end }}
+{{- end }}

--- a/api/testdata/template/single-file/file/gqlgen.yml
+++ b/api/testdata/template/single-file/file/gqlgen.yml
@@ -1,0 +1,70 @@
+# Where are all the schema files located? globs are supported eg  src/**/*.graphqls
+schema:
+  - graph/*.graphqls
+
+# Where should the generated server code go?
+exec:
+  filename: graph/generated.go
+  package: graph
+  exec_template: graph/template/exec.gotpl
+
+# Uncomment to enable federation
+# federation:
+#   filename: graph/federation.go
+#   package: graph
+
+# Where should any generated models go?
+model:
+  filename: graph/model/models_gen.go
+  package: model
+
+# Where should the resolver implementations go?
+resolver:
+  layout: follow-schema
+  dir: graph
+  package: graph
+
+# Optional: turn on use `gqlgen:"fieldName"` tags in your models
+# struct_tag: json
+
+# Optional: turn on to use []Thing instead of []*Thing
+# omit_slice_element_pointers: false
+
+# Optional: turn off to make struct-type struct fields not use pointers
+# e.g. type Thing struct { FieldA OtherThing } instead of { FieldA *OtherThing }
+# struct_fields_always_pointers: true
+
+# Optional: turn off to make resolvers return values instead of pointers for structs
+# resolvers_always_return_pointers: true
+
+# Optional: turn on to return pointers instead of values in unmarshalInput
+# return_pointers_in_unmarshalinput: false
+
+# Optional: wrap nullable input fields with Omittable
+# nullable_input_omittable: true
+
+# Optional: set to speed up generation time by not performing a final validation pass.
+# skip_validation: true
+
+# gqlgen will search for any type names in the schema in these go packages
+# if they match it will use them, otherwise it will generate them.
+autobind:
+  - "github.com/99designs/gqlgen/api/testdata/default/graph/model"
+
+# This section declares type mapping between the GraphQL and go type systems
+#
+# The first line in each type will be used as defaults for resolver arguments and
+# modelgen, the others will be allowed when binding to fields. Configure them to
+# your liking
+models:
+  ID:
+    model:
+      - github.com/99designs/gqlgen/graphql.ID
+      - github.com/99designs/gqlgen/graphql.Int
+      - github.com/99designs/gqlgen/graphql.Int64
+      - github.com/99designs/gqlgen/graphql.Int32
+  Int:
+    model:
+      - github.com/99designs/gqlgen/graphql.Int
+      - github.com/99designs/gqlgen/graphql.Int64
+      - github.com/99designs/gqlgen/graphql.Int32

--- a/api/testdata/template/single-file/file/graph/model/doc.go
+++ b/api/testdata/template/single-file/file/graph/model/doc.go
@@ -1,0 +1,1 @@
+package model

--- a/api/testdata/template/single-file/file/graph/schema.graphqls
+++ b/api/testdata/template/single-file/file/graph/schema.graphqls
@@ -1,0 +1,28 @@
+# GraphQL schema example
+#
+# https://gqlgen.com/getting-started/
+
+type Todo {
+  id: ID!
+  text: String!
+  done: Boolean!
+  user: User!
+}
+
+type User {
+  id: ID!
+  name: String!
+}
+
+type Query {
+  todos: [Todo!]!
+}
+
+input NewTodo {
+  text: String!
+  userId: String!
+}
+
+type Mutation {
+  createTodo(input: NewTodo!): Todo!
+}

--- a/api/testdata/template/single-file/file/graph/template/exec.gotpl
+++ b/api/testdata/template/single-file/file/graph/template/exec.gotpl
@@ -1,0 +1,1051 @@
+{{/* Context object: codegen.Data */}}
+{{ reserveImport "context"  }}
+{{ reserveImport "fmt"  }}
+{{ reserveImport "io"  }}
+{{ reserveImport "strconv"  }}
+{{ reserveImport "time"  }}
+{{ reserveImport "sync"  }}
+{{ reserveImport "sync/atomic" }}
+{{ reserveImport "errors"  }}
+{{ reserveImport "bytes"  }}
+{{ reserveImport "embed"  }}
+
+{{ reserveImport "github.com/vektah/gqlparser/v2" "gqlparser" }}
+{{ reserveImport "github.com/vektah/gqlparser/v2/ast" }}
+{{ reserveImport "github.com/99designs/gqlgen/graphql" }}
+{{ reserveImport "github.com/99designs/gqlgen/graphql/introspection" }}
+
+{{ if eq .Config.Exec.Layout "single-file" }}
+	// NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
+	func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
+		return &executableSchema{
+		 	schema: cfg.Schema,
+			resolvers: cfg.Resolvers,
+			directives: cfg.Directives,
+			complexity: cfg.Complexity,
+		}
+	}
+
+	type Config struct {
+		Schema    *ast.Schema
+		Resolvers  ResolverRoot
+		Directives DirectiveRoot
+		Complexity ComplexityRoot
+	}
+
+	type ResolverRoot interface {
+	{{- range $object := .Objects -}}
+		{{ if $object.HasResolvers -}}
+			{{ucFirst $object.Name}}() {{ucFirst $object.Name}}Resolver
+		{{ end }}
+	{{- end }}
+	{{- range $object := .Inputs -}}
+	{{ if $object.HasResolvers -}}
+		{{ucFirst $object.Name}}() {{ucFirst $object.Name}}Resolver
+	{{ end }}
+{{- end }}
+}
+
+	type DirectiveRoot struct {
+	{{ range $directive := .UserDirectives }}
+		{{- $directive.Declaration }}
+	{{ end }}
+	}
+
+	type ComplexityRoot struct {
+	{{- if not .Config.OmitComplexity }}
+	{{ range $object := .Objects }}
+		{{ if not $object.IsReserved -}}
+			{{ ucFirst $object.Name }} struct {
+			{{ range $_, $fields := $object.UniqueFields }}
+				{{- $field := index $fields 0 -}}
+				{{ if not $field.IsReserved -}}
+					{{ $field.GoFieldName }} {{ $field.ComplexitySignature }}
+				{{ end }}
+			{{- end }}
+			}
+		{{- end }}
+	{{ end }}
+	{{- end }}
+	}
+{{ end }}
+
+{{ range $object := .Objects -}}
+	{{ if $object.HasResolvers }}
+		type {{ucFirst $object.Name}}Resolver interface {
+		{{ range $field := $object.Fields -}}
+			{{- if $field.IsResolver }}
+				{{- $field.GoFieldName}}{{ $field.ShortResolverDeclaration }}
+			{{- end }}
+		{{ end }}
+		}
+	{{- end }}
+{{- end }}
+
+{{ range $object := .Inputs -}}
+	{{ if $object.HasResolvers }}
+		type {{$object.Name}}Resolver interface {
+		{{ range $field := $object.Fields -}}
+			{{- if $field.IsResolver }}
+				{{- $field.GoFieldName}}{{ $field.ShortResolverDeclaration }}
+			{{- end }}
+		{{ end }}
+		}
+	{{- end }}
+{{- end }}
+
+{{ range $directive := .BuiltInDirectives }}
+	var (
+		{{- $directive.FunctionImpl }}
+	)
+{{ end }}
+
+{{ if eq .Config.Exec.Layout "single-file" }}
+	type executableSchema struct {
+		schema    *ast.Schema
+		resolvers  ResolverRoot
+		directives DirectiveRoot
+		complexity ComplexityRoot
+	}
+
+	func (e *executableSchema) Schema() *ast.Schema {
+		if e.schema != nil {
+        		return e.schema
+		}
+		return parsedSchema
+	}
+
+	func (e *executableSchema) Complexity(typeName, field string, childComplexity int, rawArgs map[string]interface{}) (int, bool) {
+		ec := executionContext{nil, e, 0, 0, nil}
+		_ = ec
+		{{ if not .Config.OmitComplexity -}}
+		switch typeName + "." + field {
+		{{ range $object := .Objects }}
+			{{ if not $object.IsReserved }}
+				{{ range $_, $fields := $object.UniqueFields }}
+					{{- $len := len $fields }}
+					{{- range $i, $field := $fields }}
+						{{- $last := eq (add $i 1) $len }}
+						{{- if not $field.IsReserved }}
+							{{- if eq $i 0 }}case {{ end }}"{{$object.Name}}.{{$field.Name}}"{{ if not $last }},{{ else }}:
+								if e.complexity.{{ucFirst $object.Name}}.{{$field.GoFieldName}} == nil {
+									break
+								}
+								{{ if $field.Args }}
+									args, err := ec.{{ $field.ArgsFunc }}(context.TODO(),rawArgs)
+									if err != nil {
+										return 0, false
+									}
+								{{ end }}
+								return e.complexity.{{ucFirst $object.Name}}.{{$field.GoFieldName}}(childComplexity{{if $field.Args}}, {{$field.ComplexityArgs}} {{ end }}), true
+							{{ end }}
+						{{- end }}
+					{{- end }}
+				{{ end }}
+			{{ end }}
+		{{ end }}
+		}
+		{{- end }}
+		return 0, false
+	}
+
+	func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
+		rc := graphql.GetOperationContext(ctx)
+		ec := executionContext{rc, e, 0, 0, make(chan graphql.DeferredResult)}
+		inputUnmarshalMap := graphql.BuildUnmarshalerMap(
+			{{- range $input := .Inputs -}}
+				{{ if not $input.HasUnmarshal }}
+					ec.unmarshalInput{{ $input.Name }},
+				{{- end }}
+			{{- end }}
+		)
+		first := true
+
+		switch rc.Operation.Operation {
+		{{- if .QueryRoot }} case ast.Query:
+			return func(ctx context.Context) *graphql.Response {
+				var response graphql.Response
+				var data graphql.Marshaler
+				if first {
+					first = false
+					ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
+					{{ if .Directives.LocationDirectives "QUERY" -}}
+						data = ec._queryMiddleware(ctx, rc.Operation, func(ctx context.Context) (interface{}, error){
+							return ec._{{.QueryRoot.Name}}(ctx, rc.Operation.SelectionSet), nil
+						})
+					{{- else -}}
+						data = ec._{{.QueryRoot.Name}}(ctx, rc.Operation.SelectionSet)
+					{{- end }}
+				} else {
+					if atomic.LoadInt32(&ec.pendingDeferred) > 0 {
+						result := <-ec.deferredResults
+						atomic.AddInt32(&ec.pendingDeferred, -1)
+						data = result.Result
+						response.Path = result.Path
+						response.Label = result.Label
+						response.Errors = result.Errors
+					} else {
+						return nil
+					}
+				}
+				var buf bytes.Buffer
+				data.MarshalGQL(&buf)
+				response.Data = buf.Bytes()
+				if atomic.LoadInt32(&ec.deferred) > 0 {
+					hasNext := atomic.LoadInt32(&ec.pendingDeferred) > 0
+					response.HasNext = &hasNext
+				}
+
+				return &response
+			}
+		{{ end }}
+
+		{{- if .MutationRoot }} case ast.Mutation:
+			return func(ctx context.Context) *graphql.Response {
+				if !first { return nil }
+				first = false
+				ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
+				{{ if .Directives.LocationDirectives "MUTATION" -}}
+					data := ec._mutationMiddleware(ctx, rc.Operation, func(ctx context.Context) (interface{}, error){
+						return ec._{{.MutationRoot.Name}}(ctx, rc.Operation.SelectionSet), nil
+					})
+				{{- else -}}
+					data := ec._{{.MutationRoot.Name}}(ctx, rc.Operation.SelectionSet)
+				{{- end }}
+				var buf bytes.Buffer
+				data.MarshalGQL(&buf)
+
+				return &graphql.Response{
+					Data:       buf.Bytes(),
+				}
+			}
+		{{ end }}
+
+		{{- if .SubscriptionRoot }} case ast.Subscription:
+			{{ if .Directives.LocationDirectives "SUBSCRIPTION" -}}
+				next := ec._subscriptionMiddleware(ctx, rc.Operation, func(ctx context.Context) (interface{}, error){
+					return ec._{{.SubscriptionRoot.Name}}(ctx, rc.Operation.SelectionSet),nil
+				})
+			{{- else -}}
+				next := ec._{{.SubscriptionRoot.Name}}(ctx, rc.Operation.SelectionSet)
+			{{- end }}
+
+			var buf bytes.Buffer
+			return func(ctx context.Context) *graphql.Response {
+				buf.Reset()
+				data := next(ctx)
+
+				if data == nil {
+					return nil
+				}
+				data.MarshalGQL(&buf)
+
+				return &graphql.Response{
+					Data:       buf.Bytes(),
+				}
+			}
+		{{ end }}
+		default:
+			return graphql.OneShot(graphql.ErrorResponse(ctx, "unsupported GraphQL operation"))
+		}
+	}
+
+	type executionContext struct {
+		*graphql.OperationContext
+		*executableSchema
+		deferred        int32
+		pendingDeferred int32
+		deferredResults chan graphql.DeferredResult
+	}
+
+	func (ec *executionContext) processDeferredGroup(dg graphql.DeferredGroup) {
+		atomic.AddInt32(&ec.pendingDeferred, 1)
+		go func () {
+			ctx := graphql.WithFreshResponseContext(dg.Context)
+			dg.FieldSet.Dispatch(ctx)
+			ds := graphql.DeferredResult{
+				Path:   dg.Path,
+				Label:  dg.Label,
+				Result: dg.FieldSet,
+				Errors: graphql.GetErrors(ctx),
+			}
+			// null fields should bubble up
+			if dg.FieldSet.Invalids > 0 {
+				ds.Result = graphql.Null
+			}
+			ec.deferredResults <- ds
+		}()
+	}
+
+	func (ec *executionContext) introspectSchema() (*introspection.Schema, error) {
+		if ec.DisableIntrospection {
+			return nil, errors.New("introspection disabled")
+		}
+		return introspection.WrapSchema(ec.Schema()), nil
+	}
+
+	func (ec *executionContext) introspectType(name string) (*introspection.Type, error) {
+		if ec.DisableIntrospection {
+			return nil, errors.New("introspection disabled")
+		}
+		return introspection.WrapTypeFromDef(ec.Schema(), ec.Schema().Types[name]), nil
+	}
+
+	{{if .HasEmbeddableSources }}
+	//go:embed{{- range $source := .AugmentedSources }}{{if $source.Embeddable}} {{$source.RelativePath|quote}}{{end}}{{- end }}
+	var sourcesFS embed.FS
+
+	func sourceData(filename string) string {
+		data, err := sourcesFS.ReadFile(filename)
+		if err != nil {
+			panic(fmt.Sprintf("codegen problem: %s not available", filename))
+		}
+		return string(data)
+	}
+	{{- end }}
+
+	var sources = []*ast.Source{
+	{{- range $source := .AugmentedSources }}
+		{Name: {{$source.RelativePath|quote}}, Input: {{if (not $source.Embeddable)}}{{$source.Source|rawQuote}}{{else}}sourceData({{$source.RelativePath|quote}}){{end}}, BuiltIn: {{$source.BuiltIn}}},
+	{{- end }}
+	}
+	var parsedSchema = gqlparser.MustLoadSchema(sources...)
+{{ end }}
+{{ range $name, $args := .Args }}
+func (ec *executionContext) {{ $name }}(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+
+	{{- range $i, $arg := . }}
+		arg{{$i}}, err := ec.{{ $name }}{{$arg.Name | go}}(ctx, rawArgs)
+		if err != nil {
+			return nil, err
+		}
+		args[{{$arg.Name|quote}}] = arg{{$i}}
+	{{- end }}
+	return args, nil
+}
+
+	{{- range $i, $arg := . }}
+		func (ec *executionContext) {{ $name }}{{$arg.Name | go}}(
+			ctx context.Context,
+			rawArgs map[string]interface{},
+		) ({{ $arg.TypeReference.GO | ref}}, error) {
+			{{- if not .CallArgumentDirectivesWithNull}}
+				// We won't call the directive if the argument is null.
+				// Set call_argument_directives_with_null to true to call directives
+				// even if the argument is null.
+				_, ok := rawArgs[{{$arg.Name|quote}}]
+				if !ok {
+					var zeroVal {{ $arg.TypeReference.GO | ref}}
+					return zeroVal, nil
+				}
+			{{end}}
+			ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField({{$arg.Name|quote}}))
+			{{- if $arg.ImplDirectives }}
+				directive0 := func(ctx context.Context) (interface{}, error) {
+					tmp, ok := rawArgs[{{$arg.Name|quote}}]
+					if !ok {
+						var zeroVal {{ $arg.TypeReference.GO | ref}}
+						return zeroVal, nil
+					}
+					return ec.{{ $arg.TypeReference.UnmarshalFunc }}(ctx, tmp)
+				}
+				{{ template "implDirectives" $arg }}
+				tmp, err := directive{{$arg.ImplDirectives|len}}(ctx)
+				if err != nil {
+					var zeroVal {{ $arg.TypeReference.GO | ref}}
+					return zeroVal, graphql.ErrorOnPath(ctx, err)
+				}
+				if data, ok := tmp.({{ $arg.TypeReference.GO | ref }}) ; ok {
+					return data, nil
+				{{- if $arg.TypeReference.IsNilable }}
+					} else if tmp == nil {
+						var zeroVal {{ $arg.TypeReference.GO | ref}}
+						return zeroVal, nil
+				{{- end }}
+				} else {
+					var zeroVal {{ $arg.TypeReference.GO | ref}}
+					return zeroVal, graphql.ErrorOnPath(ctx, fmt.Errorf(`unexpected type %T from directive, should be {{ $arg.TypeReference.GO }}`, tmp))
+				}
+			{{- else }}
+				if tmp, ok := rawArgs[{{$arg.Name|quote}}]; ok {
+					return ec.{{ $arg.TypeReference.UnmarshalFunc }}(ctx, tmp)
+				}
+
+				var zeroVal {{ $arg.TypeReference.GO | ref}}
+				return zeroVal, nil
+			{{- end }}
+		}
+	{{end}}
+{{ end }}
+{{- range $object := .Objects }}{{- range $field := $object.Fields }}
+
+func (ec *executionContext) _{{$object.Name}}_{{$field.Name}}(ctx context.Context, field graphql.CollectedField{{ if not $object.Root }}, obj {{$object.Reference | ref}}{{end}}) (ret {{ if $object.Stream }}func(ctx context.Context){{ end }}graphql.Marshaler) {
+	{{- $null := "graphql.Null" }}
+	{{- if $object.Stream }}
+		{{- $null = "nil" }}
+	{{- end }}
+	fc, err := ec.{{ $field.FieldContextFunc }}(ctx, field)
+	if err != nil {
+		return {{ $null }}
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	{{- if not $.Config.OmitPanicHandler }}
+	defer func () {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = {{ $null }}
+		}
+	}()
+	{{- end }}
+	{{- if $field.TypeReference.IsRoot }}
+		{{- if $field.TypeReference.IsPtr }}
+			res := &{{ $field.TypeReference.Elem.GO | ref }}{}
+		{{- else }}
+			res := {{ $field.TypeReference.GO | ref }}{}
+		{{- end }}
+		fc.Result = res
+		return ec.{{ $field.TypeReference.MarshalFunc }}(ctx, field.Selections, res)
+	{{- else}}
+		{{- if  $.AllDirectives.LocationDirectives "FIELD" }}
+			resTmp := ec._fieldMiddleware(ctx, {{if $object.Root}}nil{{else}}obj{{end}}, func(rctx context.Context) (interface{}, error) {
+				{{ template "field" $field }}
+			})
+		{{ else }}
+			resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+				{{ template "field" $field }}
+			})
+			if err != nil {
+				ec.Error(ctx, err)
+				return {{ $null }}
+			}
+		{{- end }}
+		if resTmp == nil {
+			{{- if $field.TypeReference.GQL.NonNull }}
+				if !graphql.HasFieldError(ctx, fc) {
+					ec.Errorf(ctx, "must not be null")
+				}
+			{{- end }}
+			return {{ $null }}
+		}
+		{{- if $object.Stream }}
+			return func(ctx context.Context) graphql.Marshaler {
+				select {
+				case res, ok := <-resTmp.(<-chan {{$field.TypeReference.GO | ref}}):
+					if !ok {
+						return nil
+					}
+					return graphql.WriterFunc(func(w io.Writer) {
+						w.Write([]byte{'{'})
+						graphql.MarshalString(field.Alias).MarshalGQL(w)
+						w.Write([]byte{':'})
+						ec.{{ $field.TypeReference.MarshalFunc }}(ctx, field.Selections, res).MarshalGQL(w)
+						w.Write([]byte{'}'})
+					})
+				case <-ctx.Done():
+					return nil
+				}
+			}
+		{{- else }}
+			res := resTmp.({{$field.TypeReference.GO | ref}})
+			fc.Result = res
+			return ec.{{ $field.TypeReference.MarshalFunc }}(ctx, field.Selections, res)
+		{{- end }}
+	{{- end }}
+}
+
+func (ec *executionContext) {{ $field.FieldContextFunc }}({{ if not $field.Args }}_{{ else }}ctx{{ end }} context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object: {{quote $field.Object.Name}},
+		Field: field,
+		IsMethod: {{or $field.IsMethod $field.IsResolver}},
+		IsResolver: {{ $field.IsResolver }},
+		Child: func (ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			{{- if not $field.TypeReference.Definition.Fields }}
+				return nil, errors.New("field of type {{ $field.TypeReference.Definition.Name }} does not have child fields")
+			{{- else if ne $field.TypeReference.Definition.Kind "OBJECT" }}
+				return nil, errors.New("FieldContext.Child cannot be called on type {{ $field.TypeReference.Definition.Kind }}")
+			{{- else }}
+				switch field.Name {
+					{{- range $f := $field.TypeReference.Definition.Fields }}
+						case "{{ $f.Name }}":
+							return ec.{{ $field.ChildFieldContextFunc $f.Name }}(ctx, field)
+					{{- end }}
+				}
+				return nil, fmt.Errorf("no field named %q was found under type {{ $field.TypeReference.Definition.Name }}", field.Name)
+			{{- end }}
+		},
+	}
+	{{- if $field.Args }}
+		{{- if not $.Config.OmitPanicHandler }}
+		defer func () {
+			if r := recover(); r != nil {
+				err = ec.Recover(ctx, r)
+				ec.Error(ctx, err)
+			}
+		}()
+		{{- end }}
+		ctx = graphql.WithFieldContext(ctx, fc)
+		if fc.Args, err = ec.{{ $field.ArgsFunc }}(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+			ec.Error(ctx, err)
+			return fc, err
+		}
+	{{- end }}
+	return fc, nil
+}
+
+{{- end }}{{- end}}
+
+{{ define "field" }}
+	{{- if .HasDirectives -}}
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx  // use context from middleware stack in children
+			{{ template "fieldDefinition" . }}
+		}
+		{{ template "implDirectives" . }}
+		tmp, err := directive{{.ImplDirectives|len}}(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+		    return nil, nil
+		}
+		if data, ok := tmp.({{if .Stream}}<-chan {{end}}{{ .TypeReference.GO | ref }}) ; ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be {{if .Stream}}<-chan {{end}}{{ .TypeReference.GO }}`, tmp)
+	{{- else -}}
+		ctx = rctx  // use context from middleware stack in children
+		{{ template "fieldDefinition" . }}
+	{{- end -}}
+{{ end }}
+
+{{ define "fieldDefinition" }}
+	{{- if .IsResolver -}}
+		return ec.resolvers.{{ .ShortInvocation }}
+	{{- else if .IsMap -}}
+		switch v := {{.GoReceiverName}}[{{.Name|quote}}].(type) {
+		case {{if .Stream}}<-chan {{end}}{{.TypeReference.GO | ref}}:
+			return v, nil
+		case {{if .Stream}}<-chan {{end}}{{.TypeReference.Elem.GO | ref}}:
+			return &v, nil
+		case nil:
+			return ({{.TypeReference.GO | ref}})(nil), nil
+		default:
+			return nil, fmt.Errorf("unexpected type %T for field %s", v, {{ .Name | quote}})
+		}
+	{{- else if .IsMethod -}}
+		{{- if .VOkFunc -}}
+			v, ok := {{.GoReceiverName}}.{{.GoFieldName}}({{ .CallArgs }})
+			if !ok {
+				return nil, nil
+			}
+			return v, nil
+		{{- else if .NoErr -}}
+			return {{.GoReceiverName}}.{{.GoFieldName}}({{ .CallArgs }}), nil
+		{{- else -}}
+			return {{.GoReceiverName}}.{{.GoFieldName}}({{ .CallArgs }})
+		{{- end -}}
+	{{- else if .IsVariable -}}
+		return {{.GoReceiverName}}.{{.GoFieldName}}, nil
+	{{- end }}
+{{- end }}
+{{- range $input := .Inputs }}
+	{{- if not .HasUnmarshal }}
+	{{- $it := "it" }}
+	{{- if .PointersInUnmarshalInput }}
+	  {{- $it = "&it" }}
+	{{- end }}
+	func (ec *executionContext) unmarshalInput{{ .Name }}(ctx context.Context, obj interface{}) ({{ if .PointersInUnmarshalInput }}*{{ end }}{{.Type | ref}}, error) {
+		{{- if $input.IsMap }}
+			it := make(map[string]interface{}, len(obj.(map[string]interface{})))
+		{{- else }}
+			var it {{.Type | ref}}
+		{{- end }}
+		asMap := map[string]interface{}{}
+		for k, v := range obj.(map[string]interface{}) {
+			asMap[k] = v
+		}
+		{{ range $field := .Fields}}
+			{{- if notNil "Default" $field }}
+				if _, present := asMap[{{$field.Name|quote}}] ; !present {
+					asMap[{{$field.Name|quote}}] = {{ $field.Default | dump }}
+				}
+			{{- end}}
+		{{- end }}
+
+		fieldsInOrder := [...]string{ {{ range .Fields }}{{ quote .Name }},{{ end }} }
+		for _, k := range fieldsInOrder {
+			v, ok := asMap[k]
+			if !ok {
+				continue
+			}
+			switch k {
+			{{- range $field := .Fields }}
+			case {{$field.Name|quote}}:
+				{{- $lhs := (printf "it.%s" $field.GoFieldName) }}
+				{{- if $input.IsMap }}
+					{{- $lhs = (printf "it[%q]" $field.Name) }}
+				{{- end }}
+				ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField({{$field.Name|quote}}))
+				{{- if $field.ImplDirectives }}
+					directive0 := func(ctx context.Context) (interface{}, error) { return ec.{{ $field.TypeReference.UnmarshalFunc }}(ctx, v) }
+					{{ template "implDirectives" $field }}
+					tmp, err := directive{{$field.ImplDirectives|len}}(ctx)
+					if err != nil {
+						return {{$it}}, graphql.ErrorOnPath(ctx, err)
+					}
+					if data, ok := tmp.({{ $field.TypeReference.GO | ref }}) ; ok {
+						{{- if $field.IsResolver }}
+							if err = ec.resolvers.{{ $field.ShortInvocation }}; err != nil {
+								return {{$it}}, err
+							}
+						{{- else }}
+							{{- if $field.TypeReference.IsOmittable }}
+								{{ $lhs }} = graphql.OmittableOf(data)
+							{{- else }}
+								{{ $lhs }} = data
+							{{- end }}
+						{{- end }}
+					{{- if $field.TypeReference.IsNilable }}
+						{{- if not $field.IsResolver }}
+						} else if tmp == nil {
+							{{- if $field.TypeReference.IsOmittable }}
+								{{ $lhs }} = graphql.OmittableOf[{{ $field.TypeReference.GO | ref }}](nil)
+							{{- else }}
+								{{ $lhs }} = nil
+							{{- end }}
+						{{- end }}
+					{{- end }}
+					} else {
+						err := fmt.Errorf(`unexpected type %T from directive, should be {{ $field.TypeReference.GO }}`, tmp)
+						return {{$it}}, graphql.ErrorOnPath(ctx, err)
+					}
+				{{- else }}
+					{{- if $field.IsResolver }}
+						data, err := ec.{{ $field.TypeReference.UnmarshalFunc }}(ctx, v)
+						if err != nil {
+							return {{$it}}, err
+						}
+						if err = ec.resolvers.{{ $field.ShortInvocation }}; err != nil {
+							return {{$it}}, err
+						}
+					{{- else }}
+						data, err := ec.{{ $field.TypeReference.UnmarshalFunc }}(ctx, v)
+						if err != nil {
+							return {{$it}}, err
+						}
+						{{- if $field.TypeReference.IsOmittable }}
+							{{ $lhs }} = graphql.OmittableOf(data)
+						{{- else }}
+							{{ $lhs }} = data
+						{{- end }}
+					{{- end }}
+				{{- end }}
+			{{- end }}
+			}
+		}
+
+		return {{$it}}, nil
+	}
+	{{- end }}
+{{ end }}
+{{- range $interface := .Interfaces }}
+
+func (ec *executionContext) _{{$interface.Name}}(ctx context.Context, sel ast.SelectionSet, obj {{$interface.Type | ref}}) graphql.Marshaler {
+	switch obj := (obj).(type) {
+	case nil:
+		return graphql.Null
+	{{- range $implementor := $interface.Implementors }}
+		case {{$implementor.Type | ref}}:
+			{{- if $implementor.CanBeNil }}
+				if obj == nil {
+					return graphql.Null
+				}
+			{{- end }}
+			return ec._{{$implementor.Name}}(ctx, sel, {{ if $implementor.TakeRef }}&{{ end }}obj)
+	{{- end }}
+	default:
+		panic(fmt.Errorf("unexpected type %T", obj))
+	}
+}
+
+{{- end }}
+{{- range $object := .Objects }}
+
+var {{ $object.Name|lcFirst}}Implementors = {{$object.Implementors}}
+
+{{- if .Stream }}
+func (ec *executionContext) _{{$object.Name}}(ctx context.Context, sel ast.SelectionSet) func(ctx context.Context) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, {{$object.Name|lcFirst}}Implementors)
+	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+		Object: {{$object.Name|quote}},
+	})
+	if len(fields) != 1 {
+		ec.Errorf(ctx, "must subscribe to exactly one stream")
+		return nil
+	}
+
+	switch fields[0].Name {
+	{{- range $field := $object.Fields }}
+	case "{{$field.Name}}":
+		return ec._{{$object.Name}}_{{$field.Name}}(ctx, fields[0])
+	{{- end }}
+	default:
+		panic("unknown field " + strconv.Quote(fields[0].Name))
+	}
+}
+{{- else }}
+func (ec *executionContext) _{{$object.Name}}(ctx context.Context, sel ast.SelectionSet{{ if not $object.Root }},obj {{$object.Reference | ref }}{{ end }}) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, {{$object.Name|lcFirst}}Implementors)
+	{{- if $object.Root }}
+		ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+			Object: {{$object.Name|quote}},
+		})
+	{{end}}
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		{{- if $object.Root }}
+			innerCtx := graphql.WithRootFieldContext(ctx, &graphql.RootFieldContext{
+				Object: field.Name,
+				Field: field,
+			})
+		{{end}}
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString({{$object.Name|quote}})
+		{{- range $field := $object.Fields }}
+		case "{{$field.Name}}":
+			{{- if $field.IsConcurrent }}
+				field := field
+
+				innerFunc := func(ctx context.Context, {{ if $field.TypeReference.GQL.NonNull }}fs{{ else }}_{{ end }} *graphql.FieldSet) (res graphql.Marshaler) {
+					{{- if not $.Config.OmitPanicHandler }}
+					defer func() {
+						if r := recover(); r != nil {
+							ec.Error(ctx, ec.Recover(ctx, r))
+						}
+					}()
+					{{- end }}
+					res = ec._{{$object.Name}}_{{$field.Name}}(ctx, field{{if not $object.Root}}, obj{{end}})
+					{{- if $field.TypeReference.GQL.NonNull }}
+						if res == graphql.Null {
+							{{- if $object.IsConcurrent }}
+								atomic.AddUint32(&fs.Invalids, 1)
+							{{- else }}
+								fs.Invalids++
+							{{- end }}
+						}
+					{{- end }}
+					return res
+				}
+
+				{{if $object.Root}}
+					rrm := func(ctx context.Context) graphql.Marshaler {
+						return ec.OperationContext.RootResolverMiddleware(ctx,
+							func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+					}
+				{{end}}
+
+				{{if not $object.Root}}
+					if field.Deferrable != nil {
+						dfs, ok := deferred[field.Deferrable.Label]
+						di := 0
+						if ok {
+							dfs.AddField(field)
+							di = len(dfs.Values) - 1
+						} else {
+							dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+							deferred[field.Deferrable.Label] = dfs
+						}
+						dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+							return innerFunc(ctx, dfs)
+						})
+
+						// don't run the out.Concurrently() call below
+						out.Values[i] = graphql.Null
+						continue
+					}
+				{{end}}
+
+				out.Concurrently(i, func(ctx context.Context) graphql.Marshaler {
+					{{- if $object.Root -}}
+						return rrm(innerCtx)
+					{{- else -}}
+						return innerFunc(ctx, out)
+					{{- end -}}
+				})
+			{{- else }}
+				{{- if $object.Root -}}
+					out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+						return ec._{{$object.Name}}_{{$field.Name}}(ctx, field)
+					})
+				{{- else -}}
+					out.Values[i] = ec._{{$object.Name}}_{{$field.Name}}(ctx, field, obj)
+				{{- end -}}
+
+				{{- if $field.TypeReference.GQL.NonNull }}
+					if out.Values[i] == graphql.Null {
+						{{- if $object.IsConcurrent }}
+							atomic.AddUint32(&out.Invalids, 1)
+						{{- else }}
+							out.Invalids++
+						{{- end }}
+					}
+				{{- end }}
+			{{- end }}
+		{{- end }}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 { return graphql.Null }
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+{{- end }}
+
+{{- end }}
+{{- range $type := .ReferencedTypes }}
+	{{ with $type.UnmarshalFunc }}
+		func (ec *executionContext) {{ . }}(ctx context.Context, v interface{}) ({{ $type.GO | ref }}, error) {
+			{{- if and $type.IsNilable (not $type.GQL.NonNull) (not $type.IsPtrToPtr) }}
+				if v == nil { return nil, nil }
+			{{- end }}
+			{{- if or $type.IsPtrToSlice $type.IsPtrToIntf }}
+				res, err := ec.{{ $type.Elem.UnmarshalFunc }}(ctx, v)
+				return &res, graphql.ErrorOnPath(ctx, err)
+			{{- else if $type.IsSlice }}
+				var vSlice []interface{}
+				if v != nil {
+					vSlice = graphql.CoerceList(v)
+				}
+				var err error
+				res := make([]{{$type.GO.Elem | ref}}, len(vSlice))
+				for i := range vSlice {
+					ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+					res[i], err = ec.{{ $type.Elem.UnmarshalFunc }}(ctx, vSlice[i])
+					if err != nil {
+						return nil, err
+					}
+				}
+				return res, nil
+			{{- else if and $type.IsPtrToPtr (not $type.Unmarshaler) (not $type.IsMarshaler) }}
+				var pres {{ $type.Elem.GO | ref }}
+				if v != nil {
+					res, err := ec.{{ $type.Elem.UnmarshalFunc }}(ctx, v)
+					if err != nil {
+						return nil, graphql.ErrorOnPath(ctx, err)
+					}
+					pres = res
+				}
+				return &pres, nil
+			{{- else }}
+				{{- if $type.Unmarshaler }}
+					{{- if $type.HasEnumValues }}
+						tmp, err := {{ $type.Unmarshaler | call }}(v)
+						res := {{ $type.UnmarshalFunc }}[tmp]
+					{{- else if $type.CastType }}
+						{{- if $type.IsContext }}
+							tmp, err := {{ $type.Unmarshaler | call }}(ctx, v)
+						{{- else }}
+							tmp, err := {{ $type.Unmarshaler | call }}(v)
+						{{- end }}
+						{{- if and $type.IsNilable $type.Elem }}
+							res := {{ $type.Elem.GO | ref }}(tmp)
+						{{- else}}
+							res := {{ $type.GO | ref }}(tmp)
+						{{- end }}
+					{{- else}}
+						{{- if $type.IsContext }}
+							res, err := {{ $type.Unmarshaler | call }}(ctx, v)
+						{{- else }}
+							res, err := {{ $type.Unmarshaler | call }}(v)
+						{{- end }}
+					{{- end }}
+					{{- if and $type.IsTargetNilable (not $type.IsNilable) }}
+						return *res, graphql.ErrorOnPath(ctx, err)
+					{{- else if and (not $type.IsTargetNilable) $type.IsNilable }}
+						return &res, graphql.ErrorOnPath(ctx, err)
+					{{- else}}
+						return res, graphql.ErrorOnPath(ctx, err)
+					{{- end }}
+				{{- else if $type.IsMarshaler }}
+					{{- if and $type.IsNilable $type.Elem }}
+						var res = new({{ $type.Elem.GO | ref }})
+					{{- else}}
+						var res {{ $type.GO | ref }}
+					{{- end }}
+					{{- if $type.IsContext }}
+						err := res.UnmarshalGQLContext(ctx, v)
+					{{- else }}
+						err := res.UnmarshalGQL(v)
+					{{- end }}
+					return res, graphql.ErrorOnPath(ctx, err)
+				{{- else }}
+					res, err := ec.unmarshalInput{{ $type.GQL.Name }}(ctx, v)
+					{{- if and $type.IsNilable (not $type.IsMap) (not $type.PointersInUnmarshalInput) }}
+						return &res, graphql.ErrorOnPath(ctx, err)
+					{{- else if and (not $type.IsNilable) $type.PointersInUnmarshalInput }}
+						return *res, graphql.ErrorOnPath(ctx, err)
+					{{- else }}
+						return res, graphql.ErrorOnPath(ctx, err)
+					{{- end }}
+				{{- end }}
+			{{- end }}
+		}
+	{{- end }}
+
+	{{ with $type.MarshalFunc }}
+		func (ec *executionContext) {{ . }}(ctx context.Context, sel ast.SelectionSet, v {{ $type.GO | ref }}) graphql.Marshaler {
+			{{- if or $type.IsPtrToSlice $type.IsPtrToIntf }}
+				return ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, *v)
+			{{- else if $type.IsSlice }}
+				{{- if not $type.GQL.NonNull }}
+					if v == nil {
+						return graphql.Null
+					}
+				{{- end }}
+				ret := make(graphql.Array, len(v))
+				{{- if not $type.IsScalar }}
+					var wg sync.WaitGroup
+					isLen1 := len(v) == 1
+					if !isLen1 {
+						wg.Add(len(v))
+					}
+				{{- end }}
+				for i := range v {
+					{{- if not $type.IsScalar }}
+						i := i
+						fc := &graphql.FieldContext{
+							Index: &i,
+							Result: &v[i],
+						}
+						ctx := graphql.WithFieldContext(ctx, fc)
+						f := func(i int) {
+							{{- if not $.Config.OmitPanicHandler }}
+							defer func() {
+								if r := recover(); r != nil {
+									ec.Error(ctx, ec.Recover(ctx, r))
+									ret = nil
+								}
+							}()
+							{{- end }}
+							if !isLen1 {
+								defer wg.Done()
+							}
+							ret[i] = ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, v[i])
+						}
+						if isLen1 {
+							f(i)
+						} else {
+							go f(i)
+						}
+					{{ else }}
+						ret[i] = ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, v[i])
+					{{- end }}
+				}
+				{{ if not $type.IsScalar }} wg.Wait() {{ end }}
+				{{ if $type.Elem.GQL.NonNull }}
+					for _, e := range ret {
+						if e == graphql.Null {
+							return graphql.Null
+						}
+					}
+				{{ end }}
+				return ret
+			{{- else if and $type.IsPtrToPtr (not $type.Unmarshaler) (not $type.IsMarshaler) }}
+				if v == nil {
+					return graphql.Null
+				}
+				return ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, *v)
+			{{- else }}
+				{{- if $type.IsNilable }}
+					if v == nil {
+						{{- if $type.GQL.NonNull }}
+							if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+								ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+							}
+						{{- end }}
+						return graphql.Null
+					}
+				{{- end }}
+				{{- if $type.IsMarshaler }}
+					{{- if $type.IsContext }}
+						return graphql.WrapContextMarshaler(ctx, v)
+					{{- else }}
+						return v
+					{{- end }}
+				{{- else if $type.Marshaler }}
+					{{- $v := "v" }}
+					{{- if and $type.IsTargetNilable (not $type.IsNilable) }}
+						{{- $v = "&v" }}
+					{{- else if and (not $type.IsTargetNilable) $type.IsNilable }}
+						{{- $v = "*v" }}
+					{{- end }}
+					{{- if $type.HasEnumValues }}
+						{{- $v = printf "%v[%v]" $type.MarshalFunc $v }}
+					{{- else if $type.CastType }}
+						{{- $v = printf "%v(%v)" ($type.CastType | ref) $v}}
+					{{- end }}
+					res := {{ $type.Marshaler | call }}({{ $v }})
+					{{- if $type.GQL.NonNull }}
+						if res == graphql.Null {
+							if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+								ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+							}
+						}
+					{{- end }}
+					{{- if $type.IsContext }}
+						return graphql.WrapContextMarshaler(ctx, res)
+					{{- else }}
+						return res
+					{{- end }}
+				{{- else if $type.IsRoot }}
+					{{- if eq $type.Definition.Name "Subscription" }}
+						res := ec._{{$type.Definition.Name}}(ctx, sel)
+						return res(ctx)
+					{{- else }}
+						return ec._{{$type.Definition.Name}}(ctx, sel)
+					{{- end }}
+				{{- else }}
+					return ec._{{$type.Definition.Name}}(ctx, sel, {{ if not $type.IsNilable}}&{{end}} v)
+				{{- end }}
+			{{- end }}
+		}
+	{{- end }}
+
+	{{- if $type.HasEnumValues }}
+	{{- $enum := $type.GO }}
+	{{- if $type.IsNilable }}
+		{{- $enum = $type.GO.Elem }}
+	{{- end }}
+	var (
+		{{ $type.UnmarshalFunc }} = map[string]{{ $enum | ref }}{
+		{{- range $value := $type.EnumValues }}
+			"{{ $value.Definition.Name }}": {{ $value.Object | obj }},
+		{{- end }}
+		}
+		{{ $type.MarshalFunc }} = map[{{ $enum | ref }}]string{
+		{{- range $value := $type.EnumValues }}
+			 {{ $value.Object | obj }}: "{{ $value.Definition.Name }}",
+		{{- end }}
+		}
+	 )
+	{{- end }}
+{{- end }}

--- a/codegen/config/exec.go
+++ b/codegen/config/exec.go
@@ -20,6 +20,9 @@ type ExecConfig struct {
 	// Only for follow-schema layout:
 	FilenameTemplate string `yaml:"filename_template,omitempty"` // String template with {name} as placeholder for base name.
 	DirName          string `yaml:"dir"`
+
+	ExecTemplate    string `yaml:"exec_template,omitempty"`
+	ExecTemplateDir string `yaml:"exec_template_dir,omitempty"`
 }
 
 type ExecLayout string

--- a/codegen/config/exec.go
+++ b/codegen/config/exec.go
@@ -14,15 +14,16 @@ type ExecConfig struct {
 	Package string     `yaml:"package,omitempty"`
 	Layout  ExecLayout `yaml:"layout,omitempty"` // Default: single-file
 
+	// If `exec_template` and `exec_template_dir` are defined at the same time, an error will occur to avoid confusion.
+	ExecTemplate    string `yaml:"exec_template,omitempty"`
+	ExecTemplateDir string `yaml:"exec_template_dir,omitempty"`
+
 	// Only for single-file layout:
 	Filename string `yaml:"filename,omitempty"`
 
 	// Only for follow-schema layout:
 	FilenameTemplate string `yaml:"filename_template,omitempty"` // String template with {name} as placeholder for base name.
 	DirName          string `yaml:"dir"`
-
-	ExecTemplate    string `yaml:"exec_template,omitempty"`
-	ExecTemplateDir string `yaml:"exec_template_dir,omitempty"`
 }
 
 type ExecLayout string
@@ -63,6 +64,10 @@ func (r *ExecConfig) Check() error {
 
 	if r.Package == "" && r.Dir() != "" {
 		r.Package = code.NameForDir(r.Dir())
+	}
+
+	if r.ExecTemplate != "" && r.ExecTemplateDir != "" {
+		return errors.New("exec_template and exec_template_dir cannot be defined at the same time")
 	}
 
 	return nil

--- a/codegen/config/exec_test.go
+++ b/codegen/config/exec_test.go
@@ -1,0 +1,107 @@
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecConfig_Check(t *testing.T) {
+	type fields struct {
+		Package          string
+		Layout           ExecLayout
+		ExecTemplate     string
+		ExecTemplateDir  string
+		Filename         string
+		FilenameTemplate string
+		DirName          string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		err    error
+	}{
+		{
+			name: "single-file layout without filename",
+			fields: fields{
+				Layout: ExecLayoutSingleFile,
+			},
+			err: errors.New("filename must be specified when using single-file layout"),
+		},
+		{
+			name: "single-file layout with invalid filename",
+			fields: fields{
+				Layout:   ExecLayoutSingleFile,
+				Filename: "output.txt",
+			},
+			err: errors.New("filename should be path to a go source file when using single-file layout"),
+		},
+		{
+			name: "follow-schema layout without dir",
+			fields: fields{
+				Layout: ExecLayoutFollowSchema,
+			},
+			err: errors.New("dir must be specified when using follow-schema layout"),
+		},
+		{
+			name: "invalid layout",
+			fields: fields{
+				Layout: "invalid-layout",
+			},
+			err: errors.New("invalid layout invalid-layout"),
+		},
+		{
+			name: "package with invalid characters",
+			fields: fields{
+				Filename: "generated.go",
+				Package:  "invalid/package",
+			},
+			err: errors.New("package should be the output package name only, do not include the output filename"),
+		},
+		{
+			name: "exec_template and exec_template_dir both defined",
+			fields: fields{
+				Filename:        "generated.go",
+				ExecTemplate:    "template",
+				ExecTemplateDir: "template_dir",
+			},
+			err: errors.New("exec_template and exec_template_dir cannot be defined at the same time"),
+		},
+		{
+			name: "valid single-file layout",
+			fields: fields{
+				Layout:   ExecLayoutSingleFile,
+				Filename: "generated.go",
+			},
+			err: nil,
+		},
+		{
+			name: "valid follow-schema layout",
+			fields: fields{
+				Layout:  ExecLayoutFollowSchema,
+				DirName: "output_dir",
+			},
+			err: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ExecConfig{
+				Package:          tt.fields.Package,
+				Layout:           tt.fields.Layout,
+				ExecTemplate:     tt.fields.ExecTemplate,
+				ExecTemplateDir:  tt.fields.ExecTemplateDir,
+				Filename:         tt.fields.Filename,
+				FilenameTemplate: tt.fields.FilenameTemplate,
+				DirName:          tt.fields.DirName,
+			}
+			err := r.Check()
+			if tt.err != nil {
+				assert.EqualError(t, err, tt.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -43,6 +43,8 @@ type Options struct {
 	// this is an alternative to passing the Template option
 	TemplateFS fs.FS
 
+	// The location of the customized template files by users
+	// If TemplateDir is set, the plugin processor will look for all .gotpl files under the directory
 	TemplateDir string
 
 	// Filename is the name of the file that will be

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -43,6 +43,8 @@ type Options struct {
 	// this is an alternative to passing the Template option
 	TemplateFS fs.FS
 
+	TemplateDir string
+
 	// Filename is the name of the file that will be
 	// written to the system disk once the template is rendered.
 	Filename        string
@@ -168,9 +170,12 @@ func parseTemplates(cfg Options, t *template.Template) (*template.Template, erro
 	}
 
 	var fileSystem fs.FS
-	if cfg.TemplateFS != nil {
+	switch {
+	case cfg.TemplateDir != "":
+		fileSystem = os.DirFS(cfg.TemplateDir)
+	case cfg.TemplateFS != nil:
 		fileSystem = cfg.TemplateFS
-	} else {
+	default:
 		// load path relative to calling source file
 		_, callerFile, _, _ := runtime.Caller(2)
 		rootDir := filepath.Dir(callerFile)

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -20,6 +20,11 @@ exec:
   layout: follow-schema
   dir: graph/generated
   package: generated
+  # NOTE: It is not permitted to set `exec_template` and `exec_template_dir` at the same time.
+  # Optional: Pass in a file path to a new gotpl template to use for generating the server code
+  # exec_template: [your/path/exec.gotpl]
+  # Optional: Pass in a directory path contained new gotpl template to use for generating the server code
+  # exec_template_dir: [your/directory/path]
 
 # Enable Apollo federation support
 federation:

--- a/plugin/resolvergen/testdata/filetemplate/out/schema.custom.go
+++ b/plugin/resolvergen/testdata/filetemplate/out/schema.custom.go
@@ -33,12 +33,6 @@ func (r *CustomResolverType) Resolver() customresolver.ResolverResolver {
 type queryCustomResolverType struct{ *CustomResolverType }
 type resolverCustomResolverType struct{ *CustomResolverType }
 
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//     it when you're done.
-//   - You have helper methods in this file. Move them out to keep these resolver files clean.
 func AUserHelperFunction() {
 	// AUserHelperFunction implementation
 }

--- a/plugin/resolvergen/testdata/followschema/out/schema.resolvers.go
+++ b/plugin/resolvergen/testdata/followschema/out/schema.resolvers.go
@@ -33,12 +33,6 @@ func (r *CustomResolverType) Resolver() customresolver.ResolverResolver {
 type queryCustomResolverType struct{ *CustomResolverType }
 type resolverCustomResolverType struct{ *CustomResolverType }
 
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//     it when you're done.
-//   - You have helper methods in this file. Move them out to keep these resolver files clean.
 func AUserHelperFunction() {
 	// AUserHelperFunction implementation
 }


### PR DESCRIPTION
# Overview

I have made `gqlgen` possible to set custom templates for the server code generation that I previously proposed at #3371.

If you set the file or directory path to the template in config as below, code generation will be performed by referring to those files rather than the templates managed by gqlgen:

```yaml
# Where are all the schema files located? globs are supported eg  src/**/*.graphqls
schema:
  - graph/schema/**/*.graphqls

# Where should the generated server code go?
exec:
  filename: graph/generated/autogen.go
  package: generated
  exec_template_dir: graph/template
  # you can specify a single template file
  # exec_template: graph/template/exec.gotpl
```

This change allows users who want to change the core logic of the server for exceptional use cases to continue to use the original `gqlgen` with only custom template preparation.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
