### PR TITLE
enable testifylint.encoded-compare and fix lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,6 +65,7 @@ linters-settings:
       - bool-compare
       - compares
       - empty
+      - encoded-compare
       - error-is-as
       - error-nil
       - expected-actual

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -23,7 +23,7 @@ func TestClient(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b, err := io.ReadAll(r.Body)
 		if assert.NoError(t, err) {
-			assert.Equal(t, `{"query":"user(id:$id){name}","variables":{"id":1}}`, string(b))
+			assert.JSONEq(t, `{"query":"user(id:$id){name}","variables":{"id":1}}`, string(b))
 
 			err = json.NewEncoder(w).Encode(map[string]any{
 				"data": map[string]any{
@@ -157,7 +157,7 @@ func TestAddExtensions(t *testing.T) {
 		if !assert.NoError(t, err) {
 			return
 		}
-		assert.Equal(t, `{"query":"user(id:1){name}","extensions":{"persistedQuery":{"sha256Hash":"ceec2897e2da519612279e63f24658c3e91194cbb2974744fa9007a7e1e9f9e7","version":1}}}`, string(b))
+		assert.JSONEq(t, `{"query":"user(id:1){name}","extensions":{"persistedQuery":{"sha256Hash":"ceec2897e2da519612279e63f24658c3e91194cbb2974744fa9007a7e1e9f9e7","version":1}}}`, string(b))
 		err = json.NewEncoder(w).Encode(map[string]any{
 			"data": map[string]any{
 				"Name": "Bob",
@@ -222,7 +222,7 @@ func TestClientWithCustomTarget(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b, err := io.ReadAll(r.Body)
 		if assert.NoError(t, err) {
-			assert.Equal(t, `{"query":"user(id:$id){name}","variables":{"id":1}}`, string(b))
+			assert.JSONEq(t, `{"query":"user(id:$id){name}","variables":{"id":1}}`, string(b))
 
 			err = json.NewEncoder(w).Encode(map[string]any{
 				"data": map[string]any{

--- a/client/withfilesoption_test.go
+++ b/client/withfilesoption_test.go
@@ -56,10 +56,10 @@ func TestWithFiles(t *testing.T) {
 				contentDisposition := p.Header.Get("Content-Disposition")
 
 				if contentDisposition == `form-data; name="operations"` {
-					assert.EqualValues(t, `{"query":"{ id }","variables":{"file":{}}}`, slurp)
+					assert.JSONEq(t, `{"query":"{ id }","variables":{"file":{}}}`, string(slurp))
 				}
 				if contentDisposition == `form-data; name="map"` {
-					assert.EqualValues(t, `{"0":["variables.file"]}`, slurp)
+					assert.JSONEq(t, `{"0":["variables.file"]}`, string(slurp))
 				}
 				if regexp.MustCompile(`form-data; name="0"; filename=.*`).MatchString(contentDisposition) {
 					assert.Equal(t, `text/plain; charset=utf-8`, p.Header.Get("Content-Type"))
@@ -104,7 +104,7 @@ func TestWithFiles(t *testing.T) {
 				contentDisposition := p.Header.Get("Content-Disposition")
 
 				if contentDisposition == `form-data; name="operations"` {
-					assert.EqualValues(t, `{"query":"{ id }","variables":{"input":{"files":[{},{}]}}}`, slurp)
+					assert.JSONEq(t, `{"query":"{ id }","variables":{"input":{"files":[{},{}]}}}`, string(slurp))
 				}
 				if contentDisposition == `form-data; name="map"` {
 					// returns `{"0":["variables.input.files.0"],"1":["variables.input.files.1"]}`
@@ -163,7 +163,7 @@ func TestWithFiles(t *testing.T) {
 				contentDisposition := p.Header.Get("Content-Disposition")
 
 				if contentDisposition == `form-data; name="operations"` {
-					assert.EqualValues(t, `{"query":"{ id }","variables":{"req":{"files":[{},{}],"foo":{"bar":{}}}}}`, slurp)
+					assert.JSONEq(t, `{"query":"{ id }","variables":{"req":{"files":[{},{}],"foo":{"bar":{}}}}}`, string(slurp))
 				}
 				if contentDisposition == `form-data; name="map"` {
 					// returns `{"0":["variables.req.files.0"],"1":["variables.req.files.1"],"2":["variables.req.foo.bar"]}`
@@ -228,10 +228,10 @@ func TestWithFiles(t *testing.T) {
 				contentDisposition := p.Header.Get("Content-Disposition")
 
 				if contentDisposition == `form-data; name="operations"` {
-					assert.EqualValues(t, `{"query":"{ id }","variables":{"files":[{},{},{}]}}`, slurp)
+					assert.JSONEq(t, `{"query":"{ id }","variables":{"files":[{},{},{}]}}`, string(slurp))
 				}
 				if contentDisposition == `form-data; name="map"` {
-					assert.EqualValues(t, `{"0":["variables.files.0","variables.files.2"],"1":["variables.files.1"]}`, slurp)
+					assert.JSONEq(t, `{"0":["variables.files.0","variables.files.2"],"1":["variables.files.1"]}`, string(slurp))
 					// returns `{"0":["variables.files.0","variables.files.2"],"1":["variables.files.1"]}`
 					// but the order of file inputs is unpredictable between different OS systems
 					assert.Contains(t, string(slurp), `{"0":`)

--- a/graphql/executor/executor_test.go
+++ b/graphql/executor/executor_test.go
@@ -20,7 +20,7 @@ func TestExecutor(t *testing.T) {
 
 	t.Run("calls query on executable schema", func(t *testing.T) {
 		resp := query(exec, "", "{name}")
-		assert.Equal(t, `{"name":"test"}`, string(resp.Data))
+		assert.JSONEq(t, `{"name":"test"}`, string(resp.Data))
 	})
 
 	t.Run("validates operation", func(t *testing.T) {
@@ -51,7 +51,7 @@ func TestExecutor(t *testing.T) {
 		})
 
 		resp := query(exec, "", "{name}")
-		assert.Equal(t, `{"name":"test"}`, string(resp.Data))
+		assert.JSONEq(t, `{"name":"test"}`, string(resp.Data))
 		assert.Equal(t, []string{"first", "second"}, calls)
 	})
 
@@ -67,7 +67,7 @@ func TestExecutor(t *testing.T) {
 		})
 
 		resp := query(exec, "", "{name}")
-		assert.Equal(t, `{"name":"test"}`, string(resp.Data))
+		assert.JSONEq(t, `{"name":"test"}`, string(resp.Data))
 		assert.Equal(t, []string{"first", "second"}, calls)
 	})
 
@@ -83,7 +83,7 @@ func TestExecutor(t *testing.T) {
 		})
 
 		resp := query(exec, "", "{name}")
-		assert.Equal(t, `{"name":"test"}`, string(resp.Data))
+		assert.JSONEq(t, `{"name":"test"}`, string(resp.Data))
 		assert.Equal(t, []string{"first", "second"}, calls)
 	})
 
@@ -99,7 +99,7 @@ func TestExecutor(t *testing.T) {
 		})
 
 		resp := query(exec, "", "{name}")
-		assert.Equal(t, `{"name":"test"}`, string(resp.Data))
+		assert.JSONEq(t, `{"name":"test"}`, string(resp.Data))
 		assert.Equal(t, []string{"first", "second"}, calls)
 	})
 
@@ -118,7 +118,7 @@ func TestExecutor(t *testing.T) {
 			},
 		})
 		resp := query(exec, "", "{name}")
-		assert.Equal(t, `{"name":"test"}`, string(resp.Data))
+		assert.JSONEq(t, `{"name":"test"}`, string(resp.Data))
 		assert.Equal(t, []string{"param", "context"}, calls)
 	})
 
@@ -147,7 +147,7 @@ func TestExecutor(t *testing.T) {
 
 		t.Run("cache miss populates cache", func(t *testing.T) {
 			resp := query(exec, "Foo", qry)
-			assert.Equal(t, `{"name":"test"}`, string(resp.Data))
+			assert.JSONEq(t, `{"name":"test"}`, string(resp.Data))
 
 			cacheDoc, ok := cache.Get(ctx, qry)
 			require.True(t, ok)
@@ -160,7 +160,7 @@ func TestExecutor(t *testing.T) {
 			cache.Add(ctx, qry, doc)
 
 			resp := query(exec, "Bar", qry)
-			assert.Equal(t, `{"name":"test"}`, string(resp.Data))
+			assert.JSONEq(t, `{"name":"test"}`, string(resp.Data))
 
 			cacheDoc, ok := cache.Get(ctx, qry)
 			require.True(t, ok)

--- a/graphql/handler/extension/apq_test.go
+++ b/graphql/handler/extension/apq_test.go
@@ -27,7 +27,7 @@ func TestAPQIntegration(t *testing.T) {
 
 	resp := doRequest(h, "POST", "/graphql", `{"query":"{ name }","extensions":{"persistedQuery":{"version":1,"sha256Hash":"30166fc3298853f22709fce1e4a00e98f1b6a3160eaaaf9cb3b7db6a16073b07"}}}`)
 	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-	require.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+	require.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 
 	require.NotNil(t, stats)
 	require.True(t, stats.SentQuery)

--- a/graphql/handler/extension/complexity_test.go
+++ b/graphql/handler/extension/complexity_test.go
@@ -37,7 +37,7 @@ func TestHandlerComplexity(t *testing.T) {
 		h.SetCalculatedComplexity(2)
 		resp := doRequest(h, "POST", "/graphql", `{"query":"{ name }"}`)
 		require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-		require.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+		require.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 
 		require.Equal(t, 2, stats.ComplexityLimit)
 		require.Equal(t, 2, stats.Complexity)
@@ -48,7 +48,7 @@ func TestHandlerComplexity(t *testing.T) {
 		h.SetCalculatedComplexity(4)
 		resp := doRequest(h, "POST", "/graphql", `{"query":"{ name }"}`)
 		require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-		require.Equal(t, `{"errors":[{"message":"operation has complexity 4, which exceeds the limit of 2","extensions":{"code":"COMPLEXITY_LIMIT_EXCEEDED"}}],"data":null}`, resp.Body.String())
+		require.JSONEq(t, `{"errors":[{"message":"operation has complexity 4, which exceeds the limit of 2","extensions":{"code":"COMPLEXITY_LIMIT_EXCEEDED"}}],"data":null}`, resp.Body.String())
 
 		require.Equal(t, 2, stats.ComplexityLimit)
 		require.Equal(t, 4, stats.Complexity)
@@ -59,7 +59,7 @@ func TestHandlerComplexity(t *testing.T) {
 		h.SetCalculatedComplexity(4)
 		resp := doRequest(h, "POST", "/graphql", `{"query":"{ ok: name }"}`)
 		require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-		require.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+		require.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 
 		require.Equal(t, 4, stats.ComplexityLimit)
 		require.Equal(t, 4, stats.Complexity)
@@ -81,7 +81,7 @@ func TestFixedComplexity(t *testing.T) {
 		h.SetCalculatedComplexity(2)
 		resp := doRequest(h, "POST", "/graphql", `{"query":"{ name }"}`)
 		require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-		require.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+		require.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 
 		require.Equal(t, 2, stats.ComplexityLimit)
 		require.Equal(t, 2, stats.Complexity)
@@ -91,7 +91,7 @@ func TestFixedComplexity(t *testing.T) {
 		h.SetCalculatedComplexity(4)
 		resp := doRequest(h, "POST", "/graphql", `{"query":"{ name }"}`)
 		require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-		require.Equal(t, `{"errors":[{"message":"operation has complexity 4, which exceeds the limit of 2","extensions":{"code":"COMPLEXITY_LIMIT_EXCEEDED"}}],"data":null}`, resp.Body.String())
+		require.JSONEq(t, `{"errors":[{"message":"operation has complexity 4, which exceeds the limit of 2","extensions":{"code":"COMPLEXITY_LIMIT_EXCEEDED"}}],"data":null}`, resp.Body.String())
 
 		require.Equal(t, 2, stats.ComplexityLimit)
 		require.Equal(t, 4, stats.Complexity)
@@ -101,7 +101,7 @@ func TestFixedComplexity(t *testing.T) {
 		h.SetCalculatedComplexity(4)
 		resp := doRequest(h, "POST", "/graphql", `{ "operationName":"IntrospectionQuery", "query":"query IntrospectionQuery { __schema { queryType { name } mutationType { name }}}"}`)
 		require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-		require.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+		require.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 
 		require.Equal(t, 2, stats.ComplexityLimit)
 		require.Equal(t, 0, stats.Complexity)

--- a/graphql/handler/server_test.go
+++ b/graphql/handler/server_test.go
@@ -26,25 +26,25 @@ func TestServer(t *testing.T) {
 	t.Run("returns an error if no transport matches", func(t *testing.T) {
 		resp := post(srv, "/foo", "application/json")
 		assert.Equal(t, http.StatusBadRequest, resp.Code)
-		assert.Equal(t, `{"errors":[{"message":"transport not supported"}],"data":null}`, resp.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"transport not supported"}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("calls query on executable schema", func(t *testing.T) {
 		resp := get(srv, "/foo?query={name}")
 		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+		assert.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 	})
 
 	t.Run("mutations are forbidden", func(t *testing.T) {
 		resp := get(srv, "/foo?query=mutation{name}")
 		assert.Equal(t, http.StatusNotAcceptable, resp.Code)
-		assert.Equal(t, `{"errors":[{"message":"GET requests only allow query operations"}],"data":null}`, resp.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"GET requests only allow query operations"}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("subscriptions are forbidden", func(t *testing.T) {
 		resp := get(srv, "/foo?query=subscription{name}")
 		assert.Equal(t, http.StatusNotAcceptable, resp.Code)
-		assert.Equal(t, `{"errors":[{"message":"GET requests only allow query operations"}],"data":null}`, resp.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"GET requests only allow query operations"}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("invokes operation middleware in order", func(t *testing.T) {
@@ -120,7 +120,7 @@ func TestServer(t *testing.T) {
 		t.Run("cache miss populates cache", func(t *testing.T) {
 			resp := get(srv, "/foo?query="+url.QueryEscape(qry))
 			assert.Equal(t, http.StatusOK, resp.Code)
-			assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+			assert.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 
 			cacheDoc, ok := cache.Get(ctx, qry)
 			require.True(t, ok)
@@ -134,7 +134,7 @@ func TestServer(t *testing.T) {
 
 			resp := get(srv, "/foo?query="+url.QueryEscape(qry))
 			assert.Equal(t, http.StatusOK, resp.Code)
-			assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+			assert.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 
 			cacheDoc, ok := cache.Get(ctx, qry)
 			require.True(t, ok)

--- a/graphql/handler/transport/http_form_multipart_test.go
+++ b/graphql/handler/transport/http_form_multipart_test.go
@@ -66,7 +66,7 @@ func TestFileUpload(t *testing.T) {
 		resp := httptest.NewRecorder()
 		h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-		require.Equal(t, `{"data":{"singleUpload":"test"}}`, resp.Body.String())
+		require.JSONEq(t, `{"data":{"singleUpload":"test"}}`, resp.Body.String())
 	})
 
 	t.Run("valid single file upload with payload", func(t *testing.T) {
@@ -92,7 +92,7 @@ func TestFileUpload(t *testing.T) {
 		resp := httptest.NewRecorder()
 		h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-		require.Equal(t, `{"data":{"singleUploadWithPayload":"test"}}`, resp.Body.String())
+		require.JSONEq(t, `{"data":{"singleUploadWithPayload":"test"}}`, resp.Body.String())
 	})
 
 	t.Run("valid file list upload", func(t *testing.T) {
@@ -124,7 +124,7 @@ func TestFileUpload(t *testing.T) {
 		resp := httptest.NewRecorder()
 		h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-		require.Equal(t, `{"data":{"multipleUpload":[{"id":1},{"id":2}]}}`, resp.Body.String())
+		require.JSONEq(t, `{"data":{"multipleUpload":[{"id":1},{"id":2}]}}`, resp.Body.String())
 	})
 
 	t.Run("valid file list upload with payload", func(t *testing.T) {
@@ -156,7 +156,7 @@ func TestFileUpload(t *testing.T) {
 		resp := httptest.NewRecorder()
 		h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Code)
-		require.Equal(t, `{"data":{"multipleUploadWithPayload":[{"id":1},{"id":2}]}}`, resp.Body.String())
+		require.JSONEq(t, `{"data":{"multipleUploadWithPayload":[{"id":1},{"id":2}]}}`, resp.Body.String())
 	})
 
 	t.Run("valid file list upload with payload and file reuse", func(t *testing.T) {
@@ -184,7 +184,7 @@ func TestFileUpload(t *testing.T) {
 			resp := httptest.NewRecorder()
 			h.ServeHTTP(resp, req)
 			require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-			require.Equal(t, `{"data":{"multipleUploadWithPayload":[{"id":1},{"id":2}]}}`, resp.Body.String())
+			require.JSONEq(t, `{"data":{"multipleUploadWithPayload":[{"id":1},{"id":2}]}}`, resp.Body.String())
 		}
 
 		t.Run("payload smaller than UploadMaxMemory, stored in memory", func(t *testing.T) {
@@ -216,7 +216,7 @@ func TestFileUpload(t *testing.T) {
 		resp := httptest.NewRecorder()
 		h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
-		require.Equal(t, `{"errors":[{"message":"first part must be operations"}],"data":null}`, resp.Body.String())
+		require.JSONEq(t, `{"errors":[{"message":"first part must be operations"}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("fail parse operation", func(t *testing.T) {
@@ -226,7 +226,7 @@ func TestFileUpload(t *testing.T) {
 		resp := httptest.NewRecorder()
 		h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
-		require.Equal(t, `{"errors":[{"message":"operations form field could not be decoded"}],"data":null}`, resp.Body.String())
+		require.JSONEq(t, `{"errors":[{"message":"operations form field could not be decoded"}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("fail parse map", func(t *testing.T) {
@@ -236,7 +236,7 @@ func TestFileUpload(t *testing.T) {
 		resp := httptest.NewRecorder()
 		h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
-		require.Equal(t, `{"errors":[{"message":"map form field could not be decoded"}],"data":null}`, resp.Body.String())
+		require.JSONEq(t, `{"errors":[{"message":"map form field could not be decoded"}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("fail missing file", func(t *testing.T) {
@@ -246,7 +246,7 @@ func TestFileUpload(t *testing.T) {
 		resp := httptest.NewRecorder()
 		h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
-		require.Equal(t, `{"errors":[{"message":"failed to get key 0 from form"}],"data":null}`, resp.Body.String())
+		require.JSONEq(t, `{"errors":[{"message":"failed to get key 0 from form"}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("fail map entry with invalid operations paths prefix", func(t *testing.T) {
@@ -256,7 +256,7 @@ func TestFileUpload(t *testing.T) {
 		resp := httptest.NewRecorder()
 		h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
-		require.Equal(t, `{"errors":[{"message":"invalid operations paths for key 0"}],"data":null}`, resp.Body.String())
+		require.JSONEq(t, `{"errors":[{"message":"invalid operations paths for key 0"}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("fail parse request big body", func(t *testing.T) {
@@ -266,7 +266,7 @@ func TestFileUpload(t *testing.T) {
 		resp := httptest.NewRecorder()
 		h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-		require.Equal(t, `{"errors":[{"message":"failed to parse multipart form, request body too large"}],"data":null}`, resp.Body.String())
+		require.JSONEq(t, `{"errors":[{"message":"failed to parse multipart form, request body too large"}],"data":null}`, resp.Body.String())
 	})
 }
 

--- a/graphql/handler/transport/http_form_urlencode_test.go
+++ b/graphql/handler/transport/http_form_urlencode_test.go
@@ -20,40 +20,40 @@ func TestUrlEncodedForm(t *testing.T) {
 	t.Run("success json", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query":"{ name }"}`, "application/x-www-form-urlencoded")
 		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+		assert.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 	})
 
 	t.Run("success urlencoded", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `query=%7B%20name%20%7D`, "application/x-www-form-urlencoded")
 		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+		assert.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 	})
 
 	t.Run("success plain", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `query={ name }`, "application/x-www-form-urlencoded")
 		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+		assert.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 	})
 
 	t.Run("decode failure json", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", "notjson", "application/x-www-form-urlencoded")
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-		assert.Equal(t, `{"errors":[{"message":"Unexpected Name \"notjson\"","locations":[{"line":1,"column":1}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}],"data":null}`, resp.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"Unexpected Name \"notjson\"","locations":[{"line":1,"column":1}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("decode failure urlencoded", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", "query=%7Bnot-good", "application/x-www-form-urlencoded")
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-		assert.Equal(t, `{"errors":[{"message":"Expected Name, found \u003cInvalid\u003e","locations":[{"line":1,"column":6}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}],"data":null}`, resp.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"Expected Name, found \u003cInvalid\u003e","locations":[{"line":1,"column":6}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("parse query failure", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query":{"wrong": "format"}}`, "application/x-www-form-urlencoded")
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-		assert.Equal(t, `{"errors":[{"message":"could not cleanup body: json: cannot unmarshal object into Go struct field RawParams.query of type string"}],"data":null}`, resp.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"could not cleanup body: json: cannot unmarshal object into Go struct field RawParams.query of type string"}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("validate content type", func(t *testing.T) {
@@ -76,7 +76,7 @@ func TestUrlEncodedForm(t *testing.T) {
 			t.Run(fmt.Sprintf("allow for content type %s", contentType), func(t *testing.T) {
 				resp := doReq(h, "POST", "/graphql", `{"query":"{ name }"}`, contentType)
 				assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-				assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+				assert.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 			})
 		}
 
@@ -89,7 +89,7 @@ func TestUrlEncodedForm(t *testing.T) {
 			t.Run(fmt.Sprintf("reject for content type %s", tc), func(t *testing.T) {
 				resp := doReq(h, "POST", "/graphql", `{"query":"{ name }"}`, tc)
 				assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
-				assert.Equal(t, fmt.Sprintf(`{"errors":[{"message":"%s"}],"data":null}`, "transport not supported"), resp.Body.String())
+				assert.JSONEq(t, fmt.Sprintf(`{"errors":[{"message":"%s"}],"data":null}`, "transport not supported"), resp.Body.String())
 			})
 		}
 	})

--- a/graphql/handler/transport/http_get_test.go
+++ b/graphql/handler/transport/http_get_test.go
@@ -17,7 +17,7 @@ func TestGET(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		resp := doRequest(h, "GET", "/graphql?query={name}", ``, "application/json")
 		assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-		assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+		assert.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 	})
 
 	t.Run("has json content-type header", func(t *testing.T) {
@@ -28,24 +28,24 @@ func TestGET(t *testing.T) {
 	t.Run("decode failure", func(t *testing.T) {
 		resp := doRequest(h, "GET", "/graphql?query={name}&variables=notjson", "", "application/json")
 		assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
-		assert.Equal(t, `{"errors":[{"message":"variables could not be decoded"}],"data":null}`, resp.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"variables could not be decoded"}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("invalid variable", func(t *testing.T) {
 		resp := doRequest(h, "GET", `/graphql?query=query($id:Int!){find(id:$id)}&variables={"id":false}`, "", "application/json")
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
-		assert.Equal(t, `{"errors":[{"message":"cannot use bool as Int","path":["variable","id"],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"cannot use bool as Int","path":["variable","id"],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("parse failure", func(t *testing.T) {
 		resp := doRequest(h, "GET", "/graphql?query=!", "", "application/json")
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
-		assert.Equal(t, `{"errors":[{"message":"Unexpected !","locations":[{"line":1,"column":1}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}],"data":null}`, resp.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"Unexpected !","locations":[{"line":1,"column":1}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("no mutations", func(t *testing.T) {
 		resp := doRequest(h, "GET", "/graphql?query=mutation{name}", "", "application/json")
 		assert.Equal(t, http.StatusNotAcceptable, resp.Code, resp.Body.String())
-		assert.Equal(t, `{"errors":[{"message":"GET requests only allow query operations"}],"data":null}`, resp.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"GET requests only allow query operations"}],"data":null}`, resp.Body.String())
 	})
 }

--- a/graphql/handler/transport/http_graphql_test.go
+++ b/graphql/handler/transport/http_graphql_test.go
@@ -20,41 +20,41 @@ func TestGRAPHQL(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		resp := doGraphqlRequest(h, "POST", "/graphql", `{ name }`)
 		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+		assert.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 	})
 
 	t.Run("success even if url encoded", func(t *testing.T) {
 		resp := doGraphqlRequest(h, "POST", "/graphql", `%7B%20name%20%7D`)
 		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+		assert.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 	})
 
 	t.Run("parse failure", func(t *testing.T) {
 		resp := doGraphqlRequest(h, "POST", "/graphql", `{"!"}`)
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-		assert.Equal(t, `{"errors":[{"message":"Expected Name, found String","locations":[{"line":1,"column":3}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}],"data":null}`, resp.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"Expected Name, found String","locations":[{"line":1,"column":3}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("parse query failure", func(t *testing.T) {
 		resp := doGraphqlRequest(h, "POST", "/graphql", `%7B%H7U6Z`)
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-		assert.Equal(t, `{"errors":[{"message":"could not cleanup body: invalid URL escape \"%H7\""}],"data":null}`, resp.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"could not cleanup body: invalid URL escape \"%H7\""}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("validation failure", func(t *testing.T) {
 		resp := doGraphqlRequest(h, "POST", "/graphql", `{ title }`)
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-		assert.Equal(t, `{"errors":[{"message":"Cannot query field \"title\" on type \"Query\".","locations":[{"line":1,"column":3}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"Cannot query field \"title\" on type \"Query\".","locations":[{"line":1,"column":3}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("execution failure", func(t *testing.T) {
 		resp := doGraphqlRequest(h, "POST", "/graphql", `mutation { name }`)
 		assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-		assert.Equal(t, `{"errors":[{"message":"mutations are not supported"}],"data":null}`, resp.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"mutations are not supported"}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("validate content type", func(t *testing.T) {
@@ -78,7 +78,7 @@ func TestGRAPHQL(t *testing.T) {
 			t.Run(fmt.Sprintf("allow for content type %s", contentType), func(t *testing.T) {
 				resp := doReq(h, "POST", "/graphql", `{ name }`, contentType)
 				assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-				assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+				assert.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 			})
 		}
 
@@ -91,7 +91,7 @@ func TestGRAPHQL(t *testing.T) {
 			t.Run(fmt.Sprintf("reject for content type %s", tc), func(t *testing.T) {
 				resp := doReq(h, "POST", "/graphql", `{"query":"{ name }"}`, tc)
 				assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
-				assert.Equal(t, fmt.Sprintf(`{"errors":[{"message":"%s"}],"data":null}`, "transport not supported"), resp.Body.String())
+				assert.JSONEq(t, fmt.Sprintf(`{"errors":[{"message":"%s"}],"data":null}`, "transport not supported"), resp.Body.String())
 			})
 		}
 	})

--- a/graphql/handler/transport/http_multipart_mixed_test.go
+++ b/graphql/handler/transport/http_multipart_mixed_test.go
@@ -52,7 +52,7 @@ func TestMultipartMixed(t *testing.T) {
 		resp := doRequest(handler, srv.URL, "notjson")
 		assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-		assert.Equal(
+		assert.JSONEq(
 			t,
 			`{"errors":[{"message":"json request body could not be decoded: invalid character 'o' in literal null (expecting 'u') body:notjson"}],"data":null}`,
 			resp.Body.String(),
@@ -64,7 +64,7 @@ func TestMultipartMixed(t *testing.T) {
 		resp := doRequest(handler, srv.URL, `{"query": "!"}`)
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-		assert.Equal(
+		assert.JSONEq(
 			t,
 			`{"errors":[{"message":"Unexpected !","locations":[{"line":1,"column":1}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}],"data":null}`,
 			resp.Body.String(),
@@ -76,7 +76,7 @@ func TestMultipartMixed(t *testing.T) {
 		resp := doRequest(handler, srv.URL, `{"query": "{ title }"}`)
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-		assert.Equal(
+		assert.JSONEq(
 			t,
 			`{"errors":[{"message":"Cannot query field \"title\" on type \"Query\".","locations":[{"line":1,"column":3}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`,
 			resp.Body.String(),
@@ -90,7 +90,7 @@ func TestMultipartMixed(t *testing.T) {
 		)
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-		assert.Equal(
+		assert.JSONEq(
 			t,
 			`{"errors":[{"message":"cannot use bool as Int","path":["variable","id"],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`,
 			resp.Body.String(),
@@ -135,7 +135,7 @@ func TestMultipartMixed(t *testing.T) {
 		assert.Equal(t, "--graphql\r\n", readLine(br))
 		assert.Equal(t, "Content-Type: application/json\r\n", readLine(br))
 		assert.Equal(t, "\r\n", readLine(br))
-		assert.Equal(t,
+		assert.JSONEq(t,
 			"{\"data\":{\"name\":null},\"hasNext\":true}\r\n",
 			readLine(br),
 		)
@@ -149,7 +149,7 @@ func TestMultipartMixed(t *testing.T) {
 		assert.Equal(t, "--graphql\r\n", readLine(br))
 		assert.Equal(t, "Content-Type: application/json\r\n", readLine(br))
 		assert.Equal(t, "\r\n", readLine(br))
-		assert.Equal(
+		assert.JSONEq(
 			t,
 			"{\"incremental\":[{\"data\":{\"name\":\"test\"},\"hasNext\":false}],\"hasNext\":false}\r\n",
 			readLine(br),
@@ -213,7 +213,7 @@ func TestMultipartMixed(t *testing.T) {
 		assert.Equal(t, "--graphql\r\n", readLine(br))
 		assert.Equal(t, "Content-Type: application/json\r\n", readLine(br))
 		assert.Equal(t, "\r\n", readLine(br))
-		assert.Equal(t,
+		assert.JSONEq(t,
 			"{\"data\":{\"name\":null},\"hasNext\":true}\r\n",
 			readLine(br),
 		)
@@ -221,7 +221,7 @@ func TestMultipartMixed(t *testing.T) {
 		assert.Equal(t, "--graphql\r\n", readLine(br))
 		assert.Equal(t, "Content-Type: application/json\r\n", readLine(br))
 		assert.Equal(t, "\r\n", readLine(br))
-		assert.Equal(
+		assert.JSONEq(
 			t,
 			"{\"incremental\":[{\"data\":{\"name\":\"test\"},\"hasNext\":false}],\"hasNext\":false}\r\n",
 			readLine(br),

--- a/graphql/handler/transport/http_post_test.go
+++ b/graphql/handler/transport/http_post_test.go
@@ -20,42 +20,42 @@ func TestPOST(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query":"{ name }"}`, "application/json")
 		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+		assert.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 	})
 
 	t.Run("decode failure", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", "notjson", "application/json")
 		assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-		assert.Equal(t, `{"errors":[{"message":"json request body could not be decoded: invalid character 'o' in literal null (expecting 'u') body:notjson"}],"data":null}`, resp.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"json request body could not be decoded: invalid character 'o' in literal null (expecting 'u') body:notjson"}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("parse failure", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query": "!"}`, "application/json")
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-		assert.Equal(t, `{"errors":[{"message":"Unexpected !","locations":[{"line":1,"column":1}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}],"data":null}`, resp.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"Unexpected !","locations":[{"line":1,"column":1}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("validation failure", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query": "{ title }"}`, "application/json")
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-		assert.Equal(t, `{"errors":[{"message":"Cannot query field \"title\" on type \"Query\".","locations":[{"line":1,"column":3}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"Cannot query field \"title\" on type \"Query\".","locations":[{"line":1,"column":3}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("invalid variable", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query": "query($id:Int!){find(id:$id)}","variables":{"id":false}}`, "application/json")
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-		assert.Equal(t, `{"errors":[{"message":"cannot use bool as Int","path":["variable","id"],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"cannot use bool as Int","path":["variable","id"],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("execution failure", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query": "mutation { name }"}`, "application/json")
 		assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-		assert.Equal(t, `{"errors":[{"message":"mutations are not supported"}],"data":null}`, resp.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"mutations are not supported"}],"data":null}`, resp.Body.String())
 	})
 
 	t.Run("validate content type", func(t *testing.T) {
@@ -79,7 +79,7 @@ func TestPOST(t *testing.T) {
 			t.Run(fmt.Sprintf("allow for content type %s", contentType), func(t *testing.T) {
 				resp := doReq(h, "POST", "/graphql", `{"query":"{ name }"}`, contentType)
 				assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-				assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+				assert.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 			})
 		}
 
@@ -92,7 +92,7 @@ func TestPOST(t *testing.T) {
 			t.Run(fmt.Sprintf("reject for content type %s", tc), func(t *testing.T) {
 				resp := doReq(h, "POST", "/graphql", `{"query":"{ name }"}`, tc)
 				assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
-				assert.Equal(t, fmt.Sprintf(`{"errors":[{"message":"%s"}],"data":null}`, "transport not supported"), resp.Body.String())
+				assert.JSONEq(t, fmt.Sprintf(`{"errors":[{"message":"%s"}],"data":null}`, "transport not supported"), resp.Body.String())
 			})
 		}
 	})
@@ -110,7 +110,7 @@ func TestPOST(t *testing.T) {
 
 		resp := doReq(h, "POST", "/graphql", `{"query":"{ name }"}`)
 		assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-		assert.Equal(t, `{"data":{"name":"test"}}`, resp.Body.String())
+		assert.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 	})
 }
 

--- a/graphql/handler/transport/sse_test.go
+++ b/graphql/handler/transport/sse_test.go
@@ -56,7 +56,7 @@ func TestSSE(t *testing.T) {
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)
 		assert.Equal(t, 400, w.Code, "Request return wrong status -> %d", w.Code)
-		assert.Equal(t, `{"errors":[{"message":"transport not supported"}],"data":null}`, w.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"transport not supported"}],"data":null}`, w.Body.String())
 	})
 
 	t.Run("decode failure", func(t *testing.T) {
@@ -65,7 +65,7 @@ func TestSSE(t *testing.T) {
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)
 		assert.Equal(t, 400, w.Code, "Request return wrong status -> %d", w.Code)
-		assert.Equal(t, `{"errors":[{"message":"json request body could not be decoded: invalid character 'o' in literal null (expecting 'u') body:notjson"}],"data":null}`, w.Body.String())
+		assert.JSONEq(t, `{"errors":[{"message":"json request body could not be decoded: invalid character 'o' in literal null (expecting 'u') body:notjson"}],"data":null}`, w.Body.String())
 	})
 
 	t.Run("parse failure", func(t *testing.T) {

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -40,7 +40,7 @@ func TestWebsocket(t *testing.T) {
 
 		msg := readOp(c)
 		assert.Equal(t, "connection_error", msg.Type)
-		assert.Equal(t, `{"message":"invalid json"}`, string(msg.Payload))
+		assert.JSONEq(t, `{"message":"invalid json"}`, string(msg.Payload))
 	})
 
 	t.Run("client can terminate before init", func(t *testing.T) {
@@ -61,7 +61,7 @@ func TestWebsocket(t *testing.T) {
 
 		msg := readOp(c)
 		assert.Equal(t, connectionErrorMsg, msg.Type)
-		assert.Equal(t, `{"message":"unexpected message start"}`, string(msg.Payload))
+		assert.JSONEq(t, `{"message":"unexpected message start"}`, string(msg.Payload))
 	})
 
 	t.Run("server acks init", func(t *testing.T) {
@@ -104,7 +104,7 @@ func TestWebsocket(t *testing.T) {
 
 		msg := readOp(c)
 		assert.Equal(t, errorMsg, msg.Type)
-		assert.Equal(t, `[{"message":"Unexpected !","locations":[{"line":1,"column":1}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}]`, string(msg.Payload))
+		assert.JSONEq(t, `[{"message":"Unexpected !","locations":[{"line":1,"column":1}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}]`, string(msg.Payload))
 	})
 
 	t.Run("client can receive data", func(t *testing.T) {
@@ -125,13 +125,13 @@ func TestWebsocket(t *testing.T) {
 		msg := readOp(c)
 		require.Equal(t, dataMsg, msg.Type, string(msg.Payload))
 		require.Equal(t, "test_1", msg.ID, string(msg.Payload))
-		require.Equal(t, `{"data":{"name":"test"}}`, string(msg.Payload))
+		require.JSONEq(t, `{"data":{"name":"test"}}`, string(msg.Payload))
 
 		handler.SendNextSubscriptionMessage()
 		msg = readOp(c)
 		require.Equal(t, dataMsg, msg.Type, string(msg.Payload))
 		require.Equal(t, "test_1", msg.ID, string(msg.Payload))
-		require.Equal(t, `{"data":{"name":"test"}}`, string(msg.Payload))
+		require.JSONEq(t, `{"data":{"name":"test"}}`, string(msg.Payload))
 
 		require.NoError(t, c.WriteJSON(&operationMessage{Type: stopMsg, ID: "test_1"}))
 
@@ -283,7 +283,7 @@ func TestWebsocketInitFunc(t *testing.T) {
 
 		msg := readOp(c)
 		assert.Equal(t, connectionErrorMsg, msg.Type)
-		assert.Equal(t, `{"message":"invalid init payload"}`, string(msg.Payload))
+		assert.JSONEq(t, `{"message":"invalid init payload"}`, string(msg.Payload))
 	})
 
 	t.Run("can return context for request from WebsocketInitFunc", func(t *testing.T) {
@@ -344,7 +344,7 @@ func TestWebsocketInitFunc(t *testing.T) {
 		time.Sleep(time.Millisecond * 10)
 		m := readOp(c)
 		assert.Equal(t, connectionErrorMsg, m.Type)
-		assert.Equal(t, `{"message":"beep boop"}`, string(m.Payload))
+		assert.JSONEq(t, `{"message":"beep boop"}`, string(m.Payload))
 	})
 	t.Run("accept connection if WebsocketInitFunc is provided and is accepting connection", func(t *testing.T) {
 		h := testserver.New()
@@ -638,13 +638,13 @@ func TestWebsocketGraphqltransportwsSubprotocol(t *testing.T) {
 		msg := readOp(c)
 		require.Equal(t, graphqltransportwsNextMsg, msg.Type, string(msg.Payload))
 		require.Equal(t, "test_1", msg.ID, string(msg.Payload))
-		require.Equal(t, `{"data":{"name":"test"}}`, string(msg.Payload))
+		require.JSONEq(t, `{"data":{"name":"test"}}`, string(msg.Payload))
 
 		handler.SendNextSubscriptionMessage()
 		msg = readOp(c)
 		require.Equal(t, graphqltransportwsNextMsg, msg.Type, string(msg.Payload))
 		require.Equal(t, "test_1", msg.ID, string(msg.Payload))
-		require.Equal(t, `{"data":{"name":"test"}}`, string(msg.Payload))
+		require.JSONEq(t, `{"data":{"name":"test"}}`, string(msg.Payload))
 
 		require.NoError(t, c.WriteJSON(&operationMessage{Type: graphqltransportwsCompleteMsg, ID: "test_1"}))
 
@@ -827,7 +827,7 @@ func TestWebsocketWithPingPongInterval(t *testing.T) {
 		msg = readOp(c)
 		require.Equal(t, graphqltransportwsNextMsg, msg.Type, string(msg.Payload))
 		require.Equal(t, "test_1", msg.ID, string(msg.Payload))
-		require.Equal(t, `{"data":{"name":"test"}}`, string(msg.Payload))
+		require.JSONEq(t, `{"data":{"name":"test"}}`, string(msg.Payload))
 
 		// keepalive
 		msg = readOp(c)

--- a/graphql/jsonw_test.go
+++ b/graphql/jsonw_test.go
@@ -44,5 +44,5 @@ func TestJsonWriter(t *testing.T) {
 	b := &bytes.Buffer{}
 	obj.MarshalGQL(b)
 
-	require.Equal(t, `{"test":10,"array":[1,"2",true,false,null,1.3,true],"emptyArray":[],"child":{"child":{"child":null}}}`, b.String())
+	require.JSONEq(t, `{"test":10,"array":[1,"2",true,false,null,1.3,true],"emptyArray":[],"child":{"child":{"child":null}}}`, b.String())
 }


### PR DESCRIPTION
The PR enables `testifylint.encoded-compare` check and fixes up appeared test issues by replacing `assert.Equal` with `assert.JSONEq`.

See https://github.com/Antonboom/testifylint#encoded-compare for the reasons why `assert.JSONEq` is better than `assert.Equal` for comparing JSON strings. 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

