### PR TITLE
Expand defer tests

### DIFF
--- a/client/incremental.go
+++ b/client/incremental.go
@@ -1,0 +1,197 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+)
+
+type Incremental struct {
+	Close func() error
+	Next  func(response any) error
+}
+
+type IncrementalInitialResponse = struct {
+	Data       any             `json:"data"`
+	Label      string          `json:"label"`
+	Path       []any           `json:"path"`
+	HasNext    bool            `json:"hasNext"`
+	Errors     json.RawMessage `json:"errors"`
+	Extensions map[string]any  `json:"extensions"`
+}
+
+type IncrementalPendingData struct {
+	ID    string `json:"id"`
+	Path  []any  `json:"path"`
+	Label string `json:"label"`
+}
+
+type IncrementalCompletedData struct {
+	ID string `json:"id"`
+}
+
+type IncrementalDataResponse struct {
+	// ID         string          `json:"id"`
+	// Items      []any           `json:"items"`
+	Data       any             `json:"data"`
+	Label      string          `json:"label"`
+	Path       []any           `json:"path"`
+	HasNext    bool            `json:"hasNext"`
+	Errors     json.RawMessage `json:"errors"`
+	Extensions map[string]any  `json:"extensions"`
+}
+
+type IncrementalResponse struct {
+	// Pending     []IncrementalPendingData   `json:"pending"`
+	// Completed   []IncrementalCompletedData `json:"completed"`
+	Incremental []IncrementalDataResponse `json:"incremental"`
+	HasNext     bool                      `json:"hasNext"`
+	Errors      json.RawMessage           `json:"errors"`
+	Extensions  map[string]any            `json:"extensions"`
+}
+
+func errorIncremental(err error) *Incremental {
+	return &Incremental{
+		Close: func() error { return nil },
+		Next: func(response any) error {
+			return err
+		},
+	}
+}
+
+func (p *Client) Incremental(ctx context.Context, query string, options ...Option) *Incremental {
+	r, err := p.newRequest(query, options...)
+	if err != nil {
+		return errorIncremental(fmt.Errorf("request: %w", err))
+	}
+	r.Header.Set("Accept", "multipart/mixed")
+
+	w := httptest.NewRecorder()
+	p.h.ServeHTTP(w, r)
+
+	res := w.Result()
+	if res.StatusCode >= http.StatusBadRequest {
+		return errorIncremental(fmt.Errorf("http %d: %s", w.Code, w.Body.String()))
+	}
+	mediaType, params, err := mime.ParseMediaType(res.Header.Get("Content-Type"))
+	if err != nil {
+		return errorIncremental(fmt.Errorf("parse content-type: %w", err))
+	}
+	if mediaType != "multipart/mixed" {
+		return errorIncremental(fmt.Errorf("expected content-type multipart/mixed, got %s", mediaType))
+	}
+	boundary, ok := params["boundary"]
+	if !ok || boundary == "" {
+		return errorIncremental(fmt.Errorf("expected boundary in content-type"))
+	}
+	deferSpec, ok := params["deferspec"]
+	if !ok || deferSpec == "" {
+		return errorIncremental(fmt.Errorf("expected deferSpec in content-type"))
+	}
+
+	errCh := make(chan error, 1)
+	initCh := make(chan IncrementalInitialResponse)
+	nextCh := make(chan IncrementalResponse)
+
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		defer cancel()
+		defer res.Body.Close()
+
+		initialResponse := true
+		mr := multipart.NewReader(res.Body, boundary)
+		for {
+			type nextPart struct {
+				*multipart.Part
+				Err error
+			}
+
+			nextPartCh := make(chan nextPart)
+			go func() {
+				var next nextPart
+				next.Part, next.Err = mr.NextPart()
+				nextPartCh <- next
+			}()
+
+			var next nextPart
+			select {
+			case <-ctx.Done():
+				if err := ctx.Err(); err != nil {
+					errCh <- fmt.Errorf("context: %w", err)
+				}
+				return
+			case next = <-nextPartCh:
+			}
+
+			if next.Err == io.EOF {
+				break
+			}
+			if next.Err != nil {
+				errCh <- fmt.Errorf("next part: %w", next.Err)
+				return
+			}
+			if ct := next.Header.Get("Content-Type"); ct != "application/json" {
+				errCh <- fmt.Errorf(`expected content-type "application/json", got %q`, ct)
+				return
+			}
+
+			if initialResponse {
+				initialResponse = false
+				var data IncrementalInitialResponse
+				if err = json.NewDecoder(next.Part).Decode(&data); err != nil {
+					errCh <- fmt.Errorf("decode part: %w", err)
+					return
+				}
+				initCh <- data
+				close(initCh)
+			} else {
+				var data IncrementalResponse
+				if err = json.NewDecoder(next.Part).Decode(&data); err != nil {
+					errCh <- fmt.Errorf("decode part: %w", err)
+					return
+				}
+				nextCh <- data
+			}
+		}
+	}()
+
+	return &Incremental{
+		Close: func() error {
+			cancel()
+			return nil
+		},
+		Next: func(response any) error {
+			var data any
+			var rawErrors json.RawMessage
+
+			select {
+			case nextErr := <-errCh:
+				return nextErr
+			case initData, ok := <-initCh:
+				if !ok {
+					select {
+					case nextErr := <-errCh:
+						return nextErr
+					case nextData := <-nextCh:
+						data = nextData
+						rawErrors = nextData.Errors
+					}
+				} else {
+					data = initData
+					rawErrors = initData.Errors
+				}
+			}
+			// we want to unpack even if there is an error, so we can see partial responses
+			unpackErr := unpack(data, response, p.dc)
+			if rawErrors != nil {
+				return RawJsonError{rawErrors}
+			}
+			return unpackErr
+		},
+	}
+}

--- a/client/incremental_http.go
+++ b/client/incremental_http.go
@@ -125,6 +125,7 @@ func (p *Client) IncrementalHTTP(ctx context.Context, query string, options ...O
 
 	return &IncrementalHandler{
 		close: func() error {
+			res.Body.Close()
 			cancel(context.Canceled)
 			return nil
 		},

--- a/client/incremental_http.go
+++ b/client/incremental_http.go
@@ -69,7 +69,7 @@ func errorIncremental(err error) *IncrementalHandler {
 // IncrementalHTTP returns a GraphQL response handler for the current
 // GQLGen implementation of the [incremental delivery over HTTP spec].
 // The IncrementalHTTP spec provides for "streaming" responses triggered by
-//  the use of @stream or @defer as an alternate approach to SSE. To that end,
+// the use of @stream or @defer as an alternate approach to SSE. To that end,
 // the client retains the interface of the handler returned from
 // Client.SSE.
 //

--- a/client/incremental_http.go
+++ b/client/incremental_http.go
@@ -68,8 +68,8 @@ func errorIncremental(err error) *IncrementalHandler {
 
 // IncrementalHTTP returns a GraphQL response handler for the current
 // GQLGen implementation of the [incremental delivery over HTTP spec].
-// This spec provides for "streaming" responses triggered by the use of
-// @stream or @defer using is an alternate approach to SSE. To that end,
+// The IncrementalHTTP spec provides for "streaming" responses triggered by
+//  the use of @stream or @defer as an alternate approach to SSE. To that end,
 // the client retains the interface of the handler returned from
 // Client.SSE.
 //

--- a/codegen/testserver/followschema/defer.graphql
+++ b/codegen/testserver/followschema/defer.graphql
@@ -1,6 +1,6 @@
 extend type Query {
-    deferCase1: DeferModel
-    deferCase2: [DeferModel!]
+    deferSingle: DeferModel
+    deferMultiple: [DeferModel!]
 }
 
 type DeferModel {

--- a/codegen/testserver/followschema/resolver.go
+++ b/codegen/testserver/followschema/resolver.go
@@ -197,13 +197,13 @@ func (r *queryResolver) DefaultParameters(ctx context.Context, falsyBoolean *boo
 	panic("not implemented")
 }
 
-// DeferCase1 is the resolver for the deferCase1 field.
-func (r *queryResolver) DeferCase1(ctx context.Context) (*DeferModel, error) {
+// DeferSingle is the resolver for the deferSingle field.
+func (r *queryResolver) DeferSingle(ctx context.Context) (*DeferModel, error) {
 	panic("not implemented")
 }
 
-// DeferCase2 is the resolver for the deferCase2 field.
-func (r *queryResolver) DeferCase2(ctx context.Context) ([]*DeferModel, error) {
+// DeferMultiple is the resolver for the deferMultiple field.
+func (r *queryResolver) DeferMultiple(ctx context.Context) ([]*DeferModel, error) {
 	panic("not implemented")
 }
 

--- a/codegen/testserver/followschema/root_.generated.go
+++ b/codegen/testserver/followschema/root_.generated.go
@@ -326,8 +326,8 @@ type ComplexityRoot struct {
 		Collision                        func(childComplexity int) int
 		DefaultParameters                func(childComplexity int, falsyBoolean *bool, truthyBoolean *bool) int
 		DefaultScalar                    func(childComplexity int, arg string) int
-		DeferCase1                       func(childComplexity int) int
-		DeferCase2                       func(childComplexity int) int
+		DeferMultiple                    func(childComplexity int) int
+		DeferSingle                      func(childComplexity int) int
 		DeprecatedField                  func(childComplexity int) int
 		DirectiveArg                     func(childComplexity int, arg string) int
 		DirectiveDouble                  func(childComplexity int) int
@@ -1281,19 +1281,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.DefaultScalar(childComplexity, args["arg"].(string)), true
 
-	case "Query.deferCase1":
-		if e.complexity.Query.DeferCase1 == nil {
+	case "Query.deferMultiple":
+		if e.complexity.Query.DeferMultiple == nil {
 			break
 		}
 
-		return e.complexity.Query.DeferCase1(childComplexity), true
+		return e.complexity.Query.DeferMultiple(childComplexity), true
 
-	case "Query.deferCase2":
-		if e.complexity.Query.DeferCase2 == nil {
+	case "Query.deferSingle":
+		if e.complexity.Query.DeferSingle == nil {
 			break
 		}
 
-		return e.complexity.Query.DeferCase2(childComplexity), true
+		return e.complexity.Query.DeferSingle(childComplexity), true
 
 	case "Query.deprecatedField":
 		if e.complexity.Query.DeprecatedField == nil {

--- a/codegen/testserver/followschema/schema.generated.go
+++ b/codegen/testserver/followschema/schema.generated.go
@@ -49,8 +49,8 @@ type QueryResolver interface {
 	DeprecatedField(ctx context.Context) (string, error)
 	Overlapping(ctx context.Context) (*OverlappingFields, error)
 	DefaultParameters(ctx context.Context, falsyBoolean *bool, truthyBoolean *bool) (*DefaultParametersMirror, error)
-	DeferCase1(ctx context.Context) (*DeferModel, error)
-	DeferCase2(ctx context.Context) ([]*DeferModel, error)
+	DeferSingle(ctx context.Context) (*DeferModel, error)
+	DeferMultiple(ctx context.Context) ([]*DeferModel, error)
 	DirectiveArg(ctx context.Context, arg string) (*string, error)
 	DirectiveNullableArg(ctx context.Context, arg *int, arg2 *int, arg3 *string) (*string, error)
 	DirectiveSingleNullableArg(ctx context.Context, arg1 *string) (*string, error)
@@ -3004,8 +3004,8 @@ func (ec *executionContext) fieldContext_Query_defaultParameters(ctx context.Con
 	return fc, nil
 }
 
-func (ec *executionContext) _Query_deferCase1(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_deferCase1(ctx, field)
+func (ec *executionContext) _Query_deferSingle(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_deferSingle(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -3018,7 +3018,7 @@ func (ec *executionContext) _Query_deferCase1(ctx context.Context, field graphql
 	}()
 	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().DeferCase1(rctx)
+		return ec.resolvers.Query().DeferSingle(rctx)
 	})
 
 	if resTmp == nil {
@@ -3029,7 +3029,7 @@ func (ec *executionContext) _Query_deferCase1(ctx context.Context, field graphql
 	return ec.marshalODeferModel2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐDeferModel(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Query_deferCase1(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Query_deferSingle(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -3050,8 +3050,8 @@ func (ec *executionContext) fieldContext_Query_deferCase1(_ context.Context, fie
 	return fc, nil
 }
 
-func (ec *executionContext) _Query_deferCase2(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_deferCase2(ctx, field)
+func (ec *executionContext) _Query_deferMultiple(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_deferMultiple(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -3064,7 +3064,7 @@ func (ec *executionContext) _Query_deferCase2(ctx context.Context, field graphql
 	}()
 	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().DeferCase2(rctx)
+		return ec.resolvers.Query().DeferMultiple(rctx)
 	})
 
 	if resTmp == nil {
@@ -3075,7 +3075,7 @@ func (ec *executionContext) _Query_deferCase2(ctx context.Context, field graphql
 	return ec.marshalODeferModel2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋfollowschemaᚐDeferModelᚄ(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Query_deferCase2(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Query_deferMultiple(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -7627,7 +7627,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "deferCase1":
+		case "deferSingle":
 			field := field
 
 			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
@@ -7636,7 +7636,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Query_deferCase1(ctx, field)
+				res = ec._Query_deferSingle(ctx, field)
 				return res
 			}
 
@@ -7646,7 +7646,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "deferCase2":
+		case "deferMultiple":
 			field := field
 
 			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
@@ -7655,7 +7655,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Query_deferCase2(ctx, field)
+				res = ec._Query_deferMultiple(ctx, field)
 				return res
 			}
 

--- a/codegen/testserver/followschema/stub.go
+++ b/codegen/testserver/followschema/stub.go
@@ -71,8 +71,8 @@ type Stub struct {
 		DeprecatedField                  func(ctx context.Context) (string, error)
 		Overlapping                      func(ctx context.Context) (*OverlappingFields, error)
 		DefaultParameters                func(ctx context.Context, falsyBoolean *bool, truthyBoolean *bool) (*DefaultParametersMirror, error)
-		DeferCase1                       func(ctx context.Context) (*DeferModel, error)
-		DeferCase2                       func(ctx context.Context) ([]*DeferModel, error)
+		DeferSingle                      func(ctx context.Context) (*DeferModel, error)
+		DeferMultiple                    func(ctx context.Context) ([]*DeferModel, error)
 		DirectiveArg                     func(ctx context.Context, arg string) (*string, error)
 		DirectiveNullableArg             func(ctx context.Context, arg *int, arg2 *int, arg3 *string) (*string, error)
 		DirectiveSingleNullableArg       func(ctx context.Context, arg1 *string) (*string, error)
@@ -352,11 +352,11 @@ func (r *stubQuery) Overlapping(ctx context.Context) (*OverlappingFields, error)
 func (r *stubQuery) DefaultParameters(ctx context.Context, falsyBoolean *bool, truthyBoolean *bool) (*DefaultParametersMirror, error) {
 	return r.QueryResolver.DefaultParameters(ctx, falsyBoolean, truthyBoolean)
 }
-func (r *stubQuery) DeferCase1(ctx context.Context) (*DeferModel, error) {
-	return r.QueryResolver.DeferCase1(ctx)
+func (r *stubQuery) DeferSingle(ctx context.Context) (*DeferModel, error) {
+	return r.QueryResolver.DeferSingle(ctx)
 }
-func (r *stubQuery) DeferCase2(ctx context.Context) ([]*DeferModel, error) {
-	return r.QueryResolver.DeferCase2(ctx)
+func (r *stubQuery) DeferMultiple(ctx context.Context) ([]*DeferModel, error) {
+	return r.QueryResolver.DeferMultiple(ctx)
 }
 func (r *stubQuery) DirectiveArg(ctx context.Context, arg string) (*string, error) {
 	return r.QueryResolver.DirectiveArg(ctx, arg)

--- a/codegen/testserver/singlefile/defer.graphql
+++ b/codegen/testserver/singlefile/defer.graphql
@@ -1,6 +1,6 @@
 extend type Query {
-    deferCase1: DeferModel
-    deferCase2: [DeferModel!]
+    deferSingle: DeferModel
+    deferMultiple: [DeferModel!]
 }
 
 type DeferModel {

--- a/codegen/testserver/singlefile/defer_test.go
+++ b/codegen/testserver/singlefile/defer_test.go
@@ -77,24 +77,15 @@ func TestDefer(t *testing.T) {
 		Extensions map[string]any  `json:"extensions"`
 	}
 
-	type sseDeferredResponse struct {
-		Data struct {
-			Values []string `json:"values"`
-		}
-		Label      string          `json:"label"`
-		Path       []any           `json:"path"`
-		HasNext    bool            `json:"hasNext"`
-		Errors     json.RawMessage `json:"errors"`
-		Extensions map[string]any  `json:"extensions"`
-	}
+	type deferredResponse response[struct {
+		Values []string `json:"values"`
+	}]
 
 	type incrementalDeferredResponse struct {
-		Incremental []response[struct {
-			Values []string `json:"values"`
-		}] `json:"incremental"`
-		HasNext    bool            `json:"hasNext"`
-		Errors     json.RawMessage `json:"errors"`
-		Extensions map[string]any  `json:"extensions"`
+		Incremental []deferredResponse `json:"incremental"`
+		HasNext     bool               `json:"hasNext"`
+		Errors      json.RawMessage    `json:"errors"`
+		Extensions  map[string]any     `json:"extensions"`
 	}
 
 	pathStringer := func(path []any) string {
@@ -117,11 +108,10 @@ func TestDefer(t *testing.T) {
 	}
 
 	cases := []struct {
-		name                         string
-		query                        string
-		expectedInitialResponse      interface{}
-		expectedSSEDeferredResponses []sseDeferredResponse
-		expectedIncrementalResponses []incrementalDeferredResponse
+		name                      string
+		query                     string
+		expectedInitialResponse   interface{}
+		expectedDeferredResponses []deferredResponse
 	}{
 		{
 			name: "defer single",
@@ -148,7 +138,7 @@ func TestDefer(t *testing.T) {
 				},
 				HasNext: true,
 			},
-			expectedSSEDeferredResponses: []sseDeferredResponse{
+			expectedDeferredResponses: []deferredResponse{
 				{
 					Data: struct {
 						Values []string `json:"values"`
@@ -156,22 +146,6 @@ func TestDefer(t *testing.T) {
 						Values: []string{"test defer 1", "test defer 2", "test defer 3"},
 					},
 					Path: []any{"deferSingle"},
-				},
-			},
-			expectedIncrementalResponses: []incrementalDeferredResponse{
-				{
-					Incremental: []response[struct {
-						Values []string `json:"values"`
-					}]{
-						{
-							Data: struct {
-								Values []string `json:"values"`
-							}{
-								Values: []string{"test defer 1", "test defer 2", "test defer 3"},
-							},
-							Path: []any{"deferSingle"},
-						},
-					},
 				},
 			},
 		},
@@ -200,7 +174,7 @@ func TestDefer(t *testing.T) {
 				},
 				HasNext: true,
 			},
-			expectedSSEDeferredResponses: []sseDeferredResponse{
+			expectedDeferredResponses: []deferredResponse{
 				{
 					Data: struct {
 						Values []string `json:"values"`
@@ -208,22 +182,6 @@ func TestDefer(t *testing.T) {
 						Values: []string{"test defer 1", "test defer 2", "test defer 3"},
 					},
 					Path: []any{"deferSingle"},
-				},
-			},
-			expectedIncrementalResponses: []incrementalDeferredResponse{
-				{
-					Incremental: []response[struct {
-						Values []string `json:"values"`
-					}]{
-						{
-							Data: struct {
-								Values []string `json:"values"`
-							}{
-								Values: []string{"test defer 1", "test defer 2", "test defer 3"},
-							},
-							Path: []any{"deferSingle"},
-						},
-					},
 				},
 			},
 		},
@@ -252,7 +210,7 @@ func TestDefer(t *testing.T) {
 				},
 				HasNext: true,
 			},
-			expectedSSEDeferredResponses: []sseDeferredResponse{
+			expectedDeferredResponses: []deferredResponse{
 				{
 					Data: struct {
 						Values []string `json:"values"`
@@ -261,23 +219,6 @@ func TestDefer(t *testing.T) {
 					},
 					Label: "test label",
 					Path:  []any{"deferSingle"},
-				},
-			},
-			expectedIncrementalResponses: []incrementalDeferredResponse{
-				{
-					Incremental: []response[struct {
-						Values []string `json:"values"`
-					}]{
-						{
-							Data: struct {
-								Values []string `json:"values"`
-							}{
-								Values: []string{"test defer 1", "test defer 2", "test defer 3"},
-							},
-							Label: "test label",
-							Path:  []any{"deferSingle"},
-						},
-					},
 				},
 			},
 		},
@@ -306,7 +247,7 @@ func TestDefer(t *testing.T) {
 				},
 				HasNext: true,
 			},
-			expectedSSEDeferredResponses: []sseDeferredResponse{
+			expectedDeferredResponses: []deferredResponse{
 				{
 					Data: struct {
 						Values []string `json:"values"`
@@ -315,23 +256,6 @@ func TestDefer(t *testing.T) {
 					},
 					Label: "test label",
 					Path:  []any{"deferSingle"},
-				},
-			},
-			expectedIncrementalResponses: []incrementalDeferredResponse{
-				{
-					Incremental: []response[struct {
-						Values []string `json:"values"`
-					}]{
-						{
-							Data: struct {
-								Values []string `json:"values"`
-							}{
-								Values: []string{"test defer 1", "test defer 2", "test defer 3"},
-							},
-							Label: "test label",
-							Path:  []any{"deferSingle"},
-						},
-					},
 				},
 			},
 		},
@@ -397,7 +321,7 @@ func TestDefer(t *testing.T) {
 				},
 				HasNext: true,
 			},
-			expectedSSEDeferredResponses: []sseDeferredResponse{
+			expectedDeferredResponses: []deferredResponse{
 				{
 					Data: struct {
 						Values []string `json:"values"`
@@ -424,41 +348,6 @@ func TestDefer(t *testing.T) {
 					},
 					Label: "test label",
 					Path:  []any{"deferMultiple", float64(2)},
-				},
-			},
-			expectedIncrementalResponses: []incrementalDeferredResponse{
-				{
-					Incremental: []response[struct {
-						Values []string `json:"values"`
-					}]{
-						{
-							Data: struct {
-								Values []string `json:"values"`
-							}{
-								Values: []string{"test defer 1", "test defer 2", "test defer 3"},
-							},
-							Label: "test label",
-							Path:  []any{"deferMultiple", float64(0)},
-						},
-						{
-							Data: struct {
-								Values []string `json:"values"`
-							}{
-								Values: []string{"test defer 1", "test defer 2", "test defer 3"},
-							},
-							Label: "test label",
-							Path:  []any{"deferMultiple", float64(1)},
-						},
-						{
-							Data: struct {
-								Values []string `json:"values"`
-							}{
-								Values: []string{"test defer 1", "test defer 2", "test defer 3"},
-							},
-							Label: "test label",
-							Path:  []any{"deferMultiple", float64(2)},
-						},
-					},
 				},
 			},
 		},
@@ -511,13 +400,13 @@ func TestDefer(t *testing.T) {
 			assert.Equal(t, tc.expectedInitialResponse, resp)
 
 			// If there are no deferred responses, we can stop here.
-			if !resE.FieldByName("HasNext").Bool() && len(tc.expectedSSEDeferredResponses) == 0 {
+			if !resE.FieldByName("HasNext").Bool() && len(tc.expectedDeferredResponses) == 0 {
 				return
 			}
 
-			deferredResponses := make([]sseDeferredResponse, 0)
+			deferredResponses := make([]deferredResponse, 0)
 			for {
-				var valueResp sseDeferredResponse
+				var valueResp deferredResponse
 				require.NoError(t, read.Next(&valueResp))
 
 				if !valueResp.HasNext {
@@ -534,10 +423,10 @@ func TestDefer(t *testing.T) {
 			}
 			require.NoError(t, read.Close())
 
-			slices.SortFunc(deferredResponses, func(a, b sseDeferredResponse) int {
+			slices.SortFunc(deferredResponses, func(a, b deferredResponse) int {
 				return cmp.Compare(pathStringer(a.Path), pathStringer(b.Path))
 			})
-			assert.Equal(t, tc.expectedSSEDeferredResponses, deferredResponses)
+			assert.Equal(t, tc.expectedDeferredResponses, deferredResponses)
 		})
 
 		t.Run("using incremental delivery/"+tc.name, func(t *testing.T) {
@@ -550,33 +439,43 @@ func TestDefer(t *testing.T) {
 			assert.Equal(t, tc.expectedInitialResponse, resp)
 
 			// If there are no deferred responses, we can stop here.
-			if !reflect.ValueOf(resp).FieldByName("HasNext").Bool() && len(tc.expectedIncrementalResponses) == 0 {
+			if !reflect.ValueOf(resp).FieldByName("HasNext").Bool() && len(tc.expectedDeferredResponses) == 0 {
 				return
 			}
 
-			deferredResponses := make([]incrementalDeferredResponse, 0)
+			deferredIncrementalData := make([]deferredResponse, 0)
 			for {
 				var valueResp incrementalDeferredResponse
 				require.NoError(t, read.Next(&valueResp))
+				assert.Empty(t, valueResp.Errors)
+				assert.Empty(t, valueResp.Extensions)
+
+				// Extract the incremental data from the response.
+				//
+				// FIXME: currently the HasNext field does not describe the state of the
+				// delivery as bounded by the associated path, but rather the state of
+				// the operation as a whole. This makes it impossible to determine it
+				// from the response, so we can not define it ahead of time.
+				//
+				// It is also questionable that the incremental data objects should
+				// include hasNext, so for now we remove them from assertion. Once we
+				// align on the spec we must update this test, as the status of the
+				// path-bounded delivery should be determinative and can be asserted.
+				for _, incr := range valueResp.Incremental {
+					incr.HasNext = false
+					deferredIncrementalData = append(deferredIncrementalData, incr)
+				}
 
 				if !valueResp.HasNext {
-					deferredResponses = append(deferredResponses, valueResp)
 					break
-				} else {
-					// Remove HasNext from comparison: we don't know the order they will be
-					// delivered in, and so this can't be known in the setup. But if HasNext
-					// does not work right we will either error out or get too few
-					// responses, so it's still checked.
-					valueResp.HasNext = false
-					deferredResponses = append(deferredResponses, valueResp)
 				}
 			}
 			require.NoError(t, read.Close())
 
-			// slices.SortFunc(deferredResponses, func(a, b incrementalDeferredResponse) int {
-			// 	return cmp.Compare(pathStringer(a.Path), pathStringer(b.Path))
-			// })
-			assert.Equal(t, tc.expectedIncrementalResponses, deferredResponses)
+			slices.SortFunc(deferredIncrementalData, func(a, b deferredResponse) int {
+				return cmp.Compare(pathStringer(a.Path), pathStringer(b.Path))
+			})
+			assert.Equal(t, tc.expectedDeferredResponses, deferredIncrementalData)
 		})
 	}
 }

--- a/codegen/testserver/singlefile/defer_test.go
+++ b/codegen/testserver/singlefile/defer_test.go
@@ -110,7 +110,7 @@ func TestDefer(t *testing.T) {
 	cases := []struct {
 		name                      string
 		query                     string
-		expectedInitialResponse   interface{}
+		expectedInitialResponse   any
 		expectedDeferredResponses []deferredData
 	}{
 		{
@@ -491,14 +491,14 @@ fragment DeferFragment on DeferModel {
 				if !valueResp.HasNext {
 					deferredResponses = append(deferredResponses, valueResp)
 					break
-				} else {
-					// Remove HasNext from comparison: we don't know the order they will be
-					// delivered in, and so this can't be known in the setup. But if HasNext
-					// does not work right we will either error out or get too few
-					// responses, so it's still checked.
-					valueResp.HasNext = false
-					deferredResponses = append(deferredResponses, valueResp)
 				}
+
+				// Remove HasNext from comparison: we don't know the order they will be
+				// delivered in, and so this can't be known in the setup. But if HasNext
+				// does not work right we will either error out or get too few
+				// responses, so it's still checked.
+				valueResp.HasNext = false
+				deferredResponses = append(deferredResponses, valueResp)
 			}
 			require.NoError(t, read.Close())
 

--- a/codegen/testserver/singlefile/defer_test.go
+++ b/codegen/testserver/singlefile/defer_test.go
@@ -150,7 +150,7 @@ func TestDefer(t *testing.T) {
 			},
 		},
 		{
-			name: "defer single using fragment type",
+			name: "defer single using inline fragment with type",
 			query: `query testDefer {
 	deferSingle {
 		id
@@ -160,6 +160,45 @@ func TestDefer(t *testing.T) {
 		}
 	}
 }`,
+			expectedInitialResponse: response[struct {
+				DeferSingle deferModel
+			}]{
+				Data: struct {
+					DeferSingle deferModel
+				}{
+					DeferSingle: deferModel{
+						Id:     "1",
+						Name:   "Defer test 1",
+						Values: nil,
+					},
+				},
+				HasNext: true,
+			},
+			expectedDeferredResponses: []deferredData{
+				{
+					Data: struct {
+						Values []string `json:"values"`
+					}{
+						Values: []string{"test defer 1", "test defer 2", "test defer 3"},
+					},
+					Path: []any{"deferSingle"},
+				},
+			},
+		},
+		{
+			name: "defer single using spread fragment",
+			query: `query testDefer {
+	deferSingle {
+		id
+		name
+		... DeferFragment @defer
+	}
+}
+
+fragment DeferFragment on DeferModel {
+	values
+}
+`,
 			expectedInitialResponse: response[struct {
 				DeferSingle deferModel
 			}]{
@@ -196,6 +235,46 @@ func TestDefer(t *testing.T) {
 		}
 	}
 }`,
+			expectedInitialResponse: response[struct {
+				DeferSingle deferModel
+			}]{
+				Data: struct {
+					DeferSingle deferModel
+				}{
+					DeferSingle: deferModel{
+						Id:     "1",
+						Name:   "Defer test 1",
+						Values: nil,
+					},
+				},
+				HasNext: true,
+			},
+			expectedDeferredResponses: []deferredData{
+				{
+					Data: struct {
+						Values []string `json:"values"`
+					}{
+						Values: []string{"test defer 1", "test defer 2", "test defer 3"},
+					},
+					Label: "test label",
+					Path:  []any{"deferSingle"},
+				},
+			},
+		},
+		{
+			name: "defer single using spread fragment with label",
+			query: `query testDefer {
+	deferSingle {
+		id
+		name
+		... DeferFragment @defer(label: "test label")
+	}
+}
+
+fragment DeferFragment on DeferModel {
+	values
+}
+`,
 			expectedInitialResponse: response[struct {
 				DeferSingle deferModel
 			}]{

--- a/codegen/testserver/singlefile/generated.go
+++ b/codegen/testserver/singlefile/generated.go
@@ -335,8 +335,8 @@ type ComplexityRoot struct {
 		Collision                        func(childComplexity int) int
 		DefaultParameters                func(childComplexity int, falsyBoolean *bool, truthyBoolean *bool) int
 		DefaultScalar                    func(childComplexity int, arg string) int
-		DeferCase1                       func(childComplexity int) int
-		DeferCase2                       func(childComplexity int) int
+		DeferMultiple                    func(childComplexity int) int
+		DeferSingle                      func(childComplexity int) int
 		DeprecatedField                  func(childComplexity int) int
 		DirectiveArg                     func(childComplexity int, arg string) int
 		DirectiveDouble                  func(childComplexity int) int
@@ -553,8 +553,8 @@ type QueryResolver interface {
 	DeprecatedField(ctx context.Context) (string, error)
 	Overlapping(ctx context.Context) (*OverlappingFields, error)
 	DefaultParameters(ctx context.Context, falsyBoolean *bool, truthyBoolean *bool) (*DefaultParametersMirror, error)
-	DeferCase1(ctx context.Context) (*DeferModel, error)
-	DeferCase2(ctx context.Context) ([]*DeferModel, error)
+	DeferSingle(ctx context.Context) (*DeferModel, error)
+	DeferMultiple(ctx context.Context) ([]*DeferModel, error)
 	DirectiveArg(ctx context.Context, arg string) (*string, error)
 	DirectiveNullableArg(ctx context.Context, arg *int, arg2 *int, arg3 *string) (*string, error)
 	DirectiveSingleNullableArg(ctx context.Context, arg1 *string) (*string, error)
@@ -1434,19 +1434,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.DefaultScalar(childComplexity, args["arg"].(string)), true
 
-	case "Query.deferCase1":
-		if e.complexity.Query.DeferCase1 == nil {
+	case "Query.deferMultiple":
+		if e.complexity.Query.DeferMultiple == nil {
 			break
 		}
 
-		return e.complexity.Query.DeferCase1(childComplexity), true
+		return e.complexity.Query.DeferMultiple(childComplexity), true
 
-	case "Query.deferCase2":
-		if e.complexity.Query.DeferCase2 == nil {
+	case "Query.deferSingle":
+		if e.complexity.Query.DeferSingle == nil {
 			break
 		}
 
-		return e.complexity.Query.DeferCase2(childComplexity), true
+		return e.complexity.Query.DeferSingle(childComplexity), true
 
 	case "Query.deprecatedField":
 		if e.complexity.Query.DeprecatedField == nil {
@@ -10481,8 +10481,8 @@ func (ec *executionContext) fieldContext_Query_defaultParameters(ctx context.Con
 	return fc, nil
 }
 
-func (ec *executionContext) _Query_deferCase1(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_deferCase1(ctx, field)
+func (ec *executionContext) _Query_deferSingle(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_deferSingle(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -10495,7 +10495,7 @@ func (ec *executionContext) _Query_deferCase1(ctx context.Context, field graphql
 	}()
 	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().DeferCase1(rctx)
+		return ec.resolvers.Query().DeferSingle(rctx)
 	})
 
 	if resTmp == nil {
@@ -10506,7 +10506,7 @@ func (ec *executionContext) _Query_deferCase1(ctx context.Context, field graphql
 	return ec.marshalODeferModel2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐDeferModel(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Query_deferCase1(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Query_deferSingle(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -10527,8 +10527,8 @@ func (ec *executionContext) fieldContext_Query_deferCase1(_ context.Context, fie
 	return fc, nil
 }
 
-func (ec *executionContext) _Query_deferCase2(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_deferCase2(ctx, field)
+func (ec *executionContext) _Query_deferMultiple(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_deferMultiple(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -10541,7 +10541,7 @@ func (ec *executionContext) _Query_deferCase2(ctx context.Context, field graphql
 	}()
 	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().DeferCase2(rctx)
+		return ec.resolvers.Query().DeferMultiple(rctx)
 	})
 
 	if resTmp == nil {
@@ -10552,7 +10552,7 @@ func (ec *executionContext) _Query_deferCase2(ctx context.Context, field graphql
 	return ec.marshalODeferModel2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋsinglefileᚐDeferModelᚄ(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Query_deferCase2(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Query_deferMultiple(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -20934,7 +20934,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "deferCase1":
+		case "deferSingle":
 			field := field
 
 			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
@@ -20943,7 +20943,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Query_deferCase1(ctx, field)
+				res = ec._Query_deferSingle(ctx, field)
 				return res
 			}
 
@@ -20953,7 +20953,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "deferCase2":
+		case "deferMultiple":
 			field := field
 
 			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
@@ -20962,7 +20962,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Query_deferCase2(ctx, field)
+				res = ec._Query_deferMultiple(ctx, field)
 				return res
 			}
 

--- a/codegen/testserver/singlefile/resolver.go
+++ b/codegen/testserver/singlefile/resolver.go
@@ -197,13 +197,13 @@ func (r *queryResolver) DefaultParameters(ctx context.Context, falsyBoolean *boo
 	panic("not implemented")
 }
 
-// DeferCase1 is the resolver for the deferCase1 field.
-func (r *queryResolver) DeferCase1(ctx context.Context) (*DeferModel, error) {
+// DeferSingle is the resolver for the deferSingle field.
+func (r *queryResolver) DeferSingle(ctx context.Context) (*DeferModel, error) {
 	panic("not implemented")
 }
 
-// DeferCase2 is the resolver for the deferCase2 field.
-func (r *queryResolver) DeferCase2(ctx context.Context) ([]*DeferModel, error) {
+// DeferMultiple is the resolver for the deferMultiple field.
+func (r *queryResolver) DeferMultiple(ctx context.Context) ([]*DeferModel, error) {
 	panic("not implemented")
 }
 

--- a/codegen/testserver/singlefile/stub.go
+++ b/codegen/testserver/singlefile/stub.go
@@ -71,8 +71,8 @@ type Stub struct {
 		DeprecatedField                  func(ctx context.Context) (string, error)
 		Overlapping                      func(ctx context.Context) (*OverlappingFields, error)
 		DefaultParameters                func(ctx context.Context, falsyBoolean *bool, truthyBoolean *bool) (*DefaultParametersMirror, error)
-		DeferCase1                       func(ctx context.Context) (*DeferModel, error)
-		DeferCase2                       func(ctx context.Context) ([]*DeferModel, error)
+		DeferSingle                      func(ctx context.Context) (*DeferModel, error)
+		DeferMultiple                    func(ctx context.Context) ([]*DeferModel, error)
 		DirectiveArg                     func(ctx context.Context, arg string) (*string, error)
 		DirectiveNullableArg             func(ctx context.Context, arg *int, arg2 *int, arg3 *string) (*string, error)
 		DirectiveSingleNullableArg       func(ctx context.Context, arg1 *string) (*string, error)
@@ -352,11 +352,11 @@ func (r *stubQuery) Overlapping(ctx context.Context) (*OverlappingFields, error)
 func (r *stubQuery) DefaultParameters(ctx context.Context, falsyBoolean *bool, truthyBoolean *bool) (*DefaultParametersMirror, error) {
 	return r.QueryResolver.DefaultParameters(ctx, falsyBoolean, truthyBoolean)
 }
-func (r *stubQuery) DeferCase1(ctx context.Context) (*DeferModel, error) {
-	return r.QueryResolver.DeferCase1(ctx)
+func (r *stubQuery) DeferSingle(ctx context.Context) (*DeferModel, error) {
+	return r.QueryResolver.DeferSingle(ctx)
 }
-func (r *stubQuery) DeferCase2(ctx context.Context) ([]*DeferModel, error) {
-	return r.QueryResolver.DeferCase2(ctx)
+func (r *stubQuery) DeferMultiple(ctx context.Context) ([]*DeferModel, error) {
+	return r.QueryResolver.DeferMultiple(ctx)
 }
 func (r *stubQuery) DirectiveArg(ctx context.Context, arg string) (*string, error) {
 	return r.QueryResolver.DirectiveArg(ctx, arg)

--- a/graphql/handler/transport/http_multipart_mixed.go
+++ b/graphql/handler/transport/http_multipart_mixed.go
@@ -280,7 +280,6 @@ func (a *multipartResponseAggregator) flush(w http.ResponseWriter) {
 		// TODO: use the "HasNext" status of deferResponses items to determine
 		// the operation status and pending / complete fields, but remove from
 		// the incremental (deferResponses) object.
-		var hasNext bool
 		hasNext = a.deferResponses[len(a.deferResponses)-1].HasNext != nil &&
 			*a.deferResponses[len(a.deferResponses)-1].HasNext
 		writeIncrementalJson(w, a.deferResponses, hasNext)

--- a/graphql/handler/transport/http_multipart_mixed.go
+++ b/graphql/handler/transport/http_multipart_mixed.go
@@ -269,9 +269,22 @@ func (a *multipartResponseAggregator) flush(w http.ResponseWriter) {
 
 	if len(a.deferResponses) > 0 {
 		writeContentTypeHeader(w)
+
+		// Note: while the 2023 spec that includes "incremental" does not
+		// explicitly list the fields that should be included as part of the
+		// incremental object, it shows hasNext only on the response payload
+		// (marking the status of the operation as a whole), and instead the
+		// response payload implements pending and complete fields to mark the
+		// status of the incrementally delivered data.
+		//
+		// TODO: use the "HasNext" status of deferResponses items to determine
+		// the operation status and pending / complete fields, but remove from
+		// the incremental (deferResponses) object.
+		var hasNext bool
 		hasNext = a.deferResponses[len(a.deferResponses)-1].HasNext != nil &&
 			*a.deferResponses[len(a.deferResponses)-1].HasNext
 		writeIncrementalJson(w, a.deferResponses, hasNext)
+
 		// Reset the deferResponses so we don't send them again
 		a.deferResponses = nil
 	}


### PR DESCRIPTION
As requested in #3384 ([link](https://github.com/99designs/gqlgen/pull/3384#issuecomment-2494931134)), this updates the defer tests to cover using the `if` argument, and the `label` argument for fragment spreads.

Additionally, this PR:

- refactors the defer tests into a table test so that we can do more fine-grained, duplicative tests without repeating handler / response parsing boilerplate;
- updates the defer tests to run every test against both transports that support `@defer`, not just SSE, to ensure consistency between the implementations;
- adds a test client helper `Client.IncrementalHTTP` based on `Client.SSE` that can be used to test`@defer` against `transport.MultipartMixed`.

General notes:

- I've added a some documentation glosses that may or may not be accurate / useful. Correct me or update as you see fit.
- I am not totally sure of the multipart/mixed client implementation: did my best on that one. It's in the documentation and TODO notes, but I may have missed the point in some cases.
  - If you want, we can break this part of the PR out and keep the tests focused on SSE for now.
- In order to reduce duplication for the table tests I made a few choices (like using a generic type and reflect) that can be obscure, and you may not like that and it can be replaced. But my personal preference is to make a clear assertion that is encoded in the table test case struct, and this made it possible with a lot less repetition.

@StevenACoffman @giulio-opal 
