### PR TITLE
Update matrix to include Go 1.24

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
   coverage:
     strategy:
       matrix:
-        go: ["1.23"]
+        go: ["1.24"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/fmt-and-generate.yml
+++ b/.github/workflows/fmt-and-generate.yml
@@ -16,7 +16,7 @@ jobs:
   fmt-and-lint:
     strategy:
       matrix:
-        go: ["1.22", "1.23"]
+        go: ["1.22", "1.23", "1.24"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,8 +16,8 @@ jobs:
   integration:
     strategy:
       matrix:
-        go: ["1.22", "1.23"]
-        node: [18]
+        go: ["1.22", "1.23", "1.24"]
+        node: [22]
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
@@ -35,8 +35,8 @@ jobs:
   federation:
     strategy:
       matrix:
-        go: ["1.22", "1.23"]
-        node: [18]
+        go: ["1.22", "1.23", "1.24"]
+        node: [22]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
   init:
     strategy:
       matrix:
-        go: ["1.22", "1.23"]
+        go: ["1.22", "1.23", "1.24"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
       GOLANGCI_LINT_VERSION: v1.62.0
     strategy:
       matrix:
-        go: ["1.22", "1.23"]
+        go: ["1.22", "1.23", "1.24"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        go: ["1.22", "1.23"]
+        go: ["1.22", "1.23", "1.24"]
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     steps:


### PR DESCRIPTION
Go 1.24 is out! Hooray!
In #3505 reports problems with gqlgen and Go 1.24 due to a dependency on an old version of x/tools

However, GCP Appengine still [doesn't support Go 1.23 as generally available](https://cloud.google.com/appengine/docs/standard/go/release-notes) so we cannot drop Go 1.22 support yet. This means that we cannot update x/tools to a newer version.

Signed-off-by: Steve Coffman <steve@khanacademy.org>
