### PR TITLE
Omittable supports IsZero method for omitzero

### DIFF
--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -1,8 +1,8 @@
 module github.com/99designs/gqlgen/_examples
 
-go 1.23.0
+go 1.23.8
 
-toolchain go1.23.7
+toolchain go1.24.2
 
 replace github.com/99designs/gqlgen => ../
 

--- a/_examples/websocket-initfunc/server/go.mod
+++ b/_examples/websocket-initfunc/server/go.mod
@@ -1,6 +1,8 @@
 module github.com/gqlgen/_examples/websocket-initfunc/server
 
-go 1.23.6
+go 1.23.8
+
+toolchain go1.24.2
 
 require (
 	github.com/99designs/gqlgen v0.17.70

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/99designs/gqlgen
 
-go 1.23.0
+go 1.23.8
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 require (
 	github.com/PuerkitoBio/goquery v1.10.3

--- a/graphql/omittable_go123_test.go
+++ b/graphql/omittable_go123_test.go
@@ -1,0 +1,74 @@
+//go:build !go1.24
+
+package graphql
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOmittable_MarshalJSONBeforeGo124(t *testing.T) {
+	testCases := []struct {
+		name         string
+		input        any
+		expectedJSON string
+	}{
+		{
+			name: "simple string omitzero IsZero=true",
+			input: struct {
+				Value Omittable[string] `json:",omitzero"`
+			}{},
+			expectedJSON: `{"Value":""}`,
+		},
+		{
+			name: "string pointer omitzero IsZero=true",
+			input: struct {
+				Value Omittable[*string] `json:",omitzero"`
+			}{},
+			expectedJSON: `{"Value":null}`,
+		},
+		{
+			name: "omitted integer omitzero IsZero=true",
+			input: struct {
+				Value Omittable[int] `json:",omitzero"`
+			}{},
+			expectedJSON: `{"Value":0}`,
+		},
+		{
+			name: "omittable omittable omitzero IsZero=true", //nolint:dupword
+			input: struct {
+				Value Omittable[Omittable[uint64]] `json:",omitzero"`
+			}{},
+			expectedJSON: `{"Value":0}`,
+		},
+		{
+			name: "omittable struct Value omitzero IsZero=true",
+			input: struct {
+				Value Omittable[struct {
+					Inner string
+				}] `json:",omitzero"`
+			}{},
+			expectedJSON: `{"Value":{"Inner":""}}`,
+		},
+		{
+			name: "omittable struct Inner omitzero IsZero=true",
+			input: struct {
+				Value Omittable[struct {
+					Inner Omittable[string] `json:",omitzero"`
+				}]
+			}{},
+			expectedJSON: `{"Value":{"Inner":""}}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedJSON, string(data))
+		})
+	}
+}

--- a/graphql/omittable_go124_test.go
+++ b/graphql/omittable_go124_test.go
@@ -1,0 +1,85 @@
+//go:build go1.24
+
+package graphql
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOmittable_MarshalJSONAFromGo124(t *testing.T) {
+	s := "test"
+	testCases := []struct {
+		name         string
+		input        any
+		expectedJSON string
+	}{
+		{
+			name: "simple string omitzero IsZero=true",
+			input: struct {
+				Value Omittable[string] `json:",omitzero"`
+			}{},
+			expectedJSON: `{}`,
+		},
+		{
+			name:         "string pointer",
+			input:        struct{ Value Omittable[*string] }{Value: OmittableOf(&s)},
+			expectedJSON: `{"Value":"test"}`,
+		},
+		{
+			name: "string pointer omitzero IsZero=true",
+			input: struct {
+				Value Omittable[*string] `json:",omitzero"`
+			}{},
+			expectedJSON: `{}`,
+		},
+		{
+			name:         "omitted integer",
+			input:        struct{ Value Omittable[int] }{},
+			expectedJSON: `{"Value":0}`,
+		},
+		{
+			name: "omitted integer omitzero IsZero=true",
+			input: struct {
+				Value Omittable[int] `json:",omitzero"`
+			}{},
+			expectedJSON: `{}`,
+		},
+		{
+			name: "omittable omittable omitzero IsZero=true", //nolint:dupword
+			input: struct {
+				Value Omittable[Omittable[uint64]] `json:",omitzero"`
+			}{},
+			expectedJSON: `{}`,
+		},
+		{
+			name: "omittable struct Value omitzero IsZero=true",
+			input: struct {
+				Value Omittable[struct {
+					Inner string
+				}] `json:",omitzero"`
+			}{},
+			expectedJSON: `{}`,
+		},
+		{
+			name: "omittable struct Inner omitzero IsZero=true",
+			input: struct {
+				Value Omittable[struct {
+					Inner Omittable[string] `json:",omitzero"`
+				}]
+			}{},
+			expectedJSON: `{"Value":{}}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedJSON, string(data))
+		})
+	}
+}

--- a/graphql/omittable_test.go
+++ b/graphql/omittable_test.go
@@ -18,36 +18,95 @@ func TestOmittable_MarshalJSON(t *testing.T) {
 		{
 			name:         "simple string",
 			input:        struct{ Value Omittable[string] }{Value: OmittableOf("simple string")},
-			expectedJSON: `{"Value": "simple string"}`,
+			expectedJSON: `{"Value":"simple string"}`,
+		},
+		{
+			name: "simple string omitzero IsZero=false",
+			input: struct {
+				Value Omittable[string] `json:",omitzero"`
+			}{
+				Value: OmittableOf(""),
+			},
+			expectedJSON: `{"Value":""}`,
 		},
 		{
 			name:         "string pointer",
 			input:        struct{ Value Omittable[*string] }{Value: OmittableOf(&s)},
-			expectedJSON: `{"Value": "test"}`,
+			expectedJSON: `{"Value":"test"}`,
+		},
+		{
+			name: "string pointer omitzero IsZero=false",
+			input: struct {
+				Value Omittable[*string] `json:",omitzero"`
+			}{
+				Value: OmittableOf[*string](nil),
+			},
+			expectedJSON: `{"Value":null}`,
 		},
 		{
 			name:         "omitted integer",
 			input:        struct{ Value Omittable[int] }{},
-			expectedJSON: `{"Value": null}`,
+			expectedJSON: `{"Value":0}`,
+		},
+		{
+			name: "omitted integer omitzero IsZero=false",
+			input: struct {
+				Value Omittable[int] `json:",omitzero"`
+			}{
+				Value: OmittableOf(0),
+			},
+			expectedJSON: `{"Value":0}`,
 		},
 		{
 			name:         "omittable omittable", //nolint:dupword
 			input:        struct{ Value Omittable[Omittable[uint64]] }{Value: OmittableOf(OmittableOf(uint64(42)))},
-			expectedJSON: `{"Value": 42}`,
+			expectedJSON: `{"Value":42}`,
+		},
+		{
+			name: "omittable omittable omitzero IsZero=false", //nolint:dupword
+			input: struct {
+				Value Omittable[Omittable[uint64]] `json:",omitzero"`
+			}{
+				Value: OmittableOf(OmittableOf(uint64(0))),
+			},
+			expectedJSON: `{"Value":0}`,
 		},
 		{
 			name: "omittable struct",
 			input: struct {
 				Value Omittable[struct{ Inner string }]
 			}{Value: OmittableOf(struct{ Inner string }{})},
-			expectedJSON: `{"Value": {"Inner": ""}}`,
+			expectedJSON: `{"Value":{"Inner":""}}`,
 		},
 		{
-			name: "omitted struct",
+			name: "omittable struct Value omitzero IsZero=false",
 			input: struct {
-				Value Omittable[struct{ Inner string }]
-			}{},
-			expectedJSON: `{"Value": null}`,
+				Value Omittable[struct {
+					Inner string
+				}] `json:",omitzero"`
+			}{
+				Value: OmittableOf(struct {
+					Inner string
+				}{
+					Inner: "",
+				}),
+			},
+			expectedJSON: `{"Value":{"Inner":""}}`,
+		},
+		{
+			name: "omittable struct Inner omitzero IsZero=false",
+			input: struct {
+				Value Omittable[struct {
+					Inner Omittable[string] `json:",omitzero"`
+				}]
+			}{
+				Value: OmittableOf(struct {
+					Inner Omittable[string] `json:",omitzero"`
+				}{
+					Inner: OmittableOf(""),
+				}),
+			},
+			expectedJSON: `{"Value":{"Inner":""}}`,
 		},
 	}
 
@@ -55,7 +114,7 @@ func TestOmittable_MarshalJSON(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			data, err := json.Marshal(tc.input)
 			require.NoError(t, err)
-			assert.JSONEq(t, tc.expectedJSON, string(data))
+			assert.Equal(t, tc.expectedJSON, string(data))
 		})
 	}
 }


### PR DESCRIPTION
This PR adds IsZero to Omittable. It also adds support for MarshalGQL and MarshalGQLContext, which are necessary for correctly parsing GraphQL enums.

## Background
API may behave differently when JSON is undefined versus when it is null.

- undefined
  - no effect to name
  - json: `{}`

```go
input := UserUpdateInput{
		Name:         graphql.Omittable[string]{},
}
```

- null
  - set empty string to  name
  - json: `{"name":null}`

```go
input := UserUpdateInput{
		Name:         graphql.OmittableOf[string](null),
}
```

However, the current Omittable does not omit fields when json.Marshal is executed with set=false.
Additionally, omitempty could not specify whether the field’s type itself should be omitted. However, with the introduction of omitzero and the IsZero method in Go 1.24, it is now possible to express whether a field should be omitted.

## Reference
- https://github.com/99designs/gqlgen/issues/1416
- https://github.com/99designs/gqlgen/pull/2585
- https://github.com/99designs/gqlgen/pull/2839
- https://github.com/99designs/gqlgen/issues/3227

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
