### PR TITLE
Follow up to compliant Int work

### DIFF
--- a/codegen/testserver/compliant-int/compliant_int_test.go
+++ b/codegen/testserver/compliant-int/compliant_int_test.go
@@ -158,7 +158,7 @@ func TestIntegration(t *testing.T) {
 			}
 			err := c.Post(`query { echoIntToInt(n: 2147483648) }`, &resp)
 			if tc.willError {
-				require.EqualError(t, err, `[{"message":"2147483648 overflows 32-bit integer","path":["echoIntToInt","n"]}]`)
+				require.EqualError(t, err, `[{"message":"2147483648 overflows signed 32-bit integer","path":["echoIntToInt","n"]}]`)
 				require.Equal(t, 0, resp.EchoIntToInt)
 				return
 			}

--- a/graphql/int_test.go
+++ b/graphql/int_test.go
@@ -96,7 +96,7 @@ func mustUnmarshalInt32(t *testing.T, v any) int32 {
 
 func TestInt64(t *testing.T) {
 	t.Run("marshal", func(t *testing.T) {
-		assert.Equal(t, "123", m2s(MarshalInt(123)))
+		assert.Equal(t, "123", m2s(MarshalInt64(123)))
 	})
 
 	t.Run("unmarshal", func(t *testing.T) {

--- a/graphql/int_test.go
+++ b/graphql/int_test.go
@@ -45,9 +45,6 @@ func TestInt32(t *testing.T) {
 	})
 
 	t.Run("overflow", func(t *testing.T) {
-		var int32OverflowErr *Int32OverflowError
-		var intErr *IntegerError
-
 		cases := []struct {
 			name string
 			v    any
@@ -64,6 +61,9 @@ func TestInt32(t *testing.T) {
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
+				var int32OverflowErr *Int32OverflowError
+				var intErr *IntegerError
+
 				res, err := UnmarshalInt32(tc.v)
 				assert.EqualError(t, err, tc.err)         //nolint:testifylint // An error assertion makes more sense.
 				assert.ErrorAs(t, err, &int32OverflowErr) //nolint:testifylint // An error assertion makes more sense.
@@ -71,6 +71,20 @@ func TestInt32(t *testing.T) {
 				assert.Equal(t, int32(0), res)
 			})
 		}
+	})
+
+	t.Run("invalid string numbers are not integer errors", func(t *testing.T) {
+		var intErr *IntegerError
+
+		res, err := UnmarshalInt32("-1.03")
+		assert.EqualError(t, err, "strconv.ParseInt: parsing \"-1.03\": invalid syntax") //nolint:testifylint // An error assertion makes more sense.
+		assert.NotErrorAs(t, err, &intErr)
+		assert.Equal(t, int32(0), res)
+
+		res, err = UnmarshalInt32(json.Number(" 1"))
+		assert.EqualError(t, err, "strconv.ParseInt: parsing \" 1\": invalid syntax") //nolint:testifylint // An error assertion makes more sense.
+		assert.NotErrorAs(t, err, &intErr)
+		assert.Equal(t, int32(0), res)
 	})
 }
 
@@ -82,7 +96,7 @@ func mustUnmarshalInt32(t *testing.T, v any) int32 {
 
 func TestInt64(t *testing.T) {
 	t.Run("marshal", func(t *testing.T) {
-		assert.Equal(t, "123", m2s(MarshalInt32(123)))
+		assert.Equal(t, "123", m2s(MarshalInt(123)))
 	})
 
 	t.Run("unmarshal", func(t *testing.T) {

--- a/graphql/int_test.go
+++ b/graphql/int_test.go
@@ -65,9 +65,9 @@ func TestInt32(t *testing.T) {
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
 				res, err := UnmarshalInt32(tc.v)
-				assert.EqualError(t, err, tc.err) //nolint:testifylint // An error assertion makes more sense.
-				assert.ErrorAs(t, err, &int32OverflowErr)
-				assert.ErrorAs(t, err, &intErr)
+				assert.EqualError(t, err, tc.err)         //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &int32OverflowErr) //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &intErr)           //nolint:testifylint // An error assertion makes more sense.
 				assert.Equal(t, int32(0), res)
 			})
 		}

--- a/graphql/int_test.go
+++ b/graphql/int_test.go
@@ -15,6 +15,7 @@ func TestInt(t *testing.T) {
 	})
 
 	t.Run("unmarshal", func(t *testing.T) {
+		assert.Equal(t, 0, mustUnmarshalInt(t, nil))
 		assert.Equal(t, 123, mustUnmarshalInt(t, 123))
 		assert.Equal(t, 123, mustUnmarshalInt(t, int64(123)))
 		assert.Equal(t, 123, mustUnmarshalInt(t, json.Number("123")))
@@ -35,6 +36,7 @@ func TestInt32(t *testing.T) {
 	})
 
 	t.Run("unmarshal", func(t *testing.T) {
+		assert.Equal(t, int32(0), mustUnmarshalInt32(t, nil))
 		assert.Equal(t, int32(123), mustUnmarshalInt32(t, 123))
 		assert.Equal(t, int32(123), mustUnmarshalInt32(t, int64(123)))
 		assert.Equal(t, int32(123), mustUnmarshalInt32(t, json.Number("123")))
@@ -43,24 +45,29 @@ func TestInt32(t *testing.T) {
 	})
 
 	t.Run("overflow", func(t *testing.T) {
+		var int32OverflowErr *Int32OverflowError
+		var intErr *IntegerError
+
 		cases := []struct {
 			name string
 			v    any
 			err  string
 		}{
-			{"positive int overflow", math.MaxInt32 + 1, "2147483648 overflows 32-bit integer"},
-			{"negative int overflow", math.MinInt32 - 1, "-2147483649 overflows 32-bit integer"},
-			{"positive int overflow", int64(math.MaxInt32 + 1), "2147483648 overflows 32-bit integer"},
-			{"negative int overflow", int64(math.MinInt32 - 1), "-2147483649 overflows 32-bit integer"},
-			{"positive json.Number overflow", json.Number("2147483648"), "2147483648 overflows 32-bit integer"},
-			{"negative json.Number overflow", json.Number("-2147483649"), "-2147483649 overflows 32-bit integer"},
-			{"positive string overflow", "2147483648", "2147483648 overflows 32-bit integer"},
-			{"negative string overflow", "-2147483649", "-2147483649 overflows 32-bit integer"},
+			{"positive int overflow", math.MaxInt32 + 1, "2147483648 overflows signed 32-bit integer"},
+			{"negative int overflow", math.MinInt32 - 1, "-2147483649 overflows signed 32-bit integer"},
+			{"positive int64 overflow", int64(math.MaxInt32 + 1), "2147483648 overflows signed 32-bit integer"},
+			{"negative int64 overflow", int64(math.MinInt32 - 1), "-2147483649 overflows signed 32-bit integer"},
+			{"positive json.Number overflow", json.Number("2147483648"), "2147483648 overflows signed 32-bit integer"},
+			{"negative json.Number overflow", json.Number("-2147483649"), "-2147483649 overflows signed 32-bit integer"},
+			{"positive string overflow", "2147483648", "2147483648 overflows signed 32-bit integer"},
+			{"negative string overflow", "-2147483649", "-2147483649 overflows signed 32-bit integer"},
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
 				res, err := UnmarshalInt32(tc.v)
 				assert.EqualError(t, err, tc.err) //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &int32OverflowErr)
+				assert.ErrorAs(t, err, &intErr)
 				assert.Equal(t, int32(0), res)
 			})
 		}
@@ -79,6 +86,7 @@ func TestInt64(t *testing.T) {
 	})
 
 	t.Run("unmarshal", func(t *testing.T) {
+		assert.Equal(t, int64(0), mustUnmarshalInt64(t, nil))
 		assert.Equal(t, int64(123), mustUnmarshalInt64(t, 123))
 		assert.Equal(t, int64(123), mustUnmarshalInt64(t, int64(123)))
 		assert.Equal(t, int64(123), mustUnmarshalInt64(t, json.Number("123")))

--- a/graphql/uint.go
+++ b/graphql/uint.go
@@ -161,7 +161,7 @@ func (e *UintSignError) Unwrap() error {
 }
 
 func isSignedInteger(v string) bool {
-	if len(v) == 0 {
+	if v == "" {
 		return false
 	}
 	if v[0] != '-' && v[0] != '+' {

--- a/graphql/uint.go
+++ b/graphql/uint.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"strconv"
 )
 
@@ -18,21 +19,33 @@ func UnmarshalUint(v any) (uint, error) {
 	switch v := v.(type) {
 	case string:
 		u64, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
+			var strconvErr *strconv.NumError
+			if errors.As(err, &strconvErr) && isSignedInteger(v) {
+				return 0, newUintSignError(v)
+			}
+			return 0, err
+		}
 		return uint(u64), err
 	case int:
 		if v < 0 {
-			return 0, errors.New("cannot convert negative numbers to uint")
+			return 0, newUintSignError(strconv.FormatInt(int64(v), 10))
 		}
-
 		return uint(v), nil
 	case int64:
 		if v < 0 {
-			return 0, errors.New("cannot convert negative numbers to uint")
+			return 0, newUintSignError(strconv.FormatInt(v, 10))
 		}
-
 		return uint(v), nil
 	case json.Number:
 		u64, err := strconv.ParseUint(string(v), 10, 64)
+		if err != nil {
+			var strconvErr *strconv.NumError
+			if errors.As(err, &strconvErr) && isSignedInteger(string(v)) {
+				return 0, newUintSignError(string(v))
+			}
+			return 0, err
+		}
 		return uint(u64), err
 	case nil:
 		return 0, nil
@@ -50,21 +63,35 @@ func MarshalUint64(i uint64) Marshaler {
 func UnmarshalUint64(v any) (uint64, error) {
 	switch v := v.(type) {
 	case string:
-		return strconv.ParseUint(v, 10, 64)
+		i, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
+			var strconvErr *strconv.NumError
+			if errors.As(err, &strconvErr) && isSignedInteger(v) {
+				return 0, newUintSignError(v)
+			}
+			return 0, err
+		}
+		return i, nil
 	case int:
 		if v < 0 {
-			return 0, errors.New("cannot convert negative numbers to uint64")
+			return 0, newUintSignError(strconv.FormatInt(int64(v), 10))
 		}
-
 		return uint64(v), nil
 	case int64:
 		if v < 0 {
-			return 0, errors.New("cannot convert negative numbers to uint64")
+			return 0, newUintSignError(strconv.FormatInt(v, 10))
 		}
-
 		return uint64(v), nil
 	case json.Number:
-		return strconv.ParseUint(string(v), 10, 64)
+		i, err := strconv.ParseUint(string(v), 10, 64)
+		if err != nil {
+			var strconvErr *strconv.NumError
+			if errors.As(err, &strconvErr) && isSignedInteger(string(v)) {
+				return 0, newUintSignError(string(v))
+			}
+			return 0, err
+		}
+		return i, nil
 	case nil:
 		return 0, nil
 	default:
@@ -81,32 +108,92 @@ func MarshalUint32(i uint32) Marshaler {
 func UnmarshalUint32(v any) (uint32, error) {
 	switch v := v.(type) {
 	case string:
-		iv, err := strconv.ParseUint(v, 10, 32)
+		iv, err := strconv.ParseUint(v, 10, 64)
 		if err != nil {
+			var strconvErr *strconv.NumError
+			if errors.As(err, &strconvErr) && isSignedInteger(v) {
+				return 0, newUintSignError(v)
+			}
 			return 0, err
 		}
-		return uint32(iv), nil
+		return safeCastUint32(iv)
 	case int:
 		if v < 0 {
-			return 0, errors.New("cannot convert negative numbers to uint32")
+			return 0, newUintSignError(strconv.FormatInt(int64(v), 10))
 		}
-
-		return uint32(v), nil
+		return safeCastUint32(uint64(v))
 	case int64:
 		if v < 0 {
-			return 0, errors.New("cannot convert negative numbers to uint32")
+			return 0, newUintSignError(strconv.FormatInt(v, 10))
 		}
-
-		return uint32(v), nil
+		return safeCastUint32(uint64(v))
 	case json.Number:
-		iv, err := strconv.ParseUint(string(v), 10, 32)
+		iv, err := strconv.ParseUint(string(v), 10, 64)
 		if err != nil {
+			var strconvErr *strconv.NumError
+			if errors.As(err, &strconvErr) && isSignedInteger(string(v)) {
+				return 0, newUintSignError(string(v))
+			}
 			return 0, err
 		}
-		return uint32(iv), nil
+		return safeCastUint32(iv)
 	case nil:
 		return 0, nil
 	default:
 		return 0, fmt.Errorf("%T is not an uint", v)
 	}
+}
+
+type UintSignError struct {
+	*IntegerError
+}
+
+func newUintSignError(v string) *UintSignError {
+	return &UintSignError{
+		IntegerError: &IntegerError{
+			Message: fmt.Sprintf("%v is an invalid unsigned integer: includes sign", v),
+		},
+	}
+}
+
+func (e *UintSignError) Unwrap() error {
+	return e.IntegerError
+}
+
+func isSignedInteger(v string) bool {
+	if len(v) == 0 {
+		return false
+	}
+	if v[0] != '-' && v[0] != '+' {
+		return false
+	}
+	if _, err := strconv.ParseUint(v[1:], 10, 64); err == nil {
+		return true
+	}
+	return false
+}
+
+type Uint32OverflowError struct {
+	Value uint64
+	*IntegerError
+}
+
+func newUint32OverflowError(i uint64) *Uint32OverflowError {
+	return &Uint32OverflowError{
+		Value: i,
+		IntegerError: &IntegerError{
+			Message: fmt.Sprintf("%d overflows unsigned 32-bit integer", i),
+		},
+	}
+}
+
+func (e *Uint32OverflowError) Unwrap() error {
+	return e.IntegerError
+}
+
+func safeCastUint32(i uint64) (uint32, error) {
+	if i > math.MaxUint32 {
+		return 0, newUint32OverflowError(i)
+	}
+	return uint32(i), nil
 }

--- a/graphql/uint_test.go
+++ b/graphql/uint_test.go
@@ -22,9 +22,6 @@ func TestUint(t *testing.T) {
 	})
 
 	t.Run("can't unmarshal negative numbers", func(t *testing.T) {
-		var uintSignErr *UintSignError
-		var intErr *IntegerError
-
 		cases := []struct {
 			name string
 			v    any
@@ -37,6 +34,9 @@ func TestUint(t *testing.T) {
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
+				var uintSignErr *UintSignError
+				var intErr *IntegerError
+
 				res, err := UnmarshalUint(tc.v)
 				assert.EqualError(t, err, tc.err)    //nolint:testifylint // An error assertion makes more sense.
 				assert.ErrorAs(t, err, &uintSignErr) //nolint:testifylint // An error assertion makes more sense.
@@ -47,14 +47,27 @@ func TestUint(t *testing.T) {
 	})
 
 	t.Run("invalid string numbers are not integer errors", func(t *testing.T) {
-		var uintSignErr *UintSignError
-		var intErr *IntegerError
+		cases := []struct {
+			name string
+			v    any
+			err  string
+		}{
+			{"empty", "", `strconv.ParseUint: parsing "": invalid syntax`},
+			{"string", "-1.03", `strconv.ParseUint: parsing "-1.03": invalid syntax`},
+			{"json number", json.Number(" 1"), `strconv.ParseUint: parsing " 1": invalid syntax`},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				var uintSignErr *UintSignError
+				var intErr *IntegerError
 
-		res, err := UnmarshalUint("-1.03")
-		assert.EqualError(t, err, "strconv.ParseUint: parsing \"-1.03\": invalid syntax") //nolint:testifylint // An error assertion makes more sense.
-		assert.NotErrorAs(t, err, &uintSignErr)
-		assert.NotErrorAs(t, err, &intErr)
-		assert.Equal(t, uint(0), res)
+				res, err := UnmarshalUint(tc.v)
+				assert.EqualError(t, err, tc.err) //nolint:testifylint // An error assertion makes more sense.
+				assert.NotErrorAs(t, err, &uintSignErr)
+				assert.NotErrorAs(t, err, &intErr)
+				assert.Equal(t, uint(0), res)
+			})
+		}
 	})
 }
 
@@ -82,8 +95,6 @@ func TestUint32(t *testing.T) {
 	})
 
 	t.Run("can't unmarshal negative numbers", func(t *testing.T) {
-		var uintSignErr *UintSignError
-		var intErr *IntegerError
 
 		cases := []struct {
 			name string
@@ -97,6 +108,9 @@ func TestUint32(t *testing.T) {
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
+				var uintSignErr *UintSignError
+				var intErr *IntegerError
+
 				res, err := UnmarshalUint32(tc.v)
 				assert.EqualError(t, err, tc.err)    //nolint:testifylint // An error assertion makes more sense.
 				assert.ErrorAs(t, err, &uintSignErr) //nolint:testifylint // An error assertion makes more sense.
@@ -115,12 +129,15 @@ func TestUint32(t *testing.T) {
 		assert.NotErrorAs(t, err, &uintSignErr)
 		assert.NotErrorAs(t, err, &intErr)
 		assert.Equal(t, uint32(0), res)
+
+		res, err = UnmarshalUint32(json.Number(" 1"))
+		assert.EqualError(t, err, "strconv.ParseUint: parsing \" 1\": invalid syntax") //nolint:testifylint // An error assertion makes more sense.
+		assert.NotErrorAs(t, err, &uintSignErr)
+		assert.NotErrorAs(t, err, &intErr)
+		assert.Equal(t, uint32(0), res)
 	})
 
 	t.Run("overflow", func(t *testing.T) {
-		var uint32OverflowErr *Uint32OverflowError
-		var intErr *IntegerError
-
 		cases := []struct {
 			name string
 			v    any
@@ -133,6 +150,9 @@ func TestUint32(t *testing.T) {
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
+				var uint32OverflowErr *Uint32OverflowError
+				var intErr *IntegerError
+
 				res, err := UnmarshalUint32(tc.v)
 				assert.EqualError(t, err, tc.err)          //nolint:testifylint // An error assertion makes more sense.
 				assert.ErrorAs(t, err, &uint32OverflowErr) //nolint:testifylint // An error assertion makes more sense.
@@ -165,9 +185,6 @@ func TestUint64(t *testing.T) {
 	})
 
 	t.Run("can't unmarshal negative numbers", func(t *testing.T) {
-		var uintSignErr *UintSignError
-		var intErr *IntegerError
-
 		cases := []struct {
 			name string
 			v    any
@@ -180,6 +197,9 @@ func TestUint64(t *testing.T) {
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
+				var uintSignErr *UintSignError
+				var intErr *IntegerError
+
 				res, err := UnmarshalUint64(tc.v)
 				assert.EqualError(t, err, tc.err)    //nolint:testifylint // An error assertion makes more sense.
 				assert.ErrorAs(t, err, &uintSignErr) //nolint:testifylint // An error assertion makes more sense.
@@ -195,6 +215,12 @@ func TestUint64(t *testing.T) {
 
 		res, err := UnmarshalUint64("-1.03")
 		assert.EqualError(t, err, "strconv.ParseUint: parsing \"-1.03\": invalid syntax") //nolint:testifylint // An error assertion makes more sense.
+		assert.NotErrorAs(t, err, &uintSignErr)
+		assert.NotErrorAs(t, err, &intErr)
+		assert.Equal(t, uint64(0), res)
+
+		res, err = UnmarshalUint64(json.Number(" 1"))
+		assert.EqualError(t, err, "strconv.ParseUint: parsing \" 1\": invalid syntax") //nolint:testifylint // An error assertion makes more sense.
 		assert.NotErrorAs(t, err, &uintSignErr)
 		assert.NotErrorAs(t, err, &intErr)
 		assert.Equal(t, uint64(0), res)

--- a/graphql/uint_test.go
+++ b/graphql/uint_test.go
@@ -95,7 +95,6 @@ func TestUint32(t *testing.T) {
 	})
 
 	t.Run("can't unmarshal negative numbers", func(t *testing.T) {
-
 		cases := []struct {
 			name string
 			v    any

--- a/graphql/uint_test.go
+++ b/graphql/uint_test.go
@@ -38,9 +38,9 @@ func TestUint(t *testing.T) {
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
 				res, err := UnmarshalUint(tc.v)
-				assert.EqualError(t, err, tc.err) //nolint:testifylint // An error assertion makes more sense.
-				assert.ErrorAs(t, err, &uintSignErr)
-				assert.ErrorAs(t, err, &intErr)
+				assert.EqualError(t, err, tc.err)    //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &uintSignErr) //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &intErr)      //nolint:testifylint // An error assertion makes more sense.
 				assert.Equal(t, uint(0), res)
 			})
 		}
@@ -98,9 +98,9 @@ func TestUint32(t *testing.T) {
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
 				res, err := UnmarshalUint32(tc.v)
-				assert.EqualError(t, err, tc.err) //nolint:testifylint // An error assertion makes more sense.
-				assert.ErrorAs(t, err, &uintSignErr)
-				assert.ErrorAs(t, err, &intErr)
+				assert.EqualError(t, err, tc.err)    //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &uintSignErr) //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &intErr)      //nolint:testifylint // An error assertion makes more sense.
 				assert.Equal(t, uint32(0), res)
 			})
 		}
@@ -134,9 +134,9 @@ func TestUint32(t *testing.T) {
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
 				res, err := UnmarshalUint32(tc.v)
-				assert.EqualError(t, err, tc.err) //nolint:testifylint // An error assertion makes more sense.
-				assert.ErrorAs(t, err, &uint32OverflowErr)
-				assert.ErrorAs(t, err, &intErr)
+				assert.EqualError(t, err, tc.err)          //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &uint32OverflowErr) //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &intErr)            //nolint:testifylint // An error assertion makes more sense.
 				assert.Equal(t, uint32(0), res)
 			})
 		}
@@ -181,9 +181,9 @@ func TestUint64(t *testing.T) {
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
 				res, err := UnmarshalUint64(tc.v)
-				assert.EqualError(t, err, tc.err) //nolint:testifylint // An error assertion makes more sense.
-				assert.ErrorAs(t, err, &uintSignErr)
-				assert.ErrorAs(t, err, &intErr)
+				assert.EqualError(t, err, tc.err)    //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &uintSignErr) //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &intErr)      //nolint:testifylint // An error assertion makes more sense.
 				assert.Equal(t, uint64(0), res)
 			})
 		}

--- a/init-templates/gqlgen.yml.gotmpl
+++ b/init-templates/gqlgen.yml.gotmpl
@@ -131,11 +131,6 @@ models:
       - github.com/99designs/gqlgen/graphql.Int
       - github.com/99designs/gqlgen/graphql.Int64
       - github.com/99designs/gqlgen/graphql.Int32
-  # gqlgen provides a default GraphQL UUID convenience wrapper for github.com/google/uuid 
-  # but you can override this to provide your own GraphQL UUID implementation
-  UUID:
-    model:
-      - github.com/99designs/gqlgen/graphql.UUID
 
   # The GraphQL spec explicitly states that the Int type is a signed 32-bit
   # integer. Using Go int or int64 to represent it can lead to unexpected

--- a/init-templates/gqlgen.yml.gotmpl
+++ b/init-templates/gqlgen.yml.gotmpl
@@ -131,6 +131,11 @@ models:
       - github.com/99designs/gqlgen/graphql.Int
       - github.com/99designs/gqlgen/graphql.Int64
       - github.com/99designs/gqlgen/graphql.Int32
+  # gqlgen provides a default GraphQL UUID convenience wrapper for github.com/google/uuid 
+  # but you can override this to provide your own GraphQL UUID implementation
+  UUID:
+    model:
+      - github.com/99designs/gqlgen/graphql.UUID
 
   # The GraphQL spec explicitly states that the Int type is a signed 32-bit
   # integer. Using Go int or int64 to represent it can lead to unexpected


### PR DESCRIPTION
As [requested](https://github.com/99designs/gqlgen/pull/3409#issuecomment-2525176444), this is a follow up to #3409.

The introduction of the UUID binding in to the `gqlgen init` template was part of aligning this content and the version in the config docs. Since there is already a divergence in the federation section, I think it'd make sense to also remove the UUID from init template, since:

  - as @StevenACoffman stated, there is constant, tedious disagreement over which library to use for parsing UUIDs in Go and that should not be something this codebase has to re-litigate; IMO it is best, therefore, to de-emphasize the built in option for parsing UUIDs;
  - also, IMO, doing UUID parsing in the unmarshaler is an anti-pattern: scalar marshaler/unmarshalers should be focused on simple issues of converting from wire formats to basic data types, and avoid, where possible, validating or parsing to more complex types that could be better handled and communicated about in the resolver. This also leads me to think that the presence of a UUID unmarshaler tied into this codebase should be de-emphasized and eventually deprecated.

~~To that end, this PR removes that line that was added to the template.~~ Ed: reverted.

Additionally, this PR ensures that uint32 unmarshalers return errors if the values they marshal overflow. It also lumps int32, uint32, and uint negative signed numbers into a group of errors that can be "caught" and handled as a class, either via logs/metrics or helpful messages to clients. This can be useful since an API designed to accept only certain types of integers  may drift in scope and start to receive other integers that are valid in theory, but cause confusing errors.

I have:

 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
