### PR TITLE
Deprecate NewDefaultServer

### DIFF
--- a/_examples/chat/chat_test.go
+++ b/_examples/chat/chat_test.go
@@ -5,7 +5,9 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -14,7 +16,12 @@ import (
 )
 
 func TestChatSubscriptions(t *testing.T) {
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(New())))
+	srv := handler.New(NewExecutableSchema(New()))
+	srv.AddTransport(transport.Websocket{
+		KeepAlivePingInterval: time.Second,
+	})
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	const batchSize = 128
 	var wg sync.WaitGroup

--- a/_examples/config/server/server.go
+++ b/_examples/config/server/server.go
@@ -6,13 +6,18 @@ import (
 
 	todo "github.com/99designs/gqlgen/_examples/config"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
 )
 
 func main() {
-	http.Handle("/", playground.Handler("Todo", "/query"))
-	http.Handle("/query", handler.NewDefaultServer(
+	srv := handler.New(
 		todo.NewExecutableSchema(todo.New()),
-	))
+	)
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
+
+	http.Handle("/", playground.Handler("Todo", "/query"))
+	http.Handle("/query", srv)
 	log.Fatal(http.ListenAndServe(":8081", nil))
 }

--- a/_examples/dataloader/dataloader_test.go
+++ b/_examples/dataloader/dataloader_test.go
@@ -3,6 +3,8 @@ package dataloader
 import (
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -11,7 +13,10 @@ import (
 )
 
 func TestTodo(t *testing.T) {
-	c := client.New(LoaderMiddleware(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: &Resolver{}}))))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: &Resolver{}}))
+	srv.AddTransport(transport.POST{})
+	srv.Use(extension.Introspection{})
+	c := client.New(LoaderMiddleware(srv))
 
 	t.Run("create a new todo", func(t *testing.T) {
 		var resp any

--- a/_examples/dataloader/server/server.go
+++ b/_examples/dataloader/server/server.go
@@ -6,16 +6,21 @@ import (
 
 	"github.com/99designs/gqlgen/_examples/dataloader"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
 )
 
 func main() {
 	router := http.NewServeMux()
 
-	router.Handle("/", playground.Handler("Dataloader", "/query"))
-	router.Handle("/query", handler.NewDefaultServer(
+	srv := handler.New(
 		dataloader.NewExecutableSchema(dataloader.Config{Resolvers: &dataloader.Resolver{}}),
-	))
+	)
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
+
+	router.Handle("/", playground.Handler("Dataloader", "/query"))
+	router.Handle("/query", srv)
 
 	log.Println("connect to http://localhost:8082/ for graphql playground")
 	log.Fatal(http.ListenAndServe(":8082", dataloader.LoaderMiddleware(router)))

--- a/_examples/embedding/subdir/embedding_test.go
+++ b/_examples/embedding/subdir/embedding_test.go
@@ -3,6 +3,7 @@ package subdir
 import (
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/_examples/embedding/subdir/gendir"
@@ -11,7 +12,9 @@ import (
 )
 
 func TestEmbeddingWorks(t *testing.T) {
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: &Resolver{}})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: &Resolver{}}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 	var resp struct {
 		InSchemadir string
 		Parentdir   string
@@ -30,7 +33,9 @@ func TestEmbeddingWorks(t *testing.T) {
 }
 
 func TestEmbeddingWorksInGendir(t *testing.T) {
-	c := client.New(handler.NewDefaultServer(gendir.NewExecutableSchema(gendir.Config{Resolvers: &GendirResolver{}})))
+	srv := handler.New(gendir.NewExecutableSchema(gendir.Config{Resolvers: &GendirResolver{}}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 	var resp struct {
 		InSchemadir string
 		Parentdir   string

--- a/_examples/enum/cmd/main.go
+++ b/_examples/enum/cmd/main.go
@@ -6,11 +6,20 @@ import (
 
 	"github.com/99designs/gqlgen/_examples/enum/api"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
 )
 
 func main() {
+	srv := handler.New(
+		api.NewExecutableSchema(api.Config{Resolvers: &api.Resolver{}}),
+	)
+
+	srv.AddTransport(transport.Options{})
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
+
 	http.Handle("/", playground.Handler("Enum", "/query"))
-	http.Handle("/query", handler.NewDefaultServer(api.NewExecutableSchema(api.Config{Resolvers: &api.Resolver{}})))
+	http.Handle("/query", srv)
 	log.Fatal(http.ListenAndServe(":8081", nil))
 }

--- a/_examples/federation/accounts/server.go
+++ b/_examples/federation/accounts/server.go
@@ -9,6 +9,8 @@ import (
 	"github.com/99designs/gqlgen/_examples/federation/accounts/graph"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/debug"
+	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
 )
 
@@ -20,7 +22,12 @@ func main() {
 		port = defaultPort
 	}
 
-	srv := handler.NewDefaultServer(graph.NewExecutableSchema(graph.Config{Resolvers: &graph.Resolver{}}))
+	srv := handler.New(
+		graph.NewExecutableSchema(graph.Config{Resolvers: &graph.Resolver{}}),
+	)
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
+	srv.Use(extension.Introspection{})
 	srv.Use(&debug.Tracer{})
 
 	http.Handle("/", playground.Handler("GraphQL playground", "/query"))

--- a/_examples/federation/products/server.go
+++ b/_examples/federation/products/server.go
@@ -9,6 +9,8 @@ import (
 	"github.com/99designs/gqlgen/_examples/federation/products/graph"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/debug"
+	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
 )
 
@@ -20,7 +22,12 @@ func main() {
 		port = defaultPort
 	}
 
-	srv := handler.NewDefaultServer(graph.NewExecutableSchema(graph.Config{Resolvers: &graph.Resolver{}}))
+	srv := handler.New(
+		graph.NewExecutableSchema(graph.Config{Resolvers: &graph.Resolver{}}),
+	)
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
+	srv.Use(extension.Introspection{})
 	srv.Use(&debug.Tracer{})
 
 	http.Handle("/", playground.Handler("GraphQL playground", "/query"))

--- a/_examples/federation/reviews/server.go
+++ b/_examples/federation/reviews/server.go
@@ -9,6 +9,8 @@ import (
 	"github.com/99designs/gqlgen/_examples/federation/reviews/graph"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/debug"
+	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
 )
 
@@ -20,7 +22,12 @@ func main() {
 		port = defaultPort
 	}
 
-	srv := handler.NewDefaultServer(graph.NewExecutableSchema(graph.Config{Resolvers: &graph.Resolver{}}))
+	srv := handler.New(
+		graph.NewExecutableSchema(graph.Config{Resolvers: &graph.Resolver{}}),
+	)
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
+	srv.Use(extension.Introspection{})
 	srv.Use(&debug.Tracer{})
 
 	http.Handle("/", playground.Handler("GraphQL playground", "/query"))

--- a/_examples/federation/subgraphs/subgraphs.go
+++ b/_examples/federation/subgraphs/subgraphs.go
@@ -12,6 +12,8 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/debug"
+	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
 )
 
@@ -57,7 +59,10 @@ func newServer(name, port string, schema graphql.ExecutableSchema) *http.Server 
 	if port == "" {
 		panic(fmt.Errorf("port for %s is empty", name))
 	}
-	srv := handler.NewDefaultServer(schema)
+	srv := handler.New(schema)
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
+	srv.Use(extension.Introspection{})
 	srv.Use(&debug.Tracer{})
 	mux := http.NewServeMux()
 	mux.Handle("/", playground.Handler("GraphQL playground", "/query"))

--- a/_examples/fileupload/fileupload_test.go
+++ b/_examples/fileupload/fileupload_test.go
@@ -19,7 +19,9 @@ import (
 
 func TestFileUpload(t *testing.T) {
 	resolver := &Stub{}
-	srv := httptest.NewServer(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolver})))
+	h := handler.New(NewExecutableSchema(Config{Resolvers: resolver}))
+	h.AddTransport(transport.MultipartForm{})
+	srv := httptest.NewServer(h)
 	defer srv.Close()
 	gql := gqlclient.New(srv.Config.Handler, gqlclient.Path("/graphql"))
 

--- a/_examples/fileupload/server/server.go
+++ b/_examples/fileupload/server/server.go
@@ -22,7 +22,7 @@ func main() {
 
 	var mb int64 = 1 << 20
 
-	srv := handler.NewDefaultServer(fileupload.NewExecutableSchema(fileupload.Config{Resolvers: resolver}))
+	srv := handler.New(fileupload.NewExecutableSchema(fileupload.Config{Resolvers: resolver}))
 	srv.AddTransport(transport.POST{})
 	srv.AddTransport(transport.MultipartForm{
 		MaxMemory:     32 * mb,

--- a/_examples/scalars/scalar_test.go
+++ b/_examples/scalars/scalar_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -22,7 +24,10 @@ type RawUser struct {
 }
 
 func TestScalars(t *testing.T) {
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: &Resolver{}})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: &Resolver{}}))
+	srv.AddTransport(transport.POST{})
+	srv.Use(extension.Introspection{})
+	c := client.New(srv)
 
 	t.Run("marshaling", func(t *testing.T) {
 		var resp struct {

--- a/_examples/scalars/server/server.go
+++ b/_examples/scalars/server/server.go
@@ -6,12 +6,19 @@ import (
 
 	"github.com/99designs/gqlgen/_examples/scalars"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
 )
 
 func main() {
+	srv := handler.New(
+		scalars.NewExecutableSchema(scalars.Config{Resolvers: &scalars.Resolver{}}),
+	)
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
+
 	http.Handle("/", playground.Handler("Starwars", "/query"))
-	http.Handle("/query", handler.NewDefaultServer(scalars.NewExecutableSchema(scalars.Config{Resolvers: &scalars.Resolver{}})))
+	http.Handle("/query", srv)
 
 	log.Fatal(http.ListenAndServe(":8084", nil))
 }

--- a/_examples/selection/selection_test.go
+++ b/_examples/selection/selection_test.go
@@ -3,6 +3,7 @@ package selection
 import (
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -10,7 +11,9 @@ import (
 )
 
 func TestSelection(t *testing.T) {
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: &Resolver{}})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: &Resolver{}}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	query := `{
 			events {

--- a/_examples/selection/server/server.go
+++ b/_examples/selection/server/server.go
@@ -6,11 +6,18 @@ import (
 
 	"github.com/99designs/gqlgen/_examples/selection"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
 )
 
 func main() {
+	srv := handler.New(
+		selection.NewExecutableSchema(selection.Config{Resolvers: &selection.Resolver{}}),
+	)
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
+
 	http.Handle("/", playground.Handler("Selection Demo", "/query"))
-	http.Handle("/query", handler.NewDefaultServer(selection.NewExecutableSchema(selection.Config{Resolvers: &selection.Resolver{}})))
+	http.Handle("/query", srv)
 	log.Fatal(http.ListenAndServe(":8086", nil))
 }

--- a/_examples/starwars/benchmarks_test.go
+++ b/_examples/starwars/benchmarks_test.go
@@ -7,10 +7,12 @@ import (
 
 	"github.com/99designs/gqlgen/_examples/starwars/generated"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 )
 
 func BenchmarkSimpleQueryNoArgs(b *testing.B) {
-	server := handler.NewDefaultServer(generated.NewExecutableSchema(NewResolver()))
+	server := handler.New(generated.NewExecutableSchema(NewResolver()))
+	server.AddTransport(transport.POST{})
 
 	q := `{"query":"{ search(text:\"Luke\") { ... on Human { starships { name } } } }"}`
 

--- a/_examples/starwars/server/server.go
+++ b/_examples/starwars/server/server.go
@@ -10,11 +10,15 @@ import (
 	"github.com/99designs/gqlgen/_examples/starwars/generated"
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
 )
 
 func main() {
-	srv := handler.NewDefaultServer(generated.NewExecutableSchema(starwars.NewResolver()))
+	srv := handler.New(generated.NewExecutableSchema(starwars.NewResolver()))
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
+
 	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		rc := graphql.GetFieldContext(ctx)
 		fmt.Println("Entered", rc.Object, rc.Field.Name)

--- a/_examples/starwars/starwars_test.go
+++ b/_examples/starwars/starwars_test.go
@@ -3,6 +3,8 @@ package starwars
 import (
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/_examples/starwars/generated"
@@ -12,7 +14,10 @@ import (
 )
 
 func TestStarwars(t *testing.T) {
-	c := client.New(handler.NewDefaultServer(generated.NewExecutableSchema(NewResolver())))
+	srv := handler.New(generated.NewExecutableSchema(NewResolver()))
+	srv.AddTransport(transport.POST{})
+	srv.Use(extension.Introspection{})
+	c := client.New(srv)
 
 	t.Run("Lukes starships", func(t *testing.T) {
 		var resp struct {

--- a/_examples/todo/server/server.go
+++ b/_examples/todo/server/server.go
@@ -9,11 +9,15 @@ import (
 
 	"github.com/99designs/gqlgen/_examples/todo"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
 )
 
 func main() {
-	srv := handler.NewDefaultServer(todo.NewExecutableSchema(todo.New()))
+	srv := handler.New(todo.NewExecutableSchema(todo.New()))
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
+
 	srv.SetRecoverFunc(func(ctx context.Context, err any) (userMessage error) {
 		// send this panic somewhere
 		log.Print(err)

--- a/_examples/todo/todo_test.go
+++ b/_examples/todo/todo_test.go
@@ -3,6 +3,8 @@ package todo
 import (
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -11,7 +13,10 @@ import (
 )
 
 func TestTodo(t *testing.T) {
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(New())))
+	srv := handler.New(NewExecutableSchema(New()))
+	srv.AddTransport(transport.POST{})
+	srv.Use(extension.Introspection{})
+	c := client.New(srv)
 
 	var resp struct {
 		CreateTodo struct{ ID string }
@@ -181,7 +186,9 @@ func TestTodo(t *testing.T) {
 }
 
 func TestSkipAndIncludeDirectives(t *testing.T) {
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(New())))
+	srv := handler.New(NewExecutableSchema(New()))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("skip on field", func(t *testing.T) {
 		var resp map[string]any

--- a/_examples/type-system-extension/server/server.go
+++ b/_examples/type-system-extension/server/server.go
@@ -7,6 +7,7 @@ import (
 
 	extension "github.com/99designs/gqlgen/_examples/type-system-extension"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
 )
 
@@ -18,8 +19,7 @@ func main() {
 		port = defaultPort
 	}
 
-	http.Handle("/", playground.Handler("GraphQL playground", "/query"))
-	http.Handle("/query", handler.NewDefaultServer(
+	srv := handler.New(
 		extension.NewExecutableSchema(
 			extension.Config{
 				Resolvers: extension.NewRootResolver(),
@@ -33,7 +33,12 @@ func main() {
 				},
 			},
 		),
-	))
+	)
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
+
+	http.Handle("/", playground.Handler("GraphQL playground", "/query"))
+	http.Handle("/query", srv)
 
 	log.Printf("connect to http://localhost:%s/ for GraphQL playground", port)
 	log.Fatal(http.ListenAndServe(":"+port, nil))

--- a/_examples/uuid/server.go
+++ b/_examples/uuid/server.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/99designs/gqlgen/_examples/uuid/graph"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
 )
 
@@ -18,7 +19,11 @@ func main() {
 		port = defaultPort
 	}
 
-	srv := handler.NewDefaultServer(graph.NewExecutableSchema(graph.Config{Resolvers: &graph.Resolver{}}))
+	srv := handler.New(
+		graph.NewExecutableSchema(graph.Config{Resolvers: &graph.Resolver{}}),
+	)
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
 
 	http.Handle("/", playground.Handler("GraphQL playground", "/query"))
 	http.Handle("/query", srv)

--- a/codegen/testserver/followschema/complexity_test.go
+++ b/codegen/testserver/followschema/complexity_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -14,8 +15,8 @@ import (
 func TestComplexityCollisions(t *testing.T) {
 	resolvers := &Stub{}
 
-	srv := handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers}))
-
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
 	c := client.New(srv)
 
 	resolvers.QueryResolver.Overlapping = func(ctx context.Context) (fields *OverlappingFields, e error) {
@@ -52,7 +53,8 @@ func TestComplexityFuncs(t *testing.T) {
 	cfg.Complexity.OverlappingFields.Foo = func(childComplexity int) int { return 1000 }
 	cfg.Complexity.OverlappingFields.NewFoo = func(childComplexity int) int { return 5 }
 
-	srv := handler.NewDefaultServer(NewExecutableSchema(cfg))
+	srv := handler.New(NewExecutableSchema(cfg))
+	srv.AddTransport(transport.POST{})
 	srv.Use(extension.FixedComplexityLimit(10))
 	c := client.New(srv)
 

--- a/codegen/testserver/followschema/defaults_test.go
+++ b/codegen/testserver/followschema/defaults_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -20,7 +21,8 @@ func assertDefaults(t *testing.T, ret *DefaultParametersMirror) {
 
 func TestDefaults(t *testing.T) {
 	resolvers := &Stub{}
-	srv := handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
 	c := client.New(srv)
 
 	t.Run("default field parameters", func(t *testing.T) {

--- a/codegen/testserver/followschema/embedded_test.go
+++ b/codegen/testserver/followschema/embedded_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -28,9 +29,9 @@ func TestEmbedded(t *testing.T) {
 		return &EmbeddedCase3{&fakeUnexportedEmbeddedInterface{}}, nil
 	}
 
-	c := client.New(handler.NewDefaultServer(
-		NewExecutableSchema(Config{Resolvers: resolver}),
-	))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolver}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("embedded case 1", func(t *testing.T) {
 		var resp struct {

--- a/codegen/testserver/followschema/enums_test.go
+++ b/codegen/testserver/followschema/enums_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
-	"github.com/99designs/gqlgen/graphql/handler"
 )
 
 func TestEnumsResolver(t *testing.T) {
@@ -16,7 +17,9 @@ func TestEnumsResolver(t *testing.T) {
 		return input.Enum, nil
 	}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("input with valid enum value", func(t *testing.T) {
 		var resp struct {

--- a/codegen/testserver/followschema/fields_order_test.go
+++ b/codegen/testserver/followschema/fields_order_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 type FieldsOrderPayloadResults struct {
@@ -19,7 +19,9 @@ type FieldsOrderPayloadResults struct {
 func TestFieldsOrder(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 	resolvers.FieldsOrderInputResolver.OverrideFirstField = func(ctx context.Context, in *FieldsOrderInput, data *string) error {
 		if data != nil {
 			in.FirstField = data

--- a/codegen/testserver/followschema/generated_test.go
+++ b/codegen/testserver/followschema/generated_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -38,7 +39,8 @@ func TestUnionFragments(t *testing.T) {
 		return &Circle{Radius: 32}, nil
 	}
 
-	srv := handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
 	c := client.New(srv)
 
 	t.Run("inline fragment on union", func(t *testing.T) {

--- a/codegen/testserver/followschema/input_test.go
+++ b/codegen/testserver/followschema/input_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -14,7 +15,8 @@ import (
 
 func TestInput(t *testing.T) {
 	resolvers := &Stub{}
-	srv := handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
 	c := client.New(srv)
 
 	t.Run("when function errors on directives", func(t *testing.T) {
@@ -73,7 +75,8 @@ func TestInput(t *testing.T) {
 
 func TestInputOmittable(t *testing.T) {
 	resolvers := &Stub{}
-	srv := handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
 	c := client.New(srv)
 
 	t.Run("id field", func(t *testing.T) {

--- a/codegen/testserver/followschema/interfaces_test.go
+++ b/codegen/testserver/followschema/interfaces_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -34,12 +35,8 @@ func TestInterfaces(t *testing.T) {
 			}, nil
 		}
 
-		srv := handler.NewDefaultServer(
-			NewExecutableSchema(Config{
-				Resolvers: resolvers,
-			}),
-		)
-
+		srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+		srv.AddTransport(transport.POST{})
 		c := client.New(srv)
 
 		var resp struct {
@@ -61,7 +58,7 @@ func TestInterfaces(t *testing.T) {
 			return nil, nil
 		}
 
-		srv := handler.NewDefaultServer(
+		srv := handler.New(
 			NewExecutableSchema(Config{
 				Resolvers: resolvers,
 				Directives: DirectiveRoot{
@@ -71,7 +68,7 @@ func TestInterfaces(t *testing.T) {
 				},
 			}),
 		)
-
+		srv.AddTransport(transport.POST{})
 		c := client.New(srv)
 
 		var resp any
@@ -85,7 +82,7 @@ func TestInterfaces(t *testing.T) {
 			return
 		}
 
-		srv := handler.NewDefaultServer(
+		srv := handler.New(
 			NewExecutableSchema(Config{
 				Resolvers: resolvers,
 				Directives: DirectiveRoot{
@@ -96,7 +93,7 @@ func TestInterfaces(t *testing.T) {
 				},
 			}),
 		)
-
+		srv.AddTransport(transport.POST{})
 		c := client.New(srv)
 
 		var resp any
@@ -110,7 +107,7 @@ func TestInterfaces(t *testing.T) {
 			return
 		}
 
-		srv := handler.NewDefaultServer(
+		srv := handler.New(
 			NewExecutableSchema(Config{
 				Resolvers: resolvers,
 				Directives: DirectiveRoot{
@@ -121,7 +118,7 @@ func TestInterfaces(t *testing.T) {
 				},
 			}),
 		)
-
+		srv.AddTransport(transport.POST{})
 		c := client.New(srv)
 
 		var resp any
@@ -140,7 +137,9 @@ func TestInterfaces(t *testing.T) {
 			}, nil
 		}
 
-		c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+		srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+		srv.AddTransport(transport.POST{})
+		c := client.New(srv)
 
 		var resp struct {
 			NotAnInterface struct {
@@ -167,7 +166,9 @@ func TestInterfaces(t *testing.T) {
 			}, nil
 		}
 
-		c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+		srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+		srv.AddTransport(transport.POST{})
+		c := client.New(srv)
 
 		var resp struct {
 			NotAnInterface struct {
@@ -186,7 +187,9 @@ func TestInterfaces(t *testing.T) {
 			return ConcreteNodeInterfaceImplementor{}, nil
 		}
 
-		c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+		srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+		srv.AddTransport(transport.POST{})
+		c := client.New(srv)
 
 		var resp struct {
 			Node struct {
@@ -220,7 +223,9 @@ func TestInterfaces(t *testing.T) {
 			}, nil
 		}
 
-		c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+		srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+		srv.AddTransport(transport.POST{})
+		c := client.New(srv)
 		var resp struct {
 			Shapes []struct {
 				Coordinates struct {
@@ -268,7 +273,9 @@ func TestInterfaces(t *testing.T) {
 			}, nil
 		}
 
-		c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+		srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+		srv.AddTransport(transport.POST{})
+		c := client.New(srv)
 		var resp struct {
 			Dog struct {
 				Size struct {

--- a/codegen/testserver/followschema/introspection_test.go
+++ b/codegen/testserver/followschema/introspection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/extension"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -26,12 +27,13 @@ func TestIntrospection(t *testing.T) {
 		require.EqualError(t, err, "[{\"message\":\"introspection disabled\",\"path\":[\"__schema\"]}]")
 	})
 
-	t.Run("enabled by default", func(t *testing.T) {
+	t.Run("enabled by adding extension", func(t *testing.T) {
 		resolvers := &Stub{}
 
-		c := client.New(handler.NewDefaultServer(
-			NewExecutableSchema(Config{Resolvers: resolvers}),
-		))
+		srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+		srv.AddTransport(transport.POST{})
+		srv.Use(extension.Introspection{})
+		c := client.New(srv)
 
 		var resp any
 		err := c.Post(introspection.Query, &resp)
@@ -66,7 +68,9 @@ func TestIntrospection(t *testing.T) {
 	t.Run("disabled by middleware", func(t *testing.T) {
 		resolvers := &Stub{}
 
-		srv := handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers}))
+		srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+		srv.AddTransport(transport.POST{})
+		srv.Use(extension.Introspection{})
 		srv.AroundOperations(func(ctx context.Context, next graphql.OperationHandler) graphql.ResponseHandler {
 			graphql.GetOperationContext(ctx).DisableIntrospection = true
 			return next(ctx)

--- a/codegen/testserver/followschema/maps_test.go
+++ b/codegen/testserver/followschema/maps_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -24,9 +25,9 @@ func TestMaps(t *testing.T) {
 		return in.Map, nil
 	}
 
-	c := client.New(handler.NewDefaultServer(
-		NewExecutableSchema(Config{Resolvers: resolver}),
-	))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolver}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 	t.Run("unset", func(t *testing.T) {
 		var resp struct {
 			MapStringInterface map[string]any

--- a/codegen/testserver/followschema/middleware_test.go
+++ b/codegen/testserver/followschema/middleware_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -34,9 +35,8 @@ func TestMiddleware(t *testing.T) {
 	var mu sync.Mutex
 	areMethods := map[string]bool{}
 	areResolvers := map[string]bool{}
-	srv := handler.NewDefaultServer(
-		NewExecutableSchema(Config{Resolvers: resolvers}),
-	)
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
 	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		path, _ := ctx.Value(ckey("path")).([]int)
 		return next(context.WithValue(ctx, ckey("path"), append(path, 1)))

--- a/codegen/testserver/followschema/modelmethod_test.go
+++ b/codegen/testserver/followschema/modelmethod_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -19,9 +20,10 @@ func TestModelMethods(t *testing.T) {
 		return true, nil
 	}
 
-	c := client.New(handler.NewDefaultServer(
-		NewExecutableSchema(Config{Resolvers: resolver}),
-	))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolver}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
+
 	t.Run("without context", func(t *testing.T) {
 		var resp struct {
 			ModelMethods struct {

--- a/codegen/testserver/followschema/mutation_with_custom_scalar_test.go
+++ b/codegen/testserver/followschema/mutation_with_custom_scalar_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
-	"github.com/99designs/gqlgen/graphql/handler"
 )
 
 func TestErrorInsideMutationArgument(t *testing.T) {
@@ -16,7 +17,9 @@ func TestErrorInsideMutationArgument(t *testing.T) {
 		return "Hello world", nil
 	}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("mutation with correct input doesn't return error", func(t *testing.T) {
 		var resp map[string]any

--- a/codegen/testserver/followschema/nulls_test.go
+++ b/codegen/testserver/followschema/nulls_test.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNullBubbling(t *testing.T) {
@@ -32,7 +32,9 @@ func TestNullBubbling(t *testing.T) {
 		return []*Error{nil}, nil
 	}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("when function errors on non required field", func(t *testing.T) {
 		var resp struct {

--- a/codegen/testserver/followschema/panics_test.go
+++ b/codegen/testserver/followschema/panics_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
@@ -25,7 +26,8 @@ func TestPanics(t *testing.T) {
 		return []MarshalPanic{MarshalPanic("aa"), MarshalPanic("bb")}, nil
 	}
 
-	srv := handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
 	srv.SetRecoverFunc(func(ctx context.Context, err any) (userMessage error) {
 		return fmt.Errorf("panic: %v", err)
 	})

--- a/codegen/testserver/followschema/primitive_objects_test.go
+++ b/codegen/testserver/followschema/primitive_objects_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPrimitiveObjects(t *testing.T) {
@@ -20,7 +20,9 @@ func TestPrimitiveObjects(t *testing.T) {
 		return int(*obj), nil
 	}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("can fetch value", func(t *testing.T) {
 		var resp struct {
@@ -52,7 +54,9 @@ func TestPrimitiveStringObjects(t *testing.T) {
 		return len(string(*obj)), nil
 	}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("can fetch value", func(t *testing.T) {
 		var resp struct {

--- a/codegen/testserver/followschema/ptr_to_any_test.go
+++ b/codegen/testserver/followschema/ptr_to_any_test.go
@@ -4,16 +4,18 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPtrToAny(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	var a any = `{"some":"thing"}`
 	resolvers.QueryResolver.PtrToAnyContainer = func(ctx context.Context) (wrappedStruct *PtrToAnyContainer, e error) {

--- a/codegen/testserver/followschema/ptr_to_ptr_input_test.go
+++ b/codegen/testserver/followschema/ptr_to_ptr_input_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 type UpdatePtrToPtrResults struct {
@@ -17,7 +17,9 @@ type UpdatePtrToPtrResults struct {
 func TestPtrToPtr(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	resolvers.MutationResolver.UpdatePtrToPtr = func(ctx context.Context, in UpdatePtrToPtrOuter) (ret *PtrToPtrOuter, err error) {
 		ret = &PtrToPtrOuter{

--- a/codegen/testserver/followschema/ptr_to_slice_test.go
+++ b/codegen/testserver/followschema/ptr_to_slice_test.go
@@ -4,16 +4,18 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPtrToSlice(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	resolvers.QueryResolver.PtrToSliceContainer = func(ctx context.Context) (wrappedStruct *PtrToSliceContainer, e error) {
 		ptrToSliceContainer := PtrToSliceContainer{

--- a/codegen/testserver/followschema/response_extension_test.go
+++ b/codegen/testserver/followschema/response_extension_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -17,10 +18,8 @@ func TestResponseExtension(t *testing.T) {
 		return "Ok", nil
 	}
 
-	srv := handler.NewDefaultServer(
-		NewExecutableSchema(Config{Resolvers: resolvers}),
-	)
-
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
 	srv.AroundResponses(func(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
 		graphql.RegisterExtension(ctx, "example", "value")
 

--- a/codegen/testserver/followschema/scalar_context_test.go
+++ b/codegen/testserver/followschema/scalar_context_test.go
@@ -5,16 +5,18 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFloatInfAndNaN(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	resolvers.QueryResolver.Infinity = func(ctx context.Context) (float64, error) {
 		return math.Inf(-1), nil
@@ -29,7 +31,9 @@ func TestFloatInfAndNaN(t *testing.T) {
 func TestContextPassedToMarshal(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	resolvers.QueryResolver.StringFromContextInterface = func(ctx context.Context) (*StringFromContextInterface, error) {
 		return &StringFromContextInterface{}, nil

--- a/codegen/testserver/followschema/scalar_default_test.go
+++ b/codegen/testserver/followschema/scalar_default_test.go
@@ -4,16 +4,18 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultScalarImplementation(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	resolvers.QueryResolver.DefaultScalar = func(ctx context.Context, arg string) (i string, e error) {
 		return arg, nil

--- a/codegen/testserver/followschema/slices_test.go
+++ b/codegen/testserver/followschema/slices_test.go
@@ -4,16 +4,18 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSlices(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("nulls vs empty slices", func(t *testing.T) {
 		resolvers.QueryResolver.Slices = func(ctx context.Context) (slices *Slices, e error) {

--- a/codegen/testserver/followschema/subscription_test.go
+++ b/codegen/testserver/followschema/subscription_test.go
@@ -86,9 +86,10 @@ func TestSubscriptions(t *testing.T) {
 		return res, nil
 	}
 
-	srv := handler.NewDefaultServer(
-		NewExecutableSchema(Config{Resolvers: resolvers}),
-	)
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.Websocket{
+		KeepAlivePingInterval: time.Second,
+	})
 	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		path, _ := ctx.Value(ckey("path")).([]int)
 		return next(context.WithValue(ctx, ckey("path"), append(path, 1)))

--- a/codegen/testserver/followschema/time_test.go
+++ b/codegen/testserver/followschema/time_test.go
@@ -5,16 +5,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTime(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	resolvers.QueryResolver.User = func(ctx context.Context, id int) (user *User, e error) {
 		return &User{}, nil

--- a/codegen/testserver/followschema/typefallback_test.go
+++ b/codegen/testserver/followschema/typefallback_test.go
@@ -4,16 +4,18 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTypeFallback(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	resolvers.QueryResolver.Fallback = func(ctx context.Context, arg FallbackToStringEncoding) (FallbackToStringEncoding, error) {
 		return arg, nil

--- a/codegen/testserver/followschema/v-ok_test.go
+++ b/codegen/testserver/followschema/v-ok_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -19,9 +20,9 @@ func TestOk(t *testing.T) {
 		return &VOkCaseNil{}, nil
 	}
 
-	c := client.New(handler.NewDefaultServer(
-		NewExecutableSchema(Config{Resolvers: resolver}),
-	))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolver}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("v ok case value", func(t *testing.T) {
 		var resp struct {

--- a/codegen/testserver/followschema/validtypes_test.go
+++ b/codegen/testserver/followschema/validtypes_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidType(t *testing.T) {
@@ -19,7 +19,9 @@ func TestValidType(t *testing.T) {
 		}, nil
 	}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("fields with differing cases can be distinguished", func(t *testing.T) {
 		var resp struct {

--- a/codegen/testserver/followschema/wrapped_type_test.go
+++ b/codegen/testserver/followschema/wrapped_type_test.go
@@ -4,17 +4,20 @@ import (
 	"context"
 	"testing"
 
+	"github.com/99designs/gqlgen/client"
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
-	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/codegen/testserver/followschema/otherpkg"
-	"github.com/99designs/gqlgen/graphql/handler"
 )
 
 func TestWrappedTypes(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	resolvers.QueryResolver.WrappedScalar = func(ctx context.Context) (scalar WrappedScalar, e error) {
 		return "hello", nil

--- a/codegen/testserver/nullabledirectives/directive_test.go
+++ b/codegen/testserver/nullabledirectives/directive_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -37,7 +38,7 @@ func TestDirectives(t *testing.T) {
 		return &ok, nil
 	}
 
-	srv := handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{
+	srv := handler.New(generated.NewExecutableSchema(generated.Config{
 		Resolvers: resolvers,
 		Directives: generated.DirectiveRoot{
 			Populate: func(ctx context.Context, obj any, next graphql.Resolver, value string) (any, error) {
@@ -57,7 +58,7 @@ func TestDirectives(t *testing.T) {
 			},
 		},
 	}))
-
+	srv.AddTransport(transport.POST{})
 	c := client.New(srv)
 
 	t.Run("arg directives", func(t *testing.T) {

--- a/codegen/testserver/singlefile/complexity_test.go
+++ b/codegen/testserver/singlefile/complexity_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -14,8 +15,8 @@ import (
 func TestComplexityCollisions(t *testing.T) {
 	resolvers := &Stub{}
 
-	srv := handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers}))
-
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
 	c := client.New(srv)
 
 	resolvers.QueryResolver.Overlapping = func(ctx context.Context) (fields *OverlappingFields, e error) {
@@ -52,7 +53,8 @@ func TestComplexityFuncs(t *testing.T) {
 	cfg.Complexity.OverlappingFields.Foo = func(childComplexity int) int { return 1000 }
 	cfg.Complexity.OverlappingFields.NewFoo = func(childComplexity int) int { return 5 }
 
-	srv := handler.NewDefaultServer(NewExecutableSchema(cfg))
+	srv := handler.New(NewExecutableSchema(cfg))
+	srv.AddTransport(transport.POST{})
 	srv.Use(extension.FixedComplexityLimit(10))
 	c := client.New(srv)
 

--- a/codegen/testserver/singlefile/defaults_test.go
+++ b/codegen/testserver/singlefile/defaults_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -20,7 +21,8 @@ func assertDefaults(t *testing.T, ret *DefaultParametersMirror) {
 
 func TestDefaults(t *testing.T) {
 	resolvers := &Stub{}
-	srv := handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
 	c := client.New(srv)
 
 	t.Run("default field parameters", func(t *testing.T) {

--- a/codegen/testserver/singlefile/directive_test.go
+++ b/codegen/testserver/singlefile/directive_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -109,7 +111,7 @@ func TestDirectives(t *testing.T) {
 	resolvers.SubscriptionResolver.DirectiveUnimplemented = func(ctx context.Context) (<-chan *string, error) {
 		return okchan()
 	}
-	srv := handler.NewDefaultServer(NewExecutableSchema(Config{
+	srv := handler.New(NewExecutableSchema(Config{
 		Resolvers: resolvers,
 		Directives: DirectiveRoot{
 			//nolint:revive // can't rename min, max because it's generated code
@@ -221,7 +223,8 @@ func TestDirectives(t *testing.T) {
 			Unimplemented: nil,
 		},
 	}))
-
+	srv.AddTransport(transport.Websocket{KeepAlivePingInterval: time.Second})
+	srv.AddTransport(transport.POST{})
 	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		path, _ := ctx.Value(ckey("path")).([]int)
 		return next(context.WithValue(ctx, ckey("path"), append(path, 1)))

--- a/codegen/testserver/singlefile/embedded_test.go
+++ b/codegen/testserver/singlefile/embedded_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 type fakeUnexportedEmbeddedInterface struct{}
@@ -28,9 +28,9 @@ func TestEmbedded(t *testing.T) {
 		return &EmbeddedCase3{&fakeUnexportedEmbeddedInterface{}}, nil
 	}
 
-	c := client.New(handler.NewDefaultServer(
-		NewExecutableSchema(Config{Resolvers: resolver}),
-	))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolver}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("embedded case 1", func(t *testing.T) {
 		var resp struct {

--- a/codegen/testserver/singlefile/enums_test.go
+++ b/codegen/testserver/singlefile/enums_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
-	"github.com/99designs/gqlgen/graphql/handler"
 )
 
 func TestEnumsResolver(t *testing.T) {
@@ -16,7 +17,9 @@ func TestEnumsResolver(t *testing.T) {
 		return input.Enum, nil
 	}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("input with valid enum value", func(t *testing.T) {
 		var resp struct {

--- a/codegen/testserver/singlefile/fields_order_test.go
+++ b/codegen/testserver/singlefile/fields_order_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 type FieldsOrderPayloadResults struct {
@@ -19,7 +19,9 @@ type FieldsOrderPayloadResults struct {
 func TestFieldsOrder(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 	resolvers.FieldsOrderInputResolver.OverrideFirstField = func(ctx context.Context, in *FieldsOrderInput, data *string) error {
 		if data != nil {
 			in.FirstField = data

--- a/codegen/testserver/singlefile/generated_test.go
+++ b/codegen/testserver/singlefile/generated_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -38,7 +39,8 @@ func TestUnionFragments(t *testing.T) {
 		return &Circle{Radius: 32}, nil
 	}
 
-	srv := handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
 	c := client.New(srv)
 
 	t.Run("inline fragment on union", func(t *testing.T) {

--- a/codegen/testserver/singlefile/input_test.go
+++ b/codegen/testserver/singlefile/input_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -14,7 +15,8 @@ import (
 
 func TestInput(t *testing.T) {
 	resolvers := &Stub{}
-	srv := handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
 	c := client.New(srv)
 
 	t.Run("when function errors on directives", func(t *testing.T) {
@@ -73,7 +75,8 @@ func TestInput(t *testing.T) {
 
 func TestInputOmittable(t *testing.T) {
 	resolvers := &Stub{}
-	srv := handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
 	c := client.New(srv)
 
 	t.Run("id field", func(t *testing.T) {

--- a/codegen/testserver/singlefile/interfaces_test.go
+++ b/codegen/testserver/singlefile/interfaces_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -34,12 +35,8 @@ func TestInterfaces(t *testing.T) {
 			}, nil
 		}
 
-		srv := handler.NewDefaultServer(
-			NewExecutableSchema(Config{
-				Resolvers: resolvers,
-			}),
-		)
-
+		srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+		srv.AddTransport(transport.POST{})
 		c := client.New(srv)
 
 		var resp struct {
@@ -61,7 +58,7 @@ func TestInterfaces(t *testing.T) {
 			return nil, nil
 		}
 
-		srv := handler.NewDefaultServer(
+		srv := handler.New(
 			NewExecutableSchema(Config{
 				Resolvers: resolvers,
 				Directives: DirectiveRoot{
@@ -71,7 +68,7 @@ func TestInterfaces(t *testing.T) {
 				},
 			}),
 		)
-
+		srv.AddTransport(transport.POST{})
 		c := client.New(srv)
 
 		var resp any
@@ -85,7 +82,7 @@ func TestInterfaces(t *testing.T) {
 			return
 		}
 
-		srv := handler.NewDefaultServer(
+		srv := handler.New(
 			NewExecutableSchema(Config{
 				Resolvers: resolvers,
 				Directives: DirectiveRoot{
@@ -96,7 +93,7 @@ func TestInterfaces(t *testing.T) {
 				},
 			}),
 		)
-
+		srv.AddTransport(transport.POST{})
 		c := client.New(srv)
 
 		var resp any
@@ -110,7 +107,7 @@ func TestInterfaces(t *testing.T) {
 			return
 		}
 
-		srv := handler.NewDefaultServer(
+		srv := handler.New(
 			NewExecutableSchema(Config{
 				Resolvers: resolvers,
 				Directives: DirectiveRoot{
@@ -121,7 +118,7 @@ func TestInterfaces(t *testing.T) {
 				},
 			}),
 		)
-
+		srv.AddTransport(transport.POST{})
 		c := client.New(srv)
 
 		var resp any
@@ -140,8 +137,9 @@ func TestInterfaces(t *testing.T) {
 			}, nil
 		}
 
-		c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
-
+		srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+		srv.AddTransport(transport.POST{})
+		c := client.New(srv)
 		var resp struct {
 			NotAnInterface struct {
 				ID                      string
@@ -167,7 +165,9 @@ func TestInterfaces(t *testing.T) {
 			}, nil
 		}
 
-		c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+		srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+		srv.AddTransport(transport.POST{})
+		c := client.New(srv)
 
 		var resp struct {
 			NotAnInterface struct {
@@ -186,7 +186,9 @@ func TestInterfaces(t *testing.T) {
 			return ConcreteNodeInterfaceImplementor{}, nil
 		}
 
-		c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+		srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+		srv.AddTransport(transport.POST{})
+		c := client.New(srv)
 
 		var resp struct {
 			Node struct {
@@ -220,7 +222,9 @@ func TestInterfaces(t *testing.T) {
 			}, nil
 		}
 
-		c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+		srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+		srv.AddTransport(transport.POST{})
+		c := client.New(srv)
 		var resp struct {
 			Shapes []struct {
 				Coordinates struct {
@@ -268,7 +272,9 @@ func TestInterfaces(t *testing.T) {
 			}, nil
 		}
 
-		c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+		srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+		srv.AddTransport(transport.POST{})
+		c := client.New(srv)
 		var resp struct {
 			Dog struct {
 				Size struct {

--- a/codegen/testserver/singlefile/maps_test.go
+++ b/codegen/testserver/singlefile/maps_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
-	"github.com/99designs/gqlgen/graphql/handler"
 )
 
 func TestMaps(t *testing.T) {
@@ -24,9 +25,9 @@ func TestMaps(t *testing.T) {
 		return in.Map, nil
 	}
 
-	c := client.New(handler.NewDefaultServer(
-		NewExecutableSchema(Config{Resolvers: resolver}),
-	))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolver}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 	t.Run("unset", func(t *testing.T) {
 		var resp struct {
 			MapStringInterface map[string]any

--- a/codegen/testserver/singlefile/middleware_test.go
+++ b/codegen/testserver/singlefile/middleware_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -42,9 +43,8 @@ func TestMiddleware(t *testing.T) {
 	var mu sync.Mutex
 	areMethods := map[string]bool{}
 	areResolvers := map[string]bool{}
-	srv := handler.NewDefaultServer(
-		NewExecutableSchema(Config{Resolvers: resolvers}),
-	)
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
 	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		path, _ := ctx.Value(ckey("path")).([]int)
 		return next(context.WithValue(ctx, ckey("path"), append(path, 1)))

--- a/codegen/testserver/singlefile/modelmethod_test.go
+++ b/codegen/testserver/singlefile/modelmethod_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestModelMethods(t *testing.T) {
@@ -19,9 +19,9 @@ func TestModelMethods(t *testing.T) {
 		return true, nil
 	}
 
-	c := client.New(handler.NewDefaultServer(
-		NewExecutableSchema(Config{Resolvers: resolver}),
-	))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolver}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 	t.Run("without context", func(t *testing.T) {
 		var resp struct {
 			ModelMethods struct {

--- a/codegen/testserver/singlefile/mutation_with_custom_scalar_test.go
+++ b/codegen/testserver/singlefile/mutation_with_custom_scalar_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
-	"github.com/99designs/gqlgen/graphql/handler"
 )
 
 func TestErrorInsideMutationArgument(t *testing.T) {
@@ -16,7 +17,9 @@ func TestErrorInsideMutationArgument(t *testing.T) {
 		return "Hello world", nil
 	}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("mutation with correct input doesn't return error", func(t *testing.T) {
 		var resp map[string]any

--- a/codegen/testserver/singlefile/nulls_test.go
+++ b/codegen/testserver/singlefile/nulls_test.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNullBubbling(t *testing.T) {
@@ -32,7 +32,9 @@ func TestNullBubbling(t *testing.T) {
 		return []*Error{nil}, nil
 	}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("when function errors on non required field", func(t *testing.T) {
 		var resp struct {

--- a/codegen/testserver/singlefile/panics_test.go
+++ b/codegen/testserver/singlefile/panics_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
@@ -25,7 +26,8 @@ func TestPanics(t *testing.T) {
 		return []MarshalPanic{MarshalPanic("aa"), MarshalPanic("bb")}, nil
 	}
 
-	srv := handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
 	srv.SetRecoverFunc(func(ctx context.Context, err any) (userMessage error) {
 		return fmt.Errorf("panic: %v", err)
 	})

--- a/codegen/testserver/singlefile/primitive_objects_test.go
+++ b/codegen/testserver/singlefile/primitive_objects_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPrimitiveObjects(t *testing.T) {
@@ -20,7 +20,9 @@ func TestPrimitiveObjects(t *testing.T) {
 		return int(*obj), nil
 	}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("can fetch value", func(t *testing.T) {
 		var resp struct {
@@ -52,7 +54,9 @@ func TestPrimitiveStringObjects(t *testing.T) {
 		return len(string(*obj)), nil
 	}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("can fetch value", func(t *testing.T) {
 		var resp struct {

--- a/codegen/testserver/singlefile/ptr_to_any_test.go
+++ b/codegen/testserver/singlefile/ptr_to_any_test.go
@@ -4,16 +4,18 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPtrToAny(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	var a any = `{"some":"thing"}`
 	resolvers.QueryResolver.PtrToAnyContainer = func(ctx context.Context) (wrappedStruct *PtrToAnyContainer, e error) {

--- a/codegen/testserver/singlefile/ptr_to_ptr_input_test.go
+++ b/codegen/testserver/singlefile/ptr_to_ptr_input_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 type UpdatePtrToPtrResults struct {
@@ -17,7 +17,9 @@ type UpdatePtrToPtrResults struct {
 func TestPtrToPtr(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	resolvers.MutationResolver.UpdatePtrToPtr = func(ctx context.Context, in UpdatePtrToPtrOuter) (ret *PtrToPtrOuter, err error) {
 		ret = &PtrToPtrOuter{

--- a/codegen/testserver/singlefile/ptr_to_slice_test.go
+++ b/codegen/testserver/singlefile/ptr_to_slice_test.go
@@ -4,16 +4,18 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPtrToSlice(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	resolvers.QueryResolver.PtrToSliceContainer = func(ctx context.Context) (wrappedStruct *PtrToSliceContainer, e error) {
 		ptrToSliceContainer := PtrToSliceContainer{

--- a/codegen/testserver/singlefile/response_extension_test.go
+++ b/codegen/testserver/singlefile/response_extension_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -17,10 +18,8 @@ func TestResponseExtension(t *testing.T) {
 		return "Ok", nil
 	}
 
-	srv := handler.NewDefaultServer(
-		NewExecutableSchema(Config{Resolvers: resolvers}),
-	)
-
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
 	srv.AroundResponses(func(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
 		graphql.RegisterExtension(ctx, "example", "value")
 

--- a/codegen/testserver/singlefile/scalar_context_test.go
+++ b/codegen/testserver/singlefile/scalar_context_test.go
@@ -5,16 +5,18 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFloatInfAndNaN(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	resolvers.QueryResolver.Infinity = func(ctx context.Context) (float64, error) {
 		return math.Inf(-1), nil
@@ -29,7 +31,9 @@ func TestFloatInfAndNaN(t *testing.T) {
 func TestContextPassedToMarshal(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	resolvers.QueryResolver.StringFromContextInterface = func(ctx context.Context) (*StringFromContextInterface, error) {
 		return &StringFromContextInterface{}, nil

--- a/codegen/testserver/singlefile/scalar_default_test.go
+++ b/codegen/testserver/singlefile/scalar_default_test.go
@@ -4,16 +4,18 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultScalarImplementation(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	resolvers.QueryResolver.DefaultScalar = func(ctx context.Context, arg string) (i string, e error) {
 		return arg, nil

--- a/codegen/testserver/singlefile/slices_test.go
+++ b/codegen/testserver/singlefile/slices_test.go
@@ -4,16 +4,18 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSlices(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("nulls vs empty slices", func(t *testing.T) {
 		resolvers.QueryResolver.Slices = func(ctx context.Context) (slices *Slices, e error) {

--- a/codegen/testserver/singlefile/subscription_test.go
+++ b/codegen/testserver/singlefile/subscription_test.go
@@ -86,9 +86,8 @@ func TestSubscriptions(t *testing.T) {
 		return res, nil
 	}
 
-	srv := handler.NewDefaultServer(
-		NewExecutableSchema(Config{Resolvers: resolvers}),
-	)
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.Websocket{KeepAlivePingInterval: time.Second})
 	srv.AroundFields(func(ctx context.Context, next graphql.Resolver) (res any, err error) {
 		path, _ := ctx.Value(ckey("path")).([]int)
 		return next(context.WithValue(ctx, ckey("path"), append(path, 1)))

--- a/codegen/testserver/singlefile/time_test.go
+++ b/codegen/testserver/singlefile/time_test.go
@@ -5,16 +5,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTime(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	resolvers.QueryResolver.User = func(ctx context.Context, id int) (user *User, e error) {
 		return &User{}, nil

--- a/codegen/testserver/singlefile/typefallback_test.go
+++ b/codegen/testserver/singlefile/typefallback_test.go
@@ -4,16 +4,18 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTypeFallback(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	resolvers.QueryResolver.Fallback = func(ctx context.Context, arg FallbackToStringEncoding) (FallbackToStringEncoding, error) {
 		return arg, nil

--- a/codegen/testserver/singlefile/v-ok_test.go
+++ b/codegen/testserver/singlefile/v-ok_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOk(t *testing.T) {
@@ -19,9 +19,9 @@ func TestOk(t *testing.T) {
 		return &VOkCaseNil{}, nil
 	}
 
-	c := client.New(handler.NewDefaultServer(
-		NewExecutableSchema(Config{Resolvers: resolver}),
-	))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolver}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("v ok case value", func(t *testing.T) {
 		var resp struct {

--- a/codegen/testserver/singlefile/validtypes_test.go
+++ b/codegen/testserver/singlefile/validtypes_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidType(t *testing.T) {
@@ -19,7 +19,9 @@ func TestValidType(t *testing.T) {
 		}, nil
 	}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("fields with differing cases can be distinguished", func(t *testing.T) {
 		var resp struct {

--- a/codegen/testserver/singlefile/variadic_test.go
+++ b/codegen/testserver/singlefile/variadic_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVariadic(t *testing.T) {
@@ -15,9 +15,9 @@ func TestVariadic(t *testing.T) {
 	resolver.QueryResolver.VariadicModel = func(ctx context.Context) (*VariadicModel, error) {
 		return &VariadicModel{}, nil
 	}
-	c := client.New(handler.NewDefaultServer(
-		NewExecutableSchema(Config{Resolvers: resolver}),
-	))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolver}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	var resp struct {
 		VariadicModel struct {

--- a/codegen/testserver/singlefile/wrapped_type_test.go
+++ b/codegen/testserver/singlefile/wrapped_type_test.go
@@ -4,17 +4,20 @@ import (
 	"context"
 	"testing"
 
+	"github.com/99designs/gqlgen/client"
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
-	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/codegen/testserver/singlefile/otherpkg"
-	"github.com/99designs/gqlgen/graphql/handler"
 )
 
 func TestWrappedTypes(t *testing.T) {
 	resolvers := &Stub{}
 
-	c := client.New(handler.NewDefaultServer(NewExecutableSchema(Config{Resolvers: resolvers})))
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	resolvers.QueryResolver.WrappedScalar = func(ctx context.Context) (scalar WrappedScalar, e error) {
 		return "hello", nil

--- a/docs/content/recipes/authentication.md
+++ b/docs/content/recipes/authentication.md
@@ -79,6 +79,7 @@ import (
 
 	"github.com/99designs/gqlgen/_examples/starwars"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/go-chi/chi"
 )
@@ -88,7 +89,8 @@ func main() {
 
 	router.Use(auth.Middleware(db))
 
-	srv := handler.NewDefaultServer(starwars.NewExecutableSchema(starwars.NewResolver()))
+	srv := handler.New(starwars.NewExecutableSchema(starwars.NewResolver()))
+	srv.AddTransport(transport.POST{})
 	router.Handle("/", playground.Handler("Starwars", "/query"))
 	router.Handle("/query", srv)
 
@@ -116,8 +118,8 @@ func (r *queryResolver) Hero(ctx context.Context, episode Episode) (Character, e
 
 ### Websockets
 
-If you need access to the websocket init payload you can add your `InitFunc` in `AddTransport`.  
-Your InitFunc implementation could then attempt to extract items from the payload:  
+If you need access to the websocket init payload you can add your `InitFunc` in `AddTransport`.
+Your InitFunc implementation could then attempt to extract items from the payload:
 
 ```go
 package main
@@ -177,7 +179,6 @@ func main() {
 	})
 
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: &graph.Resolver{}}))
-	srv.AddTransport(transport.POST{})
 	srv.AddTransport(transport.Websocket{
 		KeepAlivePingInterval: 10 * time.Second,
 		Upgrader: websocket.Upgrader{
@@ -189,6 +190,7 @@ func main() {
 			return webSocketInit(ctx, initPayload)
 		},
 	})
+	srv.AddTransport(transport.POST{})
 	srv.Use(extension.Introspection{})
 
 	router.Handle("/", playground.Handler("My GraphQL App", "/app"))

--- a/docs/content/recipes/cors.md
+++ b/docs/content/recipes/cors.md
@@ -38,7 +38,9 @@ func main() {
 	}).Handler)
 
 
-	srv := handler.NewDefaultServer(starwars.NewExecutableSchema(starwars.NewResolver()))
+	srv := handler.New(starwars.NewExecutableSchema(starwars.NewResolver()))
+
+	// Handle cross-origin checks in for websocket upgrade requests:
 	srv.AddTransport(&transport.Websocket{
 		Upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
@@ -49,6 +51,7 @@ func main() {
 			WriteBufferSize: 1024,
 		},
 	})
+	srv.AddTransport(transport.POST{})
 
 	router.Handle("/", playground.Handler("Starwars", "/query"))
 	router.Handle("/query", srv)

--- a/docs/content/recipes/migration-0.11.md
+++ b/docs/content/recipes/migration-0.11.md
@@ -104,13 +104,6 @@ srv.Use(extension.AutomaticPersistedQuery{
 srv.Use(apollotracing.Tracer{})
 ```
 
-### Default server
-
-We provide a set of default extensions and transports if you aren't ready to customize them yet. Simply:
-```go
-handler.NewDefaultServer(es)
-```
-
 ### More consistent naming
 
 As part of cleaning up the names the RequestContext has been renamed to OperationContext, as there can be multiple created during the lifecycle of a request. A new ResponseContext has also been created and error handling has been moved here. This allows each response in a subscription to have its own errors. I'm not sure what bugs this might have been causing before...

--- a/docs/content/recipes/subscriptions.md
+++ b/docs/content/recipes/subscriptions.md
@@ -16,20 +16,20 @@ to be careful to configure routing correctly.
 
 In this recipe you will learn how to
 
-1. add WebSocket Transport to your server
+1. add a WebSocket Transport to your server
 2. add the `Subscription` type to your schema
 3. implement a real-time resolver.
 
-## Adding WebSocket Transport
+## Adding a WebSocket Transport
 
 To send real-time data to clients, your GraphQL server needs to have an open connection
 with the client. This is done using WebSockets.
 
-To add the WebSocket transport change your `main.go` by calling `AddTransport(&transport.Websocket{})`
+To add the WebSocket transport change your `main.go` by calling `AddTransport(transport.Websocket{})`
 on your query handler.
 
-**If you are using an external router, remember to send *ALL* `/query`-requests to your handler!**
-**Not just POST requests!**
+> If you are using an external router, remember to send *ALL* requests go to your handler (at `/query`),
+> not just POST requests!
 
 ```go
 package main
@@ -54,9 +54,12 @@ func main() {
 		port = defaultPort
 	}
 
-	srv := handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: &graph.Resolver{}}))
+	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: &graph.Resolver{}}))
 
-	srv.AddTransport(&transport.Websocket{}) // <---- This is the important part!
+	srv.AddTransport(transport.Websocket{}) // Add WebSocket first. Here there is no config, see below for examples.
+	srv.AddTransport(transport.Options{})   // If you are using the playground, it's smart to add Options and GET.
+	srv.AddTransport(transport.GET{})       // ...
+	srv.AddTransport(transport.POST{})      // ... Make sure this is after the WebSocket transport!
 
 	http.Handle("/", playground.Handler("GraphQL playground", "/query"))
 	http.Handle("/query", srv)
@@ -65,6 +68,57 @@ func main() {
 	log.Fatal(http.ListenAndServe(":"+port, nil))
 }
 ```
+
+## Configuring WebSockets
+
+The WebSocket transport is complex, and for any non-trivial application you will need to
+configure it. The transport handles this configuration by setting fields on the `transport.Websocket`
+struct. For an in-depth look at all configuration options, [explore the implementation][code].
+
+At it's most basic, the transport uses [`github.com/gorilla/websocket`][gorilla] to implement
+a WebSocket connection that sets up the subscription and then sends data to the client from
+the Go channel returned by the resolver. The initial handshake and the structure of the data
+payloads are defined by one of two protocols: `graphql-ws` or `graphql-transport-ws` Which
+one is used is negotiated by the client, defaulting to [`graphql-ws`][graphql-ws].
+
+A minimal WebSocket configuration will handle two basic things: keep-alives and security
+checks that are normally handled by HTTP middleware that may not be available or compatible
+with WebSockets:
+
+```go
+srv.AddTransport(transport.Websocket{
+	// Keep-alives are important for WebSockets to detect dead connections. This is
+	// not unlike asking a partner who seems to have zoned out while you tell them
+	// a story crucial to understanding the dynamics of your workplace: "Are you
+	// listening to me?"
+	//
+	// Failing to set a keep-alive interval can result in the connection being held
+	// open and the server expending resources to communicate with a client that has
+	// long since walked to the kitchen to make a sandwich instead.
+	KeepAlivePingInterval: 10 * time.Second,
+
+	// The `github.com/gorilla/websocket.Upgrader` is used to handle the transition
+	// from an HTTP connection to a WebSocket connection. Among other options, here
+	// you must check the origin of the request to prevent cross-site request forgery
+	// attacks.
+	Upgrader: websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool {
+				// Allow exact match on host.
+				origin := r.Header.Get("Origin")
+				if origin == "" || origin == r.Header.Get("Host") {
+					return true
+				}
+
+				// Match on allow-listed origins.
+				return slices.Contains([]string{":3000", "https://ui.mysite.com"}, origin)
+		},
+	},
+})
+```
+
+[code]: https://github.com/99designs/gqlgen/blob/master/graphql/handler/transport/websocket.go
+[gorilla]: https://pkg.go.dev/github.com/gorilla/websocket
+[graphql-ws]: https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md
 
 ## Adding Subscriptions to your Schema
 
@@ -144,9 +198,9 @@ func (r *subscriptionResolver) CurrentTime(ctx context.Context) (<-chan *model.T
 				fmt.Println("Subscription Closed")
 				// Handle deregistration of the channel here. `close(ch)`
 				return // Remember to return to end the routine.
-			
+
 			case ch <- t: // This is the actual send.
-				// Our message went through, do nothing	
+				// Our message went through, do nothing
 			}
 		}
 	}()
@@ -177,6 +231,7 @@ second. To gracefully stop the connection click the `Execute query` button again
 
 
 ## Adding Server-Sent Events transport
+
 You can use instead of WebSocket (or in addition) [Server-Sent Events](https://en.wikipedia.org/wiki/Server-sent_events)
 as transport for subscriptions. This can have advantages and disadvantages over transport via WebSocket and requires a
 compatible client library, for instance [graphql-sse](https://github.com/enisdenjo/graphql-sse). The connection between
@@ -184,25 +239,21 @@ server and client should be HTTP/2+. The client must send the subscription reque
 the header `accept: text/event-stream` and `content-type: application/json` in order to be accepted by the SSE transport.
 The underling protocol is documented at [distinct connections mode](https://github.com/enisdenjo/graphql-sse/blob/master/PROTOCOL.md).
 
-Add the SSE transport as first of all other transports, as the order is important. For that reason, `New` instead of
-`NewDefaultServer` will be used.
+Add the SSE transport as first of all other transports, as the order is important.
+
 ```go
 srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: &graph.Resolver{}}))
-srv.AddTransport(transport.SSE{}) // <---- This is the important
 
-// default server
+srv.AddTransport(transport.SSE{}) // Add SSE first.
+
+// Continue server setup:
 srv.AddTransport(transport.Options{})
 srv.AddTransport(transport.GET{})
 srv.AddTransport(transport.POST{})
-srv.AddTransport(transport.MultipartForm{})
-srv.SetQueryCache(lru.New(1000))
-srv.Use(extension.Introspection{})
-srv.Use(extension.AutomaticPersistedQuery{
-	Cache: lru.New(100),
-})
 ```
 
 The GraphQL playground does not support SSE yet. You can try out the subscription via curl:
+
 ```bash
 curl -N --request POST --url http://localhost:8080/query \
 --data '{"query":"subscription { currentTime { unixTime timeStamp } }"}' \
@@ -224,7 +275,10 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"slices"
+	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
@@ -240,9 +294,27 @@ func main() {
 		port = defaultPort
 	}
 
-	srv := handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: &graph.Resolver{}}))
-
-	srv.AddTransport(&transport.Websocket{})
+	srv := handler.New(
+		generated.NewExecutableSchema(
+			generated.Config{Resolvers: &graph.Resolver{}},
+		),
+	)
+	srv.AddTransport(transport.SSE{})
+	srv.AddTransport(transport.Websocket{
+		KeepAlivePingInterval: 10 * time.Second,
+		Upgrader: websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool {
+					origin := r.Header.Get("Origin")
+					if origin == "" || origin == r.Header.Get("Host") {
+						return true
+					}
+					return slices.Contains([]string{":3000", "https://ui.mysite.com"}, origin)
+			},
+		},
+	})
+	srv.AddTransport(transport.Options{})
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
 
 	http.Handle("/", playground.Handler("GraphQL playground", "/query"))
 	http.Handle("/query", srv)
@@ -312,10 +384,10 @@ func (r *subscriptionResolver) CurrentTime(ctx context.Context) (<-chan *model.T
 
 			select {
 			case <-ctx.Done():
-				// Exit on cancellation 
+				// Exit on cancellation
 				fmt.Println("Subscription closed.")
 				return
-			
+
 			case ch <- t:
 				// Our message went through, do nothing
 			}

--- a/docs/content/reference/complexity.md
+++ b/docs/content/reference/complexity.md
@@ -49,8 +49,11 @@ Limiting query complexity is as simple as specifying it with the provided extens
 func main() {
 	c := Config{ Resolvers: &resolvers{} }
 
-	srv := handler.NewDefaultServer(blog.NewExecutableSchema(c))
+	srv := handler.New(blog.NewExecutableSchema(c))
+	// Server setup...
+
 	srv.Use(extension.FixedComplexityLimit(5)) // This line is key
+
 	r.Handle("/query", srv)
 }
 ```
@@ -73,7 +76,8 @@ func main() {
 	c.Complexity.Query.Posts = countComplexity
 	c.Complexity.Post.Related = countComplexity
 
-	srv := handler.NewDefaultServer(blog.NewExecutableSchema(c))
+	srv := handler.New(blog.NewExecutableSchema(c))
+	srv.AddTransport(transport.POST{})
 	srv.Use(extension.FixedComplexityLimit(5))
 	http.Handle("/query", gqlHandler)
 }

--- a/docs/content/reference/dataloaders.md
+++ b/docs/content/reference/dataloaders.md
@@ -168,10 +168,13 @@ func GetUsers(ctx context.Context, userIDs []string) ([]*model.User, error) {
 Add the dataloader middleware to your server...
 ```go
 // create the query handler
-var srv http.Handler = handler.NewDefaultServer(generated.NewExecutableSchema(...))
+h := handler.New(generated.NewExecutableSchema(...))
+h.AddTransport(transport.POST{})
+
 // wrap the query handler with middleware to inject dataloader in requests.
 // pass in your dataloader dependencies, in this case the db connection.
-srv = loaders.Middleware(db, srv)
+srv = loaders.Middleware(db, h)
+
 // register the wrapped handler
 http.Handle("/query", srv)
 ```

--- a/docs/content/reference/errors.md
+++ b/docs/content/reference/errors.md
@@ -137,7 +137,10 @@ import (
 )
 
 func main() {
-	server := handler.NewDefaultServer(MakeExecutableSchema(resolvers))
+	server := handler.New(MakeExecutableSchema(resolvers))
+
+	// Server setup...
+
 	server.SetErrorPresenter(func(ctx context.Context, e error) *gqlerror.Error {
 		err := graphql.DefaultErrorPresenter(ctx, e)
 
@@ -164,9 +167,12 @@ returned from here will also go through the error presenter.
 
 You change this when creating the server:
 ```go
-server := handler.NewDefaultServer(MakeExecutableSchema(resolvers))
+server := handler.New(MakeExecutableSchema(resolvers))
+
+// Server setup...
+
 server.SetRecoverFunc(func(ctx context.Context, err interface{}) error {
-    // notify bug tracker...
+    // Notify bug tracker...
 
 		return gqlerror.Errorf("Internal server error!")
 })

--- a/graphql/handler/server.go
+++ b/graphql/handler/server.go
@@ -31,6 +31,21 @@ func New(es graphql.ExecutableSchema) *Server {
 	}
 }
 
+// NewDefaultServer is a demonstration only. Not for prod.
+//
+// Currently, the server just picks the first available transport,
+// so this example NewDefaultServer orders them, but it is just
+// for demonstration purposes.
+// You will likely want to tune and better configure Websocket transport
+// since adding a new one (To configure it) doesn't have effect.
+//
+// Also SSE support is not in here at all!
+// SSE when used over HTTP/1.1 (but not HTTP/2 or HTTP/3),
+// SSE suffers from a severe limitation to the maximum number
+// of open connections of 6 per browser. See:
+// https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#sect1
+//
+// Deprecated: This was and is just an example.
 func NewDefaultServer(es graphql.ExecutableSchema) *Server {
 	srv := New(es)
 

--- a/plugin/federation/federation_computedrequires_test.go
+++ b/plugin/federation/federation_computedrequires_test.go
@@ -4,6 +4,7 @@ package federation
 import (
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -13,11 +14,13 @@ import (
 )
 
 func TestComputedRequires(t *testing.T) {
-	c := client.New(handler.NewDefaultServer(
+	srv := handler.New(
 		generated.NewExecutableSchema(generated.Config{
 			Resolvers: &computedrequires.Resolver{},
 		}),
-	))
+	)
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("PlanetRequires entities with requires directive", func(t *testing.T) {
 		representations := []map[string]any{
@@ -134,11 +137,13 @@ func TestComputedRequires(t *testing.T) {
 }
 
 func TestMultiComputedRequires(t *testing.T) {
-	c := client.New(handler.NewDefaultServer(
+	srv := handler.New(
 		generated.NewExecutableSchema(generated.Config{
 			Resolvers: &computedrequires.Resolver{},
 		}),
-	))
+	)
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("MultiHelloRequires entities with requires directive", func(t *testing.T) {
 		representations := []map[string]any{

--- a/plugin/federation/federation_entityresolver_test.go
+++ b/plugin/federation/federation_entityresolver_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -16,11 +17,13 @@ import (
 )
 
 func TestEntityResolver(t *testing.T) {
-	c := client.New(handler.NewDefaultServer(
+	srv := handler.New(
 		generated.NewExecutableSchema(generated.Config{
 			Resolvers: &entityresolver.Resolver{},
 		}),
-	))
+	)
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("Hello entities", func(t *testing.T) {
 		representations := []map[string]any{
@@ -391,11 +394,13 @@ func TestEntityResolver(t *testing.T) {
 }
 
 func TestMultiEntityResolver(t *testing.T) {
-	c := client.New(handler.NewDefaultServer(
+	srv := handler.New(
 		generated.NewExecutableSchema(generated.Config{
 			Resolvers: &entityresolver.Resolver{},
 		}),
-	))
+	)
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("MultiHello entities", func(t *testing.T) {
 		itemCount := 10

--- a/plugin/federation/federation_explicitrequires_test.go
+++ b/plugin/federation/federation_explicitrequires_test.go
@@ -4,6 +4,7 @@ package federation
 import (
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
@@ -13,11 +14,13 @@ import (
 )
 
 func TestExplicitRequires(t *testing.T) {
-	c := client.New(handler.NewDefaultServer(
+	srv := handler.New(
 		generated.NewExecutableSchema(generated.Config{
 			Resolvers: &explicitrequires.Resolver{},
 		}),
-	))
+	)
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("PlanetRequires entities with requires directive", func(t *testing.T) {
 		representations := []map[string]any{
@@ -137,11 +140,13 @@ func TestExplicitRequires(t *testing.T) {
 }
 
 func TestMultiExplicitRequires(t *testing.T) {
-	c := client.New(handler.NewDefaultServer(
+	srv := handler.New(
 		generated.NewExecutableSchema(generated.Config{
 			Resolvers: &explicitrequires.Resolver{},
 		}),
-	))
+	)
+	srv.AddTransport(transport.POST{})
+	c := client.New(srv)
 
 	t.Run("MultiHelloRequires entities with requires directive", func(t *testing.T) {
 		representations := []map[string]any{

--- a/plugin/federation/testdata/computedrequires/main/server.go
+++ b/plugin/federation/testdata/computedrequires/main/server.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/debug"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/99designs/gqlgen/plugin/federation/testdata/computedrequires"
 	"github.com/99designs/gqlgen/plugin/federation/testdata/computedrequires/generated"
@@ -20,7 +21,11 @@ func main() {
 		port = defaultPort
 	}
 
-	srv := handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: &computedrequires.Resolver{}}))
+	srv := handler.New(
+		generated.NewExecutableSchema(generated.Config{Resolvers: &computedrequires.Resolver{}}),
+	)
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
 	srv.Use(&debug.Tracer{})
 
 	http.Handle("/", playground.Handler("GraphQL playground", "/query"))

--- a/plugin/resolvergen/testdata/filetemplate/out/schema.custom.go
+++ b/plugin/resolvergen/testdata/filetemplate/out/schema.custom.go
@@ -33,12 +33,6 @@ func (r *CustomResolverType) Resolver() customresolver.ResolverResolver {
 type queryCustomResolverType struct{ *CustomResolverType }
 type resolverCustomResolverType struct{ *CustomResolverType }
 
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//     it when you're done.
-//   - You have helper methods in this file. Move them out to keep these resolver files clean.
 func AUserHelperFunction() {
 	// AUserHelperFunction implementation
 }

--- a/plugin/resolvergen/testdata/followschema/out/schema.resolvers.go
+++ b/plugin/resolvergen/testdata/followschema/out/schema.resolvers.go
@@ -33,12 +33,6 @@ func (r *CustomResolverType) Resolver() customresolver.ResolverResolver {
 type queryCustomResolverType struct{ *CustomResolverType }
 type resolverCustomResolverType struct{ *CustomResolverType }
 
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//     it when you're done.
-//   - You have helper methods in this file. Move them out to keep these resolver files clean.
 func AUserHelperFunction() {
 	// AUserHelperFunction implementation
 }

--- a/plugin/servergen/server.gotpl
+++ b/plugin/servergen/server.gotpl
@@ -2,8 +2,12 @@
 {{ reserveImport "log" }}
 {{ reserveImport "net/http" }}
 {{ reserveImport "os" }}
+{{ reserveImport "github.com/vektah/gqlparser/v2/ast" }}
 {{ reserveImport "github.com/99designs/gqlgen/graphql/playground" }}
 {{ reserveImport "github.com/99designs/gqlgen/graphql/handler" }}
+{{ reserveImport "github.com/99designs/gqlgen/graphql/handler/extension" }}
+{{ reserveImport "github.com/99designs/gqlgen/graphql/handler/lru" }}
+{{ reserveImport "github.com/99designs/gqlgen/graphql/handler/transport" }}
 
 const defaultPort = "8080"
 
@@ -13,7 +17,18 @@ func main() {
 		port = defaultPort
 	}
 
-	srv := handler.NewDefaultServer({{ lookupImport .ExecPackageName }}.NewExecutableSchema({{ lookupImport .ExecPackageName}}.Config{Resolvers: &{{ lookupImport .ResolverPackageName}}.Resolver{}}))
+	srv := handler.New({{ lookupImport .ExecPackageName }}.NewExecutableSchema({{ lookupImport .ExecPackageName}}.Config{Resolvers: &{{ lookupImport .ResolverPackageName}}.Resolver{}}))
+
+	srv.AddTransport(transport.Options{})
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
+
+	srv.SetQueryCache(lru.New[*ast.QueryDocument](1000))
+
+	srv.Use(extension.Introspection{})
+	srv.Use(extension.AutomaticPersistedQuery{
+		Cache: lru.New[string](100),
+	})
 
 	http.Handle("/", playground.Handler("GraphQL playground", "/query"))
 	http.Handle("/query", srv)


### PR DESCRIPTION
This was only there for tests and as an example, but people have tried to use it in their production environments and found out the hard way it wasn't intended for that. Deprecating will hopefully make this more clear.

However, all the deprecation warnings for all the test usage cause the linter to fail. 😢 

I don't know of a great solution, so if you have a suggestion for how to fix this, I would appreciate it.

I'm not sure of a great way to make a test only equivalent function without using a special build constraint tag that would then cause more people to stumble on more regular `go test ./...` 

I could add a `//nolint:staticcheck // SA1019: handler.NewDefaultServer is deprecated but usage for test is ok` everywhere, but that ignores **_all_** staticcheck checks, not just the deprecation one.

I could copy-paste the NewDefaultserver function to be nested inside the various call sites, but that's a lot of duplication.

Signed-off-by: Steve Coffman <steve@khanacademy.org>
