### PR TITLE
add `worker_limit` option for server code generation

### DIFF
--- a/api/generate_test.go
+++ b/api/generate_test.go
@@ -34,6 +34,10 @@ func TestGenerate(t *testing.T) {
 			name:    "federation2",
 			workDir: filepath.Join(wd, "testdata", "federation2"),
 		},
+		{
+			name:    "worker_limit",
+			workDir: filepath.Join(wd, "testdata", "workerlimit"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/api/testdata/workerlimit/gqlgen.yml
+++ b/api/testdata/workerlimit/gqlgen.yml
@@ -1,0 +1,70 @@
+# Where are all the schema files located? globs are supported eg  src/**/*.graphqls
+schema:
+  - graph/*.graphqls
+
+# Where should the generated server code go?
+exec:
+  filename: graph/generated.go
+  package: graph
+  worker_limit: 1
+
+# Uncomment to enable federation
+# federation:
+#   filename: graph/federation.go
+#   package: graph
+
+# Where should any generated models go?
+model:
+  filename: graph/model/models_gen.go
+  package: model
+
+# Where should the resolver implementations go?
+resolver:
+  layout: follow-schema
+  dir: graph
+  package: graph
+
+# Optional: turn on use `gqlgen:"fieldName"` tags in your models
+# struct_tag: json
+
+# Optional: turn on to use []Thing instead of []*Thing
+# omit_slice_element_pointers: false
+
+# Optional: turn off to make struct-type struct fields not use pointers
+# e.g. type Thing struct { FieldA OtherThing } instead of { FieldA *OtherThing }
+# struct_fields_always_pointers: true
+
+# Optional: turn off to make resolvers return values instead of pointers for structs
+# resolvers_always_return_pointers: true
+
+# Optional: turn on to return pointers instead of values in unmarshalInput
+# return_pointers_in_unmarshalinput: false
+
+# Optional: wrap nullable input fields with Omittable
+# nullable_input_omittable: true
+
+# Optional: set to speed up generation time by not performing a final validation pass.
+# skip_validation: true
+
+# gqlgen will search for any type names in the schema in these go packages
+# if they match it will use them, otherwise it will generate them.
+autobind:
+  - "github.com/99designs/gqlgen/api/testdata/default/graph/model"
+
+# This section declares type mapping between the GraphQL and go type systems
+#
+# The first line in each type will be used as defaults for resolver arguments and
+# modelgen, the others will be allowed when binding to fields. Configure them to
+# your liking
+models:
+  ID:
+    model:
+      - github.com/99designs/gqlgen/graphql.ID
+      - github.com/99designs/gqlgen/graphql.Int
+      - github.com/99designs/gqlgen/graphql.Int64
+      - github.com/99designs/gqlgen/graphql.Int32
+  Int:
+    model:
+      - github.com/99designs/gqlgen/graphql.Int
+      - github.com/99designs/gqlgen/graphql.Int64
+      - github.com/99designs/gqlgen/graphql.Int32

--- a/api/testdata/workerlimit/graph/model/doc.go
+++ b/api/testdata/workerlimit/graph/model/doc.go
@@ -1,0 +1,1 @@
+package model

--- a/api/testdata/workerlimit/graph/schema.graphqls
+++ b/api/testdata/workerlimit/graph/schema.graphqls
@@ -1,0 +1,28 @@
+# GraphQL schema example
+#
+# https://gqlgen.com/getting-started/
+
+type Todo {
+  id: ID!
+  text: String!
+  done: Boolean!
+  user: User!
+}
+
+type User {
+  id: ID!
+  name: String!
+}
+
+type Query {
+  todos: [Todo!]!
+}
+
+input NewTodo {
+  text: String!
+  userId: String!
+}
+
+type Mutation {
+  createTodo(input: NewTodo!): Todo!
+}

--- a/codegen/config/exec.go
+++ b/codegen/config/exec.go
@@ -20,6 +20,8 @@ type ExecConfig struct {
 	// Only for follow-schema layout:
 	FilenameTemplate string `yaml:"filename_template,omitempty"` // String template with {name} as placeholder for base name.
 	DirName          string `yaml:"dir"`
+
+	WorkerLimit uint `yaml: "worker_limit"`
 }
 
 type ExecLayout string

--- a/codegen/config/exec.go
+++ b/codegen/config/exec.go
@@ -21,6 +21,10 @@ type ExecConfig struct {
 	FilenameTemplate string `yaml:"filename_template,omitempty"` // String template with {name} as placeholder for base name.
 	DirName          string `yaml:"dir"`
 
+	// Maximum number of goroutines in parallel to use when running multiple child resolvers
+	// Suppressing the number of goroutines generated can reduce memory consumption per request,
+	// but processing time may increase due to the reduced number of concurrences
+	// Default: 0 (unlimited)
 	WorkerLimit uint `yaml:"worker_limit"`
 }
 

--- a/codegen/config/exec.go
+++ b/codegen/config/exec.go
@@ -21,7 +21,7 @@ type ExecConfig struct {
 	FilenameTemplate string `yaml:"filename_template,omitempty"` // String template with {name} as placeholder for base name.
 	DirName          string `yaml:"dir"`
 
-	// Maximum number of goroutines in parallel to use when running multiple child resolvers
+	// Maximum number of goroutines in concurrency to use when running multiple child resolvers
 	// Suppressing the number of goroutines generated can reduce memory consumption per request,
 	// but processing time may increase due to the reduced number of concurrences
 	// Default: 0 (unlimited)

--- a/codegen/config/exec.go
+++ b/codegen/config/exec.go
@@ -21,7 +21,7 @@ type ExecConfig struct {
 	FilenameTemplate string `yaml:"filename_template,omitempty"` // String template with {name} as placeholder for base name.
 	DirName          string `yaml:"dir"`
 
-	WorkerLimit uint `yaml: "worker_limit"`
+	WorkerLimit uint `yaml:"worker_limit"`
 }
 
 type ExecLayout string

--- a/codegen/generated!.gotpl
+++ b/codegen/generated!.gotpl
@@ -10,6 +10,7 @@
 {{ reserveImport "bytes"  }}
 {{ reserveImport "embed"  }}
 
+{{ reserveImport "golang.org/x/sync/semaphore"}}
 {{ reserveImport "github.com/vektah/gqlparser/v2" "gqlparser" }}
 {{ reserveImport "github.com/vektah/gqlparser/v2/ast" }}
 {{ reserveImport "github.com/99designs/gqlgen/graphql" }}

--- a/codegen/type.gotpl
+++ b/codegen/type.gotpl
@@ -101,6 +101,9 @@
 				ret := make(graphql.Array, len(v))
 				{{- if not $type.IsScalar }}
 					var wg sync.WaitGroup
+					{{- if gt $.Config.Exec.WorkerLimit 0 }}
+						sm := semaphore.NewWeighted({{ $.Config.Exec.WorkerLimit }})
+					{{- end }}
 					isLen1 := len(v) == 1
 					if !isLen1 {
 						wg.Add(len(v))
@@ -124,14 +127,29 @@
 							}()
 							{{- end }}
 							if !isLen1 {
-								defer wg.Done()
+								{{- if gt $.Config.Exec.WorkerLimit 0 }}
+									defer func(){
+										sm.Release(1)
+										wg.Done()
+									}()
+								{{- else }}
+									defer wg.Done()
+								{{- end }}
 							}
 							ret[i] = ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, v[i])
 						}
 						if isLen1 {
 							f(i)
 						} else {
-							go f(i)
+							{{- if gt $.Config.Exec.WorkerLimit 0 }}
+								if err := sm.Acquire(ctx, 1); err != nil {
+									ec.Error(ctx, ctx.Err())
+								} else {
+									go f(i)
+								}
+							{{- else }}
+								go f(i)
+							{{- end }}
 						}
 					{{ else }}
 						ret[i] = ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, v[i])

--- a/init-templates/gqlgen.yml.gotmpl
+++ b/init-templates/gqlgen.yml.gotmpl
@@ -6,6 +6,8 @@ schema:
 exec:
   filename: graph/generated.go
   package: graph
+  # Optional: Maximum number of goroutines in concurrency to use per child resolvers(default: unlimited)
+  # worker_limit: 1000
 
 # Uncomment to enable federation
 # federation:


### PR DESCRIPTION
# Overview

When executing a child resolver, a goroutine is created each time if there are multiple fields.

For example, if two fields are in 10,000 objects, and they are required to execute a child resolver, 20,000 goroutines will be created at once with a single request. Since each goroutine requires at least 2 KiB, each request requires approximately 41 MiB for ONLY goroutines.

In this PR, as discussed in #3371, I introduced an option to prevent unintended big memory pressure by restricting goroutines generated at once using a semaphore. To minimize the difference in automatically generated code between before and after this patch is merged, if `worker_limit` is not set, there is no diff from the previously generated code.

```yaml
exec:
  filename: graph/generated.go
  package: graph
  worker_limit: 1000
```

If you set it as above, the following code will be generated.

```go
ret := make(graphql.Array, len(v))
var wg sync.WaitGroup
sm := semaphore.NewWeighted(1000)
isLen1 := len(v) == 1
if !isLen1 {
wg.Add(len(v))
}
for i := range v {
i := i
fc := &graphql.FieldContext{
	Index:  &i,
	Result: &v[i],
}
ctx := graphql.WithFieldContext(ctx, fc)
f := func(i int) {
	defer func() {
		if r := recover(); r != nil {
			ec.Error(ctx, ec.Recover(ctx, r))
			ret = nil
		}
	}()
	if !isLen1 {
		defer func() {
			sm.Release(1)
			wg.Done()
		}()
	}
	ret[i] = ec.marshalNTodo2ᚖgithubᚗcomᚋOldBigBuddhaᚋgqlgenᚑplaygroundᚋgraphᚋmodelᚐTodo(ctx, sel, v[i])
}
if isLen1 {
	f(i)
} else {
	if err := sm.Acquire(ctx, 1); err != nil {
		ec.Error(ctx, ctx.Err())
	} else {
		go f(i)
	}
}

}
wg.Wait()

for _, e := range ret {
if e == graphql.Null {
	return graphql.Null
}
}

return ret
```


Note that `worker_limit` is an option that reduces memory consumption at the expense of concurrency, so excessive restrictions will unnecessarily prolong execution times and degrade application performance.

I appreciate @StevenACoffman for sharing this idea with me.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
