### PR TITLE
Allows to rewrite `writeJson` to customize headers according to graphql.Response

### DIFF
--- a/graphql/handler/transport/util.go
+++ b/graphql/handler/transport/util.go
@@ -3,29 +3,38 @@ package transport
 import (
 	"encoding/json"
 	"fmt"
-	"io"
+	"net/http"
 
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
 	"github.com/99designs/gqlgen/graphql"
 )
 
-func writeJson(w io.Writer, response *graphql.Response) {
+type JsonWriter interface {
+	WriteJson(*graphql.Response)
+}
+
+func writeJson(w http.ResponseWriter, response *graphql.Response) {
+	if jsonWriter, ok := w.(JsonWriter); ok {
+		jsonWriter.WriteJson(response)
+		return
+	}
+
 	b, err := json.Marshal(response)
 	if err != nil {
 		panic(fmt.Errorf("unable to marshal %s: %w", string(response.Data), err))
 	}
-	w.Write(b)
+	_, _ = w.Write(b)
 }
 
-func writeJsonError(w io.Writer, msg string) {
+func writeJsonError(w http.ResponseWriter, msg string) {
 	writeJson(w, &graphql.Response{Errors: gqlerror.List{{Message: msg}}})
 }
 
-func writeJsonErrorf(w io.Writer, format string, args ...any) {
+func writeJsonErrorf(w http.ResponseWriter, format string, args ...any) {
 	writeJson(w, &graphql.Response{Errors: gqlerror.List{{Message: fmt.Sprintf(format, args...)}}})
 }
 
-func writeJsonGraphqlError(w io.Writer, err ...*gqlerror.Error) {
+func writeJsonGraphqlError(w http.ResponseWriter, err ...*gqlerror.Error) {
 	writeJson(w, &graphql.Response{Errors: err})
 }

--- a/graphql/handler/transport/util_test.go
+++ b/graphql/handler/transport/util_test.go
@@ -1,0 +1,46 @@
+package transport_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/99designs/gqlgen/graphql/handler/testserver"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/stretchr/testify/assert"
+)
+
+type wrapTestServer struct {
+	*testserver.TestServer
+}
+
+type wrapWriter struct {
+	http.ResponseWriter
+}
+
+func (w *wrapWriter) WriteJson(response *graphql.Response) {
+	w.Header().Add("my-customized-header", "hello")
+	b, err := json.Marshal(response)
+	if err != nil {
+		panic(err)
+	}
+	_, _ = w.Write(b)
+}
+
+func (s *wrapTestServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	wrapWriter := &wrapWriter{w}
+	s.TestServer.ServeHTTP(wrapWriter, r)
+}
+
+func TestJSONWriter(t *testing.T) {
+	wrapServer := &wrapTestServer{TestServer: testserver.New()}
+	wrapServer.AddTransport(transport.GET{})
+
+	t.Run("allows to set the customized header", func(t *testing.T) {
+		resp := doRequest(wrapServer, "GET", "/graphql?query={name}", ``, "application/json", "application/json")
+		assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+		assert.Equal(t, "hello", resp.Header().Get("my-customized-header"))
+		assert.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
+	})
+}


### PR DESCRIPTION
This closes #3694

Currently, some of the transport allows adding fixed customized HTTP response headers.
But in our case, we would like to add dynamic headers based on GraphQL's response.
And as far as I know, it has no way to add dynamic headers(for example: operation/operation name)
unless we could hijack the `writeJson` method.

This PR exports a way to rewrite the `writeJson` method:

```Go

type JsonWriter interface {
	WriteJson(*graphql.Response)
}

func writeJson(w http.ResponseWriter, response *graphql.Response) {
	if jsonWriter, ok := w.(JsonWriter); ok {
		jsonWriter.WriteJson(response)
		return
	}

	b, err := json.Marshal(response)
	if err != nil {
		panic(fmt.Errorf("unable to marshal %s: %w", string(response.Data), err))
	}
	w.Write(b)
}
```

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
