### PR TITLE
fix: only run generate code once

### DIFF
--- a/api/generate.go
+++ b/api/generate.go
@@ -136,10 +136,6 @@ func Generate(cfg *config.Config, option ...Option) error {
 		}
 	}
 
-	if err = codegen.GenerateCode(data); err != nil {
-		return fmt.Errorf("generating core failed: %w", err)
-	}
-
 	if !cfg.SkipValidation {
 		if err := validate(cfg); err != nil {
 			return fmt.Errorf("validation failed: %w", err)


### PR DESCRIPTION
in issue #2526 it's noted that `codegen.GenerateCode` is ran twice theres a vague PR that reverted this duplication #1100, but I am not clear why.

In my testing using a particularly heavy schema file I found the following

```
# Build of the master branch
/Users/brooke/Developer/gqlgen/gqlgen  34.45s user 4.15s system 145% cpu 26.486 total

# Build of this PR
/Users/brooke/Developer/gqlgen/gqlgen  26.82s user 3.92s system 151% cpu 20.223 total
```

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
