### PR TITLE
Update github.com/vektah/gqlparser/v2@v2.5.28

### DIFF
--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/rs/cors v1.11.1
 	github.com/stretchr/testify v1.10.0
 	github.com/vektah/dataloaden v0.3.0
-	github.com/vektah/gqlparser/v2 v2.5.27
+	github.com/vektah/gqlparser/v2 v2.5.28
 	golang.org/x/sync v0.15.0
 )
 

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -45,8 +45,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vektah/dataloaden v0.3.0 h1:ZfVN2QD6swgvp+tDqdH/OIT/wu3Dhu0cus0k5gIZS84=
 github.com/vektah/dataloaden v0.3.0/go.mod h1:/HUdMve7rvxZma+2ZELQeNh88+003LL7Pf/CZ089j8U=
-github.com/vektah/gqlparser/v2 v2.5.27 h1:RHPD3JOplpk5mP5JGX8RKZkt2/Vwj/PZv0HxTdwFp0s=
-github.com/vektah/gqlparser/v2 v2.5.27/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
+github.com/vektah/gqlparser/v2 v2.5.28 h1:bIulcl3LF69ba6EiZVGD88y4MkM+Jxrf3P2MX8xLRkY=
+github.com/vektah/gqlparser/v2 v2.5.28/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/mod v0.25.0 h1:n7a+ZbQKQA/Ysbyb0/6IbB1H/X41mKgbhfv7AfG/44w=
 golang.org/x/mod v0.25.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=

--- a/bin/update_gqlparser.sh
+++ b/bin/update_gqlparser.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# this script will update gqlparser to the latest version (because we do it frequently)
+# and make a new branch
+gh-find-latest() {
+  local owner=$1 project=$2
+  local output_directory=${3:-$owner-$project-release}
+  local release_url=$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/$owner/$project/releases/latest)
+  export release_tag=$(basename $release_url)
+}
+
+# Get Release tag
+gh-find-latest vektah gqlparser
+echo "Latest Release is ${release_tag}"
+
+export branchName="update_gqlparser_v2_${release_tag}"
+echo "${branchName}"
+sanitized_branch_name=$(echo ${branchName} | sed -E 's/\s+/\s/g' | sed -E 's/\./_/g')
+echo "${sanitized_branch_name}"
+git checkout -b "${sanitized_branch_name}"
+
+go get github.com/vektah/gqlparser/v2@${release_tag}
+go mod tidy
+cd _examples
+go get github.com/vektah/gqlparser/v2@${release_tag}
+go mod tidy
+cd ..
+git commit -s -S -am "Update github.com/vektah/gqlparser/v2@${release_tag}"
+go generate ./...
+git commit -s -S -am "Re-generate after update"
+
+gh pr create --title "Update gqlparser to $(gh release view -R vektah/gqlparser --json tagName --jq .tagName)" --body "Automated update of gqlparser. See $(gh release view -R vektah/gqlparser --json url --jq .url)" --base "master"
+echo done
+
+
+#gh release list --json name,isLatest --jq '.[] | select(.isLatest)|.name'

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/sosodev/duration v1.3.1
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.6
-	github.com/vektah/gqlparser/v2 v2.5.27
+	github.com/vektah/gqlparser/v2 v2.5.28
 	golang.org/x/text v0.26.0
 	golang.org/x/tools v0.34.0
 	google.golang.org/protobuf v1.36.6

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/urfave/cli/v2 v2.27.6 h1:VdRdS98FNhKZ8/Az8B7MTyGQmpIr36O1EHybx/LaZ4g=
 github.com/urfave/cli/v2 v2.27.6/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=
-github.com/vektah/gqlparser/v2 v2.5.27 h1:RHPD3JOplpk5mP5JGX8RKZkt2/Vwj/PZv0HxTdwFp0s=
-github.com/vektah/gqlparser/v2 v2.5.27/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
+github.com/vektah/gqlparser/v2 v2.5.28 h1:bIulcl3LF69ba6EiZVGD88y4MkM+Jxrf3P2MX8xLRkY=
+github.com/vektah/gqlparser/v2 v2.5.28/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=


### PR DESCRIPTION
## What's Changed in github.com/vektah/gqlparser/v2@v2.5.28
* fix: ErrorPosf() handle nil Position input by @robmyersrobmyers in https://github.com/vektah/gqlparser/pull/376
* Fix formatter when schema uses a mix of custom and default root opera… by @ascherkus in https://github.com/vektah/gqlparser/pull/374
* Bump the actions-deps group in /validator/imported with 2 updates by @dependabot in https://github.com/vektah/gqlparser/pull/372
* Bump @babel/core from 7.27.1 to 7.27.4 in /validator/imported in the actions-deps group by @dependabot in https://github.com/vektah/gqlparser/pull/373

## New Contributors
* @ascherkus made their first contribution in https://github.com/vektah/gqlparser/pull/374

**Full Changelog**: https://github.com/vektah/gqlparser/compare/v2.5.27...v2.5.28

Signed-off-by: Steve Coffman <steve@khanacademy.org>
