### PR TITLE
Better document how to construct a Server

### DIFF
--- a/graphql/handler/server.go
+++ b/graphql/handler/server.go
@@ -36,12 +36,13 @@ func New(es graphql.ExecutableSchema) *Server {
 }
 
 // NewDefaultServer returns a Server for the given executable schema which is
-// suitable as an example.
+// only suitable for use in examples.
 //
 // Deprecated:
-// NewDefaultServer is only suitable as an example. Use [New] and add transports
-// configured for your use case. See the implementation of this constructor for
-// an example.
+// The Server returned by NewDefaultServer is not suitable for production use.
+// Use [New] instead and add transports configured for your use case,
+// appropriate caches, and introspection if required. See the implementation of
+// NewDefaultServer for an example of starting point to construct a Server.
 //
 // SSE is not supported using this example. SSE when used over HTTP/1.1 (but not
 // HTTP/2 or HTTP/3) suffers from a severe limitation to the maximum number of


### PR DESCRIPTION
Expecting a functional constructor; I had a hard time working out how to make a server appropriate for production. This was compounded by all examples using NewDefaultServer. What was not written down is that you should use New and provide properly configured transports, so write that in the deprecation notice.

I have:
 - [x] Changed the NewDefaultServer deprecation notice to say what to use in place of NewDefaultServer.
 - [x] Added documentation to Server.AddTransport.
 - [x] Added documentation to Server.Use.
 - [x] Added documentation to New.
 
 Here's how it renders with pkgsite:
<img width="1040" height="612" alt="bilde" src="https://github.com/user-attachments/assets/633d05b8-0667-4764-b6b7-57a4915ee008" />

Addresses #3758 