### PR TITLE
only allow whitespace after "url" in a link directive

### DIFF
--- a/api/generate.go
+++ b/api/generate.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	urlRegex     = regexp.MustCompile(`(?s)@link.*\(.*url:.*?"(.*?)"[^)]+\)`) // regex to grab the url of a link directive, should it exist
-	versionRegex = regexp.MustCompile(`v(\d+).(\d+)$`)                        // regex to grab the version number from a url
+	urlRegex     = regexp.MustCompile(`(?s)@link.*\(.*url:\s*?"(.*?)"[^)]+\)`) // regex to grab the url of a link directive, should it exist
+	versionRegex = regexp.MustCompile(`v(\d+).(\d+)$`)                         // regex to grab the version number from a url
 )
 
 func Generate(cfg *config.Config, option ...Option) error {


### PR DESCRIPTION
Okay, this is a fun one:

Currently, there is a bug where generation will fail in the case of:

1. After the link directive the string "url:" is present somewhere else
2. Then there is a double qoute in any way (likely to be encountered because of multiline comments)
3. After that there is a closing parenthesis somewhere (can found in comments and enclosing input parameters)


All of this is because of a bug in the regex for extracting the version of the federation from the url. It it fixed in this pr by only allowing whitespace to come between the "url" in the @link and its first double qoute.

Here is a minimal example showing it in action:

```gql
extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: [])

type Foo {
  url: String
}

"""
Multiline comment has double qoutes
"""
type Bar {
  field: String # A comment with a parenthesis (not good)
}

```

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ x ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
