### PR TITLE
[BUG] fix disable suggestion bug

### DIFF
--- a/graphql/executor/executor.go
+++ b/graphql/executor/executor.go
@@ -227,6 +227,8 @@ func (e *Executor) parseQuery(
 		validator.RemoveRule("FieldsOnCorrectType")
 
 		rule := rules.FieldsOnCorrectTypeRuleWithoutSuggestions
+		// remove the rule added when it was last executed
+		validator.RemoveRule(rule.Name)
 		validator.AddRule(rule.Name, rule.RuleFunc)
 	}
 

--- a/graphql/executor/executor_test.go
+++ b/graphql/executor/executor_test.go
@@ -181,7 +181,14 @@ func TestExecutorDisableSuggestion(t *testing.T) {
 		exec.SetDisableSuggestion(true)
 		resp := query(exec, "", "{nam}")
 		assert.Equal(t, "", string(resp.Data))
+		assert.Equal(t, len(resp.Errors), 1)
 		assert.Equal(t, "input:1: Cannot query field \"nam\" on type \"Query\".\n", resp.Errors.Error())
+
+		// check if the error message is displayed correctly even if an error occurs multiple times
+		resp = query(exec, "", "{nam}")
+		assert.Equal(t, "", string(resp.Data))
+		assert.Equal(t, "input:1: Cannot query field \"nam\" on type \"Query\".\n", resp.Errors.Error())
+		assert.Equal(t, len(resp.Errors), 1)
 	})
 }
 

--- a/graphql/executor/executor_test.go
+++ b/graphql/executor/executor_test.go
@@ -181,14 +181,14 @@ func TestExecutorDisableSuggestion(t *testing.T) {
 		exec.SetDisableSuggestion(true)
 		resp := query(exec, "", "{nam}")
 		assert.Equal(t, "", string(resp.Data))
-		assert.Equal(t, len(resp.Errors), 1)
+		assert.Len(t, resp.Errors, 1)
 		assert.Equal(t, "input:1: Cannot query field \"nam\" on type \"Query\".\n", resp.Errors.Error())
 
 		// check if the error message is displayed correctly even if an error occurs multiple times
 		resp = query(exec, "", "{nam}")
 		assert.Equal(t, "", string(resp.Data))
+		assert.Len(t, resp.Errors, 1)
 		assert.Equal(t, "input:1: Cannot query field \"nam\" on type \"Query\".\n", resp.Errors.Error())
-		assert.Equal(t, len(resp.Errors), 1)
 	})
 }
 


### PR DESCRIPTION
@StevenACoffman
First, please allow me to offer my apologies. I have realized that a minor bug exists in the [Pull Request I previously submitted](https://github.com/99designs/gqlgen/pull/3411).

The issue is that when disableSuggestion is set to true, and consecutive queries are made, the resulting error messages are duplicated.

Below, I’ve included a screenshot that demonstrates the bug, along with steps to reproduce it. Please feel free to try it out in your local playground environment:
1. Set disableSuggestion to true.
2. Execute a query that would trigger suggestions.
3. Observe that the errors are outputted multiple times, creating duplicates.

# Previous Pull Request
https://github.com/99designs/gqlgen/pull/3411

# Screenshot
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/8f3af364-a1d1-4d69-af0f-fabc48751566" />

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] ~~Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))~~
