### PR TITLE
fix: lower Go version requirement to 1.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/99designs/gqlgen
 
-go 1.23.8
+go 1.23.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.10.3


### PR DESCRIPTION
This should prevent compatibility issues with tools that are on 1.23 but not on the latest patch release there.