### PR TITLE
Fix wrong variable name in gin.md

### DIFF
--- a/docs/content/recipes/gin.md
+++ b/docs/content/recipes/gin.md
@@ -39,14 +39,14 @@ func graphqlHandler() gin.HandlerFunc {
 	h := handler.New(graph.NewExecutableSchema(graph.Config{Resolvers: &graph.Resolver{}}))
 
 	// Server setup:
-	srv.AddTransport(transport.Options{})
-	srv.AddTransport(transport.GET{})
-	srv.AddTransport(transport.POST{})
+	h.AddTransport(transport.Options{})
+	h.AddTransport(transport.GET{})
+	h.AddTransport(transport.POST{})
 
-	srv.SetQueryCache(lru.New[*ast.QueryDocument](1000))
+	h.SetQueryCache(lru.New[*ast.QueryDocument](1000))
 
-	srv.Use(extension.Introspection{})
-	srv.Use(extension.AutomaticPersistedQuery{
+	h.Use(extension.Introspection{})
+	h.Use(extension.AutomaticPersistedQuery{
 		Cache: lru.New[string](100),
 	})
 


### PR DESCRIPTION
The example for Gin documentation was referencing a `srv` variable that doesn't exist.
