### PR TITLE
Add an option to allow using `appliation/json` on wildcard accept header

### DIFF
--- a/graphql/handler/transport/headers.go
+++ b/graphql/handler/transport/headers.go
@@ -11,7 +11,7 @@ const (
 	acceptApplicationGraphqlResponseJson = "application/graphql-response+json"
 )
 
-func determineResponseContentType(explicitHeaders map[string][]string, r *http.Request) string {
+func determineResponseContentType(explicitHeaders map[string][]string, r *http.Request, useGrapQLResponseJsonByDefault bool) string {
 	for k, v := range explicitHeaders {
 		if strings.EqualFold(k, "Content-Type") {
 			return v[0]
@@ -19,9 +19,10 @@ func determineResponseContentType(explicitHeaders map[string][]string, r *http.R
 	}
 
 	accept := r.Header.Get("Accept")
-	// TODO(steve): Consider adding config option to opt-in to
-	// default "application/graphql-response+json"
 	if accept == "" {
+		if useGrapQLResponseJsonByDefault {
+			return acceptApplicationGraphqlResponseJson
+		}
 		return acceptApplicationJson
 	}
 
@@ -32,7 +33,10 @@ func determineResponseContentType(explicitHeaders map[string][]string, r *http.R
 		}
 		switch mediaType {
 		case "*/*", "application/*":
-			return acceptApplicationGraphqlResponseJson
+			if useGrapQLResponseJsonByDefault {
+				return acceptApplicationGraphqlResponseJson
+			}
+			return acceptApplicationJson
 		case "application/json":
 			return acceptApplicationJson
 		case "application/graphql-response+json":

--- a/graphql/handler/transport/http_get.go
+++ b/graphql/handler/transport/http_get.go
@@ -20,6 +20,9 @@ type GET struct {
 	// Map of all headers that are added to graphql response. If not
 	// set, only one header: Content-Type: application/graphql-response+json will be set.
 	ResponseHeaders map[string][]string
+	// UseGrapQLResponseJsonByDefault determines whether to use 'application/graphql-response+json' as the response content type
+	// when the Accept header is empty or 'application/*' or '*/*'.
+	UseGrapQLResponseJsonByDefault bool
 }
 
 var _ graphql.Transport = GET{}
@@ -39,7 +42,7 @@ func (h GET) Do(w http.ResponseWriter, r *http.Request, exec graphql.GraphExecut
 		writeJsonError(w, err.Error())
 		return
 	}
-	contentType := determineResponseContentType(h.ResponseHeaders, r)
+	contentType := determineResponseContentType(h.ResponseHeaders, r, h.UseGrapQLResponseJsonByDefault)
 	responseHeaders := mergeHeaders(
 		map[string][]string{
 			"Content-Type": {contentType},

--- a/graphql/handler/transport/http_post.go
+++ b/graphql/handler/transport/http_post.go
@@ -19,6 +19,10 @@ type POST struct {
 	// Map of all headers that are added to graphql response. If not
 	// set, only one header: Content-Type: application/graphql-response+json will be set.
 	ResponseHeaders map[string][]string
+
+	// UseGrapQLResponseJsonByDefault determines whether to use 'application/graphql-response+json' as the response content type
+	// when the Accept header is empty or 'application/*' or '*/*'.
+	UseGrapQLResponseJsonByDefault bool
 }
 
 var _ graphql.Transport = POST{}
@@ -55,7 +59,7 @@ var pool = sync.Pool{
 
 func (h POST) Do(w http.ResponseWriter, r *http.Request, exec graphql.GraphExecutor) {
 	ctx := r.Context()
-	contentType := determineResponseContentType(h.ResponseHeaders, r)
+	contentType := determineResponseContentType(h.ResponseHeaders, r, h.UseGrapQLResponseJsonByDefault)
 	responseHeaders := mergeHeaders(
 		map[string][]string{
 			"Content-Type": {contentType},


### PR DESCRIPTION
This closes #3712.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
