### PR TITLE
Being extra careful in the sort makes me sleep better

### DIFF
--- a/_examples/federation/accounts/graph/generated.go
+++ b/_examples/federation/accounts/graph/generated.go
@@ -3297,13 +3297,6 @@ func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, 
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
-	case model.EmailHost:
-		return ec._EmailHost(ctx, sel, &obj)
-	case *model.EmailHost:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._EmailHost(ctx, sel, obj)
 	case model.User:
 		return ec._User(ctx, sel, &obj)
 	case *model.User:
@@ -3311,6 +3304,13 @@ func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, 
 			return graphql.Null
 		}
 		return ec._User(ctx, sel, obj)
+	case model.EmailHost:
+		return ec._EmailHost(ctx, sel, &obj)
+	case *model.EmailHost:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._EmailHost(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}

--- a/_examples/federation/products/graph/generated.go
+++ b/_examples/federation/products/graph/generated.go
@@ -3373,13 +3373,6 @@ func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, 
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
-	case model.Manufacturer:
-		return ec._Manufacturer(ctx, sel, &obj)
-	case *model.Manufacturer:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._Manufacturer(ctx, sel, obj)
 	case model.Product:
 		return ec._Product(ctx, sel, &obj)
 	case *model.Product:
@@ -3387,6 +3380,13 @@ func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, 
 			return graphql.Null
 		}
 		return ec._Product(ctx, sel, obj)
+	case model.Manufacturer:
+		return ec._Manufacturer(ctx, sel, &obj)
+	case *model.Manufacturer:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Manufacturer(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}

--- a/_examples/federation/reviews/graph/generated.go
+++ b/_examples/federation/reviews/graph/generated.go
@@ -3687,27 +3687,6 @@ func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, 
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
-	case model.EmailHost:
-		return ec._EmailHost(ctx, sel, &obj)
-	case *model.EmailHost:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._EmailHost(ctx, sel, obj)
-	case model.Manufacturer:
-		return ec._Manufacturer(ctx, sel, &obj)
-	case *model.Manufacturer:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._Manufacturer(ctx, sel, obj)
-	case model.Product:
-		return ec._Product(ctx, sel, &obj)
-	case *model.Product:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._Product(ctx, sel, obj)
 	case model.User:
 		return ec._User(ctx, sel, &obj)
 	case *model.User:
@@ -3715,6 +3694,27 @@ func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, 
 			return graphql.Null
 		}
 		return ec._User(ctx, sel, obj)
+	case model.Product:
+		return ec._Product(ctx, sel, &obj)
+	case *model.Product:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Product(ctx, sel, obj)
+	case model.Manufacturer:
+		return ec._Manufacturer(ctx, sel, &obj)
+	case *model.Manufacturer:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Manufacturer(ctx, sel, obj)
+	case model.EmailHost:
+		return ec._EmailHost(ctx, sel, &obj)
+	case *model.EmailHost:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._EmailHost(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}

--- a/codegen/interface.go
+++ b/codegen/interface.go
@@ -43,8 +43,15 @@ func (b *builder) buildInterface(typ *ast.Definition) (*Interface, error) {
 
 	// Sort so that more specific types are evaluated first.
 	implementors := b.Schema.GetPossibleTypes(typ)
+
 	sort.SliceStable(implementors, func(i, j int) bool {
-		return len(implementors[i].Interfaces) > len(implementors[j].Interfaces)
+		if len(implementors[i].Interfaces) != len(implementors[j].Interfaces) {
+			return len(implementors[i].Interfaces) > len(implementors[j].Interfaces)
+		}
+		// if they have the same name, they probably ARE the same
+		// so we need to rely on SliceStable or else order is
+		// non-deterministic and causes test failures
+		return implementors[i].Name > implementors[j].Name
 	})
 
 	for _, implementor := range implementors {

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -88,26 +88,31 @@ func Render(cfg Options) error {
 	}
 
 	roots := make([]string, 0, len(t.Templates()))
-	for _, template := range t.Templates() {
+	for _, templ := range t.Templates() {
 		// templates that end with _.gotpl are special files we don't want to include
-		if strings.HasSuffix(template.Name(), "_.gotpl") ||
+		if strings.HasSuffix(templ.Name(), "_.gotpl") ||
 			// filter out templates added with {{ template xxx }} syntax inside the template file
-			!strings.HasSuffix(template.Name(), ".gotpl") {
+			!strings.HasSuffix(templ.Name(), ".gotpl") {
 			continue
 		}
 
-		roots = append(roots, template.Name())
+		roots = append(roots, templ.Name())
 	}
 
 	// then execute all the important looking ones in order, adding them to the same file
 	sort.SliceStable(roots, func(i, j int) bool {
 		// important files go first
-		if strings.HasSuffix(roots[i], "!.gotpl") {
+		if strings.HasSuffix(roots[i], "!.gotpl") &&
+			!strings.HasSuffix(roots[j], "!.gotpl") {
 			return true
 		}
-		if strings.HasSuffix(roots[j], "!.gotpl") {
+		if strings.HasSuffix(roots[j], "!.gotpl") &&
+			!strings.HasSuffix(roots[i], "!.gotpl") {
 			return false
 		}
+		// files that have identical names are sorted dependent on input order
+		// so we rely on SliceStable here to ensure deterministic results
+		// to avoid test failures
 		return roots[i] < roots[j]
 	})
 

--- a/codegen/testserver/followschema/interfaces.generated.go
+++ b/codegen/testserver/followschema/interfaces.generated.go
@@ -1208,6 +1208,11 @@ func (ec *executionContext) _Animal(ctx context.Context, sel ast.SelectionSet, o
 			return graphql.Null
 		}
 		return ec._Horse(ctx, sel, obj)
+	case Mammalian:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Mammalian(ctx, sel, obj)
 	case Dog:
 		return ec._Dog(ctx, sel, &obj)
 	case *Dog:
@@ -1222,11 +1227,6 @@ func (ec *executionContext) _Animal(ctx context.Context, sel ast.SelectionSet, o
 			return graphql.Null
 		}
 		return ec._Cat(ctx, sel, obj)
-	case Mammalian:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._Mammalian(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -1252,16 +1252,16 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
-	case *ConcreteNodeA:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._ConcreteNodeA(ctx, sel, obj)
 	case ConcreteNodeInterface:
 		if obj == nil {
 			return graphql.Null
 		}
 		return ec._ConcreteNodeInterface(ctx, sel, obj)
+	case *ConcreteNodeA:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._ConcreteNodeA(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -1271,16 +1271,16 @@ func (ec *executionContext) _Shape(ctx context.Context, sel ast.SelectionSet, ob
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
-	case *Circle:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._Circle(ctx, sel, obj)
 	case *Rectangle:
 		if obj == nil {
 			return graphql.Null
 		}
 		return ec._Rectangle(ctx, sel, obj)
+	case *Circle:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Circle(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -1290,16 +1290,16 @@ func (ec *executionContext) _ShapeUnion(ctx context.Context, sel ast.SelectionSe
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
-	case *Circle:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._Circle(ctx, sel, obj)
 	case *Rectangle:
 		if obj == nil {
 			return graphql.Null
 		}
 		return ec._Rectangle(ctx, sel, obj)
+	case *Circle:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Circle(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}

--- a/codegen/testserver/followschema/useptr.generated.go
+++ b/codegen/testserver/followschema/useptr.generated.go
@@ -121,13 +121,6 @@ func (ec *executionContext) _TestUnion(ctx context.Context, sel ast.SelectionSet
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
-	case A:
-		return ec._A(ctx, sel, &obj)
-	case *A:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._A(ctx, sel, obj)
 	case B:
 		return ec._B(ctx, sel, &obj)
 	case *B:
@@ -135,6 +128,13 @@ func (ec *executionContext) _TestUnion(ctx context.Context, sel ast.SelectionSet
 			return graphql.Null
 		}
 		return ec._B(ctx, sel, obj)
+	case A:
+		return ec._A(ctx, sel, &obj)
+	case *A:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._A(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}

--- a/codegen/testserver/singlefile/generated.go
+++ b/codegen/testserver/singlefile/generated.go
@@ -17659,6 +17659,11 @@ func (ec *executionContext) _Animal(ctx context.Context, sel ast.SelectionSet, o
 			return graphql.Null
 		}
 		return ec._Horse(ctx, sel, obj)
+	case Mammalian:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Mammalian(ctx, sel, obj)
 	case Dog:
 		return ec._Dog(ctx, sel, &obj)
 	case *Dog:
@@ -17673,11 +17678,6 @@ func (ec *executionContext) _Animal(ctx context.Context, sel ast.SelectionSet, o
 			return graphql.Null
 		}
 		return ec._Cat(ctx, sel, obj)
-	case Mammalian:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._Mammalian(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -17726,16 +17726,16 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
-	case *ConcreteNodeA:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._ConcreteNodeA(ctx, sel, obj)
 	case ConcreteNodeInterface:
 		if obj == nil {
 			return graphql.Null
 		}
 		return ec._ConcreteNodeInterface(ctx, sel, obj)
+	case *ConcreteNodeA:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._ConcreteNodeA(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -17745,16 +17745,16 @@ func (ec *executionContext) _Shape(ctx context.Context, sel ast.SelectionSet, ob
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
-	case *Circle:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._Circle(ctx, sel, obj)
 	case *Rectangle:
 		if obj == nil {
 			return graphql.Null
 		}
 		return ec._Rectangle(ctx, sel, obj)
+	case *Circle:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Circle(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -17764,16 +17764,16 @@ func (ec *executionContext) _ShapeUnion(ctx context.Context, sel ast.SelectionSe
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
-	case *Circle:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._Circle(ctx, sel, obj)
 	case *Rectangle:
 		if obj == nil {
 			return graphql.Null
 		}
 		return ec._Rectangle(ctx, sel, obj)
+	case *Circle:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Circle(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -17783,13 +17783,6 @@ func (ec *executionContext) _TestUnion(ctx context.Context, sel ast.SelectionSet
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
-	case A:
-		return ec._A(ctx, sel, &obj)
-	case *A:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._A(ctx, sel, obj)
 	case B:
 		return ec._B(ctx, sel, &obj)
 	case *B:
@@ -17797,6 +17790,13 @@ func (ec *executionContext) _TestUnion(ctx context.Context, sel ast.SelectionSet
 			return graphql.Null
 		}
 		return ec._B(ctx, sel, obj)
+	case A:
+		return ec._A(ctx, sel, &obj)
+	case *A:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._A(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}

--- a/graphql/coercion.go
+++ b/graphql/coercion.go
@@ -7,50 +7,52 @@ import (
 // CoerceList applies coercion from a single value to a list.
 func CoerceList(v any) []any {
 	var vSlice []any
-	if v != nil {
-		switch v := v.(type) {
-		case []any:
-			// already a slice no coercion required
-			vSlice = v
-		case []string:
-			if len(v) > 0 {
-				vSlice = []any{v[0]}
-			}
-		case []json.Number:
-			if len(v) > 0 {
-				vSlice = []any{v[0]}
-			}
-		case []bool:
-			if len(v) > 0 {
-				vSlice = []any{v[0]}
-			}
-		case []map[string]any:
-			if len(v) > 0 {
-				vSlice = []any{v[0]}
-			}
-		case []float64:
-			if len(v) > 0 {
-				vSlice = []any{v[0]}
-			}
-		case []float32:
-			if len(v) > 0 {
-				vSlice = []any{v[0]}
-			}
-		case []int:
-			if len(v) > 0 {
-				vSlice = []any{v[0]}
-			}
-		case []int32:
-			if len(v) > 0 {
-				vSlice = []any{v[0]}
-			}
-		case []int64:
-			if len(v) > 0 {
-				vSlice = []any{v[0]}
-			}
-		default:
-			vSlice = []any{v}
+	if v == nil {
+		return vSlice
+	}
+
+	switch v := v.(type) {
+	case []any:
+		// already a slice no coercion required
+		vSlice = v
+	case []string:
+		if len(v) > 0 {
+			vSlice = []any{v[0]}
 		}
+	case []json.Number:
+		if len(v) > 0 {
+			vSlice = []any{v[0]}
+		}
+	case []bool:
+		if len(v) > 0 {
+			vSlice = []any{v[0]}
+		}
+	case []map[string]any:
+		if len(v) > 0 {
+			vSlice = []any{v[0]}
+		}
+	case []float64:
+		if len(v) > 0 {
+			vSlice = []any{v[0]}
+		}
+	case []float32:
+		if len(v) > 0 {
+			vSlice = []any{v[0]}
+		}
+	case []int:
+		if len(v) > 0 {
+			vSlice = []any{v[0]}
+		}
+	case []int32:
+		if len(v) > 0 {
+			vSlice = []any{v[0]}
+		}
+	case []int64:
+		if len(v) > 0 {
+			vSlice = []any{v[0]}
+		}
+	default:
+		vSlice = []any{v}
 	}
 	return vSlice
 }

--- a/plugin/federation/testdata/computedrequires/generated/exec.go
+++ b/plugin/federation/testdata/computedrequires/generated/exec.go
@@ -6792,104 +6792,6 @@ func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, 
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
-	case model.Hello:
-		return ec._Hello(ctx, sel, &obj)
-	case *model.Hello:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._Hello(ctx, sel, obj)
-	case model.HelloMultiSingleKeys:
-		return ec._HelloMultiSingleKeys(ctx, sel, &obj)
-	case *model.HelloMultiSingleKeys:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._HelloMultiSingleKeys(ctx, sel, obj)
-	case model.HelloWithErrors:
-		return ec._HelloWithErrors(ctx, sel, &obj)
-	case *model.HelloWithErrors:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._HelloWithErrors(ctx, sel, obj)
-	case model.MultiHello:
-		return ec._MultiHello(ctx, sel, &obj)
-	case *model.MultiHello:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._MultiHello(ctx, sel, obj)
-	case model.MultiHelloMultipleRequires:
-		return ec._MultiHelloMultipleRequires(ctx, sel, &obj)
-	case *model.MultiHelloMultipleRequires:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._MultiHelloMultipleRequires(ctx, sel, obj)
-	case model.MultiHelloRequires:
-		return ec._MultiHelloRequires(ctx, sel, &obj)
-	case *model.MultiHelloRequires:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._MultiHelloRequires(ctx, sel, obj)
-	case model.MultiHelloWithError:
-		return ec._MultiHelloWithError(ctx, sel, &obj)
-	case *model.MultiHelloWithError:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._MultiHelloWithError(ctx, sel, obj)
-	case model.MultiPlanetRequiresNested:
-		return ec._MultiPlanetRequiresNested(ctx, sel, &obj)
-	case *model.MultiPlanetRequiresNested:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._MultiPlanetRequiresNested(ctx, sel, obj)
-	case model.Person:
-		return ec._Person(ctx, sel, &obj)
-	case *model.Person:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._Person(ctx, sel, obj)
-	case model.PlanetMultipleRequires:
-		return ec._PlanetMultipleRequires(ctx, sel, &obj)
-	case *model.PlanetMultipleRequires:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._PlanetMultipleRequires(ctx, sel, obj)
-	case model.PlanetRequires:
-		return ec._PlanetRequires(ctx, sel, &obj)
-	case *model.PlanetRequires:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._PlanetRequires(ctx, sel, obj)
-	case model.PlanetRequiresNested:
-		return ec._PlanetRequiresNested(ctx, sel, &obj)
-	case *model.PlanetRequiresNested:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._PlanetRequiresNested(ctx, sel, obj)
-	case model.World:
-		return ec._World(ctx, sel, &obj)
-	case *model.World:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._World(ctx, sel, obj)
-	case model.WorldName:
-		return ec._WorldName(ctx, sel, &obj)
-	case *model.WorldName:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._WorldName(ctx, sel, obj)
 	case model.WorldWithMultipleKeys:
 		return ec._WorldWithMultipleKeys(ctx, sel, &obj)
 	case *model.WorldWithMultipleKeys:
@@ -6897,6 +6799,104 @@ func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, 
 			return graphql.Null
 		}
 		return ec._WorldWithMultipleKeys(ctx, sel, obj)
+	case model.WorldName:
+		return ec._WorldName(ctx, sel, &obj)
+	case *model.WorldName:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._WorldName(ctx, sel, obj)
+	case model.World:
+		return ec._World(ctx, sel, &obj)
+	case *model.World:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._World(ctx, sel, obj)
+	case model.PlanetRequiresNested:
+		return ec._PlanetRequiresNested(ctx, sel, &obj)
+	case *model.PlanetRequiresNested:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._PlanetRequiresNested(ctx, sel, obj)
+	case model.PlanetRequires:
+		return ec._PlanetRequires(ctx, sel, &obj)
+	case *model.PlanetRequires:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._PlanetRequires(ctx, sel, obj)
+	case model.PlanetMultipleRequires:
+		return ec._PlanetMultipleRequires(ctx, sel, &obj)
+	case *model.PlanetMultipleRequires:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._PlanetMultipleRequires(ctx, sel, obj)
+	case model.Person:
+		return ec._Person(ctx, sel, &obj)
+	case *model.Person:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Person(ctx, sel, obj)
+	case model.MultiPlanetRequiresNested:
+		return ec._MultiPlanetRequiresNested(ctx, sel, &obj)
+	case *model.MultiPlanetRequiresNested:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._MultiPlanetRequiresNested(ctx, sel, obj)
+	case model.MultiHelloWithError:
+		return ec._MultiHelloWithError(ctx, sel, &obj)
+	case *model.MultiHelloWithError:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._MultiHelloWithError(ctx, sel, obj)
+	case model.MultiHelloRequires:
+		return ec._MultiHelloRequires(ctx, sel, &obj)
+	case *model.MultiHelloRequires:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._MultiHelloRequires(ctx, sel, obj)
+	case model.MultiHelloMultipleRequires:
+		return ec._MultiHelloMultipleRequires(ctx, sel, &obj)
+	case *model.MultiHelloMultipleRequires:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._MultiHelloMultipleRequires(ctx, sel, obj)
+	case model.MultiHello:
+		return ec._MultiHello(ctx, sel, &obj)
+	case *model.MultiHello:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._MultiHello(ctx, sel, obj)
+	case model.HelloWithErrors:
+		return ec._HelloWithErrors(ctx, sel, &obj)
+	case *model.HelloWithErrors:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._HelloWithErrors(ctx, sel, obj)
+	case model.HelloMultiSingleKeys:
+		return ec._HelloMultiSingleKeys(ctx, sel, &obj)
+	case *model.HelloMultiSingleKeys:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._HelloMultiSingleKeys(ctx, sel, obj)
+	case model.Hello:
+		return ec._Hello(ctx, sel, &obj)
+	case *model.Hello:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Hello(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}

--- a/plugin/federation/testdata/entityresolver/generated/exec.go
+++ b/plugin/federation/testdata/entityresolver/generated/exec.go
@@ -6338,97 +6338,6 @@ func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, 
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
-	case model.Hello:
-		return ec._Hello(ctx, sel, &obj)
-	case *model.Hello:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._Hello(ctx, sel, obj)
-	case model.HelloMultiSingleKeys:
-		return ec._HelloMultiSingleKeys(ctx, sel, &obj)
-	case *model.HelloMultiSingleKeys:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._HelloMultiSingleKeys(ctx, sel, obj)
-	case model.HelloWithErrors:
-		return ec._HelloWithErrors(ctx, sel, &obj)
-	case *model.HelloWithErrors:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._HelloWithErrors(ctx, sel, obj)
-	case model.MultiHello:
-		return ec._MultiHello(ctx, sel, &obj)
-	case *model.MultiHello:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._MultiHello(ctx, sel, obj)
-	case model.MultiHelloMultipleRequires:
-		return ec._MultiHelloMultipleRequires(ctx, sel, &obj)
-	case *model.MultiHelloMultipleRequires:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._MultiHelloMultipleRequires(ctx, sel, obj)
-	case model.MultiHelloRequires:
-		return ec._MultiHelloRequires(ctx, sel, &obj)
-	case *model.MultiHelloRequires:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._MultiHelloRequires(ctx, sel, obj)
-	case model.MultiHelloWithError:
-		return ec._MultiHelloWithError(ctx, sel, &obj)
-	case *model.MultiHelloWithError:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._MultiHelloWithError(ctx, sel, obj)
-	case model.MultiPlanetRequiresNested:
-		return ec._MultiPlanetRequiresNested(ctx, sel, &obj)
-	case *model.MultiPlanetRequiresNested:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._MultiPlanetRequiresNested(ctx, sel, obj)
-	case model.PlanetMultipleRequires:
-		return ec._PlanetMultipleRequires(ctx, sel, &obj)
-	case *model.PlanetMultipleRequires:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._PlanetMultipleRequires(ctx, sel, obj)
-	case model.PlanetRequires:
-		return ec._PlanetRequires(ctx, sel, &obj)
-	case *model.PlanetRequires:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._PlanetRequires(ctx, sel, obj)
-	case model.PlanetRequiresNested:
-		return ec._PlanetRequiresNested(ctx, sel, &obj)
-	case *model.PlanetRequiresNested:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._PlanetRequiresNested(ctx, sel, obj)
-	case model.World:
-		return ec._World(ctx, sel, &obj)
-	case *model.World:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._World(ctx, sel, obj)
-	case model.WorldName:
-		return ec._WorldName(ctx, sel, &obj)
-	case *model.WorldName:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._WorldName(ctx, sel, obj)
 	case model.WorldWithMultipleKeys:
 		return ec._WorldWithMultipleKeys(ctx, sel, &obj)
 	case *model.WorldWithMultipleKeys:
@@ -6436,6 +6345,97 @@ func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, 
 			return graphql.Null
 		}
 		return ec._WorldWithMultipleKeys(ctx, sel, obj)
+	case model.WorldName:
+		return ec._WorldName(ctx, sel, &obj)
+	case *model.WorldName:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._WorldName(ctx, sel, obj)
+	case model.World:
+		return ec._World(ctx, sel, &obj)
+	case *model.World:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._World(ctx, sel, obj)
+	case model.PlanetRequiresNested:
+		return ec._PlanetRequiresNested(ctx, sel, &obj)
+	case *model.PlanetRequiresNested:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._PlanetRequiresNested(ctx, sel, obj)
+	case model.PlanetRequires:
+		return ec._PlanetRequires(ctx, sel, &obj)
+	case *model.PlanetRequires:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._PlanetRequires(ctx, sel, obj)
+	case model.PlanetMultipleRequires:
+		return ec._PlanetMultipleRequires(ctx, sel, &obj)
+	case *model.PlanetMultipleRequires:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._PlanetMultipleRequires(ctx, sel, obj)
+	case model.MultiPlanetRequiresNested:
+		return ec._MultiPlanetRequiresNested(ctx, sel, &obj)
+	case *model.MultiPlanetRequiresNested:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._MultiPlanetRequiresNested(ctx, sel, obj)
+	case model.MultiHelloWithError:
+		return ec._MultiHelloWithError(ctx, sel, &obj)
+	case *model.MultiHelloWithError:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._MultiHelloWithError(ctx, sel, obj)
+	case model.MultiHelloRequires:
+		return ec._MultiHelloRequires(ctx, sel, &obj)
+	case *model.MultiHelloRequires:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._MultiHelloRequires(ctx, sel, obj)
+	case model.MultiHelloMultipleRequires:
+		return ec._MultiHelloMultipleRequires(ctx, sel, &obj)
+	case *model.MultiHelloMultipleRequires:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._MultiHelloMultipleRequires(ctx, sel, obj)
+	case model.MultiHello:
+		return ec._MultiHello(ctx, sel, &obj)
+	case *model.MultiHello:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._MultiHello(ctx, sel, obj)
+	case model.HelloWithErrors:
+		return ec._HelloWithErrors(ctx, sel, &obj)
+	case *model.HelloWithErrors:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._HelloWithErrors(ctx, sel, obj)
+	case model.HelloMultiSingleKeys:
+		return ec._HelloMultiSingleKeys(ctx, sel, &obj)
+	case *model.HelloMultiSingleKeys:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._HelloMultiSingleKeys(ctx, sel, obj)
+	case model.Hello:
+		return ec._Hello(ctx, sel, &obj)
+	case *model.Hello:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Hello(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}

--- a/plugin/federation/testdata/explicitrequires/generated/exec.go
+++ b/plugin/federation/testdata/explicitrequires/generated/exec.go
@@ -6234,104 +6234,6 @@ func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, 
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
-	case Hello:
-		return ec._Hello(ctx, sel, &obj)
-	case *Hello:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._Hello(ctx, sel, obj)
-	case HelloMultiSingleKeys:
-		return ec._HelloMultiSingleKeys(ctx, sel, &obj)
-	case *HelloMultiSingleKeys:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._HelloMultiSingleKeys(ctx, sel, obj)
-	case HelloWithErrors:
-		return ec._HelloWithErrors(ctx, sel, &obj)
-	case *HelloWithErrors:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._HelloWithErrors(ctx, sel, obj)
-	case MultiHello:
-		return ec._MultiHello(ctx, sel, &obj)
-	case *MultiHello:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._MultiHello(ctx, sel, obj)
-	case MultiHelloMultipleRequires:
-		return ec._MultiHelloMultipleRequires(ctx, sel, &obj)
-	case *MultiHelloMultipleRequires:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._MultiHelloMultipleRequires(ctx, sel, obj)
-	case MultiHelloRequires:
-		return ec._MultiHelloRequires(ctx, sel, &obj)
-	case *MultiHelloRequires:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._MultiHelloRequires(ctx, sel, obj)
-	case MultiHelloWithError:
-		return ec._MultiHelloWithError(ctx, sel, &obj)
-	case *MultiHelloWithError:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._MultiHelloWithError(ctx, sel, obj)
-	case MultiPlanetRequiresNested:
-		return ec._MultiPlanetRequiresNested(ctx, sel, &obj)
-	case *MultiPlanetRequiresNested:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._MultiPlanetRequiresNested(ctx, sel, obj)
-	case Person:
-		return ec._Person(ctx, sel, &obj)
-	case *Person:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._Person(ctx, sel, obj)
-	case PlanetMultipleRequires:
-		return ec._PlanetMultipleRequires(ctx, sel, &obj)
-	case *PlanetMultipleRequires:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._PlanetMultipleRequires(ctx, sel, obj)
-	case PlanetRequires:
-		return ec._PlanetRequires(ctx, sel, &obj)
-	case *PlanetRequires:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._PlanetRequires(ctx, sel, obj)
-	case PlanetRequiresNested:
-		return ec._PlanetRequiresNested(ctx, sel, &obj)
-	case *PlanetRequiresNested:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._PlanetRequiresNested(ctx, sel, obj)
-	case World:
-		return ec._World(ctx, sel, &obj)
-	case *World:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._World(ctx, sel, obj)
-	case WorldName:
-		return ec._WorldName(ctx, sel, &obj)
-	case *WorldName:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._WorldName(ctx, sel, obj)
 	case WorldWithMultipleKeys:
 		return ec._WorldWithMultipleKeys(ctx, sel, &obj)
 	case *WorldWithMultipleKeys:
@@ -6339,6 +6241,104 @@ func (ec *executionContext) __Entity(ctx context.Context, sel ast.SelectionSet, 
 			return graphql.Null
 		}
 		return ec._WorldWithMultipleKeys(ctx, sel, obj)
+	case WorldName:
+		return ec._WorldName(ctx, sel, &obj)
+	case *WorldName:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._WorldName(ctx, sel, obj)
+	case World:
+		return ec._World(ctx, sel, &obj)
+	case *World:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._World(ctx, sel, obj)
+	case PlanetRequiresNested:
+		return ec._PlanetRequiresNested(ctx, sel, &obj)
+	case *PlanetRequiresNested:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._PlanetRequiresNested(ctx, sel, obj)
+	case PlanetRequires:
+		return ec._PlanetRequires(ctx, sel, &obj)
+	case *PlanetRequires:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._PlanetRequires(ctx, sel, obj)
+	case PlanetMultipleRequires:
+		return ec._PlanetMultipleRequires(ctx, sel, &obj)
+	case *PlanetMultipleRequires:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._PlanetMultipleRequires(ctx, sel, obj)
+	case Person:
+		return ec._Person(ctx, sel, &obj)
+	case *Person:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Person(ctx, sel, obj)
+	case MultiPlanetRequiresNested:
+		return ec._MultiPlanetRequiresNested(ctx, sel, &obj)
+	case *MultiPlanetRequiresNested:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._MultiPlanetRequiresNested(ctx, sel, obj)
+	case MultiHelloWithError:
+		return ec._MultiHelloWithError(ctx, sel, &obj)
+	case *MultiHelloWithError:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._MultiHelloWithError(ctx, sel, obj)
+	case MultiHelloRequires:
+		return ec._MultiHelloRequires(ctx, sel, &obj)
+	case *MultiHelloRequires:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._MultiHelloRequires(ctx, sel, obj)
+	case MultiHelloMultipleRequires:
+		return ec._MultiHelloMultipleRequires(ctx, sel, &obj)
+	case *MultiHelloMultipleRequires:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._MultiHelloMultipleRequires(ctx, sel, obj)
+	case MultiHello:
+		return ec._MultiHello(ctx, sel, &obj)
+	case *MultiHello:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._MultiHello(ctx, sel, obj)
+	case HelloWithErrors:
+		return ec._HelloWithErrors(ctx, sel, &obj)
+	case *HelloWithErrors:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._HelloWithErrors(ctx, sel, obj)
+	case HelloMultiSingleKeys:
+		return ec._HelloMultiSingleKeys(ctx, sel, &obj)
+	case *HelloMultiSingleKeys:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._HelloMultiSingleKeys(ctx, sel, obj)
+	case Hello:
+		return ec._Hello(ctx, sel, &obj)
+	case *Hello:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Hello(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}

--- a/plugin/federation/testdata/usefunctionsyntaxforexecutioncontext/generated/exec.go
+++ b/plugin/federation/testdata/usefunctionsyntaxforexecutioncontext/generated/exec.go
@@ -6362,97 +6362,6 @@ func __Entity(ctx context.Context, ec *executionContext, sel ast.SelectionSet, o
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
-	case model.Hello:
-		return _Hello(ctx, ec, sel, &obj)
-	case *model.Hello:
-		if obj == nil {
-			return graphql.Null
-		}
-		return _Hello(ctx, ec, sel, obj)
-	case model.HelloMultiSingleKeys:
-		return _HelloMultiSingleKeys(ctx, ec, sel, &obj)
-	case *model.HelloMultiSingleKeys:
-		if obj == nil {
-			return graphql.Null
-		}
-		return _HelloMultiSingleKeys(ctx, ec, sel, obj)
-	case model.HelloWithErrors:
-		return _HelloWithErrors(ctx, ec, sel, &obj)
-	case *model.HelloWithErrors:
-		if obj == nil {
-			return graphql.Null
-		}
-		return _HelloWithErrors(ctx, ec, sel, obj)
-	case model.MultiHello:
-		return _MultiHello(ctx, ec, sel, &obj)
-	case *model.MultiHello:
-		if obj == nil {
-			return graphql.Null
-		}
-		return _MultiHello(ctx, ec, sel, obj)
-	case model.MultiHelloMultipleRequires:
-		return _MultiHelloMultipleRequires(ctx, ec, sel, &obj)
-	case *model.MultiHelloMultipleRequires:
-		if obj == nil {
-			return graphql.Null
-		}
-		return _MultiHelloMultipleRequires(ctx, ec, sel, obj)
-	case model.MultiHelloRequires:
-		return _MultiHelloRequires(ctx, ec, sel, &obj)
-	case *model.MultiHelloRequires:
-		if obj == nil {
-			return graphql.Null
-		}
-		return _MultiHelloRequires(ctx, ec, sel, obj)
-	case model.MultiHelloWithError:
-		return _MultiHelloWithError(ctx, ec, sel, &obj)
-	case *model.MultiHelloWithError:
-		if obj == nil {
-			return graphql.Null
-		}
-		return _MultiHelloWithError(ctx, ec, sel, obj)
-	case model.MultiPlanetRequiresNested:
-		return _MultiPlanetRequiresNested(ctx, ec, sel, &obj)
-	case *model.MultiPlanetRequiresNested:
-		if obj == nil {
-			return graphql.Null
-		}
-		return _MultiPlanetRequiresNested(ctx, ec, sel, obj)
-	case model.PlanetMultipleRequires:
-		return _PlanetMultipleRequires(ctx, ec, sel, &obj)
-	case *model.PlanetMultipleRequires:
-		if obj == nil {
-			return graphql.Null
-		}
-		return _PlanetMultipleRequires(ctx, ec, sel, obj)
-	case model.PlanetRequires:
-		return _PlanetRequires(ctx, ec, sel, &obj)
-	case *model.PlanetRequires:
-		if obj == nil {
-			return graphql.Null
-		}
-		return _PlanetRequires(ctx, ec, sel, obj)
-	case model.PlanetRequiresNested:
-		return _PlanetRequiresNested(ctx, ec, sel, &obj)
-	case *model.PlanetRequiresNested:
-		if obj == nil {
-			return graphql.Null
-		}
-		return _PlanetRequiresNested(ctx, ec, sel, obj)
-	case model.World:
-		return _World(ctx, ec, sel, &obj)
-	case *model.World:
-		if obj == nil {
-			return graphql.Null
-		}
-		return _World(ctx, ec, sel, obj)
-	case model.WorldName:
-		return _WorldName(ctx, ec, sel, &obj)
-	case *model.WorldName:
-		if obj == nil {
-			return graphql.Null
-		}
-		return _WorldName(ctx, ec, sel, obj)
 	case model.WorldWithMultipleKeys:
 		return _WorldWithMultipleKeys(ctx, ec, sel, &obj)
 	case *model.WorldWithMultipleKeys:
@@ -6460,6 +6369,97 @@ func __Entity(ctx context.Context, ec *executionContext, sel ast.SelectionSet, o
 			return graphql.Null
 		}
 		return _WorldWithMultipleKeys(ctx, ec, sel, obj)
+	case model.WorldName:
+		return _WorldName(ctx, ec, sel, &obj)
+	case *model.WorldName:
+		if obj == nil {
+			return graphql.Null
+		}
+		return _WorldName(ctx, ec, sel, obj)
+	case model.World:
+		return _World(ctx, ec, sel, &obj)
+	case *model.World:
+		if obj == nil {
+			return graphql.Null
+		}
+		return _World(ctx, ec, sel, obj)
+	case model.PlanetRequiresNested:
+		return _PlanetRequiresNested(ctx, ec, sel, &obj)
+	case *model.PlanetRequiresNested:
+		if obj == nil {
+			return graphql.Null
+		}
+		return _PlanetRequiresNested(ctx, ec, sel, obj)
+	case model.PlanetRequires:
+		return _PlanetRequires(ctx, ec, sel, &obj)
+	case *model.PlanetRequires:
+		if obj == nil {
+			return graphql.Null
+		}
+		return _PlanetRequires(ctx, ec, sel, obj)
+	case model.PlanetMultipleRequires:
+		return _PlanetMultipleRequires(ctx, ec, sel, &obj)
+	case *model.PlanetMultipleRequires:
+		if obj == nil {
+			return graphql.Null
+		}
+		return _PlanetMultipleRequires(ctx, ec, sel, obj)
+	case model.MultiPlanetRequiresNested:
+		return _MultiPlanetRequiresNested(ctx, ec, sel, &obj)
+	case *model.MultiPlanetRequiresNested:
+		if obj == nil {
+			return graphql.Null
+		}
+		return _MultiPlanetRequiresNested(ctx, ec, sel, obj)
+	case model.MultiHelloWithError:
+		return _MultiHelloWithError(ctx, ec, sel, &obj)
+	case *model.MultiHelloWithError:
+		if obj == nil {
+			return graphql.Null
+		}
+		return _MultiHelloWithError(ctx, ec, sel, obj)
+	case model.MultiHelloRequires:
+		return _MultiHelloRequires(ctx, ec, sel, &obj)
+	case *model.MultiHelloRequires:
+		if obj == nil {
+			return graphql.Null
+		}
+		return _MultiHelloRequires(ctx, ec, sel, obj)
+	case model.MultiHelloMultipleRequires:
+		return _MultiHelloMultipleRequires(ctx, ec, sel, &obj)
+	case *model.MultiHelloMultipleRequires:
+		if obj == nil {
+			return graphql.Null
+		}
+		return _MultiHelloMultipleRequires(ctx, ec, sel, obj)
+	case model.MultiHello:
+		return _MultiHello(ctx, ec, sel, &obj)
+	case *model.MultiHello:
+		if obj == nil {
+			return graphql.Null
+		}
+		return _MultiHello(ctx, ec, sel, obj)
+	case model.HelloWithErrors:
+		return _HelloWithErrors(ctx, ec, sel, &obj)
+	case *model.HelloWithErrors:
+		if obj == nil {
+			return graphql.Null
+		}
+		return _HelloWithErrors(ctx, ec, sel, obj)
+	case model.HelloMultiSingleKeys:
+		return _HelloMultiSingleKeys(ctx, ec, sel, &obj)
+	case *model.HelloMultiSingleKeys:
+		if obj == nil {
+			return graphql.Null
+		}
+		return _HelloMultiSingleKeys(ctx, ec, sel, obj)
+	case model.Hello:
+		return _Hello(ctx, ec, sel, &obj)
+	case *model.Hello:
+		if obj == nil {
+			return graphql.Null
+		}
+		return _Hello(ctx, ec, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}


### PR DESCRIPTION
This is a follow-up from #3591 with a suggestion from @csilvers so that we not be as dependent on input order for sorting, but instead explicitly use Name as a sorting secondary sort criteria.

Also, he noticed we can be tighter with the explicitness of sorting our important file rule as well. 

For both, there is still a possibility of a genuine tie (identical in every regard) so we still need to use SortStable so that the sort is at least deterministic based on input order rather than randomly changing every time and causing test failures.

Note: There is some other completely unrelated minor stuff I lazily threw in this same PR while I was here.

The linter warned me that the `template` variable shadowed the package name which is just a bad practice, so I renamed it.

The generated `exec.go` files in Khan Academy's code has a bunch of useless if conditional wrapping:
```
	if v != nil {
		vSlice = graphql.CoerceList(v)
	}
```
Which I find very odd, because the `type.gotpl` here in gqlgen doesn't have that. While I was looking into that, I made a minor refactor of the `graphql.CoerceList` here to make it more obvious that having all those redundant checks is not necessary.

Signed-off-by: Steve Coffman <steve@khanacademy.org>
