### PR TITLE
Fixed benchmark not awaiting dispatched operation

### DIFF
--- a/codegen/testserver/benchmark/benchmark_test.go
+++ b/codegen/testserver/benchmark/benchmark_test.go
@@ -166,7 +166,8 @@ query GetUsersConnection($query: String, $first: Int, $before: String, $orderBy:
 					b.Fatal(errs)
 				}
 
-				_, _ = exec.DispatchOperation(ctx, opCtx)
+				resultHandler, ctx := exec.DispatchOperation(ctx, opCtx)
+				_ = resultHandler(ctx)
 			}
 		})
 	}


### PR DESCRIPTION
This MR addresses a bug that skews the benchmark due to not actually executing the result handler, here are updated results:

```
❯ go test -bench=. -benchmem ./codegen/testserver/benchmark
goos: linux
goarch: amd64
pkg: github.com/99designs/gqlgen/codegen/testserver/benchmark
cpu: AMD Ryzen 9 9950X3D 16-Core Processor          
BenchmarkResolvers/query_no_params-32              57170             21170 ns/op           27704 B/op        453 allocs/op
BenchmarkResolvers/query_1_param-32                54612             22505 ns/op           28704 B/op        470 allocs/op
BenchmarkResolvers/query_2_params-32               51734             22686 ns/op           29408 B/op        485 allocs/op
BenchmarkResolvers/query_3_params-32               50419             24183 ns/op           30224 B/op        513 allocs/op
BenchmarkResolvers/query_4_params-32               49288             24581 ns/op           30896 B/op        526 allocs/op
PASS
ok      github.com/99designs/gqlgen/codegen/testserver/benchmark        7.207s
```
