### PR TITLE
Update github.com/vektah/gqlparser/v2 to v2.5.30

### DIFF
--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/rs/cors v1.11.1
 	github.com/stretchr/testify v1.10.0
 	github.com/vektah/dataloaden v0.3.0
-	github.com/vektah/gqlparser/v2 v2.5.28
+	github.com/vektah/gqlparser/v2 v2.5.29
 	golang.org/x/sync v0.15.0
 )
 

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/rs/cors v1.11.1
 	github.com/stretchr/testify v1.10.0
 	github.com/vektah/dataloaden v0.3.0
-	github.com/vektah/gqlparser/v2 v2.5.29
+	github.com/vektah/gqlparser/v2 v2.5.30
 	golang.org/x/sync v0.15.0
 )
 

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -45,8 +45,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vektah/dataloaden v0.3.0 h1:ZfVN2QD6swgvp+tDqdH/OIT/wu3Dhu0cus0k5gIZS84=
 github.com/vektah/dataloaden v0.3.0/go.mod h1:/HUdMve7rvxZma+2ZELQeNh88+003LL7Pf/CZ089j8U=
-github.com/vektah/gqlparser/v2 v2.5.28 h1:bIulcl3LF69ba6EiZVGD88y4MkM+Jxrf3P2MX8xLRkY=
-github.com/vektah/gqlparser/v2 v2.5.28/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
+github.com/vektah/gqlparser/v2 v2.5.29 h1:ARb8SP46rxa+VVKMbJ6s/JsAEdjq9eJ83tUOZZa9YHw=
+github.com/vektah/gqlparser/v2 v2.5.29/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/mod v0.25.0 h1:n7a+ZbQKQA/Ysbyb0/6IbB1H/X41mKgbhfv7AfG/44w=
 golang.org/x/mod v0.25.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -45,8 +45,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vektah/dataloaden v0.3.0 h1:ZfVN2QD6swgvp+tDqdH/OIT/wu3Dhu0cus0k5gIZS84=
 github.com/vektah/dataloaden v0.3.0/go.mod h1:/HUdMve7rvxZma+2ZELQeNh88+003LL7Pf/CZ089j8U=
-github.com/vektah/gqlparser/v2 v2.5.29 h1:ARb8SP46rxa+VVKMbJ6s/JsAEdjq9eJ83tUOZZa9YHw=
-github.com/vektah/gqlparser/v2 v2.5.29/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
+github.com/vektah/gqlparser/v2 v2.5.30 h1:EqLwGAFLIzt1wpx1IPpY67DwUujF1OfzgEyDsLrN6kE=
+github.com/vektah/gqlparser/v2 v2.5.30/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/mod v0.25.0 h1:n7a+ZbQKQA/Ysbyb0/6IbB1H/X41mKgbhfv7AfG/44w=
 golang.org/x/mod v0.25.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=

--- a/bin/fmt.sh
+++ b/bin/fmt.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Script to format files and regenerate
+set -o errexit
+set -o nounset
+set -o xtrace
+set -o pipefail
+
+# set -euxo pipefail is short for:
+# set -e, -o errexit: stop the script when an error occurs
+# set -u, -o nounset: detects uninitialised variables in your script and exits with an error (including Env variables)
+# set -x, -o xtrace: prints every expression before executing it
+# set -o pipefail: If any command in a pipeline fails, use that return code for whole pipeline instead of final success
+
+
+gci write -s standard -s default -s "prefix(github.com/99designs)" --skip-generated .
+gofumpt -w .
+go generate ./...

--- a/complexity/complexity_test.go
+++ b/complexity/complexity_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/validator/rules"
 
 	"github.com/99designs/gqlgen/graphql"
 )
@@ -50,7 +51,7 @@ var schema = gqlparser.MustLoadSchema(
 
 func requireComplexity(t *testing.T, source string, complexity int) {
 	t.Helper()
-	query := gqlparser.MustLoadQuery(schema, source)
+	query := gqlparser.MustLoadQueryWithRules(schema, source, rules.NewDefaultRules())
 
 	es := &graphql.ExecutableSchemaMock{
 		ComplexityFunc: func(ctx context.Context, typeName, field string, childComplexity int, args map[string]any) (int, bool) {

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/sosodev/duration v1.3.1
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.7
-	github.com/vektah/gqlparser/v2 v2.5.29
+	github.com/vektah/gqlparser/v2 v2.5.30
 	golang.org/x/text v0.26.0
 	golang.org/x/tools v0.34.0
 	google.golang.org/protobuf v1.36.6

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/sosodev/duration v1.3.1
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.7
-	github.com/vektah/gqlparser/v2 v2.5.28
+	github.com/vektah/gqlparser/v2 v2.5.29
 	golang.org/x/text v0.26.0
 	golang.org/x/tools v0.34.0
 	google.golang.org/protobuf v1.36.6

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
 github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
-github.com/vektah/gqlparser/v2 v2.5.29 h1:ARb8SP46rxa+VVKMbJ6s/JsAEdjq9eJ83tUOZZa9YHw=
-github.com/vektah/gqlparser/v2 v2.5.29/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
+github.com/vektah/gqlparser/v2 v2.5.30 h1:EqLwGAFLIzt1wpx1IPpY67DwUujF1OfzgEyDsLrN6kE=
+github.com/vektah/gqlparser/v2 v2.5.30/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
 github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
-github.com/vektah/gqlparser/v2 v2.5.28 h1:bIulcl3LF69ba6EiZVGD88y4MkM+Jxrf3P2MX8xLRkY=
-github.com/vektah/gqlparser/v2 v2.5.28/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
+github.com/vektah/gqlparser/v2 v2.5.29 h1:ARb8SP46rxa+VVKMbJ6s/JsAEdjq9eJ83tUOZZa9YHw=
+github.com/vektah/gqlparser/v2 v2.5.29/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/graphql/executor/executor.go
+++ b/graphql/executor/executor.go
@@ -230,13 +230,13 @@ func (e *Executor) parseQuery(
 
 	// swap out the FieldsOnCorrectType rule with one that doesn't provide suggestions
 	if e.disableSuggestion {
-		validator.RemoveRule("FieldsOnCorrectType")
+		currentRules.RemoveRule("FieldsOnCorrectType")
 		rule := rules.FieldsOnCorrectTypeRuleWithoutSuggestions
-		validator.AddRule(rule.Name, rule.RuleFunc)
+		currentRules.AddRule(rule.Name, rule.RuleFunc)
 	} else { // or vice versa
-		validator.RemoveRule("FieldsOnCorrectTypeWithoutSuggestions")
+		currentRules.RemoveRule("FieldsOnCorrectTypeWithoutSuggestions")
 		rule := rules.FieldsOnCorrectTypeRule
-		validator.AddRule(rule.Name, rule.RuleFunc)
+		currentRules.AddRule(rule.Name, rule.RuleFunc)
 	}
 
 	listErr := validator.ValidateWithRules(e.es.Schema(), doc, currentRules)

--- a/graphql/executor/executor.go
+++ b/graphql/executor/executor.go
@@ -216,23 +216,30 @@ func (e *Executor) parseQuery(
 
 	stats.Validation.Start = graphql.Now()
 
-	if len(doc.Operations) == 0 {
+	if doc == nil || len(doc.Operations) == 0 {
 		err = gqlerror.Errorf("no operation provided")
 		gqlErr, _ := err.(*gqlerror.Error)
 		errcode.Set(err, errcode.ValidationFailed)
 		return nil, gqlerror.List{gqlErr}
 	}
 
+	currentRules := rules.NewDefaultRules()
+
+	// Customise rules as required
+	// TODO(steve): consider currentRules.RemoveRule(rules.MaxIntrospectionDepth.Name)
+
 	// swap out the FieldsOnCorrectType rule with one that doesn't provide suggestions
 	if e.disableSuggestion {
 		validator.RemoveRule("FieldsOnCorrectType")
-
 		rule := rules.FieldsOnCorrectTypeRuleWithoutSuggestions
-		// rule may already have been added
-		validator.ReplaceRule(rule.Name, rule.RuleFunc)
+		validator.AddRule(rule.Name, rule.RuleFunc)
+	} else { // or vice versa
+		validator.RemoveRule("FieldsOnCorrectTypeWithoutSuggestions")
+		rule := rules.FieldsOnCorrectTypeRule
+		validator.AddRule(rule.Name, rule.RuleFunc)
 	}
 
-	listErr := validator.Validate(e.es.Schema(), doc)
+	listErr := validator.ValidateWithRules(e.es.Schema(), doc, currentRules)
 	if len(listErr) != 0 {
 		for _, e := range listErr {
 			errcode.Set(e, errcode.ValidationFailed)

--- a/graphql/executor/executor_test.go
+++ b/graphql/executor/executor_test.go
@@ -170,7 +170,6 @@ func TestExecutor(t *testing.T) {
 }
 
 func TestExecutorDisableSuggestion(t *testing.T) {
-
 	t.Run("by default, the error message will include suggestions", func(t *testing.T) {
 		exec := testexecutor.New()
 		resp := query(exec, "", "{nam}")

--- a/graphql/executor/executor_test.go
+++ b/graphql/executor/executor_test.go
@@ -170,14 +170,16 @@ func TestExecutor(t *testing.T) {
 }
 
 func TestExecutorDisableSuggestion(t *testing.T) {
-	exec := testexecutor.New()
+
 	t.Run("by default, the error message will include suggestions", func(t *testing.T) {
+		exec := testexecutor.New()
 		resp := query(exec, "", "{nam}")
 		assert.Empty(t, string(resp.Data))
 		assert.Equal(t, "input:1:2: Cannot query field \"nam\" on type \"Query\". Did you mean \"name\"?\n", resp.Errors.Error())
 	})
 
 	t.Run("disable suggestion, the error message will not include suggestions", func(t *testing.T) {
+		exec := testexecutor.New()
 		exec.SetDisableSuggestion(true)
 		resp := query(exec, "", "{nam}")
 		assert.Empty(t, string(resp.Data))


### PR DESCRIPTION
## Update github.com/vektah/gqlparser/v2 to v2.5.30
### What's Changed: https://github.com/vektah/gqlparser/compare/v2.5.28...v2.5.30
* BREAKING: Fix `AddRule` and `ReplaceRule` methods behavior and add documentation by @tomoikey in https://github.com/vektah/gqlparser/pull/381
* Ensure Validation Rule order is deterministic by @StevenACoffman in https://github.com/vektah/gqlparser/pull/383
* Refactoring: not to use global rule sets (part 1) by @tomoikey in https://github.com/vektah/gqlparser/pull/379
* Refactoring: not to use global rule sets (part 2) by @tomoikey in https://github.com/vektah/gqlparser/pull/380
* Bump prettier from 3.5.3 to 3.6.0 in /validator/imported in the actions-deps group by @dependabot in https://github.com/vektah/gqlparser/pull/377
* Bump brace-expansion from 1.1.11 to 1.1.12 in /validator/imported by @dependabot in https://github.com/vektah/gqlparser/pull/378

**Full Changelog**: https://github.com/vektah/gqlparser/compare/v2.5.28...v2.5.30

Automated update of gqlparser. See releases:
+ https://github.com/vektah/gqlparser/releases/tag/v2.5.29 
+ https://github.com/vektah/gqlparser/releases/tag/v2.5.30