### PR TITLE
fix: dont unalias when used to expose internal types

### DIFF
--- a/internal/code/alias.go
+++ b/internal/code/alias.go
@@ -2,10 +2,23 @@ package code
 
 import (
 	"go/types"
+	"strings"
 )
 
 // Unalias unwraps an alias type
 func Unalias(t types.Type) types.Type {
+	if alias, ok := t.(*types.Alias); ok {
+		// If the type is an alias type, it must first check if the non-alias
+		// type is in an internal package. Only the last type in the alias
+		// chain is provided as the RHS.
+		if isAliasInternal(t.String(), unalias(t).String()) {
+			return types.NewNamed(alias.Obj(), alias.Underlying(), nil)
+		}
+	}
+	return unalias(t)
+}
+
+func unalias(t types.Type) types.Type {
 	if p, ok := t.(*types.Pointer); ok {
 		// If the type come from auto-binding,
 		// it will be a pointer to an alias type.
@@ -14,4 +27,30 @@ func Unalias(t types.Type) types.Type {
 		return types.NewPointer(Unalias(p.Elem()))
 	}
 	return types.Unalias(t)
+}
+
+// isAliasInternal checks if an alias type path is declared for a type within
+// an internal package. A best-effort attempt is made to mirror the Go internal
+// visibility rules by finding the root for the rhs, and checking to ensure
+// that the types both share the same root.
+func isAliasInternal(lhs, rhs string) bool {
+	idx := strings.LastIndex(lhs, "internal")
+	if idx != -1 {
+		// If the alias type contains an internal package, there is no reason
+		// to continue.
+		return false
+	}
+	idx = strings.LastIndex(rhs, "internal")
+	if idx < 0 {
+		return false
+	}
+	root := rhs[:idx]
+	switch {
+	// The alias type path is checked against the root of the non-alias type to
+	// ensure the types being aliased share the same root.
+	case strings.HasPrefix(lhs, root):
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/code/alias_test.go
+++ b/internal/code/alias_test.go
@@ -1,0 +1,65 @@
+package code
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsAliasInternal(t *testing.T) {
+	isInternal := []struct {
+		name string
+		lhs  string
+		rhs  string
+	}{
+		{
+			name: "same root internal alias",
+			lhs:  "github.com/org/repo/graph/model",
+			rhs:  "github.com/org/repo/internal/store/example",
+		},
+		{
+			name: "same root internal alias, path begins with internal",
+			lhs:  "graph/model",
+			rhs:  "internal/store/example",
+		},
+	}
+
+	for _, tc := range isInternal {
+		t.Run(tc.name, func(t *testing.T) {
+			require.True(t, isAliasInternal(tc.lhs, tc.rhs))
+		})
+	}
+
+	isNotInternal := []struct {
+		name string
+		lhs  string
+		rhs  string
+	}{
+		{
+			name: "same root not internal alias",
+			lhs:  "github.com/org/repo/graph/model",
+			rhs:  "github.com/org/repo/store/example",
+		},
+		{
+			name: "same root both internal",
+			lhs:  "github.com/org/repo/internal/model",
+			rhs:  "github.com/org/repo/internal/store/example",
+		},
+		{
+			name: "diff root not internal alias",
+			lhs:  "github.com/org/repo/graph/model",
+			rhs:  "github.com/org/repoB/store/example",
+		},
+		{
+			name: "diff root internal alias",
+			lhs:  "github.com/org/repo/graph/model",
+			rhs:  "github.com/org/repoB/internal/store/example",
+		},
+	}
+
+	for _, tc := range isNotInternal {
+		t.Run(tc.name, func(t *testing.T) {
+			require.False(t, isAliasInternal(tc.lhs, tc.rhs))
+		})
+	}
+}


### PR DESCRIPTION
This is an attempt at fixing #3662, where the unaliasing behavior prevents using type aliases to expose unexported types. The check attempts to narrow down the types that will skip unaliasing as much as possible to target only that particular use case.

Describe your PR and link to any relevant issues. 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
