### PR TITLE
If the graphql.AddError err arg is nil, early return

### DIFF
--- a/graphql/context_response.go
+++ b/graphql/context_response.go
@@ -51,6 +51,9 @@ func AddErrorf(ctx context.Context, format string, args ...any) {
 
 // AddError sends an error to the client, first passing it through the error presenter.
 func AddError(ctx context.Context, err error) {
+	if err == nil {
+		return
+	}
 	c := getResponseContext(ctx)
 
 	presentedError := c.errorPresenter(ctx, ErrorOnPath(ctx, err))

--- a/graphql/error.go
+++ b/graphql/error.go
@@ -10,6 +10,9 @@ import (
 type ErrorPresenterFunc func(ctx context.Context, err error) *gqlerror.Error
 
 func DefaultErrorPresenter(ctx context.Context, err error) *gqlerror.Error {
+	if err == nil {
+		return nil
+	}
 	var gqlErr *gqlerror.Error
 	if errors.As(err, &gqlErr) {
 		return gqlErr


### PR DESCRIPTION
Fixes #3410 so that graphql.AddError is a no-op if the error is nil.

Signed-off-by: Steve Coffman <steve@khanacademy.org>
