### PR TITLE
Revert default response header to application/json from  #3555

### DIFF
--- a/_examples/starwars/starwars_test.go
+++ b/_examples/starwars/starwars_test.go
@@ -220,7 +220,7 @@ func TestStarwars(t *testing.T) {
 		  }
 		}`, &resp, client.Var("episode", "INVALID"))
 
-		require.EqualError(t, err, `http 400: {"errors":[{"message":"INVALID is not a valid Episode","path":["variable","episode"],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`)
+		require.EqualError(t, err, `http 422: {"errors":[{"message":"INVALID is not a valid Episode","path":["variable","episode"],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`)
 	})
 
 	t.Run("introspection", func(t *testing.T) {

--- a/codegen/testserver/followschema/enums_test.go
+++ b/codegen/testserver/followschema/enums_test.go
@@ -40,7 +40,7 @@ func TestEnumsResolver(t *testing.T) {
 			enumInInput(input: {enum: INVALID})
 		}
 		`, &resp)
-		require.EqualError(t, err, `http 400: {"errors":[{"message":"Value \"INVALID\" does not exist in \"EnumTest!\" enum.","locations":[{"line":2,"column":30}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`)
+		require.EqualError(t, err, `http 422: {"errors":[{"message":"Value \"INVALID\" does not exist in \"EnumTest!\" enum.","locations":[{"line":2,"column":30}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`)
 	})
 
 	t.Run("input with invalid enum value via vars", func(t *testing.T) {
@@ -51,6 +51,6 @@ func TestEnumsResolver(t *testing.T) {
 			enumInInput(input: $input)
 		}
 		`, &resp, client.Var("input", map[string]any{"enum": "INVALID"}))
-		require.EqualError(t, err, `http 400: {"errors":[{"message":"INVALID is not a valid EnumTest","path":["variable","input","enum"],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`)
+		require.EqualError(t, err, `http 422: {"errors":[{"message":"INVALID is not a valid EnumTest","path":["variable","input","enum"],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`)
 	})
 }

--- a/codegen/testserver/followschema/input_test.go
+++ b/codegen/testserver/followschema/input_test.go
@@ -30,7 +30,7 @@ func TestInput(t *testing.T) {
 
 		err := c.Post(`query { inputSlice(arg: ["ok", 1, 2, "ok"]) }`, &resp)
 
-		require.EqualError(t, err, `http 400: {"errors":[{"message":"String cannot represent a non string value: 1","locations":[{"line":1,"column":32}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}},{"message":"String cannot represent a non string value: 2","locations":[{"line":1,"column":35}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`)
+		require.EqualError(t, err, `http 422: {"errors":[{"message":"String cannot represent a non string value: 1","locations":[{"line":1,"column":32}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}},{"message":"String cannot represent a non string value: 2","locations":[{"line":1,"column":35}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`)
 		require.Nil(t, resp.DirectiveArg)
 	})
 

--- a/codegen/testserver/singlefile/enums_test.go
+++ b/codegen/testserver/singlefile/enums_test.go
@@ -40,7 +40,7 @@ func TestEnumsResolver(t *testing.T) {
 			enumInInput(input: {enum: INVALID})
 		}
 		`, &resp)
-		require.EqualError(t, err, `http 400: {"errors":[{"message":"Value \"INVALID\" does not exist in \"EnumTest!\" enum.","locations":[{"line":2,"column":30}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`)
+		require.EqualError(t, err, `http 422: {"errors":[{"message":"Value \"INVALID\" does not exist in \"EnumTest!\" enum.","locations":[{"line":2,"column":30}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`)
 	})
 
 	t.Run("input with invalid enum value via vars", func(t *testing.T) {
@@ -51,6 +51,6 @@ func TestEnumsResolver(t *testing.T) {
 			enumInInput(input: $input)
 		}
 		`, &resp, client.Var("input", map[string]any{"enum": "INVALID"}))
-		require.EqualError(t, err, `http 400: {"errors":[{"message":"INVALID is not a valid EnumTest","path":["variable","input","enum"],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`)
+		require.EqualError(t, err, `http 422: {"errors":[{"message":"INVALID is not a valid EnumTest","path":["variable","input","enum"],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`)
 	})
 }

--- a/codegen/testserver/singlefile/input_test.go
+++ b/codegen/testserver/singlefile/input_test.go
@@ -30,7 +30,7 @@ func TestInput(t *testing.T) {
 
 		err := c.Post(`query { inputSlice(arg: ["ok", 1, 2, "ok"]) }`, &resp)
 
-		require.EqualError(t, err, `http 400: {"errors":[{"message":"String cannot represent a non string value: 1","locations":[{"line":1,"column":32}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}},{"message":"String cannot represent a non string value: 2","locations":[{"line":1,"column":35}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`)
+		require.EqualError(t, err, `http 422: {"errors":[{"message":"String cannot represent a non string value: 1","locations":[{"line":1,"column":32}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}},{"message":"String cannot represent a non string value: 2","locations":[{"line":1,"column":35}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`)
 		require.Nil(t, resp.DirectiveArg)
 	})
 

--- a/graphql/handler/apollofederatedtracingv1/tracing_test.go
+++ b/graphql/handler/apollofederatedtracingv1/tracing_test.go
@@ -127,7 +127,7 @@ func TestApolloTracing_withMissingOp(t *testing.T) {
 	h.Use(&apollofederatedtracingv1.Tracer{})
 
 	resp := doRequest(h, http.MethodPost, "/graphql", `{}`)
-	assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
 	b := resp.Body.Bytes()
 	t.Log(string(b))
 	var respData struct {

--- a/graphql/handler/server_test.go
+++ b/graphql/handler/server_test.go
@@ -106,7 +106,7 @@ func TestServer(t *testing.T) {
 		})
 
 		resp := get(srv, "/foo?query=invalid")
-		assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
 		assert.Len(t, errors1, 1)
 		assert.Len(t, errors2, 1)
 	})

--- a/graphql/handler/transport/headers.go
+++ b/graphql/handler/transport/headers.go
@@ -19,8 +19,10 @@ func determineResponseContentType(explicitHeaders map[string][]string, r *http.R
 	}
 
 	accept := r.Header.Get("Accept")
+	// TODO(steve): Consider adding config option to opt-in to
+	// default "application/graphql-response+json"
 	if accept == "" {
-		return acceptApplicationGraphqlResponseJson
+		return acceptApplicationJson
 	}
 
 	for _, acceptPart := range strings.Split(accept, ",") {

--- a/graphql/handler/transport/headers_test.go
+++ b/graphql/handler/transport/headers_test.go
@@ -25,7 +25,7 @@ func TestHeadersWithPOST(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query":"{ name }"}`, "", "application/json")
 		assert.Equal(t, http.StatusOK, resp.Code)
 		assert.Len(t, resp.Header(), 1)
-		assert.Equal(t, "application/graphql-response+json", resp.Header().Get("Content-Type"))
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 	})
 
 	t.Run("Headers set", func(t *testing.T) {
@@ -54,7 +54,7 @@ func TestHeadersWithGET(t *testing.T) {
 		resp := doRequest(h, "GET", "/graphql?query={name}", "", "", "application/json")
 		assert.Equal(t, http.StatusOK, resp.Code)
 		assert.Len(t, resp.Header(), 1)
-		assert.Equal(t, "application/graphql-response+json", resp.Header().Get("Content-Type"))
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 	})
 
 	t.Run("Headers set", func(t *testing.T) {

--- a/graphql/handler/transport/http_get_test.go
+++ b/graphql/handler/transport/http_get_test.go
@@ -56,8 +56,8 @@ func TestGET(t *testing.T) {
 
 	t.Run("invalid variable", func(t *testing.T) {
 		resp := doRequest(h, "GET", `/graphql?query=query($id:Int!){find(id:$id)}&variables={"id":false}`, "", "", "application/json")
-		assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
-		assert.Equal(t, "application/graphql-response+json", resp.Header().Get("Content-Type"))
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 		assert.JSONEq(t, `{"errors":[{"message":"cannot use bool as Int","path":["variable","id"],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
@@ -70,8 +70,8 @@ func TestGET(t *testing.T) {
 
 	t.Run("parse failure", func(t *testing.T) {
 		resp := doRequest(h, "GET", "/graphql?query=!", "", "", "application/json")
-		assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
-		assert.Equal(t, "application/graphql-response+json", resp.Header().Get("Content-Type"))
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 		assert.JSONEq(t, `{"errors":[{"message":"Unexpected !","locations":[{"line":1,"column":1}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 

--- a/graphql/handler/transport/http_post_test.go
+++ b/graphql/handler/transport/http_post_test.go
@@ -61,8 +61,8 @@ func TestPOST(t *testing.T) {
 
 	t.Run("parse failure", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query": "!"}`, "", "application/json")
-		assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
-		assert.Equal(t, "application/graphql-response+json", resp.Header().Get("Content-Type"))
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 		assert.JSONEq(t, `{"errors":[{"message":"Unexpected !","locations":[{"line":1,"column":1}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
@@ -75,8 +75,8 @@ func TestPOST(t *testing.T) {
 
 	t.Run("validation failure", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query": "{ title }"}`, "", "application/json")
-		assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
-		assert.Equal(t, "application/graphql-response+json", resp.Header().Get("Content-Type"))
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 		assert.JSONEq(t, `{"errors":[{"message":"Cannot query field \"title\" on type \"Query\".","locations":[{"line":1,"column":3}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
@@ -89,8 +89,8 @@ func TestPOST(t *testing.T) {
 
 	t.Run("invalid variable", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query": "query($id:Int!){find(id:$id)}","variables":{"id":false}}`, "", "application/json")
-		assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
-		assert.Equal(t, "application/graphql-response+json", resp.Header().Get("Content-Type"))
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 		assert.JSONEq(t, `{"errors":[{"message":"cannot use bool as Int","path":["variable","id"],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
 	})
 
@@ -104,7 +104,7 @@ func TestPOST(t *testing.T) {
 	t.Run("execution failure", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query": "mutation { name }"}`, "", "application/json")
 		assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-		assert.Equal(t, "application/graphql-response+json", resp.Header().Get("Content-Type"))
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 		assert.JSONEq(t, `{"errors":[{"message":"mutations are not supported"}],"data":null}`, resp.Body.String())
 	})
 


### PR DESCRIPTION
In #3555 we wanted gqlgen to **accept** `application/graphql-response+json` as but not to make it the _default_ when _no_ `Accept` header was specified. This partially reverts that change so that `application/json` is once more the default response mime type when no `Accept` header has been sent by the client.


---

https://graphql.github.io/graphql-over-http/draft/
GraphQL over HTTP is Draft status.
but many clients appear to support this.

for example, apollo client switch Accept header default to application/graphql-response+json.
https://github.com/apollographql/apollo-client/issues/12206
Apollo Client 4.0 will be shipped at Mid April 2025
https://github.com/apollographql/apollo-client/blob/main/ROADMAP.md


Signed-off-by: Steve Coffman <steve@khanacademy.org>
