### PR TITLE
New 'type' argument for goField directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 ![gqlgen](https://user-images.githubusercontent.com/980499/133180111-d064b38c-6eb9-444b-a60f-7005a6e68222.png)
 
-
 # gqlgen [![Integration](https://github.com/99designs/gqlgen/actions/workflows/integration.yml/badge.svg)](https://github.com/99designs/gqlgen/actions) [![Coverage Status](https://coveralls.io/repos/github/99designs/gqlgen/badge.svg?branch=master)](https://coveralls.io/github/99designs/gqlgen?branch=master) [![Go Report Card](https://goreportcard.com/badge/github.com/99designs/gqlgen)](https://goreportcard.com/report/github.com/99designs/gqlgen) [![Go Reference](https://pkg.go.dev/badge/github.com/99designs/gqlgen.svg)](https://pkg.go.dev/github.com/99designs/gqlgen) [![Read the Docs](https://badgen.net/badge/docs/available/green)](http://gqlgen.com/)
 
 ## What is gqlgen?
@@ -14,32 +13,34 @@
 Still not convinced enough to use **gqlgen**? Compare **gqlgen** with other Go graphql [implementations](https://gqlgen.com/feature-comparison/)
 
 ## Quick start
+
 1. [Initialise a new go module](https://golang.org/doc/tutorial/create-module)
 
-       mkdir example
-       cd example
-       go mod init example
+   mkdir example
+   cd example
+   go mod init example
 
 2. Add `github.com/99designs/gqlgen` to your [project's tools.go](https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module)
 
-       printf '//go:build tools\npackage tools\nimport (_ "github.com/99designs/gqlgen"\n _ "github.com/99designs/gqlgen/graphql/introspection")' | gofmt > tools.go
+   printf '//go:build tools\npackage tools\nimport (_ "github.com/99designs/gqlgen"\n _ "github.com/99designs/gqlgen/graphql/introspection")' | gofmt > tools.go
 
-       go mod tidy
+   go mod tidy
 
 3. Initialise gqlgen config and generate models
 
-       go run github.com/99designs/gqlgen init
+   go run github.com/99designs/gqlgen init
 
-       go mod tidy
+   go mod tidy
 
 4. Start the graphql server
 
-       go run server.go
+   go run server.go
 
 More help to get started:
- - [Getting started tutorial](https://gqlgen.com/getting-started/) - a comprehensive guide to help you get started
- - [Real-world examples](https://github.com/99designs/gqlgen/tree/master/_examples) show how to create GraphQL applications
- - [Reference docs](https://pkg.go.dev/github.com/99designs/gqlgen) for the APIs
+
+- [Getting started tutorial](https://gqlgen.com/getting-started/) - a comprehensive guide to help you get started
+- [Real-world examples](https://github.com/99designs/gqlgen/tree/master/_examples) show how to create GraphQL applications
+- [Reference docs](https://pkg.go.dev/github.com/99designs/gqlgen) for the APIs
 
 ## Reporting Issues
 
@@ -48,6 +49,7 @@ If you think you've found a bug, or something isn't behaving the way you think i
 ## Contributing
 
 We welcome contributions, Read our [Contribution Guidelines](https://github.com/99designs/gqlgen/blob/master/CONTRIBUTING.md) to learn more about contributing to **gqlgen**
+
 ## Frequently asked questions
 
 ### How do I prevent fetching child objects that might not be used?
@@ -56,9 +58,9 @@ When you have nested or recursive schema like this:
 
 ```graphql
 type User {
-  id: ID!
-  name: String!
-  friends: [User!]!
+	id: ID!
+	name: String!
+	friends: [User!]!
 }
 ```
 
@@ -109,19 +111,21 @@ func (r *userResolver) Friends(ctx context.Context, obj *User) ([]*User, error) 
 You can also use inline config with directives to achieve the same result
 
 ```graphql
-directive @goModel(model: String, models: [String!]) on OBJECT
-    | INPUT_OBJECT
-    | SCALAR
-    | ENUM
-    | INTERFACE
-    | UNION
+directive @goModel(
+	model: String
+	models: [String!]
+) on OBJECT | INPUT_OBJECT | SCALAR | ENUM | INTERFACE | UNION
 
-directive @goField(forceResolver: Boolean, name: String, omittable: Boolean) on INPUT_FIELD_DEFINITION
-    | FIELD_DEFINITION
+directive @goField(
+	forceResolver: Boolean
+	name: String
+	omittable: Boolean
+	type: String
+) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 type User @goModel(model: "github.com/you/pkg/model.User") {
-    id: ID!         @goField(name: "todoId")
-    friends: [User!]!   @goField(forceResolver: true)
+	id: ID! @goField(name: "todoId")
+	friends: [User!]! @goField(forceResolver: true)
 }
 ```
 
@@ -147,10 +151,12 @@ first model in this list is used as the default type and it will always be used 
 There isn't any way around this, gqlgen has no way to know what you want in a given context.
 
 ### Why do my interfaces have getters? Can I disable these?
+
 These were added in v0.17.14 to allow accessing common interface fields without casting to a concrete type.
 However, certain fields, like Relay-style Connections, cannot be implemented with simple getters.
 
 If you'd prefer to not have getters generated in your interfaces, you can add the following in your `gqlgen.yml`:
+
 ```yaml
 # gqlgen.yml
 omit_getters: true

--- a/_examples/config/schema.graphql
+++ b/_examples/config/schema.graphql
@@ -1,10 +1,18 @@
-directive @goModel(model: String, models: [String!]) on OBJECT | INPUT_OBJECT | SCALAR | ENUM | INTERFACE | UNION
-directive @goField(forceResolver: Boolean, name: String, omittable: Boolean) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+directive @goModel(
+    model: String
+    models: [String!]
+) on OBJECT | INPUT_OBJECT | SCALAR | ENUM | INTERFACE | UNION
+directive @goField(
+    forceResolver: Boolean
+    name: String
+    omittable: Boolean
+    type: String
+) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 type Query {
-  todos: [Todo!]!
+    todos: [Todo!]!
 }
 
 type Mutation {
-  createTodo(input: NewTodo!): Todo!
+    createTodo(input: NewTodo!): Todo!
 }

--- a/_examples/federation/accounts/graph/schema.graphqls
+++ b/_examples/federation/accounts/graph/schema.graphqls
@@ -2,6 +2,7 @@ directive @goField(
     forceResolver: Boolean
     name: String
     omittable: Boolean
+    type: String
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 extend type Query {

--- a/codegen/testserver/followschema/schema.graphql
+++ b/codegen/testserver/followschema/schema.graphql
@@ -6,6 +6,7 @@ directive @goField(
     forceResolver: Boolean
     name: String
     omittable: Boolean
+    type: String
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 directive @defer(
     if: Boolean = true
@@ -99,7 +100,7 @@ input OmittableInput {
     object: OuterInput @goField(omittable: true)
 }
 
-scalar ThirdParty @goModel(model:"followschema.ThirdParty")
+scalar ThirdParty @goModel(model: "followschema.ThirdParty")
 
 type OuterObject {
     inner: InnerObject!
@@ -113,7 +114,7 @@ type ForcedResolver {
     field: Circle @goField(forceResolver: true)
 }
 
-type EmbeddedPointer @goModel(model:"followschema.EmbeddedPointerModel") {
+type EmbeddedPointer @goModel(model: "followschema.EmbeddedPointerModel") {
     ID: String
     Title: String
 }

--- a/codegen/testserver/singlefile/schema.graphql
+++ b/codegen/testserver/singlefile/schema.graphql
@@ -6,6 +6,7 @@ directive @goField(
     forceResolver: Boolean
     name: String
     omittable: Boolean
+    type: String
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 directive @defer(
     if: Boolean = true
@@ -99,7 +100,7 @@ input OmittableInput {
     object: OuterInput @goField(omittable: true)
 }
 
-scalar ThirdParty @goModel(model:"singlefile.ThirdParty")
+scalar ThirdParty @goModel(model: "singlefile.ThirdParty")
 
 type OuterObject {
     inner: InnerObject!
@@ -113,7 +114,7 @@ type ForcedResolver {
     field: Circle @goField(forceResolver: true)
 }
 
-type EmbeddedPointer @goModel(model:"singlefile.EmbeddedPointerModel") {
+type EmbeddedPointer @goModel(model: "singlefile.EmbeddedPointerModel") {
     ID: String
     Title: String
 }

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -191,12 +191,20 @@ directive @goField(
 	forceResolver: Boolean
 	name: String
 	omittable: Boolean
+	type: String
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 directive @goTag(
 	key: String!
 	value: String
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+
+directive @goExtraField(
+	name: String
+	type: String!
+	overrideTags: String
+	description: String
+) repeatable on OBJECT | INPUT_OBJECT
 ```
 
 > Here be dragons
@@ -207,7 +215,9 @@ directive @goTag(
 Now you can use these directives when defining types in your schema:
 
 ```graphql
-type User @goModel(model: "github.com/my/app/models.User") {
+type User
+	@goModel(model: "github.com/my/app/models.User")
+	@goExtraField(name: "Activated", type: "bool") {
 	id: ID! @goField(name: "todoId")
 	name: String!
 		@goField(forceResolver: true)
@@ -222,7 +232,7 @@ type Person @goModel(forceGenerate: true) {
 }
 ```
 
-The builtin directives `goField`, `goModel` and `goTag` are automatically registered to `skip_runtime`. Any directives registered as `skip_runtime` will not exposed during introspection and are used during code generation only.
+The builtin directives `goField`, `goModel`, `goTag` and `goExtraField` are automatically registered to `skip_runtime`. Any directives registered as `skip_runtime` will not exposed during introspection and are used during code generation only.
 
 If you have created a new code generation plugin using a directive which does not require runtime execution, the directive will need to be set to `skip_runtime`.
 

--- a/plugin/federation/testdata/computedrequires/generated/exec.go
+++ b/plugin/federation/testdata/computedrequires/generated/exec.go
@@ -238,7 +238,12 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 
 var sources = []*ast.Source{
 	{Name: "../schema.graphql", Input: `directive @entityResolver(multi: Boolean) on OBJECT
-directive @goField(forceResolver: Boolean, name: String, omittable: Boolean) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+directive @goField(
+    forceResolver: Boolean
+    name: String
+    omittable: Boolean
+    type: String
+) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 type Query {
     test: String
@@ -255,10 +260,13 @@ type World @key(fields: "hello { name } foo   ") {
     hello: Hello
 }
 
-type Person @key(fields: "name"){
+type Person @key(fields: "name") {
     name: String!
     gender: Gender!
-    welcomeMessage: String @requires(fields:"gender { ... on Male {description} ... on Female {description}}")
+    welcomeMessage: String
+        @requires(
+            fields: "gender { ... on Male {description} ... on Female {description}}"
+        )
 }
 
 union Gender = Male | Female
@@ -271,7 +279,9 @@ type Female {
     description: String!
 }
 
-type WorldWithMultipleKeys @key(fields: "hello { name } foo   ") @key(fields: "bar") {
+type WorldWithMultipleKeys
+    @key(fields: "hello { name } foo   ")
+    @key(fields: "bar") {
     foo: String!
     bar: Int!
     hello: Hello
@@ -295,7 +305,9 @@ type PlanetMultipleRequires @key(fields: "name") {
     name: String! @external
     diameter: Int! @external
     density: Int! @external
-    weight(foo: String): Int! @requires(fields: "diameter density") @goField(forceResolver: true)
+    weight(foo: String): Int!
+        @requires(fields: "diameter density")
+        @goField(forceResolver: true)
     anotherField(foobar: String): String
 }
 
@@ -307,7 +319,9 @@ type PlanetRequiresNested @key(fields: "name") {
     sizes: [Int!] @requires(fields: "worlds{ foo }")
 }
 
-type MultiPlanetRequiresNested @key(fields: "name") @entityResolver(multi: true) {
+type MultiPlanetRequiresNested
+    @key(fields: "name")
+    @entityResolver(multi: true) {
     name: String! @external
     world: World! @external
     size: Int! @requires(fields: "world{ foo }")
@@ -332,7 +346,9 @@ type MultiHelloRequires @key(fields: "name") @entityResolver(multi: true) {
     key2: String! @requires(fields: "key1")
 }
 
-type MultiHelloMultipleRequires @key(fields: "name") @entityResolver(multi: true) {
+type MultiHelloMultipleRequires
+    @key(fields: "name")
+    @entityResolver(multi: true) {
     name: String! @external
     key1: String! @external
     key2: String! @external

--- a/plugin/federation/testdata/computedrequires/schema.graphql
+++ b/plugin/federation/testdata/computedrequires/schema.graphql
@@ -1,5 +1,10 @@
 directive @entityResolver(multi: Boolean) on OBJECT
-directive @goField(forceResolver: Boolean, name: String, omittable: Boolean) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+directive @goField(
+    forceResolver: Boolean
+    name: String
+    omittable: Boolean
+    type: String
+) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 type Query {
     test: String
@@ -16,10 +21,13 @@ type World @key(fields: "hello { name } foo   ") {
     hello: Hello
 }
 
-type Person @key(fields: "name"){
+type Person @key(fields: "name") {
     name: String!
     gender: Gender!
-    welcomeMessage: String @requires(fields:"gender { ... on Male {description} ... on Female {description}}")
+    welcomeMessage: String
+        @requires(
+            fields: "gender { ... on Male {description} ... on Female {description}}"
+        )
 }
 
 union Gender = Male | Female
@@ -32,7 +40,9 @@ type Female {
     description: String!
 }
 
-type WorldWithMultipleKeys @key(fields: "hello { name } foo   ") @key(fields: "bar") {
+type WorldWithMultipleKeys
+    @key(fields: "hello { name } foo   ")
+    @key(fields: "bar") {
     foo: String!
     bar: Int!
     hello: Hello
@@ -56,7 +66,9 @@ type PlanetMultipleRequires @key(fields: "name") {
     name: String! @external
     diameter: Int! @external
     density: Int! @external
-    weight(foo: String): Int! @requires(fields: "diameter density") @goField(forceResolver: true)
+    weight(foo: String): Int!
+        @requires(fields: "diameter density")
+        @goField(forceResolver: true)
     anotherField(foobar: String): String
 }
 
@@ -68,7 +80,9 @@ type PlanetRequiresNested @key(fields: "name") {
     sizes: [Int!] @requires(fields: "worlds{ foo }")
 }
 
-type MultiPlanetRequiresNested @key(fields: "name") @entityResolver(multi: true) {
+type MultiPlanetRequiresNested
+    @key(fields: "name")
+    @entityResolver(multi: true) {
     name: String! @external
     world: World! @external
     size: Int! @requires(fields: "world{ foo }")
@@ -93,7 +107,9 @@ type MultiHelloRequires @key(fields: "name") @entityResolver(multi: true) {
     key2: String! @requires(fields: "key1")
 }
 
-type MultiHelloMultipleRequires @key(fields: "name") @entityResolver(multi: true) {
+type MultiHelloMultipleRequires
+    @key(fields: "name")
+    @entityResolver(multi: true) {
     name: String! @external
     key1: String! @external
     key2: String! @external

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -417,6 +417,11 @@ func (m *Plugin) generateField(
 		}
 	}
 
+	// Replace to user-defined field type if provided.
+	if userDefinedType := cfg.Models[schemaType.Name].Fields[field.Name].Type; userDefinedType != "" {
+		typ = buildType(userDefinedType)
+	}
+
 	f := &Field{
 		Name:        field.Name,
 		GoName:      name,

--- a/plugin/modelgen/testdata/schema.graphql
+++ b/plugin/modelgen/testdata/schema.graphql
@@ -4,9 +4,10 @@ directive @goTag(
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 directive @goField(
-	forceResolver: Boolean
-	name: String
+    forceResolver: Boolean
+    name: String
     omittable: Boolean
+    type: String
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION | INTERFACE
 
 type Query {
@@ -70,11 +71,12 @@ input ExistingInput {
 }
 
 type FieldMutationHook {
-    name: String @goTag(key :"anotherTag", value: "tag")
+    name: String @goTag(key: "anotherTag", value: "tag")
     enum: ExistingEnum @goTag(key: "yetAnotherTag", value: "12")
-    noVal: String @goTag(key: "yaml") @goTag(key : "repeated", value: "true")
-    repeated: String @goTag(key: "someTag", value: "value") @goTag(key : "repeated", value: "true")
-
+    noVal: String @goTag(key: "yaml") @goTag(key: "repeated", value: "true")
+    repeated: String
+        @goTag(key: "someTag", value: "value")
+        @goTag(key: "repeated", value: "true")
 }
 
 enum ExistingEnum {
@@ -86,7 +88,7 @@ interface ExistingInterface {
     name: String
 }
 
-union ExistingUnion = MissingTypeNotNull | MissingTypeNullable  | ExistingType
+union ExistingUnion = MissingTypeNotNull | MissingTypeNullable | ExistingType
 
 "TypeWithDescription is a type with a description"
 type TypeWithDescription {
@@ -107,12 +109,11 @@ interface InterfaceWithDescription {
 "UnionWithDescription is an union with a description"
 union UnionWithDescription = TypeWithDescription | ExistingType
 
-
 interface Foo_Barer {
     name: String!
 }
 
-type _Foo_Barr implements  Foo_Barer {
+type _Foo_Barr implements Foo_Barer {
     name: String!
 }
 
@@ -200,7 +201,7 @@ type Xer implements X {
 }
 
 type ExtraFieldsTest {
-  SchemaField: String!
+    SchemaField: String!
 }
 
 type OmitEmptyJsonTagTest {

--- a/plugin/modelgen/testdata/schema_omit_resolver_fields.graphql
+++ b/plugin/modelgen/testdata/schema_omit_resolver_fields.graphql
@@ -4,9 +4,10 @@ directive @goTag(
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 directive @goField(
-	forceResolver: Boolean
-	name: String
+    forceResolver: Boolean
+    name: String
     omittable: Boolean
+    type: String
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION | INTERFACE
 
 type Base {


### PR DESCRIPTION
Sometimes it needed to customize go-type of some field in generated model.
But i don't want to replace it with fully user-defined model with goModel directive.
This PR adds ability to do this.

Example:

```graphql
type User {
    id: Int!
    name: String! @goField(type: "my.module/my-package.SuperString")
    created: Time!
    updated: Time!
}
```

```go
type User struct {
  id int
  name SuperString
  created time.Time
  updated time.Time
}
```

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
