### PR TITLE
codegen: move templates comments from generated code

### DIFF
--- a/_examples/chat/generated.go
+++ b/_examples/chat/generated.go
@@ -354,11 +354,7 @@ func (ec *executionContext) dir_user_argsUsername(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["username"]
-	if !ok {
+	if _, ok := rawArgs["username"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -396,11 +392,7 @@ func (ec *executionContext) field_Mutation_post_argsText(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["text"]
-	if !ok {
+	if _, ok := rawArgs["text"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -418,11 +410,7 @@ func (ec *executionContext) field_Mutation_post_argsUsername(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["username"]
-	if !ok {
+	if _, ok := rawArgs["username"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -440,11 +428,7 @@ func (ec *executionContext) field_Mutation_post_argsRoomName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["roomName"]
-	if !ok {
+	if _, ok := rawArgs["roomName"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -472,11 +456,7 @@ func (ec *executionContext) field_Query___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -504,11 +484,7 @@ func (ec *executionContext) field_Query_room_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -536,11 +512,7 @@ func (ec *executionContext) field_Subscription_messageAdded_argsRoomName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["roomName"]
-	if !ok {
+	if _, ok := rawArgs["roomName"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -568,11 +540,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -600,11 +568,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/_examples/config/generated.go
+++ b/_examples/config/generated.go
@@ -346,11 +346,7 @@ func (ec *executionContext) field_Mutation_createTodo_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (NewTodo, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal NewTodo
 		return zeroVal, nil
 	}
@@ -378,11 +374,7 @@ func (ec *executionContext) field_Query___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -410,11 +402,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -442,11 +430,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/_examples/dataloader/generated.go
+++ b/_examples/dataloader/generated.go
@@ -348,11 +348,7 @@ func (ec *executionContext) field_Query___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -380,11 +376,7 @@ func (ec *executionContext) field_Query_torture1d_argsCustomerIds(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["customerIds"]
-	if !ok {
+	if _, ok := rawArgs["customerIds"]; !ok {
 		var zeroVal []int
 		return zeroVal, nil
 	}
@@ -412,11 +404,7 @@ func (ec *executionContext) field_Query_torture2d_argsCustomerIds(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([][]int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["customerIds"]
-	if !ok {
+	if _, ok := rawArgs["customerIds"]; !ok {
 		var zeroVal [][]int
 		return zeroVal, nil
 	}
@@ -444,11 +432,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -476,11 +460,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/_examples/embedding/subdir/gendir/generated.go
+++ b/_examples/embedding/subdir/gendir/generated.go
@@ -257,11 +257,7 @@ func (ec *executionContext) field_Query___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -289,11 +285,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -321,11 +313,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/_examples/embedding/subdir/prelude.generated.go
+++ b/_examples/embedding/subdir/prelude.generated.go
@@ -40,11 +40,7 @@ func (ec *executionContext) dir_defer_argsIf(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["if"]
-	if !ok {
+	if _, ok := rawArgs["if"]; !ok {
 		var zeroVal *bool
 		return zeroVal, nil
 	}
@@ -62,11 +58,7 @@ func (ec *executionContext) dir_defer_argsLabel(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["label"]
-	if !ok {
+	if _, ok := rawArgs["label"]; !ok {
 		var zeroVal *string
 		return zeroVal, nil
 	}
@@ -94,11 +86,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -126,11 +114,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/_examples/embedding/subdir/root.generated.go
+++ b/_examples/embedding/subdir/root.generated.go
@@ -41,11 +41,7 @@ func (ec *executionContext) field_Query___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}

--- a/_examples/enum/api/exec.go
+++ b/_examples/enum/api/exec.go
@@ -467,11 +467,7 @@ func (ec *executionContext) field_Query___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -499,11 +495,7 @@ func (ec *executionContext) field_Query_boolTypedN_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*model.BoolTyped, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal *model.BoolTyped
 		return zeroVal, nil
 	}
@@ -531,11 +523,7 @@ func (ec *executionContext) field_Query_boolTyped_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (model.BoolTyped, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal model.BoolTyped
 		return zeroVal, nil
 	}
@@ -563,11 +551,7 @@ func (ec *executionContext) field_Query_boolUntypedN_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal *bool
 		return zeroVal, nil
 	}
@@ -595,11 +579,7 @@ func (ec *executionContext) field_Query_boolUntyped_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -627,11 +607,7 @@ func (ec *executionContext) field_Query_inPackage_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (InPackage, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal InPackage
 		return zeroVal, nil
 	}
@@ -659,11 +635,7 @@ func (ec *executionContext) field_Query_intTypedN_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*model.IntTyped, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal *model.IntTyped
 		return zeroVal, nil
 	}
@@ -691,11 +663,7 @@ func (ec *executionContext) field_Query_intTyped_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (model.IntTyped, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal model.IntTyped
 		return zeroVal, nil
 	}
@@ -723,11 +691,7 @@ func (ec *executionContext) field_Query_intUntypedN_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -755,11 +719,7 @@ func (ec *executionContext) field_Query_intUntyped_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal int
 		return zeroVal, nil
 	}
@@ -787,11 +747,7 @@ func (ec *executionContext) field_Query_stringTypedN_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*model.StringTyped, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal *model.StringTyped
 		return zeroVal, nil
 	}
@@ -819,11 +775,7 @@ func (ec *executionContext) field_Query_stringTyped_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (model.StringTyped, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal model.StringTyped
 		return zeroVal, nil
 	}
@@ -851,11 +803,7 @@ func (ec *executionContext) field_Query_stringUntypedN_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal *string
 		return zeroVal, nil
 	}
@@ -883,11 +831,7 @@ func (ec *executionContext) field_Query_stringUntyped_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -915,11 +859,7 @@ func (ec *executionContext) field_Query_varTyped_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (model.VarTyped, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal model.VarTyped
 		return zeroVal, nil
 	}
@@ -947,11 +887,7 @@ func (ec *executionContext) field_Query_varUntyped_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -979,11 +915,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -1011,11 +943,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/_examples/federation/accounts/graph/generated.go
+++ b/_examples/federation/accounts/graph/generated.go
@@ -398,11 +398,7 @@ func (ec *executionContext) field_Entity_findEmailHostByID_argsID(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -430,11 +426,7 @@ func (ec *executionContext) field_Entity_findUserByID_argsID(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -462,11 +454,7 @@ func (ec *executionContext) field_Query___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -494,11 +482,7 @@ func (ec *executionContext) field_Query__entities_argsRepresentations(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]map[string]any, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["representations"]
-	if !ok {
+	if _, ok := rawArgs["representations"]; !ok {
 		var zeroVal []map[string]any
 		return zeroVal, nil
 	}
@@ -526,11 +510,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -558,11 +538,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/_examples/federation/products/graph/generated.go
+++ b/_examples/federation/products/graph/generated.go
@@ -269,11 +269,7 @@ func (ec *executionContext) field_Entity_findManufacturerByID_argsID(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -306,11 +302,7 @@ func (ec *executionContext) field_Entity_findProductByManufacturerIDAndID_argsMa
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["manufacturerID"]
-	if !ok {
+	if _, ok := rawArgs["manufacturerID"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -328,11 +320,7 @@ func (ec *executionContext) field_Entity_findProductByManufacturerIDAndID_argsID
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -360,11 +348,7 @@ func (ec *executionContext) field_Entity_findProductByUpc_argsUpc(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["upc"]
-	if !ok {
+	if _, ok := rawArgs["upc"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -392,11 +376,7 @@ func (ec *executionContext) field_Query___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -424,11 +404,7 @@ func (ec *executionContext) field_Query__entities_argsRepresentations(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]map[string]any, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["representations"]
-	if !ok {
+	if _, ok := rawArgs["representations"]; !ok {
 		var zeroVal []map[string]any
 		return zeroVal, nil
 	}
@@ -456,11 +432,7 @@ func (ec *executionContext) field_Query_topProducts_argsFirst(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["first"]
-	if !ok {
+	if _, ok := rawArgs["first"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -488,11 +460,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -520,11 +488,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/_examples/fileupload/generated.go
+++ b/_examples/fileupload/generated.go
@@ -317,11 +317,7 @@ func (ec *executionContext) field_Mutation_multipleUploadWithPayload_argsReq(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]*model.UploadFile, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["req"]
-	if !ok {
+	if _, ok := rawArgs["req"]; !ok {
 		var zeroVal []*model.UploadFile
 		return zeroVal, nil
 	}
@@ -349,11 +345,7 @@ func (ec *executionContext) field_Mutation_multipleUpload_argsFiles(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]*graphql.Upload, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["files"]
-	if !ok {
+	if _, ok := rawArgs["files"]; !ok {
 		var zeroVal []*graphql.Upload
 		return zeroVal, nil
 	}
@@ -381,11 +373,7 @@ func (ec *executionContext) field_Mutation_singleUploadWithPayload_argsReq(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (model.UploadFile, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["req"]
-	if !ok {
+	if _, ok := rawArgs["req"]; !ok {
 		var zeroVal model.UploadFile
 		return zeroVal, nil
 	}
@@ -413,11 +401,7 @@ func (ec *executionContext) field_Mutation_singleUpload_argsFile(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (graphql.Upload, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["file"]
-	if !ok {
+	if _, ok := rawArgs["file"]; !ok {
 		var zeroVal graphql.Upload
 		return zeroVal, nil
 	}
@@ -445,11 +429,7 @@ func (ec *executionContext) field_Query___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -477,11 +457,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -509,11 +485,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/_examples/scalars/generated.go
+++ b/_examples/scalars/generated.go
@@ -355,11 +355,7 @@ func (ec *executionContext) field_Query___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -387,11 +383,7 @@ func (ec *executionContext) field_Query_search_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*model.SearchArgs, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal *model.SearchArgs
 		return zeroVal, nil
 	}
@@ -424,11 +416,7 @@ func (ec *executionContext) field_Query_userByTier_argsTier(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (model.Tier, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["tier"]
-	if !ok {
+	if _, ok := rawArgs["tier"]; !ok {
 		var zeroVal model.Tier
 		return zeroVal, nil
 	}
@@ -446,11 +434,7 @@ func (ec *executionContext) field_Query_userByTier_argsDarkMode(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*model.Prefs, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["darkMode"]
-	if !ok {
+	if _, ok := rawArgs["darkMode"]; !ok {
 		var zeroVal *model.Prefs
 		return zeroVal, nil
 	}
@@ -478,11 +462,7 @@ func (ec *executionContext) field_Query_user_argsID(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (external.ObjectID, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal external.ObjectID
 		return zeroVal, nil
 	}
@@ -510,11 +490,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -542,11 +518,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/_examples/selection/generated.go
+++ b/_examples/selection/generated.go
@@ -273,11 +273,7 @@ func (ec *executionContext) field_Query___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -305,11 +301,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -337,11 +329,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/_examples/starwars/generated/exec.go
+++ b/_examples/starwars/generated/exec.go
@@ -776,11 +776,7 @@ func (ec *executionContext) field_Droid_friendsConnection_argsFirst(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["first"]
-	if !ok {
+	if _, ok := rawArgs["first"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -798,11 +794,7 @@ func (ec *executionContext) field_Droid_friendsConnection_argsAfter(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["after"]
-	if !ok {
+	if _, ok := rawArgs["after"]; !ok {
 		var zeroVal *string
 		return zeroVal, nil
 	}
@@ -835,11 +827,7 @@ func (ec *executionContext) field_Human_friendsConnection_argsFirst(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["first"]
-	if !ok {
+	if _, ok := rawArgs["first"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -857,11 +845,7 @@ func (ec *executionContext) field_Human_friendsConnection_argsAfter(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["after"]
-	if !ok {
+	if _, ok := rawArgs["after"]; !ok {
 		var zeroVal *string
 		return zeroVal, nil
 	}
@@ -889,11 +873,7 @@ func (ec *executionContext) field_Human_height_argsUnit(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (models.LengthUnit, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["unit"]
-	if !ok {
+	if _, ok := rawArgs["unit"]; !ok {
 		var zeroVal models.LengthUnit
 		return zeroVal, nil
 	}
@@ -926,11 +906,7 @@ func (ec *executionContext) field_Mutation_createReview_argsEpisode(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (models.Episode, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["episode"]
-	if !ok {
+	if _, ok := rawArgs["episode"]; !ok {
 		var zeroVal models.Episode
 		return zeroVal, nil
 	}
@@ -948,11 +924,7 @@ func (ec *executionContext) field_Mutation_createReview_argsReview(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (models.Review, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["review"]
-	if !ok {
+	if _, ok := rawArgs["review"]; !ok {
 		var zeroVal models.Review
 		return zeroVal, nil
 	}
@@ -980,11 +952,7 @@ func (ec *executionContext) field_Query___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1012,11 +980,7 @@ func (ec *executionContext) field_Query_character_argsID(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1044,11 +1008,7 @@ func (ec *executionContext) field_Query_droid_argsID(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1076,11 +1036,7 @@ func (ec *executionContext) field_Query_hero_argsEpisode(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*models.Episode, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["episode"]
-	if !ok {
+	if _, ok := rawArgs["episode"]; !ok {
 		var zeroVal *models.Episode
 		return zeroVal, nil
 	}
@@ -1108,11 +1064,7 @@ func (ec *executionContext) field_Query_human_argsID(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1145,11 +1097,7 @@ func (ec *executionContext) field_Query_reviews_argsEpisode(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (models.Episode, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["episode"]
-	if !ok {
+	if _, ok := rawArgs["episode"]; !ok {
 		var zeroVal models.Episode
 		return zeroVal, nil
 	}
@@ -1167,11 +1115,7 @@ func (ec *executionContext) field_Query_reviews_argsSince(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*time.Time, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["since"]
-	if !ok {
+	if _, ok := rawArgs["since"]; !ok {
 		var zeroVal *time.Time
 		return zeroVal, nil
 	}
@@ -1199,11 +1143,7 @@ func (ec *executionContext) field_Query_search_argsText(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["text"]
-	if !ok {
+	if _, ok := rawArgs["text"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1231,11 +1171,7 @@ func (ec *executionContext) field_Query_starship_argsID(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1263,11 +1199,7 @@ func (ec *executionContext) field_Starship_length_argsUnit(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*models.LengthUnit, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["unit"]
-	if !ok {
+	if _, ok := rawArgs["unit"]; !ok {
 		var zeroVal *models.LengthUnit
 		return zeroVal, nil
 	}
@@ -1295,11 +1227,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -1327,11 +1255,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/_examples/todo/generated.go
+++ b/_examples/todo/generated.go
@@ -309,11 +309,7 @@ func (ec *executionContext) dir_hasRole_argsRole(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (Role, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["role"]
-	if !ok {
+	if _, ok := rawArgs["role"]; !ok {
 		var zeroVal Role
 		return zeroVal, nil
 	}
@@ -341,11 +337,7 @@ func (ec *executionContext) dir_user_argsID(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal int
 		return zeroVal, nil
 	}
@@ -373,11 +365,7 @@ func (ec *executionContext) field_MyMutation_createTodo_argsTodo(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (TodoInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["todo"]
-	if !ok {
+	if _, ok := rawArgs["todo"]; !ok {
 		var zeroVal TodoInput
 		return zeroVal, nil
 	}
@@ -410,11 +398,7 @@ func (ec *executionContext) field_MyMutation_updateTodo_argsID(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal int
 		return zeroVal, nil
 	}
@@ -432,11 +416,7 @@ func (ec *executionContext) field_MyMutation_updateTodo_argsChanges(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (map[string]any, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["changes"]
-	if !ok {
+	if _, ok := rawArgs["changes"]; !ok {
 		var zeroVal map[string]any
 		return zeroVal, nil
 	}
@@ -464,11 +444,7 @@ func (ec *executionContext) field_MyQuery___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -496,11 +472,7 @@ func (ec *executionContext) field_MyQuery_todo_argsID(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal int
 		return zeroVal, nil
 	}
@@ -528,11 +500,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -560,11 +528,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/_examples/type-system-extension/generated.go
+++ b/_examples/type-system-extension/generated.go
@@ -303,11 +303,7 @@ func (ec *executionContext) field_MyMutation_createTodo_argsTodo(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (TodoInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["todo"]
-	if !ok {
+	if _, ok := rawArgs["todo"]; !ok {
 		var zeroVal TodoInput
 		return zeroVal, nil
 	}
@@ -335,11 +331,7 @@ func (ec *executionContext) field_MyQuery___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -367,11 +359,7 @@ func (ec *executionContext) field_MyQuery_todo_argsID(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -399,11 +387,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -431,11 +415,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/codegen/args.gotpl
+++ b/codegen/args.gotpl
@@ -37,11 +37,12 @@ func (ec *executionContext) {{ $name }}(ctx context.Context, rawArgs map[string]
 		) ({{ $arg.TypeReference.GO | ref}}, error) {
 		{{- end }}
 			{{- if not .CallArgumentDirectivesWithNull}}
-				// We won't call the directive if the argument is null.
-				// Set call_argument_directives_with_null to true to call directives
-				// even if the argument is null.
-				_, ok := rawArgs[{{$arg.Name|quote}}]
-				if !ok {
+				{{- /*
+				We won't call the directive if the argument is null.
+				Set call_argument_directives_with_null to true to call directives
+				even if the argument is null.
+				*/ -}}
+				if _, ok := rawArgs[{{$arg.Name|quote}}]; !ok {
 					var zeroVal {{ $arg.TypeReference.GO | ref}}
 					return zeroVal, nil
 				}

--- a/codegen/testserver/compliant-int/generated-compliant-strict/schema.go
+++ b/codegen/testserver/compliant-int/generated-compliant-strict/schema.go
@@ -286,11 +286,7 @@ func (ec *executionContext) field_Query___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -318,11 +314,7 @@ func (ec *executionContext) field_Query_echoInt64InputToInt64Object_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (Input64, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal Input64
 		return zeroVal, nil
 	}
@@ -350,11 +342,7 @@ func (ec *executionContext) field_Query_echoInt64ToInt64_argsN(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["n"]
-	if !ok {
+	if _, ok := rawArgs["n"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -382,11 +370,7 @@ func (ec *executionContext) field_Query_echoIntInputToIntObject_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (Input, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal Input
 		return zeroVal, nil
 	}
@@ -414,11 +398,7 @@ func (ec *executionContext) field_Query_echoIntToInt_argsN(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int32, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["n"]
-	if !ok {
+	if _, ok := rawArgs["n"]; !ok {
 		var zeroVal *int32
 		return zeroVal, nil
 	}
@@ -446,11 +426,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -478,11 +454,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/codegen/testserver/compliant-int/generated-default/schema.go
+++ b/codegen/testserver/compliant-int/generated-default/schema.go
@@ -286,11 +286,7 @@ func (ec *executionContext) field_Query___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -318,11 +314,7 @@ func (ec *executionContext) field_Query_echoInt64InputToInt64Object_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (Input64, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal Input64
 		return zeroVal, nil
 	}
@@ -350,11 +342,7 @@ func (ec *executionContext) field_Query_echoInt64ToInt64_argsN(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["n"]
-	if !ok {
+	if _, ok := rawArgs["n"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -382,11 +370,7 @@ func (ec *executionContext) field_Query_echoIntInputToIntObject_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (Input, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal Input
 		return zeroVal, nil
 	}
@@ -414,11 +398,7 @@ func (ec *executionContext) field_Query_echoIntToInt_argsN(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["n"]
-	if !ok {
+	if _, ok := rawArgs["n"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -446,11 +426,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -478,11 +454,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/codegen/testserver/followschema/defaults.generated.go
+++ b/codegen/testserver/followschema/defaults.generated.go
@@ -40,11 +40,7 @@ func (ec *executionContext) field_Mutation_defaultInput_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (DefaultInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal DefaultInput
 		return zeroVal, nil
 	}
@@ -72,11 +68,7 @@ func (ec *executionContext) field_Mutation_overrideValueViaInput_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (FieldsOrderInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal FieldsOrderInput
 		return zeroVal, nil
 	}
@@ -104,11 +96,7 @@ func (ec *executionContext) field_Mutation_updatePtrToPtr_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (UpdatePtrToPtrOuter, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal UpdatePtrToPtrOuter
 		return zeroVal, nil
 	}
@@ -136,11 +124,7 @@ func (ec *executionContext) field_Mutation_updateSomething_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (SpecialInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal SpecialInput
 		return zeroVal, nil
 	}

--- a/codegen/testserver/followschema/directive.generated.go
+++ b/codegen/testserver/followschema/directive.generated.go
@@ -43,11 +43,7 @@ func (ec *executionContext) dir_length_argsMin(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["min"]
-	if !ok {
+	if _, ok := rawArgs["min"]; !ok {
 		var zeroVal int
 		return zeroVal, nil
 	}
@@ -65,11 +61,7 @@ func (ec *executionContext) dir_length_argsMax(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["max"]
-	if !ok {
+	if _, ok := rawArgs["max"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -87,11 +79,7 @@ func (ec *executionContext) dir_length_argsMessage(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["message"]
-	if !ok {
+	if _, ok := rawArgs["message"]; !ok {
 		var zeroVal *string
 		return zeroVal, nil
 	}
@@ -119,11 +107,7 @@ func (ec *executionContext) dir_logged_argsID(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -151,11 +135,7 @@ func (ec *executionContext) dir_order1_argsLocation(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["location"]
-	if !ok {
+	if _, ok := rawArgs["location"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -183,11 +163,7 @@ func (ec *executionContext) dir_order2_argsLocation(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["location"]
-	if !ok {
+	if _, ok := rawArgs["location"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -215,11 +191,7 @@ func (ec *executionContext) dir_populate_argsValue(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["value"]
-	if !ok {
+	if _, ok := rawArgs["value"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -252,11 +224,7 @@ func (ec *executionContext) dir_range_argsMin(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["min"]
-	if !ok {
+	if _, ok := rawArgs["min"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -274,11 +242,7 @@ func (ec *executionContext) dir_range_argsMax(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["max"]
-	if !ok {
+	if _, ok := rawArgs["max"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}

--- a/codegen/testserver/followschema/panics.generated.go
+++ b/codegen/testserver/followschema/panics.generated.go
@@ -38,11 +38,7 @@ func (ec *executionContext) field_Panics_argUnmarshal_argsU(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]MarshalPanic, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["u"]
-	if !ok {
+	if _, ok := rawArgs["u"]; !ok {
 		var zeroVal []MarshalPanic
 		return zeroVal, nil
 	}
@@ -70,11 +66,7 @@ func (ec *executionContext) field_Panics_fieldFuncMarshal_argsU(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]MarshalPanic, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["u"]
-	if !ok {
+	if _, ok := rawArgs["u"]; !ok {
 		var zeroVal []MarshalPanic
 		return zeroVal, nil
 	}

--- a/codegen/testserver/followschema/prelude.generated.go
+++ b/codegen/testserver/followschema/prelude.generated.go
@@ -35,11 +35,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -67,11 +63,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/codegen/testserver/followschema/schema.generated.go
+++ b/codegen/testserver/followschema/schema.generated.go
@@ -144,11 +144,7 @@ func (ec *executionContext) dir_defer_argsIf(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["if"]
-	if !ok {
+	if _, ok := rawArgs["if"]; !ok {
 		var zeroVal *bool
 		return zeroVal, nil
 	}
@@ -166,11 +162,7 @@ func (ec *executionContext) dir_defer_argsLabel(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["label"]
-	if !ok {
+	if _, ok := rawArgs["label"]; !ok {
 		var zeroVal *string
 		return zeroVal, nil
 	}
@@ -198,11 +190,7 @@ func (ec *executionContext) field_Pet_friends_argsLimit(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["limit"]
-	if !ok {
+	if _, ok := rawArgs["limit"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -230,11 +218,7 @@ func (ec *executionContext) field_Query___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -267,11 +251,7 @@ func (ec *executionContext) field_Query_defaultParameters_argsFalsyBoolean(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["falsyBoolean"]
-	if !ok {
+	if _, ok := rawArgs["falsyBoolean"]; !ok {
 		var zeroVal *bool
 		return zeroVal, nil
 	}
@@ -289,11 +269,7 @@ func (ec *executionContext) field_Query_defaultParameters_argsTruthyBoolean(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["truthyBoolean"]
-	if !ok {
+	if _, ok := rawArgs["truthyBoolean"]; !ok {
 		var zeroVal *bool
 		return zeroVal, nil
 	}
@@ -321,11 +297,7 @@ func (ec *executionContext) field_Query_defaultScalar_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -353,11 +325,7 @@ func (ec *executionContext) field_Query_directiveArg_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -422,11 +390,7 @@ func (ec *executionContext) field_Query_directiveFieldDef_argsRet(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["ret"]
-	if !ok {
+	if _, ok := rawArgs["ret"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -454,11 +418,7 @@ func (ec *executionContext) field_Query_directiveInputNullable_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*InputDirectives, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal *InputDirectives
 		return zeroVal, nil
 	}
@@ -486,11 +446,7 @@ func (ec *executionContext) field_Query_directiveInputType_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (InnerInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal InnerInput
 		return zeroVal, nil
 	}
@@ -540,11 +496,7 @@ func (ec *executionContext) field_Query_directiveInput_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (InputDirectives, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal InputDirectives
 		return zeroVal, nil
 	}
@@ -582,11 +534,7 @@ func (ec *executionContext) field_Query_directiveNullableArg_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -634,11 +582,7 @@ func (ec *executionContext) field_Query_directiveNullableArg_argsArg2(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg2"]
-	if !ok {
+	if _, ok := rawArgs["arg2"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -686,11 +630,7 @@ func (ec *executionContext) field_Query_directiveNullableArg_argsArg3(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg3"]
-	if !ok {
+	if _, ok := rawArgs["arg3"]; !ok {
 		var zeroVal *string
 		return zeroVal, nil
 	}
@@ -743,11 +683,7 @@ func (ec *executionContext) field_Query_directiveSingleNullableArg_argsArg1(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg1"]
-	if !ok {
+	if _, ok := rawArgs["arg1"]; !ok {
 		var zeroVal *string
 		return zeroVal, nil
 	}
@@ -812,11 +748,7 @@ func (ec *executionContext) field_Query_enumInInput_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*InputWithEnumValue, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal *InputWithEnumValue
 		return zeroVal, nil
 	}
@@ -844,11 +776,7 @@ func (ec *executionContext) field_Query_fallback_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (FallbackToStringEncoding, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal FallbackToStringEncoding
 		return zeroVal, nil
 	}
@@ -876,11 +804,7 @@ func (ec *executionContext) field_Query_inputNullableSlice_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal []string
 		return zeroVal, nil
 	}
@@ -908,11 +832,7 @@ func (ec *executionContext) field_Query_inputOmittable_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (OmittableInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal OmittableInput
 		return zeroVal, nil
 	}
@@ -940,11 +860,7 @@ func (ec *executionContext) field_Query_inputSlice_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal []string
 		return zeroVal, nil
 	}
@@ -972,11 +888,7 @@ func (ec *executionContext) field_Query_mapInput_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (map[string]interface{}, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal map[string]interface{}
 		return zeroVal, nil
 	}
@@ -1004,11 +916,7 @@ func (ec *executionContext) field_Query_mapNestedStringInterface_argsIn(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*NestedMapInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["in"]
-	if !ok {
+	if _, ok := rawArgs["in"]; !ok {
 		var zeroVal *NestedMapInput
 		return zeroVal, nil
 	}
@@ -1036,11 +944,7 @@ func (ec *executionContext) field_Query_mapStringInterface_argsIn(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (map[string]interface{}, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["in"]
-	if !ok {
+	if _, ok := rawArgs["in"]; !ok {
 		var zeroVal map[string]interface{}
 		return zeroVal, nil
 	}
@@ -1068,11 +972,7 @@ func (ec *executionContext) field_Query_nestedInputs_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([][]*OuterInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal [][]*OuterInput
 		return zeroVal, nil
 	}
@@ -1100,11 +1000,7 @@ func (ec *executionContext) field_Query_nullableArg_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -1132,11 +1028,7 @@ func (ec *executionContext) field_Query_recursive_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*RecursiveInputSlice, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal *RecursiveInputSlice
 		return zeroVal, nil
 	}
@@ -1164,11 +1056,7 @@ func (ec *executionContext) field_Query_user_argsID(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal int
 		return zeroVal, nil
 	}
@@ -1196,11 +1084,7 @@ func (ec *executionContext) field_Subscription_directiveArg_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1275,11 +1159,7 @@ func (ec *executionContext) field_Subscription_directiveNullableArg_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -1327,11 +1207,7 @@ func (ec *executionContext) field_Subscription_directiveNullableArg_argsArg2(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg2"]
-	if !ok {
+	if _, ok := rawArgs["arg2"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -1379,11 +1255,7 @@ func (ec *executionContext) field_Subscription_directiveNullableArg_argsArg3(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg3"]
-	if !ok {
+	if _, ok := rawArgs["arg3"]; !ok {
 		var zeroVal *string
 		return zeroVal, nil
 	}
@@ -1436,11 +1308,7 @@ func (ec *executionContext) field_User_pets_argsLimit(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["limit"]
-	if !ok {
+	if _, ok := rawArgs["limit"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}

--- a/codegen/testserver/followschema/validtypes.generated.go
+++ b/codegen/testserver/followschema/validtypes.generated.go
@@ -158,11 +158,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsBreak(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["break"]
-	if !ok {
+	if _, ok := rawArgs["break"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -180,11 +176,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsDefault(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["default"]
-	if !ok {
+	if _, ok := rawArgs["default"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -202,11 +194,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsFunc(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["func"]
-	if !ok {
+	if _, ok := rawArgs["func"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -224,11 +212,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsInterface(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["interface"]
-	if !ok {
+	if _, ok := rawArgs["interface"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -246,11 +230,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsSelect(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["select"]
-	if !ok {
+	if _, ok := rawArgs["select"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -268,11 +248,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsCase(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["case"]
-	if !ok {
+	if _, ok := rawArgs["case"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -290,11 +266,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsDefer(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["defer"]
-	if !ok {
+	if _, ok := rawArgs["defer"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -312,11 +284,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsGo(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["go"]
-	if !ok {
+	if _, ok := rawArgs["go"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -334,11 +302,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsMap(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["map"]
-	if !ok {
+	if _, ok := rawArgs["map"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -356,11 +320,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsStruct(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["struct"]
-	if !ok {
+	if _, ok := rawArgs["struct"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -378,11 +338,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsChan(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["chan"]
-	if !ok {
+	if _, ok := rawArgs["chan"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -400,11 +356,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsElse(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["else"]
-	if !ok {
+	if _, ok := rawArgs["else"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -422,11 +374,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsGoto(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["goto"]
-	if !ok {
+	if _, ok := rawArgs["goto"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -444,11 +392,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsPackage(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["package"]
-	if !ok {
+	if _, ok := rawArgs["package"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -466,11 +410,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsSwitch(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["switch"]
-	if !ok {
+	if _, ok := rawArgs["switch"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -488,11 +428,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsConst(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["const"]
-	if !ok {
+	if _, ok := rawArgs["const"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -510,11 +446,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsFallthrough(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["fallthrough"]
-	if !ok {
+	if _, ok := rawArgs["fallthrough"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -532,11 +464,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsIf(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["if"]
-	if !ok {
+	if _, ok := rawArgs["if"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -554,11 +482,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsRange(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["range"]
-	if !ok {
+	if _, ok := rawArgs["range"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -576,11 +500,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsType(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["type"]
-	if !ok {
+	if _, ok := rawArgs["type"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -598,11 +518,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsContinue(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["continue"]
-	if !ok {
+	if _, ok := rawArgs["continue"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -620,11 +536,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsFor(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["for"]
-	if !ok {
+	if _, ok := rawArgs["for"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -642,11 +554,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsImport(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["import"]
-	if !ok {
+	if _, ok := rawArgs["import"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -664,11 +572,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsReturn(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["return"]
-	if !ok {
+	if _, ok := rawArgs["return"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -686,11 +590,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsVar(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["var"]
-	if !ok {
+	if _, ok := rawArgs["var"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -708,11 +608,7 @@ func (ec *executionContext) field_ValidType_validArgs_args_(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["_"]
-	if !ok {
+	if _, ok := rawArgs["_"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -740,11 +636,7 @@ func (ec *executionContext) field_ValidType_validInputKeywords_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*ValidInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal *ValidInput
 		return zeroVal, nil
 	}

--- a/codegen/testserver/followschema/variadic.generated.go
+++ b/codegen/testserver/followschema/variadic.generated.go
@@ -32,11 +32,7 @@ func (ec *executionContext) field_VariadicModel_value_argsRank(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["rank"]
-	if !ok {
+	if _, ok := rawArgs["rank"]; !ok {
 		var zeroVal int
 		return zeroVal, nil
 	}

--- a/codegen/testserver/followschema/wrapped_type.generated.go
+++ b/codegen/testserver/followschema/wrapped_type.generated.go
@@ -40,11 +40,7 @@ func (ec *executionContext) field_WrappedMap_get_argsKey(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["key"]
-	if !ok {
+	if _, ok := rawArgs["key"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -72,11 +68,7 @@ func (ec *executionContext) field_WrappedSlice_get_argsIdx(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["idx"]
-	if !ok {
+	if _, ok := rawArgs["idx"]; !ok {
 		var zeroVal int
 		return zeroVal, nil
 	}

--- a/codegen/testserver/nullabledirectives/generated/directive.generated.go
+++ b/codegen/testserver/nullabledirectives/generated/directive.generated.go
@@ -38,11 +38,7 @@ func (ec *executionContext) dir_populate_argsValue(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["value"]
-	if !ok {
+	if _, ok := rawArgs["value"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}

--- a/codegen/testserver/nullabledirectives/generated/prelude.generated.go
+++ b/codegen/testserver/nullabledirectives/generated/prelude.generated.go
@@ -40,11 +40,7 @@ func (ec *executionContext) dir_defer_argsIf(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["if"]
-	if !ok {
+	if _, ok := rawArgs["if"]; !ok {
 		var zeroVal *bool
 		return zeroVal, nil
 	}
@@ -62,11 +58,7 @@ func (ec *executionContext) dir_defer_argsLabel(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["label"]
-	if !ok {
+	if _, ok := rawArgs["label"]; !ok {
 		var zeroVal *string
 		return zeroVal, nil
 	}

--- a/codegen/testserver/singlefile/generated.go
+++ b/codegen/testserver/singlefile/generated.go
@@ -2511,11 +2511,7 @@ func (ec *executionContext) dir_defer_argsIf(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["if"]
-	if !ok {
+	if _, ok := rawArgs["if"]; !ok {
 		var zeroVal *bool
 		return zeroVal, nil
 	}
@@ -2533,11 +2529,7 @@ func (ec *executionContext) dir_defer_argsLabel(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["label"]
-	if !ok {
+	if _, ok := rawArgs["label"]; !ok {
 		var zeroVal *string
 		return zeroVal, nil
 	}
@@ -2575,11 +2567,7 @@ func (ec *executionContext) dir_length_argsMin(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["min"]
-	if !ok {
+	if _, ok := rawArgs["min"]; !ok {
 		var zeroVal int
 		return zeroVal, nil
 	}
@@ -2597,11 +2585,7 @@ func (ec *executionContext) dir_length_argsMax(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["max"]
-	if !ok {
+	if _, ok := rawArgs["max"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -2619,11 +2603,7 @@ func (ec *executionContext) dir_length_argsMessage(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["message"]
-	if !ok {
+	if _, ok := rawArgs["message"]; !ok {
 		var zeroVal *string
 		return zeroVal, nil
 	}
@@ -2651,11 +2631,7 @@ func (ec *executionContext) dir_logged_argsID(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -2683,11 +2659,7 @@ func (ec *executionContext) dir_order1_argsLocation(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["location"]
-	if !ok {
+	if _, ok := rawArgs["location"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -2715,11 +2687,7 @@ func (ec *executionContext) dir_order2_argsLocation(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["location"]
-	if !ok {
+	if _, ok := rawArgs["location"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -2747,11 +2715,7 @@ func (ec *executionContext) dir_populate_argsValue(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["value"]
-	if !ok {
+	if _, ok := rawArgs["value"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -2784,11 +2748,7 @@ func (ec *executionContext) dir_range_argsMin(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["min"]
-	if !ok {
+	if _, ok := rawArgs["min"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -2806,11 +2766,7 @@ func (ec *executionContext) dir_range_argsMax(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["max"]
-	if !ok {
+	if _, ok := rawArgs["max"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -2838,11 +2794,7 @@ func (ec *executionContext) field_Mutation_defaultInput_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (DefaultInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal DefaultInput
 		return zeroVal, nil
 	}
@@ -2870,11 +2822,7 @@ func (ec *executionContext) field_Mutation_overrideValueViaInput_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (FieldsOrderInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal FieldsOrderInput
 		return zeroVal, nil
 	}
@@ -2902,11 +2850,7 @@ func (ec *executionContext) field_Mutation_updatePtrToPtr_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (UpdatePtrToPtrOuter, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal UpdatePtrToPtrOuter
 		return zeroVal, nil
 	}
@@ -2934,11 +2878,7 @@ func (ec *executionContext) field_Mutation_updateSomething_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (SpecialInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal SpecialInput
 		return zeroVal, nil
 	}
@@ -2966,11 +2906,7 @@ func (ec *executionContext) field_Panics_argUnmarshal_argsU(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]MarshalPanic, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["u"]
-	if !ok {
+	if _, ok := rawArgs["u"]; !ok {
 		var zeroVal []MarshalPanic
 		return zeroVal, nil
 	}
@@ -2998,11 +2934,7 @@ func (ec *executionContext) field_Panics_fieldFuncMarshal_argsU(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]MarshalPanic, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["u"]
-	if !ok {
+	if _, ok := rawArgs["u"]; !ok {
 		var zeroVal []MarshalPanic
 		return zeroVal, nil
 	}
@@ -3030,11 +2962,7 @@ func (ec *executionContext) field_Pet_friends_argsLimit(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["limit"]
-	if !ok {
+	if _, ok := rawArgs["limit"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -3062,11 +2990,7 @@ func (ec *executionContext) field_Query___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -3099,11 +3023,7 @@ func (ec *executionContext) field_Query_defaultParameters_argsFalsyBoolean(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["falsyBoolean"]
-	if !ok {
+	if _, ok := rawArgs["falsyBoolean"]; !ok {
 		var zeroVal *bool
 		return zeroVal, nil
 	}
@@ -3121,11 +3041,7 @@ func (ec *executionContext) field_Query_defaultParameters_argsTruthyBoolean(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["truthyBoolean"]
-	if !ok {
+	if _, ok := rawArgs["truthyBoolean"]; !ok {
 		var zeroVal *bool
 		return zeroVal, nil
 	}
@@ -3153,11 +3069,7 @@ func (ec *executionContext) field_Query_defaultScalar_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -3185,11 +3097,7 @@ func (ec *executionContext) field_Query_directiveArg_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -3254,11 +3162,7 @@ func (ec *executionContext) field_Query_directiveFieldDef_argsRet(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["ret"]
-	if !ok {
+	if _, ok := rawArgs["ret"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -3286,11 +3190,7 @@ func (ec *executionContext) field_Query_directiveInputNullable_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*InputDirectives, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal *InputDirectives
 		return zeroVal, nil
 	}
@@ -3318,11 +3218,7 @@ func (ec *executionContext) field_Query_directiveInputType_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (InnerInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal InnerInput
 		return zeroVal, nil
 	}
@@ -3372,11 +3268,7 @@ func (ec *executionContext) field_Query_directiveInput_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (InputDirectives, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal InputDirectives
 		return zeroVal, nil
 	}
@@ -3414,11 +3306,7 @@ func (ec *executionContext) field_Query_directiveNullableArg_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -3466,11 +3354,7 @@ func (ec *executionContext) field_Query_directiveNullableArg_argsArg2(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg2"]
-	if !ok {
+	if _, ok := rawArgs["arg2"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -3518,11 +3402,7 @@ func (ec *executionContext) field_Query_directiveNullableArg_argsArg3(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg3"]
-	if !ok {
+	if _, ok := rawArgs["arg3"]; !ok {
 		var zeroVal *string
 		return zeroVal, nil
 	}
@@ -3575,11 +3455,7 @@ func (ec *executionContext) field_Query_directiveSingleNullableArg_argsArg1(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg1"]
-	if !ok {
+	if _, ok := rawArgs["arg1"]; !ok {
 		var zeroVal *string
 		return zeroVal, nil
 	}
@@ -3644,11 +3520,7 @@ func (ec *executionContext) field_Query_enumInInput_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*InputWithEnumValue, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal *InputWithEnumValue
 		return zeroVal, nil
 	}
@@ -3676,11 +3548,7 @@ func (ec *executionContext) field_Query_fallback_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (FallbackToStringEncoding, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal FallbackToStringEncoding
 		return zeroVal, nil
 	}
@@ -3708,11 +3576,7 @@ func (ec *executionContext) field_Query_inputNullableSlice_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal []string
 		return zeroVal, nil
 	}
@@ -3740,11 +3604,7 @@ func (ec *executionContext) field_Query_inputOmittable_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (OmittableInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal OmittableInput
 		return zeroVal, nil
 	}
@@ -3772,11 +3632,7 @@ func (ec *executionContext) field_Query_inputSlice_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal []string
 		return zeroVal, nil
 	}
@@ -3804,11 +3660,7 @@ func (ec *executionContext) field_Query_mapInput_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (map[string]interface{}, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal map[string]interface{}
 		return zeroVal, nil
 	}
@@ -3836,11 +3688,7 @@ func (ec *executionContext) field_Query_mapNestedStringInterface_argsIn(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*NestedMapInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["in"]
-	if !ok {
+	if _, ok := rawArgs["in"]; !ok {
 		var zeroVal *NestedMapInput
 		return zeroVal, nil
 	}
@@ -3868,11 +3716,7 @@ func (ec *executionContext) field_Query_mapStringInterface_argsIn(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (map[string]interface{}, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["in"]
-	if !ok {
+	if _, ok := rawArgs["in"]; !ok {
 		var zeroVal map[string]interface{}
 		return zeroVal, nil
 	}
@@ -3900,11 +3744,7 @@ func (ec *executionContext) field_Query_nestedInputs_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([][]*OuterInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal [][]*OuterInput
 		return zeroVal, nil
 	}
@@ -3932,11 +3772,7 @@ func (ec *executionContext) field_Query_nullableArg_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -3964,11 +3800,7 @@ func (ec *executionContext) field_Query_recursive_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*RecursiveInputSlice, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal *RecursiveInputSlice
 		return zeroVal, nil
 	}
@@ -3996,11 +3828,7 @@ func (ec *executionContext) field_Query_user_argsID(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal int
 		return zeroVal, nil
 	}
@@ -4028,11 +3856,7 @@ func (ec *executionContext) field_Subscription_directiveArg_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4107,11 +3931,7 @@ func (ec *executionContext) field_Subscription_directiveNullableArg_argsArg(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg"]
-	if !ok {
+	if _, ok := rawArgs["arg"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -4159,11 +3979,7 @@ func (ec *executionContext) field_Subscription_directiveNullableArg_argsArg2(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg2"]
-	if !ok {
+	if _, ok := rawArgs["arg2"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -4211,11 +4027,7 @@ func (ec *executionContext) field_Subscription_directiveNullableArg_argsArg3(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["arg3"]
-	if !ok {
+	if _, ok := rawArgs["arg3"]; !ok {
 		var zeroVal *string
 		return zeroVal, nil
 	}
@@ -4268,11 +4080,7 @@ func (ec *executionContext) field_User_pets_argsLimit(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["limit"]
-	if !ok {
+	if _, ok := rawArgs["limit"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -4425,11 +4233,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsBreak(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["break"]
-	if !ok {
+	if _, ok := rawArgs["break"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4447,11 +4251,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsDefault(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["default"]
-	if !ok {
+	if _, ok := rawArgs["default"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4469,11 +4269,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsFunc(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["func"]
-	if !ok {
+	if _, ok := rawArgs["func"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4491,11 +4287,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsInterface(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["interface"]
-	if !ok {
+	if _, ok := rawArgs["interface"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4513,11 +4305,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsSelect(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["select"]
-	if !ok {
+	if _, ok := rawArgs["select"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4535,11 +4323,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsCase(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["case"]
-	if !ok {
+	if _, ok := rawArgs["case"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4557,11 +4341,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsDefer(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["defer"]
-	if !ok {
+	if _, ok := rawArgs["defer"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4579,11 +4359,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsGo(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["go"]
-	if !ok {
+	if _, ok := rawArgs["go"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4601,11 +4377,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsMap(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["map"]
-	if !ok {
+	if _, ok := rawArgs["map"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4623,11 +4395,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsStruct(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["struct"]
-	if !ok {
+	if _, ok := rawArgs["struct"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4645,11 +4413,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsChan(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["chan"]
-	if !ok {
+	if _, ok := rawArgs["chan"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4667,11 +4431,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsElse(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["else"]
-	if !ok {
+	if _, ok := rawArgs["else"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4689,11 +4449,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsGoto(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["goto"]
-	if !ok {
+	if _, ok := rawArgs["goto"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4711,11 +4467,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsPackage(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["package"]
-	if !ok {
+	if _, ok := rawArgs["package"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4733,11 +4485,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsSwitch(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["switch"]
-	if !ok {
+	if _, ok := rawArgs["switch"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4755,11 +4503,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsConst(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["const"]
-	if !ok {
+	if _, ok := rawArgs["const"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4777,11 +4521,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsFallthrough(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["fallthrough"]
-	if !ok {
+	if _, ok := rawArgs["fallthrough"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4799,11 +4539,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsIf(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["if"]
-	if !ok {
+	if _, ok := rawArgs["if"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4821,11 +4557,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsRange(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["range"]
-	if !ok {
+	if _, ok := rawArgs["range"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4843,11 +4575,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsType(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["type"]
-	if !ok {
+	if _, ok := rawArgs["type"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4865,11 +4593,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsContinue(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["continue"]
-	if !ok {
+	if _, ok := rawArgs["continue"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4887,11 +4611,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsFor(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["for"]
-	if !ok {
+	if _, ok := rawArgs["for"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4909,11 +4629,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsImport(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["import"]
-	if !ok {
+	if _, ok := rawArgs["import"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4931,11 +4647,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsReturn(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["return"]
-	if !ok {
+	if _, ok := rawArgs["return"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4953,11 +4665,7 @@ func (ec *executionContext) field_ValidType_validArgs_argsVar(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["var"]
-	if !ok {
+	if _, ok := rawArgs["var"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -4975,11 +4683,7 @@ func (ec *executionContext) field_ValidType_validArgs_args_(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["_"]
-	if !ok {
+	if _, ok := rawArgs["_"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -5007,11 +4711,7 @@ func (ec *executionContext) field_ValidType_validInputKeywords_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*ValidInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal *ValidInput
 		return zeroVal, nil
 	}
@@ -5039,11 +4739,7 @@ func (ec *executionContext) field_VariadicModel_value_argsRank(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["rank"]
-	if !ok {
+	if _, ok := rawArgs["rank"]; !ok {
 		var zeroVal int
 		return zeroVal, nil
 	}
@@ -5071,11 +4767,7 @@ func (ec *executionContext) field_WrappedMap_get_argsKey(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["key"]
-	if !ok {
+	if _, ok := rawArgs["key"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -5103,11 +4795,7 @@ func (ec *executionContext) field_WrappedSlice_get_argsIdx(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["idx"]
-	if !ok {
+	if _, ok := rawArgs["idx"]; !ok {
 		var zeroVal int
 		return zeroVal, nil
 	}
@@ -5135,11 +4823,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -5167,11 +4851,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/codegen/testserver/usefunctionsyntaxforexecutioncontext/generated.go
+++ b/codegen/testserver/usefunctionsyntaxforexecutioncontext/generated.go
@@ -427,11 +427,7 @@ func dir_log_argsMessage(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (*string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["message"]
-	if !ok {
+	if _, ok := rawArgs["message"]; !ok {
 		var zeroVal *string
 		return zeroVal, nil
 	}
@@ -460,11 +456,7 @@ func field_Mutation_createUser_argsInput(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (CreateUserInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["input"]
-	if !ok {
+	if _, ok := rawArgs["input"]; !ok {
 		var zeroVal CreateUserInput
 		return zeroVal, nil
 	}
@@ -493,11 +485,7 @@ func field_Mutation_deleteUser_argsID(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -526,11 +514,7 @@ func field_Query___type_argsName(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -559,11 +543,7 @@ func field_Query_getEntity_argsID(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -592,11 +572,7 @@ func field_Query_getUser_argsID(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["id"]
-	if !ok {
+	if _, ok := rawArgs["id"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -625,11 +601,7 @@ func field_Query_listUsers_argsFilter(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (*UserFilter, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["filter"]
-	if !ok {
+	if _, ok := rawArgs["filter"]; !ok {
 		var zeroVal *UserFilter
 		return zeroVal, nil
 	}
@@ -658,11 +630,7 @@ func field___Type_enumValues_argsIncludeDeprecated(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -691,11 +659,7 @@ func field___Type_fields_argsIncludeDeprecated(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/integration/server/generated.go
+++ b/integration/server/generated.go
@@ -379,11 +379,7 @@ func (ec *executionContext) dir_magic_argsKind(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["kind"]
-	if !ok {
+	if _, ok := rawArgs["kind"]; !ok {
 		var zeroVal *int
 		return zeroVal, nil
 	}
@@ -411,11 +407,7 @@ func (ec *executionContext) field_Query___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -443,11 +435,7 @@ func (ec *executionContext) field_Query_coercion_argsValue(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]*models.ListCoercion, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["value"]
-	if !ok {
+	if _, ok := rawArgs["value"]; !ok {
 		var zeroVal []*models.ListCoercion
 		return zeroVal, nil
 	}
@@ -475,11 +463,7 @@ func (ec *executionContext) field_Query_complexity_argsValue(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["value"]
-	if !ok {
+	if _, ok := rawArgs["value"]; !ok {
 		var zeroVal int
 		return zeroVal, nil
 	}
@@ -507,11 +491,7 @@ func (ec *executionContext) field_Query_date_argsFilter(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (models.DateFilter, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["filter"]
-	if !ok {
+	if _, ok := rawArgs["filter"]; !ok {
 		var zeroVal models.DateFilter
 		return zeroVal, nil
 	}
@@ -539,11 +519,7 @@ func (ec *executionContext) field_Query_error_argsType(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*models.ErrorType, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["type"]
-	if !ok {
+	if _, ok := rawArgs["type"]; !ok {
 		var zeroVal *models.ErrorType
 		return zeroVal, nil
 	}
@@ -571,11 +547,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -603,11 +575,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/plugin/federation/testdata/entityresolver/generated/exec.go
+++ b/plugin/federation/testdata/entityresolver/generated/exec.go
@@ -886,11 +886,7 @@ func (ec *executionContext) field_Entity_findHelloByName_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -923,11 +919,7 @@ func (ec *executionContext) field_Entity_findHelloMultiSingleKeysByKey1AndKey2_a
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["key1"]
-	if !ok {
+	if _, ok := rawArgs["key1"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -945,11 +937,7 @@ func (ec *executionContext) field_Entity_findHelloMultiSingleKeysByKey1AndKey2_a
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["key2"]
-	if !ok {
+	if _, ok := rawArgs["key2"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -977,11 +965,7 @@ func (ec *executionContext) field_Entity_findHelloWithErrorsByName_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1009,11 +993,7 @@ func (ec *executionContext) field_Entity_findManyMultiHelloByNames_argsReps(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]*model.MultiHelloByNamesInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["reps"]
-	if !ok {
+	if _, ok := rawArgs["reps"]; !ok {
 		var zeroVal []*model.MultiHelloByNamesInput
 		return zeroVal, nil
 	}
@@ -1041,11 +1021,7 @@ func (ec *executionContext) field_Entity_findManyMultiHelloMultipleRequiresByNam
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]*model.MultiHelloMultipleRequiresByNamesInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["reps"]
-	if !ok {
+	if _, ok := rawArgs["reps"]; !ok {
 		var zeroVal []*model.MultiHelloMultipleRequiresByNamesInput
 		return zeroVal, nil
 	}
@@ -1073,11 +1049,7 @@ func (ec *executionContext) field_Entity_findManyMultiHelloRequiresByNames_argsR
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]*model.MultiHelloRequiresByNamesInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["reps"]
-	if !ok {
+	if _, ok := rawArgs["reps"]; !ok {
 		var zeroVal []*model.MultiHelloRequiresByNamesInput
 		return zeroVal, nil
 	}
@@ -1105,11 +1077,7 @@ func (ec *executionContext) field_Entity_findManyMultiHelloWithErrorByNames_args
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]*model.MultiHelloWithErrorByNamesInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["reps"]
-	if !ok {
+	if _, ok := rawArgs["reps"]; !ok {
 		var zeroVal []*model.MultiHelloWithErrorByNamesInput
 		return zeroVal, nil
 	}
@@ -1137,11 +1105,7 @@ func (ec *executionContext) field_Entity_findManyMultiPlanetRequiresNestedByName
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]*model.MultiPlanetRequiresNestedByNamesInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["reps"]
-	if !ok {
+	if _, ok := rawArgs["reps"]; !ok {
 		var zeroVal []*model.MultiPlanetRequiresNestedByNamesInput
 		return zeroVal, nil
 	}
@@ -1169,11 +1133,7 @@ func (ec *executionContext) field_Entity_findPlanetMultipleRequiresByName_argsNa
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1201,11 +1161,7 @@ func (ec *executionContext) field_Entity_findPlanetRequiresByName_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1233,11 +1189,7 @@ func (ec *executionContext) field_Entity_findPlanetRequiresNestedByName_argsName
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1270,11 +1222,7 @@ func (ec *executionContext) field_Entity_findWorldByHelloNameAndFoo_argsHelloNam
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["helloName"]
-	if !ok {
+	if _, ok := rawArgs["helloName"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1292,11 +1240,7 @@ func (ec *executionContext) field_Entity_findWorldByHelloNameAndFoo_argsFoo(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["foo"]
-	if !ok {
+	if _, ok := rawArgs["foo"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1324,11 +1268,7 @@ func (ec *executionContext) field_Entity_findWorldNameByName_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1356,11 +1296,7 @@ func (ec *executionContext) field_Entity_findWorldWithMultipleKeysByBar_argsBar(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["bar"]
-	if !ok {
+	if _, ok := rawArgs["bar"]; !ok {
 		var zeroVal int
 		return zeroVal, nil
 	}
@@ -1393,11 +1329,7 @@ func (ec *executionContext) field_Entity_findWorldWithMultipleKeysByHelloNameAnd
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["helloName"]
-	if !ok {
+	if _, ok := rawArgs["helloName"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1415,11 +1347,7 @@ func (ec *executionContext) field_Entity_findWorldWithMultipleKeysByHelloNameAnd
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["foo"]
-	if !ok {
+	if _, ok := rawArgs["foo"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1447,11 +1375,7 @@ func (ec *executionContext) field_Query___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1479,11 +1403,7 @@ func (ec *executionContext) field_Query__entities_argsRepresentations(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]map[string]any, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["representations"]
-	if !ok {
+	if _, ok := rawArgs["representations"]; !ok {
 		var zeroVal []map[string]any
 		return zeroVal, nil
 	}
@@ -1511,11 +1431,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -1543,11 +1459,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/plugin/federation/testdata/explicitrequires/generated/exec.go
+++ b/plugin/federation/testdata/explicitrequires/generated/exec.go
@@ -357,11 +357,7 @@ func (ec *executionContext) field_Entity_findHelloByName_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -394,11 +390,7 @@ func (ec *executionContext) field_Entity_findHelloMultiSingleKeysByKey1AndKey2_a
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["key1"]
-	if !ok {
+	if _, ok := rawArgs["key1"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -416,11 +408,7 @@ func (ec *executionContext) field_Entity_findHelloMultiSingleKeysByKey1AndKey2_a
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["key2"]
-	if !ok {
+	if _, ok := rawArgs["key2"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -448,11 +436,7 @@ func (ec *executionContext) field_Entity_findHelloWithErrorsByName_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -480,11 +464,7 @@ func (ec *executionContext) field_Entity_findManyMultiHelloByNames_argsReps(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]*MultiHelloByNamesInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["reps"]
-	if !ok {
+	if _, ok := rawArgs["reps"]; !ok {
 		var zeroVal []*MultiHelloByNamesInput
 		return zeroVal, nil
 	}
@@ -512,11 +492,7 @@ func (ec *executionContext) field_Entity_findManyMultiHelloMultipleRequiresByNam
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]*MultiHelloMultipleRequiresByNamesInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["reps"]
-	if !ok {
+	if _, ok := rawArgs["reps"]; !ok {
 		var zeroVal []*MultiHelloMultipleRequiresByNamesInput
 		return zeroVal, nil
 	}
@@ -544,11 +520,7 @@ func (ec *executionContext) field_Entity_findManyMultiHelloRequiresByNames_argsR
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]*MultiHelloRequiresByNamesInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["reps"]
-	if !ok {
+	if _, ok := rawArgs["reps"]; !ok {
 		var zeroVal []*MultiHelloRequiresByNamesInput
 		return zeroVal, nil
 	}
@@ -576,11 +548,7 @@ func (ec *executionContext) field_Entity_findManyMultiHelloWithErrorByNames_args
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]*MultiHelloWithErrorByNamesInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["reps"]
-	if !ok {
+	if _, ok := rawArgs["reps"]; !ok {
 		var zeroVal []*MultiHelloWithErrorByNamesInput
 		return zeroVal, nil
 	}
@@ -608,11 +576,7 @@ func (ec *executionContext) field_Entity_findManyMultiPlanetRequiresNestedByName
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]*MultiPlanetRequiresNestedByNamesInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["reps"]
-	if !ok {
+	if _, ok := rawArgs["reps"]; !ok {
 		var zeroVal []*MultiPlanetRequiresNestedByNamesInput
 		return zeroVal, nil
 	}
@@ -640,11 +604,7 @@ func (ec *executionContext) field_Entity_findPersonByName_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -672,11 +632,7 @@ func (ec *executionContext) field_Entity_findPlanetMultipleRequiresByName_argsNa
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -704,11 +660,7 @@ func (ec *executionContext) field_Entity_findPlanetRequiresByName_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -736,11 +688,7 @@ func (ec *executionContext) field_Entity_findPlanetRequiresNestedByName_argsName
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -773,11 +721,7 @@ func (ec *executionContext) field_Entity_findWorldByHelloNameAndFoo_argsHelloNam
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["helloName"]
-	if !ok {
+	if _, ok := rawArgs["helloName"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -795,11 +739,7 @@ func (ec *executionContext) field_Entity_findWorldByHelloNameAndFoo_argsFoo(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["foo"]
-	if !ok {
+	if _, ok := rawArgs["foo"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -827,11 +767,7 @@ func (ec *executionContext) field_Entity_findWorldNameByName_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -859,11 +795,7 @@ func (ec *executionContext) field_Entity_findWorldWithMultipleKeysByBar_argsBar(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["bar"]
-	if !ok {
+	if _, ok := rawArgs["bar"]; !ok {
 		var zeroVal int
 		return zeroVal, nil
 	}
@@ -896,11 +828,7 @@ func (ec *executionContext) field_Entity_findWorldWithMultipleKeysByHelloNameAnd
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["helloName"]
-	if !ok {
+	if _, ok := rawArgs["helloName"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -918,11 +846,7 @@ func (ec *executionContext) field_Entity_findWorldWithMultipleKeysByHelloNameAnd
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["foo"]
-	if !ok {
+	if _, ok := rawArgs["foo"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -950,11 +874,7 @@ func (ec *executionContext) field_Query___type_argsName(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -982,11 +902,7 @@ func (ec *executionContext) field_Query__entities_argsRepresentations(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) ([]map[string]any, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["representations"]
-	if !ok {
+	if _, ok := rawArgs["representations"]; !ok {
 		var zeroVal []map[string]any
 		return zeroVal, nil
 	}
@@ -1014,11 +930,7 @@ func (ec *executionContext) field___Type_enumValues_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -1046,11 +958,7 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}

--- a/plugin/federation/testdata/usefunctionsyntaxforexecutioncontext/generated/exec.go
+++ b/plugin/federation/testdata/usefunctionsyntaxforexecutioncontext/generated/exec.go
@@ -887,11 +887,7 @@ func field_Entity_findHelloByName_argsName(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -925,11 +921,7 @@ func field_Entity_findHelloMultiSingleKeysByKey1AndKey2_argsKey1(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["key1"]
-	if !ok {
+	if _, ok := rawArgs["key1"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -948,11 +940,7 @@ func field_Entity_findHelloMultiSingleKeysByKey1AndKey2_argsKey2(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["key2"]
-	if !ok {
+	if _, ok := rawArgs["key2"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -981,11 +969,7 @@ func field_Entity_findHelloWithErrorsByName_argsName(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1014,11 +998,7 @@ func field_Entity_findManyMultiHelloByNames_argsReps(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) ([]*model.MultiHelloByNamesInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["reps"]
-	if !ok {
+	if _, ok := rawArgs["reps"]; !ok {
 		var zeroVal []*model.MultiHelloByNamesInput
 		return zeroVal, nil
 	}
@@ -1047,11 +1027,7 @@ func field_Entity_findManyMultiHelloMultipleRequiresByNames_argsReps(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) ([]*model.MultiHelloMultipleRequiresByNamesInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["reps"]
-	if !ok {
+	if _, ok := rawArgs["reps"]; !ok {
 		var zeroVal []*model.MultiHelloMultipleRequiresByNamesInput
 		return zeroVal, nil
 	}
@@ -1080,11 +1056,7 @@ func field_Entity_findManyMultiHelloRequiresByNames_argsReps(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) ([]*model.MultiHelloRequiresByNamesInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["reps"]
-	if !ok {
+	if _, ok := rawArgs["reps"]; !ok {
 		var zeroVal []*model.MultiHelloRequiresByNamesInput
 		return zeroVal, nil
 	}
@@ -1113,11 +1085,7 @@ func field_Entity_findManyMultiHelloWithErrorByNames_argsReps(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) ([]*model.MultiHelloWithErrorByNamesInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["reps"]
-	if !ok {
+	if _, ok := rawArgs["reps"]; !ok {
 		var zeroVal []*model.MultiHelloWithErrorByNamesInput
 		return zeroVal, nil
 	}
@@ -1146,11 +1114,7 @@ func field_Entity_findManyMultiPlanetRequiresNestedByNames_argsReps(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) ([]*model.MultiPlanetRequiresNestedByNamesInput, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["reps"]
-	if !ok {
+	if _, ok := rawArgs["reps"]; !ok {
 		var zeroVal []*model.MultiPlanetRequiresNestedByNamesInput
 		return zeroVal, nil
 	}
@@ -1179,11 +1143,7 @@ func field_Entity_findPlanetMultipleRequiresByName_argsName(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1212,11 +1172,7 @@ func field_Entity_findPlanetRequiresByName_argsName(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1245,11 +1201,7 @@ func field_Entity_findPlanetRequiresNestedByName_argsName(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1283,11 +1235,7 @@ func field_Entity_findWorldByHelloNameAndFoo_argsHelloName(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["helloName"]
-	if !ok {
+	if _, ok := rawArgs["helloName"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1306,11 +1254,7 @@ func field_Entity_findWorldByHelloNameAndFoo_argsFoo(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["foo"]
-	if !ok {
+	if _, ok := rawArgs["foo"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1339,11 +1283,7 @@ func field_Entity_findWorldNameByName_argsName(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1372,11 +1312,7 @@ func field_Entity_findWorldWithMultipleKeysByBar_argsBar(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["bar"]
-	if !ok {
+	if _, ok := rawArgs["bar"]; !ok {
 		var zeroVal int
 		return zeroVal, nil
 	}
@@ -1410,11 +1346,7 @@ func field_Entity_findWorldWithMultipleKeysByHelloNameAndFoo_argsHelloName(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["helloName"]
-	if !ok {
+	if _, ok := rawArgs["helloName"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1433,11 +1365,7 @@ func field_Entity_findWorldWithMultipleKeysByHelloNameAndFoo_argsFoo(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["foo"]
-	if !ok {
+	if _, ok := rawArgs["foo"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1466,11 +1394,7 @@ func field_Query___type_argsName(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["name"]
-	if !ok {
+	if _, ok := rawArgs["name"]; !ok {
 		var zeroVal string
 		return zeroVal, nil
 	}
@@ -1499,11 +1423,7 @@ func field_Query__entities_argsRepresentations(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) ([]map[string]any, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["representations"]
-	if !ok {
+	if _, ok := rawArgs["representations"]; !ok {
 		var zeroVal []map[string]any
 		return zeroVal, nil
 	}
@@ -1532,11 +1452,7 @@ func field___Type_enumValues_argsIncludeDeprecated(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}
@@ -1565,11 +1481,7 @@ func field___Type_fields_argsIncludeDeprecated(
 	ec *executionContext,
 	rawArgs map[string]any,
 ) (bool, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["includeDeprecated"]
-	if !ok {
+	if _, ok := rawArgs["includeDeprecated"]; !ok {
 		var zeroVal bool
 		return zeroVal, nil
 	}


### PR DESCRIPTION
Template comments should not be included in the generated assets (it repeats itself for every arg).

cc @giautm 