### PR TITLE
Unalias before checking if is interface

### DIFF
--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -499,6 +499,7 @@ func isValid(t types.Type) bool {
 }
 
 func (b *Binder) CopyModifiersFromAst(t *ast.Type, base types.Type) types.Type {
+	base = types.Unalias(base)
 	if t.Elem != nil {
 		child := b.CopyModifiersFromAst(t.Elem, base)
 		if _, isStruct := child.Underlying().(*types.Struct); isStruct && !b.cfg.OmitSliceElementPointers {
@@ -553,8 +554,9 @@ func hasMethod(it types.Type, name string) bool {
 }
 
 func basicUnderlying(it types.Type) *types.Basic {
+	it = types.Unalias(it)
 	if ptr, isPtr := it.(*types.Pointer); isPtr {
-		it = ptr.Elem()
+		it = types.Unalias(ptr.Elem())
 	}
 	namedType, ok := it.(*types.Named)
 	if !ok {


### PR DESCRIPTION
Follow-up to #3471: Use Go 1.22 unalias

When you bind a type with an `Any` scalar field to a go struct where that field is an `interface{}`, you have a 50-50 chance you get the generated code with Interface, otherwise Any.

This is extremely annoying. Please see https://github.com/99designs/gqlgen/issues/3414#issuecomment-2574886429

This PR does NOT fix that issue, but seems like it's a good precaution.

Signed-off-by: Steve Coffman <steve@khanacademy.org>
