### PR TITLE
Improve gqlgen performance by bulking name only package loads

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -68,6 +68,14 @@ type Config struct {
 
 var cfgFilenames = []string{".gqlgen.yml", "gqlgen.yml", "gqlgen.yaml"}
 
+// templatePackageNames is a list of packages names that the default templates use, in order to preload those for performance considerations
+// any additional package added to the base templates should be added here to improve performance and load all packages in bulk
+var templatePackageNames = []string{
+	"context", "fmt", "io", "strconv", "time", "sync", "strings", "sync/atomic", "embed", "golang.org/x/sync/semaphore",
+	"errors", "bytes", "github.com/vektah/gqlparser/v2", "github.com/vektah/gqlparser/v2/ast",
+	"github.com/99designs/gqlgen/graphql", "github.com/99designs/gqlgen/graphql/introspection",
+}
+
 // DefaultConfig creates a copy of the default config
 func DefaultConfig() *Config {
 	falseValue := false
@@ -235,6 +243,7 @@ func (c *Config) Init() error {
 		c.Packages = code.NewPackages(
 			code.WithBuildTags(c.GoBuildTags...),
 			code.PackagePrefixToCache("github.com/99designs/gqlgen/graphql"),
+			code.WithPreloadNames(templatePackageNames...),
 		)
 	}
 
@@ -881,6 +890,7 @@ func (c *Config) LoadSchema() error {
 		c.Packages = code.NewPackages(
 			code.WithBuildTags(c.GoBuildTags...),
 			code.PackagePrefixToCache("github.com/99designs/gqlgen/graphql"),
+			code.WithPreloadNames(templatePackageNames...),
 		)
 	}
 

--- a/internal/code/packages.go
+++ b/internal/code/packages.go
@@ -229,6 +229,10 @@ func (p *Packages) LoadAllNames(importPaths ...string) {
 		}
 
 		for _, pkg := range pkgs {
+			if pkg.Name == "" {
+				pkg.Name = SanitizePackageName(filepath.Base(pkg.PkgPath))
+			}
+
 			p.importToName[pkg.PkgPath] = pkg.Name
 		}
 	}
@@ -238,12 +242,8 @@ func (p *Packages) LoadAllNames(importPaths ...string) {
 func (p *Packages) NameForPackage(importPath string) string {
 	p.numNameCalls++
 	p.LoadAllNames(importPath)
-	name := p.importToName[importPath]
-	if name == "" {
-		return SanitizePackageName(filepath.Base(importPath))
-	}
 
-	return name
+	return p.importToName[importPath]
 }
 
 // Evict removes a given package import path from the cache. Further calls to Load will fetch it from disk.

--- a/internal/code/packages_test.go
+++ b/internal/code/packages_test.go
@@ -68,6 +68,18 @@ func TestNameForPackage(t *testing.T) {
 	assert.Equal(t, "github_com", p.NameForPackage("github.com"))
 }
 
+func TestLoadAllNames(t *testing.T) {
+	var p Packages
+
+	p.LoadAllNames("github.com/99designs/gqlgen/api", "github.com/99designs/gqlgen/docs", "github.com")
+
+	// should now be cached
+	assert.Equal(t, 0, p.numNameCalls)
+	assert.Equal(t, "api", p.importToName["github.com/99designs/gqlgen/api"])
+	assert.Equal(t, "docs", p.importToName["github.com/99designs/gqlgen/docs"])
+	assert.Equal(t, "github_com", p.importToName["github.com"])
+}
+
 func initialState(t *testing.T, opts ...Option) *Packages {
 	p := NewPackages(opts...)
 	pkgs := p.LoadAll(

--- a/plugin/resolvergen/resolver.go
+++ b/plugin/resolvergen/resolver.go
@@ -187,10 +187,17 @@ func (m *Plugin) generatePerSchema(data *codegen.Data) error {
 		}
 	}
 
+	var allImports []string
 	for _, file := range files {
 		file.imports = rewriter.ExistingImports(file.name)
 		file.RemainingSource = rewriter.RemainingSource(file.name)
+
+		for _, i := range file.imports {
+			allImports = append(allImports, i.ImportPath)
+		}
 	}
+	data.Config.Packages.LoadAllNames(allImports...) // Preload all names in one Load call for performance reasons
+
 	newResolverTemplate := resolverTemplate
 	if data.Config.Resolver.ResolverTemplate != "" {
 		newResolverTemplate = readResolverTemplate(data.Config.Resolver.ResolverTemplate)


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

This is a performance improvement set to bulk load packages wherever possible - it has major performance implications - in a large monorepo it improved generation time from 1:30m to 24s

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
