### PR TITLE
Adds use_function_syntax_for_execution_context to init template

### DIFF
--- a/init-templates/gqlgen.yml.gotmpl
+++ b/init-templates/gqlgen.yml.gotmpl
@@ -102,6 +102,10 @@ resolver:
 # argument values but to set them even if they're null.
 call_argument_directives_with_null: true
 
+# This enables gql server to use function syntax for execution context
+# instead of generating receiver methods of the execution context.
+# use_function_syntax_for_execution_context: true
+
 # Optional: set build tags that will be used to load packages
 # go_build_tags:
 #  - private


### PR DESCRIPTION
There was a configuration option, `use_function_syntax_for_execution_context`, defined in the `docs/content/config.md` but was missing from the init template. This aims to provide a more comprehensive init template for available config options.  