### PR TITLE
feat: add logger for use with tracing middleware

### DIFF
--- a/graphql/handler/apollofederatedtracingv1/logger/logger.go
+++ b/graphql/handler/apollofederatedtracingv1/logger/logger.go
@@ -1,0 +1,31 @@
+package tracing_logger
+
+import "log"
+
+// Logger is an interface that can be implemented to log errors that occur during the tracing process
+// This can use the default Go logger or a custom logger (e.g. logrus or zap)
+type Logger interface {
+	Print(args ...interface{})
+	Println(args ...interface{})
+	Printf(format string, args ...interface{})
+}
+
+func New() *NoopLogger {
+	return &NoopLogger{
+		log.New(NullWriter(1), "", log.LstdFlags),
+	}
+}
+
+type NullWriter int
+
+func (NullWriter) Write([]byte) (int, error) { return 0, nil }
+
+type NoopLogger struct {
+	*log.Logger
+}
+
+func (l *NoopLogger) Print(args ...interface{}) {}
+
+func (l *NoopLogger) Printf(format string, args ...interface{}) {}
+
+func (l *NoopLogger) Println(v ...interface{}) {}

--- a/graphql/handler/apollofederatedtracingv1/logger/logger.go
+++ b/graphql/handler/apollofederatedtracingv1/logger/logger.go
@@ -5,9 +5,9 @@ import "log"
 // Logger is an interface that can be implemented to log errors that occur during the tracing process
 // This can use the default Go logger or a custom logger (e.g. logrus or zap)
 type Logger interface {
-	Print(args ...interface{})
-	Println(args ...interface{})
-	Printf(format string, args ...interface{})
+	Print(args any)
+	Println(args any)
+	Printf(format string, args any)
 }
 
 func New() *NoopLogger {
@@ -24,8 +24,8 @@ type NoopLogger struct {
 	*log.Logger
 }
 
-func (l *NoopLogger) Print(args ...interface{}) {}
+func (l *NoopLogger) Print(args any) {}
 
-func (l *NoopLogger) Printf(format string, args ...interface{}) {}
+func (l *NoopLogger) Printf(format string, args any) {}
 
-func (l *NoopLogger) Println(v ...interface{}) {}
+func (l *NoopLogger) Println(v any) {}

--- a/graphql/handler/apollofederatedtracingv1/logger/logger.go
+++ b/graphql/handler/apollofederatedtracingv1/logger/logger.go
@@ -1,4 +1,4 @@
-package tracing_logger
+package logger
 
 import "log"
 
@@ -10,7 +10,7 @@ type Logger interface {
 	Printf(format string, args any)
 }
 
-func New() *NoopLogger {
+func NewNoopLogger() *NoopLogger {
 	return &NoopLogger{
 		log.New(NullWriter(1), "", log.LstdFlags),
 	}

--- a/graphql/handler/apollofederatedtracingv1/logger/logger_test.go
+++ b/graphql/handler/apollofederatedtracingv1/logger/logger_test.go
@@ -1,28 +1,28 @@
-package tracing_logger_test
+package logger_test
 
 import (
 	"testing"
 
-	tracing_logger "github.com/99designs/gqlgen/graphql/handler/apollofederatedtracingv1/logger"
+	"github.com/99designs/gqlgen/graphql/handler/apollofederatedtracingv1/logger"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNoopLogger_Print(t *testing.T) {
-	l := tracing_logger.New()
+	l := logger.NewNoopLogger()
 	assert.NotPanics(t, func() {
 		l.Print("test")
 	})
 }
 
 func TestNoopLogger_Printf(t *testing.T) {
-	l := tracing_logger.New()
+	l := logger.NewNoopLogger()
 	assert.NotPanics(t, func() {
 		l.Printf("test %s", "formatted")
 	})
 }
 
 func TestNoopLogger_Println(t *testing.T) {
-	l := tracing_logger.New()
+	l := logger.NewNoopLogger()
 	assert.NotPanics(t, func() {
 		l.Println("test")
 	})

--- a/graphql/handler/apollofederatedtracingv1/logger/logger_test.go
+++ b/graphql/handler/apollofederatedtracingv1/logger/logger_test.go
@@ -1,0 +1,29 @@
+package tracing_logger_test
+
+import (
+	"testing"
+
+	tracing_logger "github.com/99designs/gqlgen/graphql/handler/apollofederatedtracingv1/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoopLogger_Print(t *testing.T) {
+	l := tracing_logger.New()
+	assert.NotPanics(t, func() {
+		l.Print("test")
+	})
+}
+
+func TestNoopLogger_Printf(t *testing.T) {
+	l := tracing_logger.New()
+	assert.NotPanics(t, func() {
+		l.Printf("test %s", "formatted")
+	})
+}
+
+func TestNoopLogger_Println(t *testing.T) {
+	l := tracing_logger.New()
+	assert.NotPanics(t, func() {
+		l.Println("test")
+	})
+}

--- a/graphql/handler/apollofederatedtracingv1/tracing.go
+++ b/graphql/handler/apollofederatedtracingv1/tracing.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/99designs/gqlgen/graphql"
+	tracing_logger "github.com/99designs/gqlgen/graphql/handler/apollofederatedtracingv1/logger"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
@@ -23,6 +24,10 @@ type (
 		Version      string
 		Hostname     string
 		ErrorOptions *ErrorOptions
+
+		// Logger is used to log errors that occur during the tracing process; if nil, no logging will occur
+		// This can use the default Go logger or a custom logger (e.g. logrus or zap)
+		Logger tracing_logger.Logger
 	}
 
 	treeBuilderKey string
@@ -80,7 +85,7 @@ func (t *Tracer) InterceptOperation(ctx context.Context, next graphql.OperationH
 		return next(ctx)
 	}
 
-	return next(context.WithValue(ctx, key, NewTreeBuilder(t.ErrorOptions)))
+	return next(context.WithValue(ctx, key, NewTreeBuilder(t.ErrorOptions, t.Logger)))
 }
 
 // InterceptField is called on each field's resolution, including information about the path and parent node.

--- a/graphql/handler/apollofederatedtracingv1/tree_builder.go
+++ b/graphql/handler/apollofederatedtracingv1/tree_builder.go
@@ -44,7 +44,7 @@ func NewTreeBuilder(errorOptions *ErrorOptions, logger tracing_logger.Logger) *T
 
 	if logger == nil {
 		// defaults to a noop logger
-		logger = tracing_logger.New()
+		logger = tracing_logger.NewNoopLogger()
 	}
 
 	switch errorOptions.ErrorOption {


### PR DESCRIPTION
In #3506, it was discussed to allow users to bring a custom logger to print out the various error logs that might happen during the tracing process to allow users to properly set the right structured logging consistently across the application. 

This adds a new `Logger` attribute on the `Tracer` struct that can take in a Logger that abides by the standard `log` library standard (that is it has at a minimum has the Print/ln/f functions). 

Defaults to a no-op logger. 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
