### PR TITLE
Remove json.Marshaler in resolver

### DIFF
--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -202,7 +202,6 @@ type TypeReference struct {
 	Marshaler                *types.Func // When using external marshalling functions this will point to the Marshal function
 	Unmarshaler              *types.Func // When using external marshalling functions this will point to the Unmarshal function
 	IsMarshaler              bool        // Does the type implement graphql.Marshaler and graphql.Unmarshaler
-	IsJSONMarshaler          bool        // Does the type implement json.Marshaler and json.Unmarshaler
 	IsOmittable              bool        // Is the type wrapped with Omittable
 	IsContext                bool        // Is the Marshaler/Unmarshaller the context version; applies to either the method or interface variety.
 	PointersInUnmarshalInput bool        // Inverse values and pointers in return.
@@ -456,9 +455,6 @@ func (b *Binder) TypeReference(schemaType *ast.Type, bindTarget types.Type) (ret
 		} else if hasMethod(t, "MarshalGQL") && hasMethod(t, "UnmarshalGQL") {
 			ref.GO = t
 			ref.IsMarshaler = true
-		} else if hasMethod(t, "MarshalJSON") && hasMethod(t, "UnmarshalJSON") {
-			ref.GO = t
-			ref.IsJSONMarshaler = true
 		} else if underlying := basicUnderlying(t); def.IsLeafType() && underlying != nil && underlying.Kind() == types.String {
 			// TODO delete before v1. Backwards compatibility case for named types wrapping strings (see #595)
 

--- a/codegen/type.gotpl
+++ b/codegen/type.gotpl
@@ -89,14 +89,6 @@
 						err := res.UnmarshalGQL(v)
 					{{- end }}
 						return res, graphql.ErrorOnPath(ctx, err)
-				{{- else if $type.IsJSONMarshaler }}
-					{{- if and $type.IsNilable $type.Elem }}
-						var res = new({{ $type.Elem.GO | ref }})
-					{{- else}}
-						var res {{ $type.GO | ref }}
-					{{- end }}
-						err := res.UnmarshalJSON(v)
-						return res, graphql.ErrorOnPath(ctx, err)
 				{{- else }}
 					{{ if $useFunctionSyntaxForExecutionContext -}}
 					res, err := unmarshalInput{{ $type.GQL.Name }}(ctx, ec, v)


### PR DESCRIPTION
In gqlgen resolvers, we should use only graphql.Marshaler instead of json.Marshaler.

Fix https://github.com/99designs/gqlgen/pull/3663#issuecomment-2816974655

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
