### PR TITLE
Override template ref to be any instead of interface{}

### DIFF
--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -248,7 +248,13 @@ func isDelimiter(c rune) bool {
 }
 
 func ref(p types.Type) string {
-	return CurrentImports.LookupType(p)
+	typeString := CurrentImports.LookupType(p)
+	// TODO(steve): figure out why this is needed
+	// otherwise inconsistent sometimes
+	if typeString == "interface{}" {
+		return "any"
+	}
+	return typeString
 }
 
 func obj(obj types.Object) string {


### PR DESCRIPTION
This fixes #3414 so that `ref` template functions used when generating will consistently use `any` over `interface{}`. Linters, like revive, will flag the use of `interface{}` and the recommendation is to use `gofmt -w -r 'interface{} -> any'` to change them all to `any`. This PR coerces the value to always prefer `any`, which is a dirty hack that will probably bite me. I am not sure why the behavior is inconsistent without this change. I think somehow the template is supplied with `$type.GO` inconsistently (despite my putting `types.Unalias` seemingly all over the place in other PRs). If someone has a better idea, I would love to hear about it.

+ When the type.gotpl template file pipes the `$type.GO` to [`ref` here](https://github.com/99designs/gqlgen/blob/40ad172503feee2d19d6e5481887c74db7ddab20/codegen/type.gotpl#L116)
+ That calls the [`ref` function here](https://github.com/99designs/gqlgen/blob/40ad172503feee2d19d6e5481887c74db7ddab20/codegen/templates/templates.go#L250)
+ Which then calls [`CurrentImports.LookupType` here](https://github.com/99designs/gqlgen/blob/40ad172503feee2d19d6e5481887c74db7ddab20/codegen/templates/import.go#L118)
+ Which passes the Qualifier Function using [`s.Lookup(i.Path()` that is implemented here](https://github.com/99designs/gqlgen/blob/40ad172503feee2d19d6e5481887c74db7ddab20/codegen/templates/import.go#L82)

> When you bind a type with an `Any` scalar field to a go struct where that field is an `interface{}` it will sometimes generate the scalar marshaller (eg `marshalNAny2interface`) with a parameter/return type of `interface{}` to match that field.
> 
> I'm guessing it's a race condition sort of thing, where you're using threads to traverse the graph in parallel and generate the schema gen code.  One thread sees something like an input with no go type to reference and generates the marshaller with default type of `any` while another thread sees the go struct with type `interface{}` being mapped to a field on the graph of type `Any` and uses that (`interface{}`) type when generating the marshaller.
> 
> I've made an example repo to show this happening.  Just run the regen.sh script (or run `go run github.com/99designs/gqlgen` repeatedly) to see it sometimes generate the schema_gen.go file exactly as it's committed and sometime with a diff in the schema_gen.go file.
> 
> Example repo: https://github.com/evellior/gqlgen-test

Signed-off-by: Steve Coffman <steve@khanacademy.org>
