### PR TITLE
feat: add errors to ftv1 traces

### DIFF
--- a/graphql/handler/apollofederatedtracingv1/tracing.go
+++ b/graphql/handler/apollofederatedtracingv1/tracing.go
@@ -19,17 +19,17 @@ const (
 
 type (
 	Tracer struct {
-		ClientName string
-		Version    string
-		Hostname   string
-		Errors     TraceErrors
+		ClientName   string
+		Version      string
+		Hostname     string
+		ErrorOptions *ErrorOptions
 	}
 
 	treeBuilderKey string
 )
 
-type TraceErrors struct {
-	// ErrorOption is the option to handle errors in the trace, it can be one of the following:
+type ErrorOptions struct {
+	// ErrorOptions is the option to handle errors in the trace, it can be one of the following:
 	// - "masked": masks all errors
 	// - "all": includes all errors
 	// - "transform": includes all errors but transforms them using TransformFunction, which can allow users to redact sensitive information
@@ -80,7 +80,7 @@ func (t *Tracer) InterceptOperation(ctx context.Context, next graphql.OperationH
 		return next(ctx)
 	}
 
-	return next(context.WithValue(ctx, key, NewTreeBuilder(t.Errors)))
+	return next(context.WithValue(ctx, key, NewTreeBuilder(t.ErrorOptions)))
 }
 
 // InterceptField is called on each field's resolution, including information about the path and parent node.

--- a/graphql/handler/apollofederatedtracingv1/tracing.go
+++ b/graphql/handler/apollofederatedtracingv1/tracing.go
@@ -22,7 +22,7 @@ type (
 		ClientName string
 		Version    string
 		Hostname   string
-		Errors     *TraceErrors
+		Errors     TraceErrors
 	}
 
 	treeBuilderKey string
@@ -79,39 +79,8 @@ func (t *Tracer) InterceptOperation(ctx context.Context, next graphql.OperationH
 	if !t.shouldTrace(ctx) {
 		return next(ctx)
 	}
-	if t.Errors == nil {
-		t.Errors = &TraceErrors{
-			ErrorOption:       ERROR_MASKED,
-			TransformFunction: defaultErrorTransform,
-		}
-	}
 
-	switch t.Errors.ErrorOption {
-	case ERROR_MASKED:
-		t.Errors.TransformFunction = defaultErrorTransform
-	case ERROR_UNMODIFIED:
-		t.Errors.TransformFunction = nil
-	case ERROR_TRANSFORM:
-		if t.Errors.TransformFunction == nil {
-			t.Errors.TransformFunction = defaultErrorTransform
-		}
-	default:
-		t.Errors = &TraceErrors{
-			ErrorOption:       ERROR_MASKED,
-			TransformFunction: defaultErrorTransform,
-		}
-	}
-	if t.Errors == nil || t.Errors.ErrorOption == ERROR_MASKED {
-		t.Errors = &TraceErrors{
-			ErrorOption:       ERROR_MASKED,
-			TransformFunction: defaultErrorTransform,
-		}
-	} else if t.Errors.ErrorOption == ERROR_TRANSFORM && t.Errors.TransformFunction == nil {
-		t.Errors.TransformFunction = defaultErrorTransform
-	} else if t.Errors.ErrorOption == ERROR_UNMODIFIED {
-		t.Errors.TransformFunction = nil
-	}
-	return next(context.WithValue(ctx, key, NewTreeBuilder(*t.Errors)))
+	return next(context.WithValue(ctx, key, NewTreeBuilder(t.Errors)))
 }
 
 // InterceptField is called on each field's resolution, including information about the path and parent node.
@@ -162,8 +131,4 @@ func (t *Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHan
 	}(val)
 	resp := next(ctx)
 	return resp
-}
-
-func defaultErrorTransform(_ gqlerror.Error) gqlerror.Error {
-	return *gqlerror.Errorf("<masked>")
 }

--- a/graphql/handler/apollofederatedtracingv1/tracing.go
+++ b/graphql/handler/apollofederatedtracingv1/tracing.go
@@ -79,6 +79,28 @@ func (t *Tracer) InterceptOperation(ctx context.Context, next graphql.OperationH
 	if !t.shouldTrace(ctx) {
 		return next(ctx)
 	}
+	if t.Errors == nil {
+		t.Errors = &TraceErrors{
+			ErrorOption:       ERROR_MASKED,
+			TransformFunction: defaultErrorTransform,
+		}
+	}
+
+	switch t.Errors.ErrorOption {
+	case ERROR_MASKED:
+		t.Errors.TransformFunction = defaultErrorTransform
+	case ERROR_UNMODIFIED:
+		t.Errors.TransformFunction = nil
+	case ERROR_TRANSFORM:
+		if t.Errors.TransformFunction == nil {
+			t.Errors.TransformFunction = defaultErrorTransform
+		}
+	default:
+		t.Errors = &TraceErrors{
+			ErrorOption:       ERROR_MASKED,
+			TransformFunction: defaultErrorTransform,
+		}
+	}
 	if t.Errors == nil || t.Errors.ErrorOption == ERROR_MASKED {
 		t.Errors = &TraceErrors{
 			ErrorOption:       ERROR_MASKED,

--- a/graphql/handler/apollofederatedtracingv1/tracing.go
+++ b/graphql/handler/apollofederatedtracingv1/tracing.go
@@ -34,7 +34,7 @@ type TraceErrors struct {
 	// - "all": includes all errors
 	// - "transform": includes all errors but transforms them using TransformFunction, which can allow users to redact sensitive information
 	ErrorOption       string
-	TransformFunction func(gqlerror.Error) gqlerror.Error
+	TransformFunction func(g *gqlerror.Error) *gqlerror.Error
 }
 
 const (

--- a/graphql/handler/apollofederatedtracingv1/tracing_test.go
+++ b/graphql/handler/apollofederatedtracingv1/tracing_test.go
@@ -107,7 +107,6 @@ func TestApolloTracing_withFail(t *testing.T) {
 	resp := doRequest(h, http.MethodPost, "/graphql", `{"operationName":"A","extensions":{"persistedQuery":{"version":1,"sha256Hash":"338bbc16ac780daf81845339fbf0342061c1e9d2b702c96d3958a13a557083a6"}}}`)
 	assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
 	b := resp.Body.Bytes()
-	t.Log(string(b))
 	var respData struct {
 		Errors gqlerror.List
 	}

--- a/graphql/handler/apollofederatedtracingv1/tree_builder.go
+++ b/graphql/handler/apollofederatedtracingv1/tree_builder.go
@@ -131,7 +131,7 @@ func (tb *TreeBuilder) DidEncounterErrors(ctx context.Context, gqlErrors gqlerro
 
 	for _, err := range gqlErrors {
 		if err != nil {
-			tb.addProtobufError(*err)
+			tb.addProtobufError(err)
 		}
 	}
 }
@@ -183,7 +183,7 @@ func (tb *TreeBuilder) ensureParentNode(path *graphql.FieldContext) *generated.T
 }
 
 func (tb *TreeBuilder) addProtobufError(
-	gqlError gqlerror.Error,
+	gqlError *gqlerror.Error,
 ) {
 	if tb.startTime == nil {
 		fmt.Println(errors.New("addProtobufError called before StartTimer"))
@@ -231,6 +231,6 @@ func (tb *TreeBuilder) addProtobufError(
 	tb.mu.Unlock()
 }
 
-func defaultErrorTransform(_ gqlerror.Error) gqlerror.Error {
-	return *gqlerror.Errorf("<masked>")
+func defaultErrorTransform(_ *gqlerror.Error) *gqlerror.Error {
+	return gqlerror.Errorf("<masked>")
 }

--- a/graphql/handler/apollofederatedtracingv1/tree_builder.go
+++ b/graphql/handler/apollofederatedtracingv1/tree_builder.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -74,12 +73,12 @@ func NewTreeBuilder(errorOptions *ErrorOptions) *TreeBuilder {
 
 // StartTimer marks the time using protobuf timestamp format for use in timing calculations
 func (tb *TreeBuilder) StartTimer(ctx context.Context) {
-	if tb.startTime != nil {
-		fmt.Println(errors.New("StartTimer called twice"))
-	}
-	if tb.stopped {
-		fmt.Println(errors.New("StartTimer called after StopTimer"))
-	}
+	// if tb.startTime != nil {
+	// 	fmt.Println(errors.New("StartTimer called twice"))
+	// }
+	// if tb.stopped {
+	// 	fmt.Println(errors.New("StartTimer called after StopTimer"))
+	// }
 
 	opCtx := graphql.GetOperationContext(ctx)
 	start := opCtx.Stats.OperationStart
@@ -90,12 +89,12 @@ func (tb *TreeBuilder) StartTimer(ctx context.Context) {
 
 // StopTimer marks the end of the timer, along with setting the related fields in the protobuf representation
 func (tb *TreeBuilder) StopTimer(ctx context.Context) {
-	if tb.startTime == nil {
-		fmt.Println(errors.New("StopTimer called before StartTimer"))
-	}
-	if tb.stopped {
-		fmt.Println(errors.New("StopTimer called twice"))
-	}
+	// if tb.startTime == nil {
+	// 	fmt.Println(errors.New("StopTimer called before StartTimer"))
+	// }
+	// if tb.stopped {
+	// 	fmt.Println(errors.New("StopTimer called twice"))
+	// }
 
 	ts := graphql.Now().UTC()
 	tb.Trace.DurationNs = uint64(ts.Sub(*tb.startTime).Nanoseconds())
@@ -106,14 +105,14 @@ func (tb *TreeBuilder) StopTimer(ctx context.Context) {
 // On each field, it calculates the time started at as now - tree.StartTime, as well as a deferred function upon full resolution of the
 // field as now - tree.StartTime; these are used by Apollo to calculate how fields are being resolved in the AST
 func (tb *TreeBuilder) WillResolveField(ctx context.Context) {
-	if tb.startTime == nil {
-		fmt.Println(errors.New("WillResolveField called before StartTimer"))
-		return
-	}
-	if tb.stopped {
-		fmt.Println(errors.New("WillResolveField called after StopTimer"))
-		return
-	}
+	// if tb.startTime == nil {
+	// 	fmt.Println(errors.New("WillResolveField called before StartTimer"))
+	// 	return
+	// }
+	// if tb.stopped {
+	// 	fmt.Println(errors.New("WillResolveField called after StopTimer"))
+	//	return
+	// }
 	fc := graphql.GetFieldContext(ctx)
 
 	node := tb.newNode(fc)
@@ -128,11 +127,11 @@ func (tb *TreeBuilder) WillResolveField(ctx context.Context) {
 
 func (tb *TreeBuilder) DidEncounterErrors(ctx context.Context, gqlErrors gqlerror.List) {
 	if tb.startTime == nil {
-		fmt.Println(errors.New("DidEncounterErrors called before StartTimer"))
+	// 	fmt.Println(errors.New("DidEncounterErrors called before StartTimer"))
 		return
 	}
 	if tb.stopped {
-		fmt.Println(errors.New("DidEncounterErrors called after StopTimer"))
+	//	fmt.Println(errors.New("DidEncounterErrors called after StopTimer"))
 		return
 	}
 
@@ -193,11 +192,11 @@ func (tb *TreeBuilder) addProtobufError(
 	gqlError *gqlerror.Error,
 ) {
 	if tb.startTime == nil {
-		fmt.Println(errors.New("addProtobufError called before StartTimer"))
+		// fmt.Println(errors.New("addProtobufError called before StartTimer"))
 		return
 	}
 	if tb.stopped {
-		fmt.Println(errors.New("addProtobufError called after StopTimer"))
+		// fmt.Println(errors.New("addProtobufError called after StopTimer"))
 		return
 	}
 	tb.mu.Lock()
@@ -206,7 +205,7 @@ func (tb *TreeBuilder) addProtobufError(
 	if tb.nodes[gqlError.Path.String()].self != nil {
 		nodeRef = tb.nodes[gqlError.Path.String()].self
 	} else {
-		fmt.Println("Error: Path not found in node map")
+		// fmt.Println("Error: Path not found in node map")
 		tb.mu.Unlock()
 		return
 	}
@@ -225,7 +224,7 @@ func (tb *TreeBuilder) addProtobufError(
 
 	gqlJson, err := json.Marshal(gqlError)
 	if err != nil {
-		fmt.Println(err)
+		// fmt.Println(err)
 		tb.mu.Unlock()
 		return
 	}

--- a/graphql/handler/apollofederatedtracingv1/tree_builder.go
+++ b/graphql/handler/apollofederatedtracingv1/tree_builder.go
@@ -19,7 +19,7 @@ type TreeBuilder struct {
 	Trace        *generated.Trace
 	rootNode     generated.Trace_Node
 	nodes        map[string]NodeMap // nodes is used to store a pointer map using the node path (e.g. todo[0].id) to itself as well as it's parent
-	errorOptions TraceErrors
+	errorOptions *ErrorOptions
 
 	startTime *time.Time
 	stopped   bool
@@ -32,7 +32,14 @@ type NodeMap struct {
 }
 
 // NewTreeBuilder is used to start the node tree with a default root node, along with the related tree nodes map entry
-func NewTreeBuilder(errorOptions TraceErrors) *TreeBuilder {
+func NewTreeBuilder(errorOptions *ErrorOptions) *TreeBuilder {
+	if errorOptions == nil {
+		errorOptions = &ErrorOptions{
+			ErrorOption:       ERROR_MASKED,
+			TransformFunction: defaultErrorTransform,
+		}
+	}
+
 	switch errorOptions.ErrorOption {
 	case ERROR_MASKED:
 		errorOptions.TransformFunction = defaultErrorTransform
@@ -43,7 +50,7 @@ func NewTreeBuilder(errorOptions TraceErrors) *TreeBuilder {
 			errorOptions.TransformFunction = defaultErrorTransform
 		}
 	default:
-		errorOptions = TraceErrors{
+		errorOptions = &ErrorOptions{
 			ErrorOption:       ERROR_MASKED,
 			TransformFunction: defaultErrorTransform,
 		}

--- a/graphql/handler/apollofederatedtracingv1/tree_builder.go
+++ b/graphql/handler/apollofederatedtracingv1/tree_builder.go
@@ -200,6 +200,7 @@ func (tb *TreeBuilder) addProtobufError(
 		nodeRef = tb.nodes[gqlError.Path.String()].self
 	} else {
 		fmt.Println("Error: Path not found in node map")
+		tb.mu.Unlock()
 		return
 	}
 
@@ -218,6 +219,7 @@ func (tb *TreeBuilder) addProtobufError(
 	gqlJson, err := json.Marshal(gqlError)
 	if err != nil {
 		fmt.Println(err)
+		tb.mu.Unlock()
 		return
 	}
 

--- a/graphql/handler/apollofederatedtracingv1/tree_builder.go
+++ b/graphql/handler/apollofederatedtracingv1/tree_builder.go
@@ -127,11 +127,11 @@ func (tb *TreeBuilder) WillResolveField(ctx context.Context) {
 
 func (tb *TreeBuilder) DidEncounterErrors(ctx context.Context, gqlErrors gqlerror.List) {
 	if tb.startTime == nil {
-	// 	fmt.Println(errors.New("DidEncounterErrors called before StartTimer"))
+		// 	fmt.Println(errors.New("DidEncounterErrors called before StartTimer"))
 		return
 	}
 	if tb.stopped {
-	//	fmt.Println(errors.New("DidEncounterErrors called after StopTimer"))
+		//	fmt.Println(errors.New("DidEncounterErrors called after StopTimer"))
 		return
 	}
 

--- a/graphql/handler/apollofederatedtracingv1/tree_builder.go
+++ b/graphql/handler/apollofederatedtracingv1/tree_builder.go
@@ -3,7 +3,6 @@ package apollofederatedtracingv1
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"sync"
 	"time"
 


### PR DESCRIPTION
This just adds the missing functionality that was missing from my initial `ftv1` implementation ( see #2132 ) for the `apollofederatedtracingv1` package. Addresses #3403.

This further adds the ability to define a transform function for the users that want to control what is sent in said traces; example:

```go
	srv.Use(&apollofederatedtracingv1.Tracer{
		ErrorOptions: &apollofederatedtracingv1.ErrorOptions{
			ErrorOption: apollofederatedtracingv1.ERROR_TRANSFORM,
			TransformFunction: func(err gqlerror.Error) gqlerror.Error {
				return gqlerror.Error{
					Message: "transformed",
				}
			},
		},
	})
```

The other valid options for `ErrorOption` are: 

* `ERROR_UNMODIFIED` - sends an unmodified error in the trace, which is potentially dangerous for sensitive information
* `ERROR_MASKED` - replaces the message in the error with `<masked>`; this is the default behavior

This matches with the [Apollo Server implementation](https://github.com/apollographql/apollo-server/blob/88a8db546bac6e18b167e55760a061daa9b119a1/packages/server/src/plugin/traceTreeBuilder.ts#L44-L47) to avoid sending sensitive information. 

If using `ERROR_TRANSFORM`, the `TransformFunction` is invoked and the user can customize the message/other data as needed, although modifying the message is the only expected thing in this case (although other data could be helpful). 

Visuals included in PR to help illustrate what it looks like in Apollo Studio. 
![image](https://github.com/user-attachments/assets/0d465fcb-4b2a-45e5-8abb-b81265b05806)
![image](https://github.com/user-attachments/assets/1f239f4c-01ea-4cfd-8ec8-725890dcf9a4)
![image](https://github.com/user-attachments/assets/b9564648-c87f-4a2f-9b6f-aedb3d68804d)

The `<redacted>` is coming from the Apollo Router, and is unimportant for this PR. `transformed` used the example above.  

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
