### PR TITLE
more actionable federation errors for nil key field queries

### DIFF
--- a/_examples/federation/accounts/graph/federation.go
+++ b/_examples/federation/accounts/graph/federation.go
@@ -218,6 +218,9 @@ func (ec *executionContext) resolveManyEntities(
 }
 
 func entityResolverNameForEmailHost(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -231,20 +234,28 @@ func entityResolverNameForEmailHost(ctx context.Context, rep EntityRepresentatio
 		m = rep
 		val, ok = m["id"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field id for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"id\" for EmailHost", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for EmailHost", ErrTypeNotFound))
+			break
 		}
 		return "findEmailHostByID", nil
 	}
-	return "", fmt.Errorf("%w for EmailHost", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for EmailHost due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForUser(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -258,15 +269,20 @@ func entityResolverNameForUser(ctx context.Context, rep EntityRepresentation) (s
 		m = rep
 		val, ok = m["id"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field id for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"id\" for User", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound))
+			break
 		}
 		return "findUserByID", nil
 	}
-	return "", fmt.Errorf("%w for User", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for User due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }

--- a/_examples/federation/accounts/graph/federation.go
+++ b/_examples/federation/accounts/graph/federation.go
@@ -231,13 +231,13 @@ func entityResolverNameForEmailHost(ctx context.Context, rep EntityRepresentatio
 		m = rep
 		val, ok = m["id"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field id for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findEmailHostByID", nil
 	}
@@ -258,13 +258,13 @@ func entityResolverNameForUser(ctx context.Context, rep EntityRepresentation) (s
 		m = rep
 		val, ok = m["id"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field id for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findUserByID", nil
 	}

--- a/_examples/federation/products/graph/federation.go
+++ b/_examples/federation/products/graph/federation.go
@@ -246,13 +246,13 @@ func entityResolverNameForManufacturer(ctx context.Context, rep EntityRepresenta
 		m = rep
 		val, ok = m["id"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field id for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManufacturerByID", nil
 	}
@@ -273,14 +273,15 @@ func entityResolverNameForProduct(ctx context.Context, rep EntityRepresentation)
 		m = rep
 		val, ok = m["manufacturer"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field manufacturer for User", ErrTypeNotFound)
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			break
+			// nested field value is not a map[string]interface
+			return "", fmt.Errorf("%w for Product due to nested Keyfield not being map value", ErrTypeNotFound)
 		}
 		val, ok = m["id"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field id for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
@@ -288,13 +289,13 @@ func entityResolverNameForProduct(ctx context.Context, rep EntityRepresentation)
 		m = rep
 		val, ok = m["id"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field id for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findProductByManufacturerIDAndID", nil
 	}
@@ -311,13 +312,13 @@ func entityResolverNameForProduct(ctx context.Context, rep EntityRepresentation)
 		m = rep
 		val, ok = m["upc"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field upc for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findProductByUpc", nil
 	}

--- a/_examples/federation/products/graph/federation.go
+++ b/_examples/federation/products/graph/federation.go
@@ -233,6 +233,9 @@ func (ec *executionContext) resolveManyEntities(
 }
 
 func entityResolverNameForManufacturer(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -246,20 +249,28 @@ func entityResolverNameForManufacturer(ctx context.Context, rep EntityRepresenta
 		m = rep
 		val, ok = m["id"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field id for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"id\" for Manufacturer", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for Manufacturer", ErrTypeNotFound))
+			break
 		}
 		return "findManufacturerByID", nil
 	}
-	return "", fmt.Errorf("%w for Manufacturer", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for Manufacturer due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForProduct(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -273,15 +284,21 @@ func entityResolverNameForProduct(ctx context.Context, rep EntityRepresentation)
 		m = rep
 		val, ok = m["manufacturer"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field manufacturer for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"manufacturer\" for Product", ErrTypeNotFound))
+			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			// nested field value is not a map[string]interface
-			return "", fmt.Errorf("%w for Product due to nested Keyfield not being map value", ErrTypeNotFound)
+			// nested field value is not a map[string]interface so don't use it
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to nested Key Field \"manufacturer\" value not matching map[string]any for Product", ErrTypeNotFound))
+			break
 		}
 		val, ok = m["id"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field id for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"id\" for Product", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
@@ -289,13 +306,17 @@ func entityResolverNameForProduct(ctx context.Context, rep EntityRepresentation)
 		m = rep
 		val, ok = m["id"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field id for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"id\" for Product", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for Product", ErrTypeNotFound))
+			break
 		}
 		return "findProductByManufacturerIDAndID", nil
 	}
@@ -312,15 +333,20 @@ func entityResolverNameForProduct(ctx context.Context, rep EntityRepresentation)
 		m = rep
 		val, ok = m["upc"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field upc for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"upc\" for Product", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for Product", ErrTypeNotFound))
+			break
 		}
 		return "findProductByUpc", nil
 	}
-	return "", fmt.Errorf("%w for Product", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for Product due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }

--- a/_examples/federation/reviews/graph/federation.go
+++ b/_examples/federation/reviews/graph/federation.go
@@ -246,6 +246,9 @@ func (ec *executionContext) resolveManyEntities(
 }
 
 func entityResolverNameForProduct(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -259,15 +262,21 @@ func entityResolverNameForProduct(ctx context.Context, rep EntityRepresentation)
 		m = rep
 		val, ok = m["manufacturer"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field manufacturer for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"manufacturer\" for Product", ErrTypeNotFound))
+			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			// nested field value is not a map[string]interface
-			return "", fmt.Errorf("%w for Product due to nested Keyfield not being map value", ErrTypeNotFound)
+			// nested field value is not a map[string]interface so don't use it
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to nested Key Field \"manufacturer\" value not matching map[string]any for Product", ErrTypeNotFound))
+			break
 		}
 		val, ok = m["id"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field id for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"id\" for Product", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
@@ -275,20 +284,28 @@ func entityResolverNameForProduct(ctx context.Context, rep EntityRepresentation)
 		m = rep
 		val, ok = m["id"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field id for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"id\" for Product", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for Product", ErrTypeNotFound))
+			break
 		}
 		return "findManyProductByManufacturerIDAndIDs", nil
 	}
-	return "", fmt.Errorf("%w for Product", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for Product due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForUser(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -302,15 +319,20 @@ func entityResolverNameForUser(ctx context.Context, rep EntityRepresentation) (s
 		m = rep
 		val, ok = m["id"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field id for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"id\" for User", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound))
+			break
 		}
 		return "findUserByID", nil
 	}
-	return "", fmt.Errorf("%w for User", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for User due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }

--- a/_examples/federation/reviews/graph/federation.go
+++ b/_examples/federation/reviews/graph/federation.go
@@ -259,14 +259,15 @@ func entityResolverNameForProduct(ctx context.Context, rep EntityRepresentation)
 		m = rep
 		val, ok = m["manufacturer"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field manufacturer for User", ErrTypeNotFound)
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			break
+			// nested field value is not a map[string]interface
+			return "", fmt.Errorf("%w for Product due to nested Keyfield not being map value", ErrTypeNotFound)
 		}
 		val, ok = m["id"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field id for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
@@ -274,13 +275,13 @@ func entityResolverNameForProduct(ctx context.Context, rep EntityRepresentation)
 		m = rep
 		val, ok = m["id"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field id for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyProductByManufacturerIDAndIDs", nil
 	}
@@ -301,13 +302,13 @@ func entityResolverNameForUser(ctx context.Context, rep EntityRepresentation) (s
 		m = rep
 		val, ok = m["id"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field id for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findUserByID", nil
 	}

--- a/plugin/federation/federation.gotpl
+++ b/plugin/federation/federation.gotpl
@@ -294,6 +294,9 @@ func (ec *executionContext) resolveManyEntities(
 	{{- if .Resolvers }}
 
 		func entityResolverNameFor{{$entity.Name}}(ctx context.Context, rep EntityRepresentation) (string, error) {
+			// we collect errors because a later entity resolver may work fine
+			// when an entity has multiple keys
+			entityResolverErrs := []error{}
 			{{- range .Resolvers }}
 				for {
 					var (
@@ -310,12 +313,16 @@ func (ec *executionContext) resolveManyEntities(
 						{{- range $i, $field := .Field }}
 							val, ok = m["{{.}}"]
 							if !ok {
-								return "", fmt.Errorf("%w due to missing Key Field {{.}} for User", ErrTypeNotFound)
+								entityResolverErrs = append(entityResolverErrs,
+									fmt.Errorf("%w due to missing Key Field \"{{.}}\" for {{$entity.Name}}", ErrTypeNotFound))
+								break
 							}
 							{{- if (ne $i $keyField.Field.LastIndex ) }}
 								if m, ok = val.(map[string]interface{}); !ok {
-									// nested field value is not a map[string]interface
-									return "", fmt.Errorf("%w for {{$entity.Name}} due to nested Keyfield not being map value", ErrTypeNotFound)
+									// nested field value is not a map[string]interface so don't use it
+									entityResolverErrs = append(entityResolverErrs,
+										fmt.Errorf("%w due to nested Key Field \"{{.}}\" value not matching map[string]any for {{$entity.Name}}", ErrTypeNotFound))
+									break
 								}
 							{{- else}}
 								if allNull {
@@ -325,12 +332,15 @@ func (ec *executionContext) resolveManyEntities(
 						{{- end}}
 					{{- end }}
 					if allNull {
-						return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+						entityResolverErrs = append(entityResolverErrs,
+							fmt.Errorf("%w due to all null value KeyFields for {{$entity.Name}}", ErrTypeNotFound))
+						break
 					}
 					return "{{.ResolverName}}", nil
 				}
 			{{- end }}
-			return "", fmt.Errorf("%w for {{$entity.Name}}", ErrTypeNotFound)
+			return "", fmt.Errorf("%w for {{$entity.Name}} due to %v", ErrTypeNotFound,
+				errors.Join(entityResolverErrs...).Error())
 		}
 	{{- end }}
 {{- end }}

--- a/plugin/federation/federation.gotpl
+++ b/plugin/federation/federation.gotpl
@@ -310,11 +310,12 @@ func (ec *executionContext) resolveManyEntities(
 						{{- range $i, $field := .Field }}
 							val, ok = m["{{.}}"]
 							if !ok {
-								break
+								return "", fmt.Errorf("%w due to missing Key Field {{.}} for User", ErrTypeNotFound)
 							}
 							{{- if (ne $i $keyField.Field.LastIndex ) }}
 								if m, ok = val.(map[string]interface{}); !ok {
-									break
+									// nested field value is not a map[string]interface
+									return "", fmt.Errorf("%w for {{$entity.Name}} due to nested Keyfield not being map value", ErrTypeNotFound)
 								}
 							{{- else}}
 								if allNull {
@@ -324,7 +325,7 @@ func (ec *executionContext) resolveManyEntities(
 						{{- end}}
 					{{- end }}
 					if allNull {
-						break
+						return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 					}
 					return "{{.ResolverName}}", nil
 				}

--- a/plugin/federation/federation_entityresolver_test.go
+++ b/plugin/federation/federation_entityresolver_test.go
@@ -173,12 +173,12 @@ func TestEntityResolver(t *testing.T) {
 				Bar int `json:"bar"`
 			} `json:"_entities"`
 		}
-
+		eq := entityQuery([]string{
+			"WorldWithMultipleKeys {foo hello {name}}",
+			"WorldWithMultipleKeys {bar}",
+		})
 		err := c.Post(
-			entityQuery([]string{
-				"WorldWithMultipleKeys {foo hello {name}}",
-				"WorldWithMultipleKeys {bar}",
-			}),
+			eq,
 			&resp,
 			client.Var("representations", representations),
 		)

--- a/plugin/federation/testdata/allthethings/generated/federation.go
+++ b/plugin/federation/testdata/allthethings/generated/federation.go
@@ -376,6 +376,9 @@ func (ec *executionContext) resolveManyEntities(
 }
 
 func entityResolverNameForExternalExtension(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -389,20 +392,28 @@ func entityResolverNameForExternalExtension(ctx context.Context, rep EntityRepre
 		m = rep
 		val, ok = m["upc"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"upc\" for ExternalExtension", ErrTypeNotFound))
 			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for ExternalExtension", ErrTypeNotFound))
 			break
 		}
 		return "findExternalExtensionByUpc", nil
 	}
-	return "", fmt.Errorf("%w for ExternalExtension", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for ExternalExtension due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForHello(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -416,20 +427,28 @@ func entityResolverNameForHello(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["name"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for Hello", ErrTypeNotFound))
 			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for Hello", ErrTypeNotFound))
 			break
 		}
 		return "findHelloByName", nil
 	}
-	return "", fmt.Errorf("%w for Hello", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for Hello due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiHelloMultiKey(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -443,12 +462,16 @@ func entityResolverNameForMultiHelloMultiKey(ctx context.Context, rep EntityRepr
 		m = rep
 		val, ok = m["name"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiHelloMultiKey", ErrTypeNotFound))
 			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiHelloMultiKey", ErrTypeNotFound))
 			break
 		}
 		return "findManyMultiHelloMultiKeyByNames", nil
@@ -466,20 +489,28 @@ func entityResolverNameForMultiHelloMultiKey(ctx context.Context, rep EntityRepr
 		m = rep
 		val, ok = m["key2"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"key2\" for MultiHelloMultiKey", ErrTypeNotFound))
 			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiHelloMultiKey", ErrTypeNotFound))
 			break
 		}
 		return "findManyMultiHelloMultiKeyByKey2s", nil
 	}
-	return "", fmt.Errorf("%w for MultiHelloMultiKey", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiHelloMultiKey due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForNestedKey(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -493,6 +524,8 @@ func entityResolverNameForNestedKey(ctx context.Context, rep EntityRepresentatio
 		m = rep
 		val, ok = m["id"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"id\" for NestedKey", ErrTypeNotFound))
 			break
 		}
 		if allNull {
@@ -501,27 +534,40 @@ func entityResolverNameForNestedKey(ctx context.Context, rep EntityRepresentatio
 		m = rep
 		val, ok = m["hello"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"hello\" for NestedKey", ErrTypeNotFound))
 			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
+			// nested field value is not a map[string]interface so don't use it
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to nested Key Field \"hello\" value not matching map[string]any for NestedKey", ErrTypeNotFound))
 			break
 		}
 		val, ok = m["name"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for NestedKey", ErrTypeNotFound))
 			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for NestedKey", ErrTypeNotFound))
 			break
 		}
 		return "findNestedKeyByIDAndHelloName", nil
 	}
-	return "", fmt.Errorf("%w for NestedKey", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for NestedKey due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForVeryNestedKey(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -535,6 +581,8 @@ func entityResolverNameForVeryNestedKey(ctx context.Context, rep EntityRepresent
 		m = rep
 		val, ok = m["id"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"id\" for VeryNestedKey", ErrTypeNotFound))
 			break
 		}
 		if allNull {
@@ -543,13 +591,20 @@ func entityResolverNameForVeryNestedKey(ctx context.Context, rep EntityRepresent
 		m = rep
 		val, ok = m["hello"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"hello\" for VeryNestedKey", ErrTypeNotFound))
 			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
+			// nested field value is not a map[string]interface so don't use it
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to nested Key Field \"hello\" value not matching map[string]any for VeryNestedKey", ErrTypeNotFound))
 			break
 		}
 		val, ok = m["name"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for VeryNestedKey", ErrTypeNotFound))
 			break
 		}
 		if allNull {
@@ -558,13 +613,20 @@ func entityResolverNameForVeryNestedKey(ctx context.Context, rep EntityRepresent
 		m = rep
 		val, ok = m["world"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"world\" for VeryNestedKey", ErrTypeNotFound))
 			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
+			// nested field value is not a map[string]interface so don't use it
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to nested Key Field \"world\" value not matching map[string]any for VeryNestedKey", ErrTypeNotFound))
 			break
 		}
 		val, ok = m["foo"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"foo\" for VeryNestedKey", ErrTypeNotFound))
 			break
 		}
 		if allNull {
@@ -573,13 +635,20 @@ func entityResolverNameForVeryNestedKey(ctx context.Context, rep EntityRepresent
 		m = rep
 		val, ok = m["world"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"world\" for VeryNestedKey", ErrTypeNotFound))
 			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
+			// nested field value is not a map[string]interface so don't use it
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to nested Key Field \"world\" value not matching map[string]any for VeryNestedKey", ErrTypeNotFound))
 			break
 		}
 		val, ok = m["bar"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"bar\" for VeryNestedKey", ErrTypeNotFound))
 			break
 		}
 		if allNull {
@@ -588,34 +657,52 @@ func entityResolverNameForVeryNestedKey(ctx context.Context, rep EntityRepresent
 		m = rep
 		val, ok = m["more"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"more\" for VeryNestedKey", ErrTypeNotFound))
 			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
+			// nested field value is not a map[string]interface so don't use it
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to nested Key Field \"more\" value not matching map[string]any for VeryNestedKey", ErrTypeNotFound))
 			break
 		}
 		val, ok = m["world"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"world\" for VeryNestedKey", ErrTypeNotFound))
 			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
+			// nested field value is not a map[string]interface so don't use it
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to nested Key Field \"world\" value not matching map[string]any for VeryNestedKey", ErrTypeNotFound))
 			break
 		}
 		val, ok = m["foo"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"foo\" for VeryNestedKey", ErrTypeNotFound))
 			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for VeryNestedKey", ErrTypeNotFound))
 			break
 		}
 		return "findVeryNestedKeyByIDAndHelloNameAndWorldFooAndWorldBarAndMoreWorldFoo", nil
 	}
-	return "", fmt.Errorf("%w for VeryNestedKey", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for VeryNestedKey due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -629,12 +716,16 @@ func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["foo"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"foo\" for World", ErrTypeNotFound))
 			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for World", ErrTypeNotFound))
 			break
 		}
 		return "findWorldByFoo", nil
@@ -652,15 +743,20 @@ func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["bar"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"bar\" for World", ErrTypeNotFound))
 			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for World", ErrTypeNotFound))
 			break
 		}
 		return "findWorldByBar", nil
 	}
-	return "", fmt.Errorf("%w for World", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for World due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }

--- a/plugin/federation/testdata/computedrequires/generated/federation.go
+++ b/plugin/federation/testdata/computedrequires/generated/federation.go
@@ -608,13 +608,13 @@ func entityResolverNameForHello(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findHelloByName", nil
 	}
@@ -635,7 +635,7 @@ func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["key1"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field key1 for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
@@ -643,13 +643,13 @@ func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["key2"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field key2 for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findHelloMultiSingleKeysByKey1AndKey2", nil
 	}
@@ -670,13 +670,13 @@ func entityResolverNameForHelloWithErrors(ctx context.Context, rep EntityReprese
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findHelloWithErrorsByName", nil
 	}
@@ -697,13 +697,13 @@ func entityResolverNameForMultiHello(ctx context.Context, rep EntityRepresentati
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiHelloByNames", nil
 	}
@@ -724,13 +724,13 @@ func entityResolverNameForMultiHelloMultipleRequires(ctx context.Context, rep En
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiHelloMultipleRequiresByNames", nil
 	}
@@ -751,13 +751,13 @@ func entityResolverNameForMultiHelloRequires(ctx context.Context, rep EntityRepr
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiHelloRequiresByNames", nil
 	}
@@ -778,13 +778,13 @@ func entityResolverNameForMultiHelloWithError(ctx context.Context, rep EntityRep
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiHelloWithErrorByNames", nil
 	}
@@ -805,13 +805,13 @@ func entityResolverNameForMultiPlanetRequiresNested(ctx context.Context, rep Ent
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiPlanetRequiresNestedByNames", nil
 	}
@@ -832,13 +832,13 @@ func entityResolverNameForPerson(ctx context.Context, rep EntityRepresentation) 
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findPersonByName", nil
 	}
@@ -859,13 +859,13 @@ func entityResolverNameForPlanetMultipleRequires(ctx context.Context, rep Entity
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findPlanetMultipleRequiresByName", nil
 	}
@@ -886,13 +886,13 @@ func entityResolverNameForPlanetRequires(ctx context.Context, rep EntityRepresen
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findPlanetRequiresByName", nil
 	}
@@ -913,13 +913,13 @@ func entityResolverNameForPlanetRequiresNested(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findPlanetRequiresNestedByName", nil
 	}
@@ -940,14 +940,15 @@ func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["hello"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field hello for User", ErrTypeNotFound)
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			break
+			// nested field value is not a map[string]interface
+			return "", fmt.Errorf("%w for World due to nested Keyfield not being map value", ErrTypeNotFound)
 		}
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
@@ -955,13 +956,13 @@ func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["foo"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field foo for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findWorldByHelloNameAndFoo", nil
 	}
@@ -982,13 +983,13 @@ func entityResolverNameForWorldName(ctx context.Context, rep EntityRepresentatio
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findWorldNameByName", nil
 	}
@@ -1009,14 +1010,15 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["hello"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field hello for User", ErrTypeNotFound)
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			break
+			// nested field value is not a map[string]interface
+			return "", fmt.Errorf("%w for WorldWithMultipleKeys due to nested Keyfield not being map value", ErrTypeNotFound)
 		}
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
@@ -1024,13 +1026,13 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["foo"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field foo for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findWorldWithMultipleKeysByHelloNameAndFoo", nil
 	}
@@ -1047,13 +1049,13 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["bar"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field bar for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findWorldWithMultipleKeysByBar", nil
 	}

--- a/plugin/federation/testdata/computedrequires/generated/federation.go
+++ b/plugin/federation/testdata/computedrequires/generated/federation.go
@@ -595,6 +595,9 @@ func (ec *executionContext) resolveManyEntities(
 }
 
 func entityResolverNameForHello(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -608,20 +611,28 @@ func entityResolverNameForHello(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for Hello", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for Hello", ErrTypeNotFound))
+			break
 		}
 		return "findHelloByName", nil
 	}
-	return "", fmt.Errorf("%w for Hello", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for Hello due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -635,7 +646,9 @@ func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["key1"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field key1 for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"key1\" for HelloMultiSingleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
@@ -643,20 +656,28 @@ func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["key2"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field key2 for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"key2\" for HelloMultiSingleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for HelloMultiSingleKeys", ErrTypeNotFound))
+			break
 		}
 		return "findHelloMultiSingleKeysByKey1AndKey2", nil
 	}
-	return "", fmt.Errorf("%w for HelloMultiSingleKeys", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for HelloMultiSingleKeys due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForHelloWithErrors(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -670,20 +691,28 @@ func entityResolverNameForHelloWithErrors(ctx context.Context, rep EntityReprese
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for HelloWithErrors", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for HelloWithErrors", ErrTypeNotFound))
+			break
 		}
 		return "findHelloWithErrorsByName", nil
 	}
-	return "", fmt.Errorf("%w for HelloWithErrors", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for HelloWithErrors due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiHello(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -697,20 +726,28 @@ func entityResolverNameForMultiHello(ctx context.Context, rep EntityRepresentati
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiHello", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiHello", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiHelloByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiHello", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiHello due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiHelloMultipleRequires(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -724,20 +761,28 @@ func entityResolverNameForMultiHelloMultipleRequires(ctx context.Context, rep En
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiHelloMultipleRequires", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiHelloMultipleRequires", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiHelloMultipleRequiresByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiHelloMultipleRequires", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiHelloMultipleRequires due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiHelloRequires(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -751,20 +796,28 @@ func entityResolverNameForMultiHelloRequires(ctx context.Context, rep EntityRepr
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiHelloRequires", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiHelloRequires", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiHelloRequiresByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiHelloRequires", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiHelloRequires due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiHelloWithError(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -778,20 +831,28 @@ func entityResolverNameForMultiHelloWithError(ctx context.Context, rep EntityRep
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiHelloWithError", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiHelloWithError", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiHelloWithErrorByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiHelloWithError", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiHelloWithError due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiPlanetRequiresNested(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -805,20 +866,28 @@ func entityResolverNameForMultiPlanetRequiresNested(ctx context.Context, rep Ent
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiPlanetRequiresNested", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiPlanetRequiresNested", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiPlanetRequiresNestedByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiPlanetRequiresNested", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiPlanetRequiresNested due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForPerson(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -832,20 +901,28 @@ func entityResolverNameForPerson(ctx context.Context, rep EntityRepresentation) 
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for Person", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for Person", ErrTypeNotFound))
+			break
 		}
 		return "findPersonByName", nil
 	}
-	return "", fmt.Errorf("%w for Person", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for Person due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForPlanetMultipleRequires(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -859,20 +936,28 @@ func entityResolverNameForPlanetMultipleRequires(ctx context.Context, rep Entity
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for PlanetMultipleRequires", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for PlanetMultipleRequires", ErrTypeNotFound))
+			break
 		}
 		return "findPlanetMultipleRequiresByName", nil
 	}
-	return "", fmt.Errorf("%w for PlanetMultipleRequires", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for PlanetMultipleRequires due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForPlanetRequires(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -886,20 +971,28 @@ func entityResolverNameForPlanetRequires(ctx context.Context, rep EntityRepresen
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for PlanetRequires", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for PlanetRequires", ErrTypeNotFound))
+			break
 		}
 		return "findPlanetRequiresByName", nil
 	}
-	return "", fmt.Errorf("%w for PlanetRequires", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for PlanetRequires due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForPlanetRequiresNested(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -913,20 +1006,28 @@ func entityResolverNameForPlanetRequiresNested(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for PlanetRequiresNested", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for PlanetRequiresNested", ErrTypeNotFound))
+			break
 		}
 		return "findPlanetRequiresNestedByName", nil
 	}
-	return "", fmt.Errorf("%w for PlanetRequiresNested", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for PlanetRequiresNested due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -940,15 +1041,21 @@ func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["hello"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field hello for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"hello\" for World", ErrTypeNotFound))
+			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			// nested field value is not a map[string]interface
-			return "", fmt.Errorf("%w for World due to nested Keyfield not being map value", ErrTypeNotFound)
+			// nested field value is not a map[string]interface so don't use it
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to nested Key Field \"hello\" value not matching map[string]any for World", ErrTypeNotFound))
+			break
 		}
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for World", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
@@ -956,20 +1063,28 @@ func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["foo"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field foo for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"foo\" for World", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for World", ErrTypeNotFound))
+			break
 		}
 		return "findWorldByHelloNameAndFoo", nil
 	}
-	return "", fmt.Errorf("%w for World", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for World due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForWorldName(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -983,20 +1098,28 @@ func entityResolverNameForWorldName(ctx context.Context, rep EntityRepresentatio
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for WorldName", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for WorldName", ErrTypeNotFound))
+			break
 		}
 		return "findWorldNameByName", nil
 	}
-	return "", fmt.Errorf("%w for WorldName", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for WorldName due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -1010,15 +1133,21 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["hello"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field hello for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"hello\" for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			// nested field value is not a map[string]interface
-			return "", fmt.Errorf("%w for WorldWithMultipleKeys due to nested Keyfield not being map value", ErrTypeNotFound)
+			// nested field value is not a map[string]interface so don't use it
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to nested Key Field \"hello\" value not matching map[string]any for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
@@ -1026,13 +1155,17 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["foo"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field foo for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"foo\" for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		return "findWorldWithMultipleKeysByHelloNameAndFoo", nil
 	}
@@ -1049,15 +1182,20 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["bar"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field bar for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"bar\" for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		return "findWorldWithMultipleKeysByBar", nil
 	}
-	return "", fmt.Errorf("%w for WorldWithMultipleKeys", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for WorldWithMultipleKeys due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }

--- a/plugin/federation/testdata/entityresolver/generated/federation.go
+++ b/plugin/federation/testdata/entityresolver/generated/federation.go
@@ -605,13 +605,13 @@ func entityResolverNameForHello(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findHelloByName", nil
 	}
@@ -632,7 +632,7 @@ func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["key1"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field key1 for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
@@ -640,13 +640,13 @@ func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["key2"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field key2 for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findHelloMultiSingleKeysByKey1AndKey2", nil
 	}
@@ -667,13 +667,13 @@ func entityResolverNameForHelloWithErrors(ctx context.Context, rep EntityReprese
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findHelloWithErrorsByName", nil
 	}
@@ -694,13 +694,13 @@ func entityResolverNameForMultiHello(ctx context.Context, rep EntityRepresentati
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiHelloByNames", nil
 	}
@@ -721,13 +721,13 @@ func entityResolverNameForMultiHelloMultipleRequires(ctx context.Context, rep En
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiHelloMultipleRequiresByNames", nil
 	}
@@ -748,13 +748,13 @@ func entityResolverNameForMultiHelloRequires(ctx context.Context, rep EntityRepr
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiHelloRequiresByNames", nil
 	}
@@ -775,13 +775,13 @@ func entityResolverNameForMultiHelloWithError(ctx context.Context, rep EntityRep
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiHelloWithErrorByNames", nil
 	}
@@ -802,13 +802,13 @@ func entityResolverNameForMultiPlanetRequiresNested(ctx context.Context, rep Ent
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiPlanetRequiresNestedByNames", nil
 	}
@@ -829,13 +829,13 @@ func entityResolverNameForPlanetMultipleRequires(ctx context.Context, rep Entity
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findPlanetMultipleRequiresByName", nil
 	}
@@ -856,13 +856,13 @@ func entityResolverNameForPlanetRequires(ctx context.Context, rep EntityRepresen
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findPlanetRequiresByName", nil
 	}
@@ -883,13 +883,13 @@ func entityResolverNameForPlanetRequiresNested(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findPlanetRequiresNestedByName", nil
 	}
@@ -910,14 +910,15 @@ func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["hello"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field hello for User", ErrTypeNotFound)
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			break
+			// nested field value is not a map[string]interface
+			return "", fmt.Errorf("%w for World due to nested Keyfield not being map value", ErrTypeNotFound)
 		}
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
@@ -925,13 +926,13 @@ func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["foo"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field foo for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findWorldByHelloNameAndFoo", nil
 	}
@@ -952,13 +953,13 @@ func entityResolverNameForWorldName(ctx context.Context, rep EntityRepresentatio
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findWorldNameByName", nil
 	}
@@ -979,14 +980,15 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["hello"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field hello for User", ErrTypeNotFound)
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			break
+			// nested field value is not a map[string]interface
+			return "", fmt.Errorf("%w for WorldWithMultipleKeys due to nested Keyfield not being map value", ErrTypeNotFound)
 		}
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
@@ -994,13 +996,13 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["foo"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field foo for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findWorldWithMultipleKeysByHelloNameAndFoo", nil
 	}
@@ -1017,13 +1019,13 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["bar"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field bar for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findWorldWithMultipleKeysByBar", nil
 	}

--- a/plugin/federation/testdata/entityresolver/generated/federation.go
+++ b/plugin/federation/testdata/entityresolver/generated/federation.go
@@ -592,6 +592,9 @@ func (ec *executionContext) resolveManyEntities(
 }
 
 func entityResolverNameForHello(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -605,20 +608,28 @@ func entityResolverNameForHello(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for Hello", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for Hello", ErrTypeNotFound))
+			break
 		}
 		return "findHelloByName", nil
 	}
-	return "", fmt.Errorf("%w for Hello", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for Hello due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -632,7 +643,9 @@ func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["key1"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field key1 for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"key1\" for HelloMultiSingleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
@@ -640,20 +653,28 @@ func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["key2"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field key2 for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"key2\" for HelloMultiSingleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for HelloMultiSingleKeys", ErrTypeNotFound))
+			break
 		}
 		return "findHelloMultiSingleKeysByKey1AndKey2", nil
 	}
-	return "", fmt.Errorf("%w for HelloMultiSingleKeys", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for HelloMultiSingleKeys due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForHelloWithErrors(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -667,20 +688,28 @@ func entityResolverNameForHelloWithErrors(ctx context.Context, rep EntityReprese
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for HelloWithErrors", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for HelloWithErrors", ErrTypeNotFound))
+			break
 		}
 		return "findHelloWithErrorsByName", nil
 	}
-	return "", fmt.Errorf("%w for HelloWithErrors", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for HelloWithErrors due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiHello(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -694,20 +723,28 @@ func entityResolverNameForMultiHello(ctx context.Context, rep EntityRepresentati
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiHello", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiHello", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiHelloByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiHello", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiHello due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiHelloMultipleRequires(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -721,20 +758,28 @@ func entityResolverNameForMultiHelloMultipleRequires(ctx context.Context, rep En
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiHelloMultipleRequires", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiHelloMultipleRequires", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiHelloMultipleRequiresByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiHelloMultipleRequires", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiHelloMultipleRequires due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiHelloRequires(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -748,20 +793,28 @@ func entityResolverNameForMultiHelloRequires(ctx context.Context, rep EntityRepr
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiHelloRequires", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiHelloRequires", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiHelloRequiresByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiHelloRequires", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiHelloRequires due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiHelloWithError(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -775,20 +828,28 @@ func entityResolverNameForMultiHelloWithError(ctx context.Context, rep EntityRep
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiHelloWithError", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiHelloWithError", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiHelloWithErrorByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiHelloWithError", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiHelloWithError due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiPlanetRequiresNested(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -802,20 +863,28 @@ func entityResolverNameForMultiPlanetRequiresNested(ctx context.Context, rep Ent
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiPlanetRequiresNested", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiPlanetRequiresNested", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiPlanetRequiresNestedByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiPlanetRequiresNested", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiPlanetRequiresNested due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForPlanetMultipleRequires(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -829,20 +898,28 @@ func entityResolverNameForPlanetMultipleRequires(ctx context.Context, rep Entity
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for PlanetMultipleRequires", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for PlanetMultipleRequires", ErrTypeNotFound))
+			break
 		}
 		return "findPlanetMultipleRequiresByName", nil
 	}
-	return "", fmt.Errorf("%w for PlanetMultipleRequires", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for PlanetMultipleRequires due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForPlanetRequires(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -856,20 +933,28 @@ func entityResolverNameForPlanetRequires(ctx context.Context, rep EntityRepresen
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for PlanetRequires", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for PlanetRequires", ErrTypeNotFound))
+			break
 		}
 		return "findPlanetRequiresByName", nil
 	}
-	return "", fmt.Errorf("%w for PlanetRequires", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for PlanetRequires due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForPlanetRequiresNested(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -883,20 +968,28 @@ func entityResolverNameForPlanetRequiresNested(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for PlanetRequiresNested", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for PlanetRequiresNested", ErrTypeNotFound))
+			break
 		}
 		return "findPlanetRequiresNestedByName", nil
 	}
-	return "", fmt.Errorf("%w for PlanetRequiresNested", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for PlanetRequiresNested due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -910,15 +1003,21 @@ func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["hello"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field hello for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"hello\" for World", ErrTypeNotFound))
+			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			// nested field value is not a map[string]interface
-			return "", fmt.Errorf("%w for World due to nested Keyfield not being map value", ErrTypeNotFound)
+			// nested field value is not a map[string]interface so don't use it
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to nested Key Field \"hello\" value not matching map[string]any for World", ErrTypeNotFound))
+			break
 		}
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for World", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
@@ -926,20 +1025,28 @@ func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["foo"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field foo for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"foo\" for World", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for World", ErrTypeNotFound))
+			break
 		}
 		return "findWorldByHelloNameAndFoo", nil
 	}
-	return "", fmt.Errorf("%w for World", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for World due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForWorldName(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -953,20 +1060,28 @@ func entityResolverNameForWorldName(ctx context.Context, rep EntityRepresentatio
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for WorldName", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for WorldName", ErrTypeNotFound))
+			break
 		}
 		return "findWorldNameByName", nil
 	}
-	return "", fmt.Errorf("%w for WorldName", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for WorldName due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -980,15 +1095,21 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["hello"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field hello for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"hello\" for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			// nested field value is not a map[string]interface
-			return "", fmt.Errorf("%w for WorldWithMultipleKeys due to nested Keyfield not being map value", ErrTypeNotFound)
+			// nested field value is not a map[string]interface so don't use it
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to nested Key Field \"hello\" value not matching map[string]any for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
@@ -996,13 +1117,17 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["foo"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field foo for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"foo\" for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		return "findWorldWithMultipleKeysByHelloNameAndFoo", nil
 	}
@@ -1019,15 +1144,20 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["bar"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field bar for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"bar\" for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		return "findWorldWithMultipleKeysByBar", nil
 	}
-	return "", fmt.Errorf("%w for WorldWithMultipleKeys", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for WorldWithMultipleKeys due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }

--- a/plugin/federation/testdata/explicitrequires/generated/federation.go
+++ b/plugin/federation/testdata/explicitrequires/generated/federation.go
@@ -606,6 +606,9 @@ func (ec *executionContext) resolveManyEntities(
 }
 
 func entityResolverNameForHello(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -619,20 +622,28 @@ func entityResolverNameForHello(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for Hello", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for Hello", ErrTypeNotFound))
+			break
 		}
 		return "findHelloByName", nil
 	}
-	return "", fmt.Errorf("%w for Hello", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for Hello due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -646,7 +657,9 @@ func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["key1"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field key1 for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"key1\" for HelloMultiSingleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
@@ -654,20 +667,28 @@ func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["key2"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field key2 for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"key2\" for HelloMultiSingleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for HelloMultiSingleKeys", ErrTypeNotFound))
+			break
 		}
 		return "findHelloMultiSingleKeysByKey1AndKey2", nil
 	}
-	return "", fmt.Errorf("%w for HelloMultiSingleKeys", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for HelloMultiSingleKeys due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForHelloWithErrors(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -681,20 +702,28 @@ func entityResolverNameForHelloWithErrors(ctx context.Context, rep EntityReprese
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for HelloWithErrors", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for HelloWithErrors", ErrTypeNotFound))
+			break
 		}
 		return "findHelloWithErrorsByName", nil
 	}
-	return "", fmt.Errorf("%w for HelloWithErrors", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for HelloWithErrors due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiHello(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -708,20 +737,28 @@ func entityResolverNameForMultiHello(ctx context.Context, rep EntityRepresentati
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiHello", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiHello", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiHelloByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiHello", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiHello due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiHelloMultipleRequires(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -735,20 +772,28 @@ func entityResolverNameForMultiHelloMultipleRequires(ctx context.Context, rep En
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiHelloMultipleRequires", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiHelloMultipleRequires", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiHelloMultipleRequiresByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiHelloMultipleRequires", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiHelloMultipleRequires due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiHelloRequires(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -762,20 +807,28 @@ func entityResolverNameForMultiHelloRequires(ctx context.Context, rep EntityRepr
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiHelloRequires", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiHelloRequires", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiHelloRequiresByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiHelloRequires", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiHelloRequires due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiHelloWithError(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -789,20 +842,28 @@ func entityResolverNameForMultiHelloWithError(ctx context.Context, rep EntityRep
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiHelloWithError", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiHelloWithError", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiHelloWithErrorByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiHelloWithError", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiHelloWithError due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiPlanetRequiresNested(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -816,20 +877,28 @@ func entityResolverNameForMultiPlanetRequiresNested(ctx context.Context, rep Ent
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiPlanetRequiresNested", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiPlanetRequiresNested", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiPlanetRequiresNestedByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiPlanetRequiresNested", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiPlanetRequiresNested due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForPerson(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -843,20 +912,28 @@ func entityResolverNameForPerson(ctx context.Context, rep EntityRepresentation) 
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for Person", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for Person", ErrTypeNotFound))
+			break
 		}
 		return "findPersonByName", nil
 	}
-	return "", fmt.Errorf("%w for Person", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for Person due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForPlanetMultipleRequires(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -870,20 +947,28 @@ func entityResolverNameForPlanetMultipleRequires(ctx context.Context, rep Entity
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for PlanetMultipleRequires", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for PlanetMultipleRequires", ErrTypeNotFound))
+			break
 		}
 		return "findPlanetMultipleRequiresByName", nil
 	}
-	return "", fmt.Errorf("%w for PlanetMultipleRequires", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for PlanetMultipleRequires due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForPlanetRequires(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -897,20 +982,28 @@ func entityResolverNameForPlanetRequires(ctx context.Context, rep EntityRepresen
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for PlanetRequires", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for PlanetRequires", ErrTypeNotFound))
+			break
 		}
 		return "findPlanetRequiresByName", nil
 	}
-	return "", fmt.Errorf("%w for PlanetRequires", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for PlanetRequires due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForPlanetRequiresNested(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -924,20 +1017,28 @@ func entityResolverNameForPlanetRequiresNested(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for PlanetRequiresNested", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for PlanetRequiresNested", ErrTypeNotFound))
+			break
 		}
 		return "findPlanetRequiresNestedByName", nil
 	}
-	return "", fmt.Errorf("%w for PlanetRequiresNested", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for PlanetRequiresNested due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -951,15 +1052,21 @@ func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["hello"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field hello for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"hello\" for World", ErrTypeNotFound))
+			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			// nested field value is not a map[string]interface
-			return "", fmt.Errorf("%w for World due to nested Keyfield not being map value", ErrTypeNotFound)
+			// nested field value is not a map[string]interface so don't use it
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to nested Key Field \"hello\" value not matching map[string]any for World", ErrTypeNotFound))
+			break
 		}
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for World", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
@@ -967,20 +1074,28 @@ func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["foo"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field foo for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"foo\" for World", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for World", ErrTypeNotFound))
+			break
 		}
 		return "findWorldByHelloNameAndFoo", nil
 	}
-	return "", fmt.Errorf("%w for World", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for World due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForWorldName(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -994,20 +1109,28 @@ func entityResolverNameForWorldName(ctx context.Context, rep EntityRepresentatio
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for WorldName", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for WorldName", ErrTypeNotFound))
+			break
 		}
 		return "findWorldNameByName", nil
 	}
-	return "", fmt.Errorf("%w for WorldName", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for WorldName due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -1021,15 +1144,21 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["hello"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field hello for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"hello\" for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			// nested field value is not a map[string]interface
-			return "", fmt.Errorf("%w for WorldWithMultipleKeys due to nested Keyfield not being map value", ErrTypeNotFound)
+			// nested field value is not a map[string]interface so don't use it
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to nested Key Field \"hello\" value not matching map[string]any for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
@@ -1037,13 +1166,17 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["foo"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field foo for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"foo\" for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		return "findWorldWithMultipleKeysByHelloNameAndFoo", nil
 	}
@@ -1060,15 +1193,20 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["bar"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field bar for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"bar\" for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		return "findWorldWithMultipleKeysByBar", nil
 	}
-	return "", fmt.Errorf("%w for WorldWithMultipleKeys", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for WorldWithMultipleKeys due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }

--- a/plugin/federation/testdata/explicitrequires/generated/federation.go
+++ b/plugin/federation/testdata/explicitrequires/generated/federation.go
@@ -619,13 +619,13 @@ func entityResolverNameForHello(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findHelloByName", nil
 	}
@@ -646,7 +646,7 @@ func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["key1"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field key1 for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
@@ -654,13 +654,13 @@ func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["key2"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field key2 for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findHelloMultiSingleKeysByKey1AndKey2", nil
 	}
@@ -681,13 +681,13 @@ func entityResolverNameForHelloWithErrors(ctx context.Context, rep EntityReprese
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findHelloWithErrorsByName", nil
 	}
@@ -708,13 +708,13 @@ func entityResolverNameForMultiHello(ctx context.Context, rep EntityRepresentati
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiHelloByNames", nil
 	}
@@ -735,13 +735,13 @@ func entityResolverNameForMultiHelloMultipleRequires(ctx context.Context, rep En
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiHelloMultipleRequiresByNames", nil
 	}
@@ -762,13 +762,13 @@ func entityResolverNameForMultiHelloRequires(ctx context.Context, rep EntityRepr
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiHelloRequiresByNames", nil
 	}
@@ -789,13 +789,13 @@ func entityResolverNameForMultiHelloWithError(ctx context.Context, rep EntityRep
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiHelloWithErrorByNames", nil
 	}
@@ -816,13 +816,13 @@ func entityResolverNameForMultiPlanetRequiresNested(ctx context.Context, rep Ent
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiPlanetRequiresNestedByNames", nil
 	}
@@ -843,13 +843,13 @@ func entityResolverNameForPerson(ctx context.Context, rep EntityRepresentation) 
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findPersonByName", nil
 	}
@@ -870,13 +870,13 @@ func entityResolverNameForPlanetMultipleRequires(ctx context.Context, rep Entity
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findPlanetMultipleRequiresByName", nil
 	}
@@ -897,13 +897,13 @@ func entityResolverNameForPlanetRequires(ctx context.Context, rep EntityRepresen
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findPlanetRequiresByName", nil
 	}
@@ -924,13 +924,13 @@ func entityResolverNameForPlanetRequiresNested(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findPlanetRequiresNestedByName", nil
 	}
@@ -951,14 +951,15 @@ func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["hello"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field hello for User", ErrTypeNotFound)
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			break
+			// nested field value is not a map[string]interface
+			return "", fmt.Errorf("%w for World due to nested Keyfield not being map value", ErrTypeNotFound)
 		}
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
@@ -966,13 +967,13 @@ func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["foo"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field foo for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findWorldByHelloNameAndFoo", nil
 	}
@@ -993,13 +994,13 @@ func entityResolverNameForWorldName(ctx context.Context, rep EntityRepresentatio
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findWorldNameByName", nil
 	}
@@ -1020,14 +1021,15 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["hello"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field hello for User", ErrTypeNotFound)
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			break
+			// nested field value is not a map[string]interface
+			return "", fmt.Errorf("%w for WorldWithMultipleKeys due to nested Keyfield not being map value", ErrTypeNotFound)
 		}
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
@@ -1035,13 +1037,13 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["foo"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field foo for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findWorldWithMultipleKeysByHelloNameAndFoo", nil
 	}
@@ -1058,13 +1060,13 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["bar"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field bar for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findWorldWithMultipleKeysByBar", nil
 	}

--- a/plugin/federation/testdata/federation2/generated/federation.go
+++ b/plugin/federation/testdata/federation2/generated/federation.go
@@ -199,6 +199,9 @@ func (ec *executionContext) resolveManyEntities(
 }
 
 func entityResolverNameForExternalExtension(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -212,15 +215,20 @@ func entityResolverNameForExternalExtension(ctx context.Context, rep EntityRepre
 		m = rep
 		val, ok = m["upc"]
 		if !ok {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"upc\" for ExternalExtension", ErrTypeNotFound))
 			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for ExternalExtension", ErrTypeNotFound))
 			break
 		}
 		return "findExternalExtensionByUpc", nil
 	}
-	return "", fmt.Errorf("%w for ExternalExtension", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for ExternalExtension due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }

--- a/plugin/federation/testdata/usefunctionsyntaxforexecutioncontext/generated/federation.go
+++ b/plugin/federation/testdata/usefunctionsyntaxforexecutioncontext/generated/federation.go
@@ -605,13 +605,13 @@ func entityResolverNameForHello(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findHelloByName", nil
 	}
@@ -632,7 +632,7 @@ func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["key1"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field key1 for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
@@ -640,13 +640,13 @@ func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["key2"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field key2 for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findHelloMultiSingleKeysByKey1AndKey2", nil
 	}
@@ -667,13 +667,13 @@ func entityResolverNameForHelloWithErrors(ctx context.Context, rep EntityReprese
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findHelloWithErrorsByName", nil
 	}
@@ -694,13 +694,13 @@ func entityResolverNameForMultiHello(ctx context.Context, rep EntityRepresentati
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiHelloByNames", nil
 	}
@@ -721,13 +721,13 @@ func entityResolverNameForMultiHelloMultipleRequires(ctx context.Context, rep En
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiHelloMultipleRequiresByNames", nil
 	}
@@ -748,13 +748,13 @@ func entityResolverNameForMultiHelloRequires(ctx context.Context, rep EntityRepr
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiHelloRequiresByNames", nil
 	}
@@ -775,13 +775,13 @@ func entityResolverNameForMultiHelloWithError(ctx context.Context, rep EntityRep
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiHelloWithErrorByNames", nil
 	}
@@ -802,13 +802,13 @@ func entityResolverNameForMultiPlanetRequiresNested(ctx context.Context, rep Ent
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findManyMultiPlanetRequiresNestedByNames", nil
 	}
@@ -829,13 +829,13 @@ func entityResolverNameForPlanetMultipleRequires(ctx context.Context, rep Entity
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findPlanetMultipleRequiresByName", nil
 	}
@@ -856,13 +856,13 @@ func entityResolverNameForPlanetRequires(ctx context.Context, rep EntityRepresen
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findPlanetRequiresByName", nil
 	}
@@ -883,13 +883,13 @@ func entityResolverNameForPlanetRequiresNested(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findPlanetRequiresNestedByName", nil
 	}
@@ -910,14 +910,15 @@ func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["hello"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field hello for User", ErrTypeNotFound)
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			break
+			// nested field value is not a map[string]interface
+			return "", fmt.Errorf("%w for World due to nested Keyfield not being map value", ErrTypeNotFound)
 		}
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
@@ -925,13 +926,13 @@ func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["foo"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field foo for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findWorldByHelloNameAndFoo", nil
 	}
@@ -952,13 +953,13 @@ func entityResolverNameForWorldName(ctx context.Context, rep EntityRepresentatio
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findWorldNameByName", nil
 	}
@@ -979,14 +980,15 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["hello"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field hello for User", ErrTypeNotFound)
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			break
+			// nested field value is not a map[string]interface
+			return "", fmt.Errorf("%w for WorldWithMultipleKeys due to nested Keyfield not being map value", ErrTypeNotFound)
 		}
 		val, ok = m["name"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
@@ -994,13 +996,13 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["foo"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field foo for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findWorldWithMultipleKeysByHelloNameAndFoo", nil
 	}
@@ -1017,13 +1019,13 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["bar"]
 		if !ok {
-			break
+			return "", fmt.Errorf("%w due to missing Key Field bar for User", ErrTypeNotFound)
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			break
+			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
 		}
 		return "findWorldWithMultipleKeysByBar", nil
 	}

--- a/plugin/federation/testdata/usefunctionsyntaxforexecutioncontext/generated/federation.go
+++ b/plugin/federation/testdata/usefunctionsyntaxforexecutioncontext/generated/federation.go
@@ -592,6 +592,9 @@ func (ec *executionContext) resolveManyEntities(
 }
 
 func entityResolverNameForHello(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -605,20 +608,28 @@ func entityResolverNameForHello(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for Hello", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for Hello", ErrTypeNotFound))
+			break
 		}
 		return "findHelloByName", nil
 	}
-	return "", fmt.Errorf("%w for Hello", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for Hello due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -632,7 +643,9 @@ func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["key1"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field key1 for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"key1\" for HelloMultiSingleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
@@ -640,20 +653,28 @@ func entityResolverNameForHelloMultiSingleKeys(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["key2"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field key2 for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"key2\" for HelloMultiSingleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for HelloMultiSingleKeys", ErrTypeNotFound))
+			break
 		}
 		return "findHelloMultiSingleKeysByKey1AndKey2", nil
 	}
-	return "", fmt.Errorf("%w for HelloMultiSingleKeys", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for HelloMultiSingleKeys due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForHelloWithErrors(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -667,20 +688,28 @@ func entityResolverNameForHelloWithErrors(ctx context.Context, rep EntityReprese
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for HelloWithErrors", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for HelloWithErrors", ErrTypeNotFound))
+			break
 		}
 		return "findHelloWithErrorsByName", nil
 	}
-	return "", fmt.Errorf("%w for HelloWithErrors", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for HelloWithErrors due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiHello(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -694,20 +723,28 @@ func entityResolverNameForMultiHello(ctx context.Context, rep EntityRepresentati
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiHello", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiHello", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiHelloByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiHello", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiHello due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiHelloMultipleRequires(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -721,20 +758,28 @@ func entityResolverNameForMultiHelloMultipleRequires(ctx context.Context, rep En
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiHelloMultipleRequires", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiHelloMultipleRequires", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiHelloMultipleRequiresByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiHelloMultipleRequires", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiHelloMultipleRequires due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiHelloRequires(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -748,20 +793,28 @@ func entityResolverNameForMultiHelloRequires(ctx context.Context, rep EntityRepr
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiHelloRequires", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiHelloRequires", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiHelloRequiresByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiHelloRequires", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiHelloRequires due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiHelloWithError(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -775,20 +828,28 @@ func entityResolverNameForMultiHelloWithError(ctx context.Context, rep EntityRep
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiHelloWithError", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiHelloWithError", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiHelloWithErrorByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiHelloWithError", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiHelloWithError due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForMultiPlanetRequiresNested(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -802,20 +863,28 @@ func entityResolverNameForMultiPlanetRequiresNested(ctx context.Context, rep Ent
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for MultiPlanetRequiresNested", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for MultiPlanetRequiresNested", ErrTypeNotFound))
+			break
 		}
 		return "findManyMultiPlanetRequiresNestedByNames", nil
 	}
-	return "", fmt.Errorf("%w for MultiPlanetRequiresNested", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for MultiPlanetRequiresNested due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForPlanetMultipleRequires(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -829,20 +898,28 @@ func entityResolverNameForPlanetMultipleRequires(ctx context.Context, rep Entity
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for PlanetMultipleRequires", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for PlanetMultipleRequires", ErrTypeNotFound))
+			break
 		}
 		return "findPlanetMultipleRequiresByName", nil
 	}
-	return "", fmt.Errorf("%w for PlanetMultipleRequires", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for PlanetMultipleRequires due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForPlanetRequires(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -856,20 +933,28 @@ func entityResolverNameForPlanetRequires(ctx context.Context, rep EntityRepresen
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for PlanetRequires", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for PlanetRequires", ErrTypeNotFound))
+			break
 		}
 		return "findPlanetRequiresByName", nil
 	}
-	return "", fmt.Errorf("%w for PlanetRequires", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for PlanetRequires due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForPlanetRequiresNested(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -883,20 +968,28 @@ func entityResolverNameForPlanetRequiresNested(ctx context.Context, rep EntityRe
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for PlanetRequiresNested", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for PlanetRequiresNested", ErrTypeNotFound))
+			break
 		}
 		return "findPlanetRequiresNestedByName", nil
 	}
-	return "", fmt.Errorf("%w for PlanetRequiresNested", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for PlanetRequiresNested due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -910,15 +1003,21 @@ func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["hello"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field hello for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"hello\" for World", ErrTypeNotFound))
+			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			// nested field value is not a map[string]interface
-			return "", fmt.Errorf("%w for World due to nested Keyfield not being map value", ErrTypeNotFound)
+			// nested field value is not a map[string]interface so don't use it
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to nested Key Field \"hello\" value not matching map[string]any for World", ErrTypeNotFound))
+			break
 		}
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for World", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
@@ -926,20 +1025,28 @@ func entityResolverNameForWorld(ctx context.Context, rep EntityRepresentation) (
 		m = rep
 		val, ok = m["foo"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field foo for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"foo\" for World", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for World", ErrTypeNotFound))
+			break
 		}
 		return "findWorldByHelloNameAndFoo", nil
 	}
-	return "", fmt.Errorf("%w for World", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for World due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForWorldName(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -953,20 +1060,28 @@ func entityResolverNameForWorldName(ctx context.Context, rep EntityRepresentatio
 		m = rep
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for WorldName", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for WorldName", ErrTypeNotFound))
+			break
 		}
 		return "findWorldNameByName", nil
 	}
-	return "", fmt.Errorf("%w for WorldName", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for WorldName due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }
 
 func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityRepresentation) (string, error) {
+	// we collect errors because a later entity resolver may work fine
+	// when an entity has multiple keys
+	entityResolverErrs := []error{}
 	for {
 		var (
 			m   EntityRepresentation
@@ -980,15 +1095,21 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["hello"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field hello for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"hello\" for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		if m, ok = val.(map[string]interface{}); !ok {
-			// nested field value is not a map[string]interface
-			return "", fmt.Errorf("%w for WorldWithMultipleKeys due to nested Keyfield not being map value", ErrTypeNotFound)
+			// nested field value is not a map[string]interface so don't use it
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to nested Key Field \"hello\" value not matching map[string]any for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		val, ok = m["name"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field name for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"name\" for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
@@ -996,13 +1117,17 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["foo"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field foo for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"foo\" for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		return "findWorldWithMultipleKeysByHelloNameAndFoo", nil
 	}
@@ -1019,15 +1144,20 @@ func entityResolverNameForWorldWithMultipleKeys(ctx context.Context, rep EntityR
 		m = rep
 		val, ok = m["bar"]
 		if !ok {
-			return "", fmt.Errorf("%w due to missing Key Field bar for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to missing Key Field \"bar\" for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		if allNull {
 			allNull = val == nil
 		}
 		if allNull {
-			return "", fmt.Errorf("%w due to all null value KeyFields for User", ErrTypeNotFound)
+			entityResolverErrs = append(entityResolverErrs,
+				fmt.Errorf("%w due to all null value KeyFields for WorldWithMultipleKeys", ErrTypeNotFound))
+			break
 		}
 		return "findWorldWithMultipleKeysByBar", nil
 	}
-	return "", fmt.Errorf("%w for WorldWithMultipleKeys", ErrTypeNotFound)
+	return "", fmt.Errorf("%w for WorldWithMultipleKeys due to %v", ErrTypeNotFound,
+		errors.Join(entityResolverErrs...).Error())
 }


### PR DESCRIPTION
In #3029 @clayne11 altered the federation behavior, so that null values for key Fields would now also skip using the resolver (since it would never work). This was both a security and performance enhancement, as expensive safelisted queries with nil KeyField values could have been sent for no reason.

However, the error messages for this change were not very specific and as a result, were not very clearly actionable.
I **think** I correctly understand the cases and have added more specific error messages, but I would definitely appreciate confirmation from @clayne11 or @kanodia-parag or anyone else that I'm not subtly misleading people.

I am collecting entity resolution errors as it is valid for entities with multiple key fields to fail with some resolvers and then succeed with a different resolver.