### PR TITLE
chore: enable nolintlint to lint `//nolint` directives

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,6 +86,7 @@ linters:
     - ineffassign
     - misspell
     - nakedret
+    - nolintlint
     - perfsprint
     - prealloc
     - revive

--- a/_examples/dataloader/dataloaders.go
+++ b/_examples/dataloader/dataloaders.go
@@ -24,7 +24,7 @@ type loaders struct {
 	itemsByOrder     *ItemSliceLoader
 }
 
-// nolint: gosec
+//nolint:gosec
 func LoaderMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ldrs := loaders{}

--- a/_examples/dataloader/resolvers.go
+++ b/_examples/dataloader/resolvers.go
@@ -67,7 +67,8 @@ func (r *queryResolver) Customers(ctx context.Context) ([]*Customer, error) {
 }
 
 // this method is here to test code generation of nested arrays
-// nolint: gosec
+//
+//nolint:gosec
 func (r *queryResolver) Torture1d(ctx context.Context, customerIds []int) ([]*Customer, error) {
 	result := make([]*Customer, len(customerIds))
 	for i, id := range customerIds {
@@ -77,7 +78,8 @@ func (r *queryResolver) Torture1d(ctx context.Context, customerIds []int) ([]*Cu
 }
 
 // this method is here to test code generation of nested arrays
-// nolint: gosec
+//
+//nolint:gosec
 func (r *queryResolver) Torture2d(ctx context.Context, customerIds [][]int) ([][]*Customer, error) {
 	result := make([][]*Customer, len(customerIds))
 	for i := range customerIds {

--- a/plugin/federation/test_data/model2/federation.go
+++ b/plugin/federation/test_data/model2/federation.go
@@ -1,6 +1,6 @@
 package model2
 
-type FieldSet string //nolint:deadcode,unused
+type FieldSet string //nolint:deadcode
 
 type Hello struct {
 	Name      string


### PR DESCRIPTION
This PR enables `nolintlint` linter in golangci-lint. This simple linter controls `//nolint` directives and suggests removing unused `//nolint` comments.

I have:
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
