### PR TITLE
chore: update golangci-lint to v1.62.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   golangci-lint:
     env:
-      GOLANGCI_LINT_VERSION: v1.60.2
+      GOLANGCI_LINT_VERSION: v1.62.0
     strategy:
       matrix:
         go: ["1.22", "1.23"]

--- a/codegen/testserver/followschema/directive_test.go
+++ b/codegen/testserver/followschema/directive_test.go
@@ -112,6 +112,7 @@ func TestDirectives(t *testing.T) {
 	srv := handler.NewDefaultServer(NewExecutableSchema(Config{
 		Resolvers: resolvers,
 		Directives: DirectiveRoot{
+			//nolint:revive // can't rename min, max because it's generated code
 			Length: func(ctx context.Context, obj any, next graphql.Resolver, min int, max *int, message *string) (any, error) {
 				e := func(msg string) error {
 					if message == nil {
@@ -133,6 +134,7 @@ func TestDirectives(t *testing.T) {
 				}
 				return res, nil
 			},
+			//nolint:revive // can't rename min, max because it's generated code
 			Range: func(ctx context.Context, obj any, next graphql.Resolver, min *int, max *int) (any, error) {
 				res, err := next(ctx)
 				if err != nil {

--- a/codegen/testserver/singlefile/directive_test.go
+++ b/codegen/testserver/singlefile/directive_test.go
@@ -112,6 +112,7 @@ func TestDirectives(t *testing.T) {
 	srv := handler.NewDefaultServer(NewExecutableSchema(Config{
 		Resolvers: resolvers,
 		Directives: DirectiveRoot{
+			//nolint:revive // can't rename min, max because it's generated code
 			Length: func(ctx context.Context, obj any, next graphql.Resolver, min int, max *int, message *string) (any, error) {
 				e := func(msg string) error {
 					if message == nil {
@@ -133,6 +134,7 @@ func TestDirectives(t *testing.T) {
 				}
 				return res, nil
 			},
+			//nolint:revive // can't rename min, max because it's generated code
 			Range: func(ctx context.Context, obj any, next graphql.Resolver, min *int, max *int) (any, error) {
 				res, err := next(ctx)
 				if err != nil {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -104,9 +104,9 @@ func WebsocketUpgrader(upgrader websocket.Upgrader) Option {
 }
 
 // Deprecated: switch to graphql/handler.New
-func RecoverFunc(recover graphql.RecoverFunc) Option {
+func RecoverFunc(recoverFn graphql.RecoverFunc) Option {
 	return func(cfg *Config) {
-		cfg.recover = recover
+		cfg.recover = recoverFn
 	}
 }
 


### PR DESCRIPTION
The PR upgrades the version for golangci-lint to the latest [v1.62.0](https://golangci-lint.run/product/changelog/#v1620).

Additionally, fixes these new lint issues:
```
❯ golangci-lint run
handler/handler.go:107:18: redefines-builtin-id: redefinition of the built-in function recover (revive)
func RecoverFunc(recover graphql.RecoverFunc) Option {
                 ^
codegen/testserver/followschema/directive_test.go:115:70: redefines-builtin-id: redefinition of the built-in function min (revive)
                        Length: func(ctx context.Context, obj any, next graphql.Resolver, min int, max *int, message *string) (any, error) {
                                                                                          ^
codegen/testserver/followschema/directive_test.go:136:69: redefines-builtin-id: redefinition of the built-in function min (revive)
                        Range: func(ctx context.Context, obj any, next graphql.Resolver, min *int, max *int) (any, error) {
                                                                                         ^
codegen/testserver/singlefile/directive_test.go:115:70: redefines-builtin-id: redefinition of the built-in function min (revive)
                        Length: func(ctx context.Context, obj any, next graphql.Resolver, min int, max *int, message *string) (any, error) {
                                                                                          ^
```

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
