### PR TITLE
Fix duplicated keys

### DIFF
--- a/graphql/fieldset.go
+++ b/graphql/fieldset.go
@@ -58,13 +58,18 @@ func (m *FieldSet) Dispatch(ctx context.Context) {
 
 func (m *FieldSet) MarshalGQL(writer io.Writer) {
 	writer.Write(openBrace)
+	writtenFields := make(map[string]bool, len(m.fields))
 	for i, field := range m.fields {
+		if writtenFields[field.Alias] {
+			continue
+		}
 		if i != 0 {
 			writer.Write(comma)
 		}
 		writeQuotedString(writer, field.Alias)
 		writer.Write(colon)
 		m.Values[i].MarshalGQL(writer)
+		writtenFields[field.Alias] = true
 	}
 	writer.Write(closeBrace)
 }

--- a/graphql/fieldset_test.go
+++ b/graphql/fieldset_test.go
@@ -1,0 +1,25 @@
+package graphql
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+func TestFieldSet_MarshalGQL(t *testing.T) {
+	t.Run("Should_Deduplicate_Keys", func(t *testing.T) {
+		fs := NewFieldSet([]CollectedField{
+			{Field: &ast.Field{Alias: "__typename"}},
+			{Field: &ast.Field{Alias: "__typename"}},
+		})
+		fs.Values[0] = MarshalString("A")
+		fs.Values[1] = MarshalString("A")
+
+		b := bytes.NewBuffer(nil)
+		fs.MarshalGQL(b)
+
+		assert.Equal(t, "{\"__typename\":\"A\"}", string(b.Bytes()))
+	})
+}


### PR DESCRIPTION
This is to add key deduplication logic to fix the related  [issue/3374](https://github.com/99designs/gqlgen/issues/3374).

Here's a screenshot of a test run from the repository https://github.com/dkempner/gqlgen-union-double-typename.

<img width="1499" alt="Screenshot 2025-05-30 at 11 31 49 PM" src="https://github.com/user-attachments/assets/7c68aaa4-4da3-43c5-a9f8-e172bfae7856" />

I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

This is to add key deduplication logic to fix the related  [issue/3374](https://github.com/99designs/gqlgen/issues/3374)
