### PR TITLE
chore: reenable revive.use-any and fix exlusion list

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,7 +53,7 @@ linters:
       enable-all-rules: false
       rules:
         - name: empty-lines
-#        - name: use-any # this causes problems in some generated files
+        - name: use-any
         - name: struct-tag
         - name: blank-imports
         - name: context-as-argument
@@ -114,12 +114,13 @@ linters:
       - linters:
           - gocritic
         path: _examples/federation/products/graph/entity.resolvers.go
+      # revive.use-any causes problems in some generated files
       - path: graphql/map.go
-        text: 'use-any: since GO 1.18 ''interface{}'' can be replaced by ''any'''
+        text: 'use-any'
       - path: codegen/testserver/followschema/resolver.go
-        text: 'use-any: since GO 1.18 ''interface{}'' can be replaced by ''any'''
+        text: 'use-any'
       - path: codegen/testserver/singlefile/resolver.go
-        text: 'use-any: since GO 1.18 ''interface{}'' can be replaced by ''any'''
+        text: 'use-any'
       - linters:
           - staticcheck
         path: codegen/testserver/generated_test.go

--- a/plugin/federation/test_data/model/federation.go
+++ b/plugin/federation/test_data/model/federation.go
@@ -1,6 +1,6 @@
 package model
 
-type _FieldSet string //nolint:deadcode,unused
+type _FieldSet string //nolint:unused
 
 type Hello struct {
 	Name      string

--- a/plugin/federation/test_data/model2/federation.go
+++ b/plugin/federation/test_data/model2/federation.go
@@ -1,6 +1,6 @@
 package model2
 
-type FieldSet string //nolint:deadcode
+type FieldSet string
 
 type Hello struct {
 	Name      string

--- a/plugin/federation/testdata/allthethings/model/federation.go
+++ b/plugin/federation/testdata/allthethings/model/federation.go
@@ -1,6 +1,6 @@
 package model
 
-type _FieldSet string //nolint:deadcode,unused
+type _FieldSet string //nolint:unused
 
 type Hello struct {
 	Name      string


### PR DESCRIPTION
- Enable `revive.use-any` and fix exclusions rules for `use-any` to ignore some generated files that should use `interface{}` and not `any` (rule text changed from `'use-any: since GO 1.18 'interface{}' can be replaced by 'any'` to `'use-any: since Go 1.18 'interface{}' can be replaced by 'any'`)
- Remove not relevant `//nolint:deadcode` because `deadcode` linter was removed in golangci-lint v2.