### PR TITLE
Add Directives to Resolver Comments

### DIFF
--- a/plugin/resolvergen/resolver.gotpl
+++ b/plugin/resolvergen/resolver.gotpl
@@ -23,6 +23,19 @@
 		{{with $resolver.Comment}}{{.|prefixLines "// "}}{{end}}
 	{{- else if not $.OmitTemplateComment -}}
 		// {{ $resolver.Field.GoFieldName }} is the resolver for the {{ $resolver.Field.Name }} field.
+		{{- if $resolver.Field.Directives }}
+			// Directives:
+			{{- range $directive := $resolver.Field.Directives }}
+			// @{{ $directive.Name }}
+				{{- if $directive.Args -}}
+					(
+					{{- range $arg := $directive.Args -}}
+						{{$arg.VarName}}: {{$arg.Value}}
+					{{- end -}}
+					)
+				{{- end -}}
+			{{- end -}}
+		{{- end -}}
 	{{- end }}
 	func (r *{{lcFirst $resolver.Object.Name}}{{ucFirst $.ResolverType}}) {{$resolver.Field.GoFieldName}}{{ with $resolver.PrevDecl }}{{ $resolver.Field.ShortResolverSignature .Type }}{{ else }}{{ $resolver.Field.ShortResolverDeclaration }}{{ end }}{
 		{{ $resolver.Implementation }}

--- a/plugin/resolvergen/testdata/schema.graphql
+++ b/plugin/resolvergen/testdata/schema.graphql
@@ -1,7 +1,10 @@
 type Query {
-    resolver: Resolver!
+    resolver: Resolver! @test
 }
 
 type Resolver {
-    name: String!
+    name: String! @test2(param: "asd") @test
 }
+
+directive @test on FIELD_DEFINITION
+directive @test2(param: String!) on FIELD_DEFINITION

--- a/plugin/resolvergen/testdata/singlefile/out/resolver.go
+++ b/plugin/resolvergen/testdata/singlefile/out/resolver.go
@@ -9,11 +9,16 @@ import (
 type CustomResolverType struct{}
 
 // Resolver is the resolver for the resolver field.
+// Directives:
+// @test
 func (r *queryCustomResolverType) Resolver(ctx context.Context) (*Resolver, error) {
 	panic("not implemented")
 }
 
 // Name is the resolver for the name field.
+// Directives:
+// @test2(param: asd)
+// @test
 func (r *resolverCustomResolverType) Name(ctx context.Context, obj *Resolver) (string, error) {
 	panic("not implemented")
 }


### PR DESCRIPTION
The default resolver template for code generation is altered such that, the directives that are called are listed in the comment area above the resolver function definition. Parameters of the directives are also included in the output.

This PR closes my issue  #3762 

As this is a very minor (non-functional) feature, I have not included the following items ->
I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
