### PR TITLE
Gracefully close websocket connections

### DIFF
--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -238,13 +238,12 @@ func (c *wsConnection) init() bool {
 
 func (c *wsConnection) write(msg *message) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	// don't write anything to a closed / closing connection
 	if c.serverClosed {
-		c.mu.Unlock()
 		return
 	}
 	c.handlePossibleError(c.me.Send(msg), false)
-	c.mu.Unlock()
 }
 
 func (c *wsConnection) run() {

--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -563,6 +563,8 @@ func (c *wsConnection) close(closeCode int, message string) {
 			// either we get net.ErrClosed or some other error
 			// either way, bail on the graceful shutdown as it's either
 			// impossible or very likely not happening
+			// TODO: optimize this to bypass the select statement to avoid
+			// waiting the entire closeTimeout
 			if err != nil {
 				return
 			}

--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -332,9 +332,12 @@ func (c *wsConnection) run() {
 		case connectionCloseMessageType:
 			c.mu.Lock()
 			c.clientClosed = true
-			// normal termination
+			// server already initiated the graceful shutdown
+			// we don't need to send another close message
 			if c.serverClosed {
 				c.clientCloseReceiver <- struct{}{}
+				c.mu.Unlock()
+				return
 			}
 			c.mu.Unlock()
 			c.close(websocket.CloseNormalClosure, "terminated")


### PR DESCRIPTION
Fixes #3633 as follow-up to discussion #2847

This is intended to gracefully close WebSocket connections, because the Gorilla/websocket doesn't provide us a nice way to do that.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
