### PR TITLE
Modified error handling in UnmarshalString to marshal non-string input into a JSON string

### DIFF
--- a/graphql/string.go
+++ b/graphql/string.go
@@ -64,6 +64,11 @@ func UnmarshalString(v any) (string, error) {
 	case nil:
 		return "", nil
 	default:
-		return "", fmt.Errorf("%T is not a string", v)
+		payload, err := json.Marshal(v)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal value of type %T: %w", v, err)
+		}
+
+		return string(payload), nil
 	}
 }

--- a/graphql/string_test.go
+++ b/graphql/string_test.go
@@ -31,6 +31,8 @@ func TestString(t *testing.T) {
 		assert.Equal(t, "true", mustUnmarshalString(t, true))
 		assert.Equal(t, "false", mustUnmarshalString(t, false))
 		assert.Equal(t, "", mustUnmarshalString(t, nil))
+		assert.Equal(t, `{"hello":"world"}`, mustUnmarshalString(t, map[string]interface{}{"hello": "world"}))
+		assert.Equal(t, `{"hello":123}`, mustUnmarshalString(t, map[string]interface{}{"hello": 123}))
 	})
 }
 


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

This PR updates the UnmarshalString function to handle non-string inputs by marshaling them into JSON instead of immediately returning an error. This change ensures that generic scalars are handled more gracefully in scenarios where input types do not exactly match the expected string type.


I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
