### PR TITLE
refactor: remove unneeded check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,12 @@ linters-settings:
       - paramTypeCombine
       - preferFprint
       - yodaStyleExpr
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment
+      - shadow
+      - unusedwrite # TODO: fix and enable
   errcheck:
     exclude-functions:
       - (io.Writer).Write

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -356,7 +356,6 @@ func (m *Plugin) generateField(
 	schemaType *ast.Definition,
 	field *ast.FieldDefinition,
 ) (*Field, error) {
-	var omittableType types.Type
 	var typ types.Type
 	fieldDef := cfg.Schema.Types[field.Type.Name()]
 
@@ -449,13 +448,9 @@ func (m *Plugin) generateField(
 			return nil, fmt.Errorf("generror: field %v.%v: omittable is only applicable to nullable input fields", schemaType.Name, field.Name)
 		}
 
-		var err error
-
-		if omittableType == nil {
-			omittableType, err = binder.FindTypeFromName("github.com/99designs/gqlgen/graphql.Omittable")
-			if err != nil {
-				return nil, err
-			}
+		omittableType, err := binder.FindTypeFromName("github.com/99designs/gqlgen/graphql.Omittable")
+		if err != nil {
+			return nil, err
 		}
 
 		f.Type, err = binder.InstantiateType(omittableType, []types.Type{f.Type})


### PR DESCRIPTION
`omittableType == nil` is always `true`, because `omittableType` is declared as `var omittableType types.Type` and is `nil` (`types.Type` is an interface). This was found by the `govet.nilness` check:

```sh
❯ golangci-lint run
plugin/modelgen/models.go:454:20: nilness: tautological condition: nil == nil (govet)
                if omittableType == nil {
                                 ^
```

I have:
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
