### PR TITLE
fix use_function_syntax_for_execution_context with @goEnum/@goModel

### DIFF
--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -308,6 +308,10 @@ func (ref *TypeReference) MarshalFunc() string {
 	return "marshal" + ref.UniquenessKey()
 }
 
+func (ref *TypeReference) MarshalFuncFunctionSyntax() string {
+	return ref.MarshalFunc() + "F"
+}
+
 func (ref *TypeReference) UnmarshalFunc() string {
 	if ref.Definition == nil {
 		panic(errors.New("Definition missing for " + ref.GQL.Name()))
@@ -318,6 +322,10 @@ func (ref *TypeReference) UnmarshalFunc() string {
 	}
 
 	return "unmarshal" + ref.UniquenessKey()
+}
+
+func (ref *TypeReference) UnmarshalFuncFunctionSyntax() string {
+	return ref.UnmarshalFunc() + "F"
 }
 
 func (ref *TypeReference) IsTargetNilable() bool {

--- a/codegen/testserver/usefunctionsyntaxforexecutioncontext/generated.go
+++ b/codegen/testserver/usefunctionsyntaxforexecutioncontext/generated.go
@@ -1878,9 +1878,9 @@ func _User_role(ctx context.Context, ec *executionContext, field graphql.Collect
 		}
 		return graphql.Null
 	}
-	res := resTmp.(Role)
+	res := resTmp.(RoleModel)
 	fc.Result = res
-	return marshalNRole2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRole(ctx, ec, field.Selections, res)
+	return marshalNRole2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModel(ctx, ec, field.Selections, res)
 }
 
 func fieldContext_User_role(_ context.Context, ec *executionContext, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -3929,7 +3929,7 @@ func unmarshalInputCreateUserInput(ctx context.Context, ec *executionContext, ob
 			it.Age = data
 		case "role":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("role"))
-			data, err := unmarshalORole2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRole(ctx, ec, v)
+			data, err := unmarshalORole2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModel(ctx, ec, v)
 			if err != nil {
 				return it, err
 			}
@@ -3981,7 +3981,7 @@ func unmarshalInputUserFilter(ctx context.Context, ec *executionContext, obj any
 			it.Age = data
 		case "roles":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("roles"))
-			data, err := unmarshalORole2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleᚄ(ctx, ec, v)
+			data, err := unmarshalORole2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModelᚄ(ctx, ec, v)
 			if err != nil {
 				return it, err
 			}
@@ -4752,15 +4752,35 @@ func marshalNMutationResponse2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋt
 	return _MutationResponse(ctx, ec, sel, v)
 }
 
-func unmarshalNRole2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRole(ctx context.Context, ec *executionContext, v any) (Role, error) {
-	var res Role
-	err := res.UnmarshalGQL(v)
+func unmarshalNRole2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModel(ctx context.Context, ec *executionContext, v any) (RoleModel, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalNRole2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModelF[tmp]
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func marshalNRole2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRole(ctx context.Context, ec *executionContext, sel ast.SelectionSet, v Role) graphql.Marshaler {
-	return v
+func marshalNRole2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModel(ctx context.Context, ec *executionContext, sel ast.SelectionSet, v RoleModel) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(marshalNRole2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModelF[v])
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
 }
+
+var (
+	unmarshalNRole2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModelF = map[string]RoleModel{
+		"ADMIN": RoleModelAdmin,
+		"USER":  RoleModelUser,
+		"GUEST": RoleModelGuest,
+	}
+	marshalNRole2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModelF = map[RoleModel]string{
+		RoleModelAdmin: "ADMIN",
+		RoleModelUser:  "USER",
+		RoleModelGuest: "GUEST",
+	}
+)
 
 func unmarshalNString2string(ctx context.Context, ec *executionContext, v any) (string, error) {
 	res, err := graphql.UnmarshalString(v)
@@ -5192,17 +5212,17 @@ func marshalOInt2ᚖint(ctx context.Context, ec *executionContext, sel ast.Selec
 	return res
 }
 
-func unmarshalORole2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleᚄ(ctx context.Context, ec *executionContext, v any) ([]Role, error) {
+func unmarshalORole2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModelᚄ(ctx context.Context, ec *executionContext, v any) ([]RoleModel, error) {
 	if v == nil {
 		return nil, nil
 	}
 	var vSlice []any
 	vSlice = graphql.CoerceList(v)
 	var err error
-	res := make([]Role, len(vSlice))
+	res := make([]RoleModel, len(vSlice))
 	for i := range vSlice {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = unmarshalNRole2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRole(ctx, ec, vSlice[i])
+		res[i], err = unmarshalNRole2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModel(ctx, ec, vSlice[i])
 		if err != nil {
 			return nil, err
 		}
@@ -5210,7 +5230,7 @@ func unmarshalORole2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserver�
 	return res, nil
 }
 
-func marshalORole2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleᚄ(ctx context.Context, ec *executionContext, sel ast.SelectionSet, v []Role) graphql.Marshaler {
+func marshalORole2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModelᚄ(ctx context.Context, ec *executionContext, sel ast.SelectionSet, v []RoleModel) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
@@ -5237,7 +5257,7 @@ func marshalORole2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋ
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = marshalNRole2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRole(ctx, ec, sel, v[i])
+			ret[i] = marshalNRole2githubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModel(ctx, ec, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -5257,20 +5277,85 @@ func marshalORole2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋ
 	return ret
 }
 
-func unmarshalORole2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRole(ctx context.Context, ec *executionContext, v any) (*Role, error) {
+var (
+	unmarshalORole2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModelᚄF = map[string]RoleModel{
+		"ADMIN": RoleModelAdmin,
+		"USER":  RoleModelUser,
+		"GUEST": RoleModelGuest,
+	}
+	marshalORole2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModelᚄF = map[RoleModel]string{
+		RoleModelAdmin: "ADMIN",
+		RoleModelUser:  "USER",
+		RoleModelGuest: "GUEST",
+	}
+)
+
+func unmarshalORole2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModel(ctx context.Context, ec *executionContext, v any) (*RoleModel, error) {
 	if v == nil {
 		return nil, nil
 	}
-	var res = new(Role)
-	err := res.UnmarshalGQL(v)
-	return res, graphql.ErrorOnPath(ctx, err)
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalORole2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModelF[tmp]
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func marshalORole2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRole(ctx context.Context, ec *executionContext, sel ast.SelectionSet, v *Role) graphql.Marshaler {
+func marshalORole2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModel(ctx context.Context, ec *executionContext, sel ast.SelectionSet, v *RoleModel) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
-	return v
+	_ = sel
+	_ = ctx
+	res := graphql.MarshalString(marshalORole2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModelF[*v])
+	return res
+}
+
+var (
+	unmarshalORole2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModelF = map[string]RoleModel{
+		"ADMIN": RoleModelAdmin,
+		"USER":  RoleModelUser,
+		"GUEST": RoleModelGuest,
+	}
+	marshalORole2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModelF = map[RoleModel]string{
+		RoleModelAdmin: "ADMIN",
+		RoleModelUser:  "USER",
+		RoleModelGuest: "GUEST",
+	}
+)
+
+func unmarshalOString2ᚕstringᚄ(ctx context.Context, ec *executionContext, v any) ([]string, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]string, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = unmarshalNString2string(ctx, ec, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func marshalOString2ᚕstringᚄ(ctx context.Context, ec *executionContext, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = marshalNString2string(ctx, ec, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func unmarshalOString2ᚖstring(ctx context.Context, ec *executionContext, v any) (*string, error) {

--- a/codegen/testserver/usefunctionsyntaxforexecutioncontext/generated_test.go
+++ b/codegen/testserver/usefunctionsyntaxforexecutioncontext/generated_test.go
@@ -35,7 +35,7 @@ func TestQuery(t *testing.T) {
 			Name:      "test",
 			Email:     "testEmail",
 			Age:       testAge,
-			Role:      "ADMIN",
+			Role:      RoleModelAdmin,
 			CreatedAt: &createdAt,
 		}, nil
 	}
@@ -47,7 +47,7 @@ func TestQuery(t *testing.T) {
 				Name:      "test1",
 				Email:     "testEmail",
 				Age:       testAge,
-				Role:      "ADMIN",
+				Role:      RoleModelAdmin,
 				CreatedAt: &createdAt,
 			},
 			{
@@ -55,7 +55,7 @@ func TestQuery(t *testing.T) {
 				Name:      "test2",
 				Email:     "testEmail",
 				Age:       testAge,
-				Role:      "ADMIN",
+				Role:      RoleModelAdmin,
 				CreatedAt: &createdAt,
 			},
 		}, nil

--- a/codegen/testserver/usefunctionsyntaxforexecutioncontext/models-gen.go
+++ b/codegen/testserver/usefunctionsyntaxforexecutioncontext/models-gen.go
@@ -2,13 +2,6 @@
 
 package usefunctionsyntaxforexecutioncontext
 
-import (
-	"bytes"
-	"fmt"
-	"io"
-	"strconv"
-)
-
 type Entity interface {
 	IsEntity()
 	GetID() string
@@ -27,10 +20,10 @@ func (this Admin) GetID() string         { return this.ID }
 func (this Admin) GetCreatedAt() *string { return this.CreatedAt }
 
 type CreateUserInput struct {
-	Name  string `json:"name"`
-	Email string `json:"email"`
-	Age   *int   `json:"age,omitempty"`
-	Role  *Role  `json:"role,omitempty"`
+	Name  string     `json:"name"`
+	Email string     `json:"email"`
+	Age   *int       `json:"age,omitempty"`
+	Role  *RoleModel `json:"role,omitempty"`
 }
 
 type Mutation struct {
@@ -48,12 +41,12 @@ type Subscription struct {
 }
 
 type User struct {
-	ID        string  `json:"id"`
-	Name      string  `json:"name"`
-	Email     string  `json:"email"`
-	Age       *int    `json:"age,omitempty"`
-	Role      Role    `json:"role"`
-	CreatedAt *string `json:"createdAt,omitempty"`
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Email     string    `json:"email"`
+	Age       *int      `json:"age,omitempty"`
+	Role      RoleModel `json:"role"`
+	CreatedAt *string   `json:"createdAt,omitempty"`
 }
 
 func (User) IsEntity()                  {}
@@ -61,66 +54,9 @@ func (this User) GetID() string         { return this.ID }
 func (this User) GetCreatedAt() *string { return this.CreatedAt }
 
 type UserFilter struct {
-	Name     *string `json:"name,omitempty"`
-	Email    *string `json:"email,omitempty"`
-	Age      *int    `json:"age,omitempty"`
-	Roles    []Role  `json:"roles,omitempty"`
-	IsActive *bool   `json:"isActive,omitempty"`
-}
-
-type Role string
-
-const (
-	RoleAdmin Role = "ADMIN"
-	RoleUser  Role = "USER"
-	RoleGuest Role = "GUEST"
-)
-
-var AllRole = []Role{
-	RoleAdmin,
-	RoleUser,
-	RoleGuest,
-}
-
-func (e Role) IsValid() bool {
-	switch e {
-	case RoleAdmin, RoleUser, RoleGuest:
-		return true
-	}
-	return false
-}
-
-func (e Role) String() string {
-	return string(e)
-}
-
-func (e *Role) UnmarshalGQL(v any) error {
-	str, ok := v.(string)
-	if !ok {
-		return fmt.Errorf("enums must be strings")
-	}
-
-	*e = Role(str)
-	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid Role", str)
-	}
-	return nil
-}
-
-func (e Role) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
-}
-
-func (e *Role) UnmarshalJSON(b []byte) error {
-	s, err := strconv.Unquote(string(b))
-	if err != nil {
-		return err
-	}
-	return e.UnmarshalGQL(s)
-}
-
-func (e Role) MarshalJSON() ([]byte, error) {
-	var buf bytes.Buffer
-	e.MarshalGQL(&buf)
-	return buf.Bytes(), nil
+	Name     *string     `json:"name,omitempty"`
+	Email    *string     `json:"email,omitempty"`
+	Age      *int        `json:"age,omitempty"`
+	Roles    []RoleModel `json:"roles,omitempty"`
+	IsActive *bool       `json:"isActive,omitempty"`
 }

--- a/codegen/testserver/usefunctionsyntaxforexecutioncontext/models.go
+++ b/codegen/testserver/usefunctionsyntaxforexecutioncontext/models.go
@@ -1,0 +1,9 @@
+package usefunctionsyntaxforexecutioncontext
+
+type RoleModel string
+
+var (
+	RoleModelAdmin RoleModel = "admin"
+	RoleModelUser  RoleModel = "user"
+	RoleModelGuest RoleModel = "guest"
+)

--- a/codegen/testserver/usefunctionsyntaxforexecutioncontext/models.go
+++ b/codegen/testserver/usefunctionsyntaxforexecutioncontext/models.go
@@ -3,7 +3,7 @@ package usefunctionsyntaxforexecutioncontext
 type RoleModel string
 
 var (
-	RoleModelAdmin RoleModel = "admin"
-	RoleModelUser  RoleModel = "user"
-	RoleModelGuest RoleModel = "guest"
+	RoleModelAdmin RoleModel = "ADMIN"
+	RoleModelUser  RoleModel = "USER"
+	RoleModelGuest RoleModel = "GUEST"
 )

--- a/codegen/testserver/usefunctionsyntaxforexecutioncontext/test.graphql
+++ b/codegen/testserver/usefunctionsyntaxforexecutioncontext/test.graphql
@@ -1,14 +1,19 @@
 # Custom directive to log field access (limited to fields, not input fields)
 directive @log(message: String) on FIELD_DEFINITION
+directive @goModel(
+    model: String
+    models: [String!]
+) on OBJECT | INPUT_OBJECT | SCALAR | ENUM | INTERFACE | UNION
+directive @goEnum(value: String) on ENUM_VALUE
 
 # Custom scalar for Date
 scalar Date
 
 # Enum for user roles
-enum Role {
-  ADMIN
-  USER
-  GUEST
+enum Role @goModel(model: "github.com/99designs/gqlgen/codegen/testserver/usefunctionsyntaxforexecutioncontext.RoleModel") {
+  ADMIN @goEnum(value: "github.com/99designs/gqlgen/codegen/testserver/usefunctionsyntaxforexecutioncontext.RoleModelAdmin")
+  USER @goEnum(value: "github.com/99designs/gqlgen/codegen/testserver/usefunctionsyntaxforexecutioncontext.RoleModelUser")
+  GUEST @goEnum(value: "github.com/99designs/gqlgen/codegen/testserver/usefunctionsyntaxforexecutioncontext.RoleModelGuest")
 }
 
 # Interface representing an Entity with common fields

--- a/codegen/type.gotpl
+++ b/codegen/type.gotpl
@@ -51,7 +51,11 @@
 				{{- if $type.Unmarshaler }}
 					{{- if $type.HasEnumValues }}
 						tmp, err := {{ $type.Unmarshaler | call }}(v)
+						{{ if $useFunctionSyntaxForExecutionContext -}}
+						res := {{ $type.UnmarshalFuncFunctionSyntax }}[tmp]
+						{{- else -}}
 						res := {{ $type.UnmarshalFunc }}[tmp]
+						{{- end -}}
 					{{- else if $type.CastType }}
 						{{- if $type.IsContext }}
 							tmp, err := {{ $type.Unmarshaler | call }}(ctx, v)
@@ -237,7 +241,11 @@
 						{{- $v = "*v" }}
 					{{- end }}
 					{{- if $type.HasEnumValues }}
+						{{- if $useFunctionSyntaxForExecutionContext -}}
+						{{- $v = printf "%v[%v]" $type.MarshalFuncFunctionSyntax $v }}
+						{{- else -}}
 						{{- $v = printf "%v[%v]" $type.MarshalFunc $v }}
+						{{- end -}}
 					{{- else if $type.CastType }}
 						{{- $v = printf "%v(%v)" ($type.CastType | ref) $v}}
 					{{- end }}
@@ -286,12 +294,20 @@
 		{{- $enum = $type.GO.Elem }}
 	{{- end }}
 	var (
+		{{ if $useFunctionSyntaxForExecutionContext -}}
+		{{ $type.UnmarshalFuncFunctionSyntax }} = map[string]{{ $enum | ref }}{
+		{{- else -}}
 		{{ $type.UnmarshalFunc }} = map[string]{{ $enum | ref }}{
+		{{- end -}}
 		{{- range $value := $type.EnumValues }}
 			"{{ $value.Definition.Name }}": {{ $value.Object | obj }},
 		{{- end }}
 		}
+		{{ if $useFunctionSyntaxForExecutionContext -}}
+		{{ $type.MarshalFuncFunctionSyntax }} = map[{{ $enum | ref }}]string{
+		{{- else -}}
 		{{ $type.MarshalFunc }} = map[{{ $enum | ref }}]string{
+		{{- end -}}
 		{{- range $value := $type.EnumValues }}
 			 {{ $value.Object | obj }}: "{{ $value.Definition.Name }}",
 		{{- end }}


### PR DESCRIPTION
Adds a fix for #3605
to allow using both the use_function_syntax_for_execution_context option with binding enums to types with `@goModel` and `@goEnum` by creating a unique type for marshal/unmarshal of these enums.

Describe your PR and link to any relevant issues. 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
