### PR TITLE
refactor: fix copyloopvar, dupword lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,7 +74,9 @@ linters:
   disable-all: true
   enable:
     - bodyclose
+    - copyloopvar
     - dupl
+    - dupword
     - errcheck
     - gocritic
     - gofmt

--- a/_examples/federation/subgraphs/subgraphs.go
+++ b/_examples/federation/subgraphs/subgraphs.go
@@ -41,7 +41,6 @@ func (s *Subgraphs) Shutdown(ctx context.Context) error {
 func (s *Subgraphs) ListenAndServe(ctx context.Context) error {
 	group, _ := errgroup.WithContext(ctx)
 	for _, srv := range s.servers {
-		srv := srv
 		group.Go(func() error {
 			err := srv.ListenAndServe()
 			if err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/codegen/testserver/followschema/directive_test.go
+++ b/codegen/testserver/followschema/directive_test.go
@@ -20,7 +20,7 @@ func isNil(input any) bool {
 		return true
 	}
 	// Using reflect to check if the value is nil. This is necessary for
-	// for any types that are not nil types but have a nil value (e.g. *string).
+	// any types that are not nil types but have a nil value (e.g. *string).
 	value := reflect.ValueOf(input)
 	return value.IsNil()
 }

--- a/codegen/testserver/nullabledirectives/directive_test.go
+++ b/codegen/testserver/nullabledirectives/directive_test.go
@@ -21,7 +21,7 @@ func isNil(input any) bool {
 		return true
 	}
 	// Using reflect to check if the value is nil. This is necessary for
-	// for any types that are not nil types but have a nil value (e.g. *string).
+	// any types that are not nil types but have a nil value (e.g. *string).
 	value := reflect.ValueOf(input)
 	return value.IsNil()
 }

--- a/codegen/testserver/singlefile/directive_test.go
+++ b/codegen/testserver/singlefile/directive_test.go
@@ -20,7 +20,7 @@ func isNil(input any) bool {
 		return true
 	}
 	// Using reflect to check if the value is nil. This is necessary for
-	// for any types that are not nil types but have a nil value (e.g. *string).
+	// any types that are not nil types but have a nil value (e.g. *string).
 	value := reflect.ValueOf(input)
 	return value.IsNil()
 }

--- a/graphql/context_operation_test.go
+++ b/graphql/context_operation_test.go
@@ -169,7 +169,7 @@ func TestCollectFields(t *testing.T) {
 		require.Equal(t, []string{"fieldA", "fieldB", "fieldC"}, getNames(collected))
 	})
 
-	t.Run("handles inline fragments with with include and skip", func(t *testing.T) {
+	t.Run("handles inline fragments with include and skip", func(t *testing.T) {
 		ctx := testContext(ast.SelectionSet{
 			&ast.InlineFragment{
 				TypeCondition: "",

--- a/graphql/omittable_test.go
+++ b/graphql/omittable_test.go
@@ -31,7 +31,7 @@ func TestOmittable_MarshalJSON(t *testing.T) {
 			expectedJSON: `{"Value": null}`,
 		},
 		{
-			name:         "omittable omittable",
+			name:         "omittable omittable", //nolint:dupword
 			input:        struct{ Value Omittable[Omittable[uint64]] }{Value: OmittableOf(OmittableOf(uint64(42)))},
 			expectedJSON: `{"Value": 42}`,
 		},

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -200,7 +200,6 @@ func TestModelGeneration(t *testing.T) {
 			},
 		}
 		for _, tc := range cases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				typeSpec, ok := generated.Scope.Lookup(tc.name).Decl.(*ast.TypeSpec)
 				require.True(t, ok)


### PR DESCRIPTION
The PR enables [`copyloopvar`](https://golangci-lint.run/usage/linters/#copyloopvar) and [`dupword`](https://golangci-lint.run/usage/linters/#dupword) linters in golangci-lint config and fixes appeared lint issues.

`tc := tc`, which is found by `copyloopvar`, is not needed in Go 1.22+.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
