### PR TITLE
websocket subscribe missing header bugfix

### DIFF
--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -54,6 +54,7 @@ type (
 		receivedPong    bool
 		exec            graphql.GraphExecutor
 		closed          bool
+		headers         http.Header
 
 		initPayload InitPayload
 	}
@@ -119,6 +120,7 @@ func (t Websocket) Do(w http.ResponseWriter, r *http.Request, exec graphql.Graph
 		ctx:       r.Context(),
 		exec:      exec,
 		me:        me,
+		headers:   r.Header,
 		Websocket: t,
 	}
 
@@ -386,6 +388,8 @@ func (c *wsConnection) subscribe(start time.Time, msg *message) {
 		Start: start,
 		End:   graphql.Now(),
 	}
+
+	params.Headers = c.headers
 
 	rc, err := c.exec.CreateOperationContext(ctx, params)
 	if err != nil {


### PR DESCRIPTION
Make serving requests from websockets, the headers of the request are being lost along the function chain. 

This PR adds them back along so that the server is able to access the request headers via the 

`graphql.GetOperationContext(ctx)` method 


I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [X] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
