### PR TITLE
Fix: Apollo FTv1 tracing doesn't wait for field resolver completion

### DIFF
--- a/graphql/handler/apollofederatedtracingv1/tracing.go
+++ b/graphql/handler/apollofederatedtracingv1/tracing.go
@@ -94,11 +94,18 @@ func (t *Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (any
 	if !t.shouldTrace(ctx) {
 		return next(ctx)
 	}
+
+	var stop func()
 	if tb := t.getTreeBuilder(ctx); tb != nil {
-		tb.WillResolveField(ctx)
+		stop = tb.WillResolveField(ctx)
 	}
 
-	return next(ctx)
+	res, err := next(ctx)
+	if stop != nil {
+		stop()
+	}
+
+	return res, err
 }
 
 // InterceptResponse is called before the overall response is sent, but before each field resolves; as a result

--- a/graphql/handler/apollofederatedtracingv1/tracing.go
+++ b/graphql/handler/apollofederatedtracingv1/tracing.go
@@ -94,18 +94,14 @@ func (t *Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (any
 	if !t.shouldTrace(ctx) {
 		return next(ctx)
 	}
-
-	var stop func()
 	if tb := t.getTreeBuilder(ctx); tb != nil {
-		stop = tb.WillResolveField(ctx)
+		stop := tb.WillResolveField(ctx)
+		if stop != nil {
+			defer stop()
+		}
 	}
 
-	res, err := next(ctx)
-	if stop != nil {
-		stop()
-	}
-
-	return res, err
+	return next(ctx)
 }
 
 // InterceptResponse is called before the overall response is sent, but before each field resolves; as a result

--- a/graphql/handler/apollofederatedtracingv1/tree_builder.go
+++ b/graphql/handler/apollofederatedtracingv1/tree_builder.go
@@ -113,7 +113,7 @@ func (tb *TreeBuilder) StopTimer(ctx context.Context) {
 }
 
 // On each field, it calculates the time started at as now - tree.StartTime, as well as a deferred function upon full resolution of the
-// field as now - tree.StartTime; these are used by Apollo to calculate how fields are being resolved in the AST
+// field as (now - tree.StartTime); these are used by Apollo to calculate how fields are being resolved in the AST
 func (tb *TreeBuilder) WillResolveField(ctx context.Context) func() {
 	if tb.startTime == nil {
 		tb.logger.Println(errors.New("WillResolveField called before StartTimer"))

--- a/graphql/handler/apollofederatedtracingv1/tree_builder.go
+++ b/graphql/handler/apollofederatedtracingv1/tree_builder.go
@@ -114,25 +114,25 @@ func (tb *TreeBuilder) StopTimer(ctx context.Context) {
 
 // On each field, it calculates the time started at as now - tree.StartTime, as well as a deferred function upon full resolution of the
 // field as now - tree.StartTime; these are used by Apollo to calculate how fields are being resolved in the AST
-func (tb *TreeBuilder) WillResolveField(ctx context.Context) {
+func (tb *TreeBuilder) WillResolveField(ctx context.Context) func() {
 	if tb.startTime == nil {
 		tb.logger.Println(errors.New("WillResolveField called before StartTimer"))
-		return
+		return nil
 	}
 	if tb.stopped {
 		tb.logger.Println(errors.New("WillResolveField called after StopTimer"))
-		return
+		return nil
 	}
 	fc := graphql.GetFieldContext(ctx)
 
 	node := tb.newNode(fc)
 	node.StartTime = uint64(graphql.Now().Sub(*tb.startTime).Nanoseconds())
-	defer func() {
-		node.EndTime = uint64(graphql.Now().Sub(*tb.startTime).Nanoseconds())
-	}()
-
 	node.Type = fc.Field.Definition.Type.String()
 	node.ParentType = fc.Object
+
+	return func() {
+		node.EndTime = uint64(graphql.Now().Sub(*tb.startTime).Nanoseconds())
+	}
 }
 
 func (tb *TreeBuilder) DidEncounterErrors(ctx context.Context, gqlErrors gqlerror.List) {


### PR DESCRIPTION
This PR fixes an issue in Apollo Federation Tracing (FTv1) where the `EndTime` of a field span was recorded too early — before the field resolver had actually completed execution. This resulted in inaccurate tracing data, as the span duration didn't reflect the true time spent resolving the field.