### PR TITLE
feat: bind from basic type to named type

### DIFF
--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -476,7 +476,18 @@ func (b *Binder) TypeReference(schemaType *ast.Type, bindTarget types.Type) (ret
 		ref.GO = b.CopyModifiersFromAst(schemaType, ref.GO)
 
 		if bindTarget != nil {
-			if err = code.CompatibleTypes(ref.GO, bindTarget); err != nil {
+			// if the bind type implements the graphql.ContextMarshaler/graphql.ContextUnmarshaler/graphql.Marshaler/graphql.Unmarshaler interface, we can use it
+			if hasMethod(bindTarget, "MarshalGQLContext") && hasMethod(bindTarget, "UnmarshalGQLContext") {
+				ref.IsContext = true
+				ref.IsMarshaler = true
+				ref.Marshaler = nil
+				ref.Unmarshaler = nil
+			} else if hasMethod(bindTarget, "MarshalGQL") && hasMethod(bindTarget, "UnmarshalGQL") {
+				ref.IsContext = false
+				ref.IsMarshaler = true
+				ref.Marshaler = nil
+				ref.Unmarshaler = nil
+			} else if err = code.CompatibleTypes(ref.GO, bindTarget); err != nil {
 				continue
 			}
 			ref.GO = bindTarget


### PR DESCRIPTION
According this [pull request](https://github.com/99designs/gqlgen/pull/3617), we can set a custom type for a field.

Example:
```
type User {
    id: Int!
    number: Int! @goField(type: "my.module/my-package.SuperNumber")
}

type User struct {
  id int
  number SuperNumber
}
```

However, it will generate a new resolver like below:
```
type ResolverRoot interface {
	User()UserResolver
}
type UserResolver interface {
	Number(ctx context.Context, obj *User, number int) error
}
```

This pull request provides a convenient way without the Resolver interface via graphql.ContextMarshaler/graphql.ContextUnmarshaler/graphql.Marshaler/graphql.Unmarshaler interface

```
type SuperNumber uint64

func (e *SuperNumber) UnmarshalGQLContext(ctx context.Context, v interface{}) error {
	id, ok := v.(int)
	if !ok {
		return errors.New("not a int")
	}

	*e = SuperNumber(id)
	return nil
}

func (e SuperNumber) MarshalGQLContext(_ context.Context, w io.Writer) error {
	fmt.Fprint(w, e)
	return nil
}
```

I have:
 - [V] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [V] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
