### PR TITLE
add config local_prefix for imports group split

### DIFF
--- a/api/generate.go
+++ b/api/generate.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"syscall"
 
+	"golang.org/x/tools/imports"
+
 	"github.com/99designs/gqlgen/codegen"
 	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/99designs/gqlgen/plugin"
@@ -54,6 +56,10 @@ func Generate(cfg *config.Config, option ...Option) error {
 
 	for _, o := range option {
 		o(cfg, &plugins)
+	}
+
+	if cfg.LocalPrefix != "" {
+		imports.LocalPrefix = cfg.LocalPrefix
 	}
 
 	for _, p := range plugins {

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	Models                               TypeMap                    `yaml:"models,omitempty"`
 	StructTag                            string                     `yaml:"struct_tag,omitempty"`
 	Directives                           map[string]DirectiveConfig `yaml:"directives,omitempty"`
+	LocalPrefix                          string                     `yaml:"local_prefix,omitempty"`
 	GoBuildTags                          StringList                 `yaml:"go_build_tags,omitempty"`
 	GoInitialisms                        GoInitialismsConfig        `yaml:"go_initialisms,omitempty"`
 	OmitSliceElementPointers             bool                       `yaml:"omit_slice_element_pointers,omitempty"`

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -68,6 +68,9 @@ resolver:
 # Optional: turn on use ` + "`" + `gqlgen:"fieldName"` + "`" + ` tags in your models
 # struct_tag: json
 
+# Optional: turn on to split imports in generated files into local modules and third-party packages
+# local_prefix: github.com/myrepo
+
 # Optional: turn on to use []Thing instead of []*Thing
 # omit_slice_element_pointers: false
 


### PR DESCRIPTION
#3586 

I think this question is abort "golang.org/x/tools/imports" LocalPrefix

add config local_prefix and use it in api.Generate before all generate plugins