### PR TITLE
Update gqlparser to add column for error string output

### DIFF
--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -38,3 +38,5 @@ require (
 )
 
 replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.5.0
+
+replace github.com/vektah/gqlparser/v2 => github.com/robmyersrobmyers/gqlparser/v2 v2.0.0-20250424065456-c67c9da91637

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/rs/cors v1.11.1
 	github.com/stretchr/testify v1.10.0
 	github.com/vektah/dataloaden v0.3.0
-	github.com/vektah/gqlparser/v2 v2.5.25
+	github.com/vektah/gqlparser/v2 v2.5.26
 	golang.org/x/sync v0.13.0
 
 )
@@ -38,5 +38,3 @@ require (
 )
 
 replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.5.0
-
-replace github.com/vektah/gqlparser/v2 => github.com/robmyersrobmyers/gqlparser/v2 v2.0.0-20250424065456-c67c9da91637

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -34,6 +34,8 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/robmyersrobmyers/gqlparser/v2 v2.0.0-20250424065456-c67c9da91637 h1:x87ikF2aS1LJsx3Ck/7OpOZUymFGH04adWkDwBtARLA=
+github.com/robmyersrobmyers/gqlparser/v2 v2.0.0-20250424065456-c67c9da91637/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
 github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
@@ -45,8 +47,6 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vektah/dataloaden v0.3.0 h1:ZfVN2QD6swgvp+tDqdH/OIT/wu3Dhu0cus0k5gIZS84=
 github.com/vektah/dataloaden v0.3.0/go.mod h1:/HUdMve7rvxZma+2ZELQeNh88+003LL7Pf/CZ089j8U=
-github.com/vektah/gqlparser/v2 v2.5.25 h1:FmWtFEa+invTIzWlWK6Vk7BVEZU/97QBzeI8Z1JjGt8=
-github.com/vektah/gqlparser/v2 v2.5.25/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
 golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -34,8 +34,6 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/robmyersrobmyers/gqlparser/v2 v2.0.0-20250424065456-c67c9da91637 h1:x87ikF2aS1LJsx3Ck/7OpOZUymFGH04adWkDwBtARLA=
-github.com/robmyersrobmyers/gqlparser/v2 v2.0.0-20250424065456-c67c9da91637/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
 github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
@@ -47,6 +45,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vektah/dataloaden v0.3.0 h1:ZfVN2QD6swgvp+tDqdH/OIT/wu3Dhu0cus0k5gIZS84=
 github.com/vektah/dataloaden v0.3.0/go.mod h1:/HUdMve7rvxZma+2ZELQeNh88+003LL7Pf/CZ089j8U=
+github.com/vektah/gqlparser/v2 v2.5.26 h1:REqqFkO8+SOEgZHR/eHScjjVjGS8Nk3RMO/juiTobN4=
+github.com/vektah/gqlparser/v2 v2.5.26/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
 golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=

--- a/go.mod
+++ b/go.mod
@@ -36,3 +36,5 @@ require (
 	golang.org/x/sync v0.13.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 )
+
+replace github.com/vektah/gqlparser/v2 => github.com/robmyersrobmyers/gqlparser/v2 v2.0.0-20250424065456-c67c9da91637

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/sosodev/duration v1.3.1
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.6
-	github.com/vektah/gqlparser/v2 v2.5.25
+	github.com/vektah/gqlparser/v2 v2.5.26
 	golang.org/x/text v0.24.0
 	golang.org/x/tools v0.32.0
 	google.golang.org/protobuf v1.36.6
@@ -36,5 +36,3 @@ require (
 	golang.org/x/sync v0.13.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 )
-
-replace github.com/vektah/gqlparser/v2 => github.com/robmyersrobmyers/gqlparser/v2 v2.0.0-20250424065456-c67c9da91637

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/robmyersrobmyers/gqlparser/v2 v2.0.0-20250424065456-c67c9da91637 h1:x87ikF2aS1LJsx3Ck/7OpOZUymFGH04adWkDwBtARLA=
-github.com/robmyersrobmyers/gqlparser/v2 v2.0.0-20250424065456-c67c9da91637/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
@@ -48,6 +46,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/urfave/cli/v2 v2.27.6 h1:VdRdS98FNhKZ8/Az8B7MTyGQmpIr36O1EHybx/LaZ4g=
 github.com/urfave/cli/v2 v2.27.6/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=
+github.com/vektah/gqlparser/v2 v2.5.26 h1:REqqFkO8+SOEgZHR/eHScjjVjGS8Nk3RMO/juiTobN4=
+github.com/vektah/gqlparser/v2 v2.5.26/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/robmyersrobmyers/gqlparser/v2 v2.0.0-20250424065456-c67c9da91637 h1:x87ikF2aS1LJsx3Ck/7OpOZUymFGH04adWkDwBtARLA=
+github.com/robmyersrobmyers/gqlparser/v2 v2.0.0-20250424065456-c67c9da91637/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
@@ -46,8 +48,6 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/urfave/cli/v2 v2.27.6 h1:VdRdS98FNhKZ8/Az8B7MTyGQmpIr36O1EHybx/LaZ4g=
 github.com/urfave/cli/v2 v2.27.6/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=
-github.com/vektah/gqlparser/v2 v2.5.25 h1:FmWtFEa+invTIzWlWK6Vk7BVEZU/97QBzeI8Z1JjGt8=
-github.com/vektah/gqlparser/v2 v2.5.25/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/graphql/executor/executor_test.go
+++ b/graphql/executor/executor_test.go
@@ -174,7 +174,7 @@ func TestExecutorDisableSuggestion(t *testing.T) {
 	t.Run("by default, the error message will include suggestions", func(t *testing.T) {
 		resp := query(exec, "", "{nam}")
 		assert.Empty(t, string(resp.Data))
-		assert.Equal(t, "input:1: Cannot query field \"nam\" on type \"Query\". Did you mean \"name\"?\n", resp.Errors.Error())
+		assert.Equal(t, "input:1:2: Cannot query field \"nam\" on type \"Query\". Did you mean \"name\"?\n", resp.Errors.Error())
 	})
 
 	t.Run("disable suggestion, the error message will not include suggestions", func(t *testing.T) {
@@ -182,13 +182,13 @@ func TestExecutorDisableSuggestion(t *testing.T) {
 		resp := query(exec, "", "{nam}")
 		assert.Empty(t, string(resp.Data))
 		assert.Len(t, resp.Errors, 1)
-		assert.Equal(t, "input:1: Cannot query field \"nam\" on type \"Query\".\n", resp.Errors.Error())
+		assert.Equal(t, "input:1:2: Cannot query field \"nam\" on type \"Query\".\n", resp.Errors.Error())
 
 		// check if the error message is displayed correctly even if an error occurs multiple times
 		resp = query(exec, "", "{nam}")
 		assert.Empty(t, string(resp.Data))
 		assert.Len(t, resp.Errors, 1)
-		assert.Equal(t, "input:1: Cannot query field \"nam\" on type \"Query\".\n", resp.Errors.Error())
+		assert.Equal(t, "input:1:2: Cannot query field \"nam\" on type \"Query\".\n", resp.Errors.Error())
 	})
 }
 

--- a/plugin/modelgen/out/generated.go
+++ b/plugin/modelgen/out/generated.go
@@ -11,6 +11,8 @@ import (
 	"github.com/99designs/gqlgen/plugin/modelgen/internal/extrafields"
 )
 
+// Add any new functions or any additional code/template functionality here
+
 type A interface {
 	IsA()
 	GetA() string

--- a/plugin/modelgen/out/generated_omit_root_models.go
+++ b/plugin/modelgen/out/generated_omit_root_models.go
@@ -3,6 +3,7 @@
 package out
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strconv"
@@ -51,4 +52,18 @@ func (e *SomeContent) UnmarshalGQL(v any) error {
 
 func (e SomeContent) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *SomeContent) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e SomeContent) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
 }

--- a/plugin/modelgen/out_enable_model_json_omitempty_tag_false/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitempty_tag_false/generated.go
@@ -3,6 +3,7 @@
 package out_enable_model_json_omitempty_tag_false
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strconv"
@@ -207,6 +208,11 @@ type OmitEmptyJSONTagTest struct {
 	Value       *string `json:"Value" database:"OmitEmptyJsonTagTestValue"`
 }
 
+type OmitZeroJSONTagTest struct {
+	ValueNonNil string  `json:"ValueNonNil" database:"OmitZeroJSONTagTestValueNonNil"`
+	Value       *string `json:"Value" database:"OmitZeroJSONTagTestValue"`
+}
+
 type Query struct {
 }
 
@@ -289,6 +295,20 @@ func (e EnumWithDescription) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e EnumWithDescription) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
 type MissingEnum string
 
 const (
@@ -328,4 +348,18 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *MissingEnum) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e MissingEnum) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
 }

--- a/plugin/modelgen/out_enable_model_json_omitempty_tag_false_omitzero_tag_false/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitempty_tag_false_omitzero_tag_false/generated.go
@@ -3,6 +3,7 @@
 package out_enable_model_json_omitempty_tag_false_omitzero_tag_false
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strconv"
@@ -294,6 +295,20 @@ func (e EnumWithDescription) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e EnumWithDescription) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
 type MissingEnum string
 
 const (
@@ -333,4 +348,18 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *MissingEnum) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e MissingEnum) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
 }

--- a/plugin/modelgen/out_enable_model_json_omitempty_tag_false_omitzero_tag_nil/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitempty_tag_false_omitzero_tag_nil/generated.go
@@ -3,6 +3,7 @@
 package out_enable_model_json_omitempty_tag_false_omitzero_tag_nil
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strconv"
@@ -294,6 +295,20 @@ func (e EnumWithDescription) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e EnumWithDescription) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
 type MissingEnum string
 
 const (
@@ -333,4 +348,18 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *MissingEnum) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e MissingEnum) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
 }

--- a/plugin/modelgen/out_enable_model_json_omitempty_tag_false_omitzero_tag_true/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitempty_tag_false_omitzero_tag_true/generated.go
@@ -3,6 +3,7 @@
 package out_enable_model_json_omitempty_tag_false_omitzero_tag_true
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strconv"
@@ -294,6 +295,20 @@ func (e EnumWithDescription) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e EnumWithDescription) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
 type MissingEnum string
 
 const (
@@ -333,4 +348,18 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *MissingEnum) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e MissingEnum) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
 }

--- a/plugin/modelgen/out_enable_model_json_omitempty_tag_nil/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitempty_tag_nil/generated.go
@@ -3,6 +3,7 @@
 package out_enable_model_json_omitempty_tag_nil
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strconv"
@@ -206,6 +207,11 @@ type OmitEmptyJSONTagTest struct {
 	Value       *string `json:"Value,omitempty" database:"OmitEmptyJsonTagTestValue"`
 }
 
+type OmitZeroJSONTagTest struct {
+	ValueNonNil string  `json:"ValueNonNil" database:"OmitZeroJSONTagTestValueNonNil"`
+	Value       *string `json:"Value,omitempty" database:"OmitZeroJSONTagTestValue"`
+}
+
 type Query struct {
 }
 
@@ -288,6 +294,20 @@ func (e EnumWithDescription) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e EnumWithDescription) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
 type MissingEnum string
 
 const (
@@ -327,4 +347,18 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *MissingEnum) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e MissingEnum) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
 }

--- a/plugin/modelgen/out_enable_model_json_omitempty_tag_true/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitempty_tag_true/generated.go
@@ -3,6 +3,7 @@
 package out_enable_model_json_omitempty_tag_true
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strconv"
@@ -207,6 +208,11 @@ type OmitEmptyJSONTagTest struct {
 	Value       *string `json:"Value,omitempty" database:"OmitEmptyJsonTagTestValue"`
 }
 
+type OmitZeroJSONTagTest struct {
+	ValueNonNil string  `json:"ValueNonNil" database:"OmitZeroJSONTagTestValueNonNil"`
+	Value       *string `json:"Value,omitempty" database:"OmitZeroJSONTagTestValue"`
+}
+
 type Query struct {
 }
 
@@ -289,6 +295,20 @@ func (e EnumWithDescription) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e EnumWithDescription) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
 type MissingEnum string
 
 const (
@@ -328,4 +348,18 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *MissingEnum) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e MissingEnum) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
 }

--- a/plugin/modelgen/out_enable_model_json_omitzero_tag_false/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitzero_tag_false/generated.go
@@ -3,6 +3,7 @@
 package out_enable_model_json_omitzero_tag_false
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strconv"
@@ -294,6 +295,20 @@ func (e EnumWithDescription) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e EnumWithDescription) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
 type MissingEnum string
 
 const (
@@ -333,4 +348,18 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *MissingEnum) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e MissingEnum) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
 }

--- a/plugin/modelgen/out_enable_model_json_omitzero_tag_nil/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitzero_tag_nil/generated.go
@@ -3,6 +3,7 @@
 package out_enable_model_json_omitzero_tag_nil
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strconv"
@@ -294,6 +295,20 @@ func (e EnumWithDescription) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e EnumWithDescription) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
 type MissingEnum string
 
 const (
@@ -333,4 +348,18 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *MissingEnum) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e MissingEnum) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
 }

--- a/plugin/modelgen/out_enable_model_json_omitzero_tag_true/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitzero_tag_true/generated.go
@@ -3,6 +3,7 @@
 package out_enable_model_json_omitzero_tag_true
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strconv"
@@ -294,6 +295,20 @@ func (e EnumWithDescription) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e EnumWithDescription) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
 type MissingEnum string
 
 const (
@@ -333,4 +348,18 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *MissingEnum) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e MissingEnum) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
 }

--- a/plugin/modelgen/out_nullable_input_omittable/generated.go
+++ b/plugin/modelgen/out_nullable_input_omittable/generated.go
@@ -3,6 +3,7 @@
 package out_nullable_input_omittable
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strconv"
@@ -206,6 +207,11 @@ type OmitEmptyJSONTagTest struct {
 	Value       *string `json:"Value,omitempty" database:"OmitEmptyJsonTagTestValue"`
 }
 
+type OmitZeroJSONTagTest struct {
+	ValueNonNil string  `json:"ValueNonNil" database:"OmitZeroJSONTagTestValueNonNil"`
+	Value       *string `json:"Value,omitempty" database:"OmitZeroJSONTagTestValue"`
+}
+
 type Query struct {
 }
 
@@ -288,6 +294,20 @@ func (e EnumWithDescription) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e EnumWithDescription) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
 type MissingEnum string
 
 const (
@@ -327,4 +347,18 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *MissingEnum) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e MissingEnum) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
 }

--- a/plugin/modelgen/out_struct_pointers/generated.go
+++ b/plugin/modelgen/out_struct_pointers/generated.go
@@ -3,6 +3,7 @@
 package out_struct_pointers
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strconv"
@@ -166,6 +167,11 @@ type OmitEmptyJSONTagTest struct {
 	Value       *string `json:"Value,omitempty" database:"OmitEmptyJsonTagTestValue"`
 }
 
+type OmitZeroJSONTagTest struct {
+	ValueNonNil string  `json:"ValueNonNil" database:"OmitZeroJSONTagTestValueNonNil"`
+	Value       *string `json:"Value,omitempty" database:"OmitZeroJSONTagTestValue"`
+}
+
 type Query struct {
 }
 
@@ -246,6 +252,20 @@ func (e EnumWithDescription) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e EnumWithDescription) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
 type MissingEnum string
 
 const (
@@ -285,4 +305,18 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *MissingEnum) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e MissingEnum) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
 }


### PR DESCRIPTION
Updates gqlparser to update the error string to output the column numbers (in addition to the line numbers).

This PR is for @StevenACoffman to demonstrate the impact of adding column numbers to the errors in gqlparser.  I had to update 3 test cases accordingly. 

[Related gqlparser ticket.](https://github.com/vektah/gqlparser/issues/367)

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
