### PR TITLE
Docs: add info on concurrent field resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ type User @goModel(model: "github.com/you/pkg/model.User") {
 }
 ```
 
+The field resolvers will be executed concurrently in separate goroutines.
+
 ### Can I change the type of the ID from type String to Type Int?
 
 Yes! You can by remapping it in config as seen below:

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ type User @goModel(model: "github.com/you/pkg/model.User") {
 }
 ```
 
-The field resolvers will be executed concurrently in separate goroutines.
+The field resolvers will be executed concurrently in separate goroutines. The degree of concurrency can be customized with the [`worker_limit` configuration attribute](https://gqlgen.com/config/).
 
 ### Can I change the type of the ID from type String to Type Int?
 


### PR DESCRIPTION
Documents the default (concurrent) behavior of field resolvers.
I was a little uncertain about this behavior, but i tried logging the go routine id in some test subresolvers and found that they were not identical. I suppose this is what was discussed here: https://github.com/99designs/gqlgen/pull/3203

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
