### PR TITLE
Add Support For All SIgned and Unsigned Integers

### DIFF
--- a/graphql/int.go
+++ b/graphql/int.go
@@ -67,14 +67,6 @@ func interfaceToSignedNumber[N number](v any) (N, error) {
 	switch v := v.(type) {
 	case int, int8, int16, int32, int64:
 		return safeCastSignedNumber[N](reflect.ValueOf(v).Int())
-	case uint, uint8, uint16, uint32:
-		return safeCastSignedNumber[N](int64(reflect.ValueOf(v).Uint()))
-	case uint64:
-		if v > math.MaxInt64 {
-			return 0, newNumberOverflowError[int64](v, 64)
-		}
-
-		return safeCastSignedNumber[N](int64(v))
 	case string:
 		iv, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
@@ -125,18 +117,11 @@ func newNumberOverflowError[N maxNumber](i any, bitsize int) *NumberOverflowErro
 				Message: fmt.Sprintf("%d overflows signed %d-bit integer", i, bitsize),
 			},
 		}
-	case uint64:
-		return &NumberOverflowError{
-			Value: v,
-			IntegerError: &IntegerError{
-				Message: fmt.Sprintf("%d overflows unsigned %d-bit integer", i, bitsize),
-			},
-		}
 	default:
 		return &NumberOverflowError{
 			Value: v,
 			IntegerError: &IntegerError{
-				Message: fmt.Sprintf("%T overflows %d-bit integer", v, bitsize),
+				Message: fmt.Sprintf("%d overflows unsigned %d-bit integer", i, bitsize),
 			},
 		}
 	}
@@ -154,24 +139,12 @@ func safeCastSignedNumber[N number](val int64) (N, error) {
 		if val > math.MaxInt8 || val < math.MinInt8 {
 			return 0, newNumberOverflowError[int64](val, 8)
 		}
-	case uint8:
-		if val > math.MaxUint8 || val < 0 {
-			return 0, newNumberOverflowError[int64](val, 8)
-		}
 	case int16:
 		if val > math.MaxInt16 || val < math.MinInt16 {
 			return 0, newNumberOverflowError[int64](val, 16)
 		}
-	case uint16:
-		if val > math.MaxUint16 || val < 0 {
-			return 0, newNumberOverflowError[int64](val, 16)
-		}
 	case int32:
 		if val > math.MaxInt32 || val < math.MinInt32 {
-			return 0, newNumberOverflowError[int64](val, 32)
-		}
-	case uint32:
-		if val > math.MaxUint32 || val < 0 {
 			return 0, newNumberOverflowError[int64](val, 32)
 		}
 	case int:
@@ -179,10 +152,6 @@ func safeCastSignedNumber[N number](val int64) (N, error) {
 			return 0, newNumberOverflowError[int64](val, 32)
 		}
 	case int64:
-	case uint64, uint:
-		if val < 0 {
-			return 0, newNumberOverflowError[int64](val, 64)
-		}
 	default:
 		return 0, fmt.Errorf("invalid type %T", zero)
 	}

--- a/graphql/int.go
+++ b/graphql/int.go
@@ -73,7 +73,7 @@ func interfaceToSignedNumber[N number](v any) (N, error) {
 	case int32:
 		return safeCastSignedNumber[N](int64(v))
 	case int64:
-		return safeCastSignedNumber[N](int64(v))
+		return safeCastSignedNumber[N](v)
 	case uint:
 		return safeCastSignedNumber[N](int64(v))
 	case uint8:

--- a/graphql/int.go
+++ b/graphql/int.go
@@ -83,6 +83,10 @@ func interfaceToSignedNumber[N number](v any) (N, error) {
 	case uint32:
 		return safeCastSignedNumber[N](int64(v))
 	case uint64:
+		if v > math.MaxInt64 {
+			return 0, newNumberOverflowError[int64](v, 64)
+		}
+
 		return safeCastSignedNumber[N](int64(v))
 	case string:
 		iv, err := strconv.ParseInt(v, 10, 64)

--- a/graphql/int_test.go
+++ b/graphql/int_test.go
@@ -9,6 +9,134 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestInt8(t *testing.T) {
+	t.Run("marshal", func(t *testing.T) {
+		assert.Equal(t, "123", m2s(MarshalInt8(123)))
+	})
+
+	t.Run("unmarshal", func(t *testing.T) {
+		assert.Equal(t, int8(0), mustUnmarshalInt8(t, nil))
+		assert.Equal(t, int8(123), mustUnmarshalInt8(t, 123))
+		assert.Equal(t, int8(123), mustUnmarshalInt8(t, int64(123)))
+		assert.Equal(t, int8(123), mustUnmarshalInt8(t, json.Number("123")))
+		assert.Equal(t, int8(123), mustUnmarshalInt8(t, "123"))
+		assert.Equal(t, int8(0), mustUnmarshalInt8(t, nil))
+	})
+
+	t.Run("overflow", func(t *testing.T) {
+		cases := []struct {
+			name string
+			v    any
+			err  string
+		}{
+			{"positive int overflow", math.MaxInt8 + 1, "128 overflows signed 8-bit integer"},
+			{"negative int overflow", math.MinInt8 - 1, "-129 overflows signed 8-bit integer"},
+			{"positive int64 overflow", int64(math.MaxInt8 + 1), "128 overflows signed 8-bit integer"},
+			{"negative int64 overflow", int64(math.MinInt8 - 1), "-129 overflows signed 8-bit integer"},
+			{"positive json.Number overflow", json.Number("128"), "128 overflows signed 8-bit integer"},
+			{"negative json.Number overflow", json.Number("-129"), "-129 overflows signed 8-bit integer"},
+			{"positive string overflow", "128", "128 overflows signed 8-bit integer"},
+			{"negative string overflow", "-129", "-129 overflows signed 8-bit integer"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				var numberOverflowErr *NumberOverflowError
+				var intErr *IntegerError
+
+				res, err := UnmarshalInt8(tc.v)
+				assert.EqualError(t, err, tc.err)          //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &numberOverflowErr) //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &intErr)            //nolint:testifylint // An error assertion makes more sense.
+				assert.Equal(t, int8(0), res)
+			})
+		}
+	})
+
+	t.Run("invalid string numbers are not integer errors", func(t *testing.T) {
+		var intErr *IntegerError
+
+		res, err := UnmarshalInt8("-1.03")
+		assert.EqualError(t, err, "strconv.ParseInt: parsing \"-1.03\": invalid syntax") //nolint:testifylint // An error assertion makes more sense.
+		assert.NotErrorAs(t, err, &intErr)
+		assert.Equal(t, int8(0), res)
+
+		res, err = UnmarshalInt8(json.Number(" 1"))
+		assert.EqualError(t, err, "strconv.ParseInt: parsing \" 1\": invalid syntax") //nolint:testifylint // An error assertion makes more sense.
+		assert.NotErrorAs(t, err, &intErr)
+		assert.Equal(t, int8(0), res)
+	})
+}
+
+func mustUnmarshalInt8(t *testing.T, v any) int8 {
+	res, err := UnmarshalInt8(v)
+	require.NoError(t, err)
+	return res
+}
+
+func TestInt16(t *testing.T) {
+	t.Run("marshal", func(t *testing.T) {
+		assert.Equal(t, "123", m2s(MarshalInt16(123)))
+	})
+
+	t.Run("unmarshal", func(t *testing.T) {
+		assert.Equal(t, int16(0), mustUnmarshalInt16(t, nil))
+		assert.Equal(t, int16(123), mustUnmarshalInt16(t, 123))
+		assert.Equal(t, int16(123), mustUnmarshalInt16(t, int64(123)))
+		assert.Equal(t, int16(123), mustUnmarshalInt16(t, json.Number("123")))
+		assert.Equal(t, int16(123), mustUnmarshalInt16(t, "123"))
+		assert.Equal(t, int16(0), mustUnmarshalInt16(t, nil))
+	})
+
+	t.Run("overflow", func(t *testing.T) {
+		cases := []struct {
+			name string
+			v    any
+			err  string
+		}{
+			{"positive int overflow", math.MaxInt16 + 1, "32768 overflows signed 16-bit integer"},
+			{"negative int overflow", math.MinInt16 - 1, "-32769 overflows signed 16-bit integer"},
+			{"positive int64 overflow", int64(math.MaxInt16 + 1), "32768 overflows signed 16-bit integer"},
+			{"negative int64 overflow", int64(math.MinInt16 - 1), "-32769 overflows signed 16-bit integer"},
+			{"positive json.Number overflow", json.Number("32768"), "32768 overflows signed 16-bit integer"},
+			{"negative json.Number overflow", json.Number("-32769"), "-32769 overflows signed 16-bit integer"},
+			{"positive string overflow", "32768", "32768 overflows signed 16-bit integer"},
+			{"negative string overflow", "-32769", "-32769 overflows signed 16-bit integer"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				var numberOverflowErr *NumberOverflowError
+				var intErr *IntegerError
+
+				res, err := UnmarshalInt16(tc.v)
+				assert.EqualError(t, err, tc.err)          //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &numberOverflowErr) //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &intErr)            //nolint:testifylint // An error assertion makes more sense.
+				assert.Equal(t, int16(0), res)
+			})
+		}
+	})
+
+	t.Run("invalid string numbers are not integer errors", func(t *testing.T) {
+		var intErr *IntegerError
+
+		res, err := UnmarshalInt16("-1.03")
+		assert.EqualError(t, err, "strconv.ParseInt: parsing \"-1.03\": invalid syntax") //nolint:testifylint // An error assertion makes more sense.
+		assert.NotErrorAs(t, err, &intErr)
+		assert.Equal(t, int16(0), res)
+
+		res, err = UnmarshalInt16(json.Number(" 1"))
+		assert.EqualError(t, err, "strconv.ParseInt: parsing \" 1\": invalid syntax") //nolint:testifylint // An error assertion makes more sense.
+		assert.NotErrorAs(t, err, &intErr)
+		assert.Equal(t, int16(0), res)
+	})
+}
+
+func mustUnmarshalInt16(t *testing.T, v any) int16 {
+	res, err := UnmarshalInt16(v)
+	require.NoError(t, err)
+	return res
+}
+
 func TestInt(t *testing.T) {
 	t.Run("marshal", func(t *testing.T) {
 		assert.Equal(t, "123", m2s(MarshalInt(123)))
@@ -61,13 +189,13 @@ func TestInt32(t *testing.T) {
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
-				var int32OverflowErr *Int32OverflowError
+				var numberOverflowErr *NumberOverflowError
 				var intErr *IntegerError
 
 				res, err := UnmarshalInt32(tc.v)
-				assert.EqualError(t, err, tc.err)         //nolint:testifylint // An error assertion makes more sense.
-				assert.ErrorAs(t, err, &int32OverflowErr) //nolint:testifylint // An error assertion makes more sense.
-				assert.ErrorAs(t, err, &intErr)           //nolint:testifylint // An error assertion makes more sense.
+				assert.EqualError(t, err, tc.err)          //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &numberOverflowErr) //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &intErr)            //nolint:testifylint // An error assertion makes more sense.
 				assert.Equal(t, int32(0), res)
 			})
 		}

--- a/graphql/uint.go
+++ b/graphql/uint.go
@@ -143,17 +143,32 @@ func (e *UintSignError) Unwrap() error {
 func safeCastUnsignedNumber[N number](val uint64) (N, error) {
 	bitsize := fmt.Sprintf("%T", N(0))
 	switch bitsize {
-	case "int8", "uint8":
+	case "int8":
+		if val > math.MaxInt8 {
+			return 0, newNumberOverflowError[uint64](val, 8)
+		}
+		return N(val), nil
+	case "uint8":
 		if val > math.MaxUint8 {
 			return 0, newNumberOverflowError[uint64](val, 8)
 		}
 		return N(val), nil
-	case "int16", "uint16":
+	case "int16":
+		if val > math.MaxInt16 {
+			return 0, newNumberOverflowError[uint64](val, 16)
+		}
+		return N(val), nil
+	case "uint16":
 		if val > math.MaxUint16 {
 			return 0, newNumberOverflowError[uint64](val, 16)
 		}
 		return N(val), nil
-	case "int32", "uint32":
+	case "int32":
+		if val > math.MaxInt32 {
+			return 0, newNumberOverflowError[uint64](val, 32)
+		}
+		return N(val), nil
+	case "uint32":
 		if val > math.MaxUint32 {
 			return 0, newNumberOverflowError[uint64](val, 32)
 		}

--- a/graphql/uint.go
+++ b/graphql/uint.go
@@ -16,87 +16,27 @@ func MarshalUint(i uint) Marshaler {
 }
 
 func UnmarshalUint(v any) (uint, error) {
-	switch v := v.(type) {
-	case string:
-		u64, err := strconv.ParseUint(v, 10, 64)
-		if err != nil {
-			var strconvErr *strconv.NumError
-			if errors.As(err, &strconvErr) && isSignedInteger(v) {
-				return 0, newUintSignError(v)
-			}
-			return 0, err
-		}
-		return uint(u64), err
-	case int:
-		if v < 0 {
-			return 0, newUintSignError(strconv.FormatInt(int64(v), 10))
-		}
-		return uint(v), nil
-	case int64:
-		if v < 0 {
-			return 0, newUintSignError(strconv.FormatInt(v, 10))
-		}
-		return uint(v), nil
-	case json.Number:
-		u64, err := strconv.ParseUint(string(v), 10, 64)
-		if err != nil {
-			var strconvErr *strconv.NumError
-			if errors.As(err, &strconvErr) && isSignedInteger(string(v)) {
-				return 0, newUintSignError(string(v))
-			}
-			return 0, err
-		}
-		return uint(u64), err
-	case nil:
-		return 0, nil
-	default:
-		return 0, fmt.Errorf("%T is not an uint", v)
-	}
+	return interfaceToUnsignedNumber[uint](v)
 }
 
-func MarshalUint64(i uint64) Marshaler {
+func MarshalUint8(i uint8) Marshaler {
 	return WriterFunc(func(w io.Writer) {
-		_, _ = io.WriteString(w, strconv.FormatUint(i, 10))
+		_, _ = io.WriteString(w, strconv.FormatUint(uint64(i), 10))
 	})
 }
 
-func UnmarshalUint64(v any) (uint64, error) {
-	switch v := v.(type) {
-	case string:
-		i, err := strconv.ParseUint(v, 10, 64)
-		if err != nil {
-			var strconvErr *strconv.NumError
-			if errors.As(err, &strconvErr) && isSignedInteger(v) {
-				return 0, newUintSignError(v)
-			}
-			return 0, err
-		}
-		return i, nil
-	case int:
-		if v < 0 {
-			return 0, newUintSignError(strconv.FormatInt(int64(v), 10))
-		}
-		return uint64(v), nil
-	case int64:
-		if v < 0 {
-			return 0, newUintSignError(strconv.FormatInt(v, 10))
-		}
-		return uint64(v), nil
-	case json.Number:
-		i, err := strconv.ParseUint(string(v), 10, 64)
-		if err != nil {
-			var strconvErr *strconv.NumError
-			if errors.As(err, &strconvErr) && isSignedInteger(string(v)) {
-				return 0, newUintSignError(string(v))
-			}
-			return 0, err
-		}
-		return i, nil
-	case nil:
-		return 0, nil
-	default:
-		return 0, fmt.Errorf("%T is not an uint", v)
-	}
+func UnmarshalUint8(v any) (uint8, error) {
+	return interfaceToUnsignedNumber[uint8](v)
+}
+
+func MarshalUint16(i uint16) Marshaler {
+	return WriterFunc(func(w io.Writer) {
+		_, _ = io.WriteString(w, strconv.FormatUint(uint64(i), 10))
+	})
+}
+
+func UnmarshalUint16(v any) (uint16, error) {
+	return interfaceToUnsignedNumber[uint16](v)
 }
 
 func MarshalUint32(i uint32) Marshaler {
@@ -106,9 +46,58 @@ func MarshalUint32(i uint32) Marshaler {
 }
 
 func UnmarshalUint32(v any) (uint32, error) {
+	return interfaceToUnsignedNumber[uint32](v)
+}
+
+func MarshalUint64(i uint64) Marshaler {
+	return WriterFunc(func(w io.Writer) {
+		_, _ = io.WriteString(w, strconv.FormatUint(i, 10))
+	})
+}
+
+func UnmarshalUint64(v any) (uint64, error) {
+	return interfaceToUnsignedNumber[uint64](v)
+}
+
+func interfaceToUnsignedNumber[N number](v any) (N, error) {
 	switch v := v.(type) {
+	case int:
+		if v < 0 {
+			return 0, newUintSignError(strconv.FormatInt(int64(v), 10))
+		}
+		return safeCastUnsignedNumber[N](uint64(v))
+	case int8:
+		if v < 0 {
+			return 0, newUintSignError(strconv.FormatInt(int64(v), 10))
+		}
+		return safeCastUnsignedNumber[N](uint64(v))
+	case int16:
+		if v < 0 {
+			return 0, newUintSignError(strconv.FormatInt(int64(v), 10))
+		}
+		return safeCastUnsignedNumber[N](uint64(v))
+	case int32:
+		if v < 0 {
+			return 0, newUintSignError(strconv.FormatInt(int64(v), 10))
+		}
+		return safeCastUnsignedNumber[N](uint64(v))
+	case int64:
+		if v < 0 {
+			return 0, newUintSignError(strconv.FormatInt(int64(v), 10))
+		}
+		return safeCastUnsignedNumber[N](uint64(v))
+	case uint:
+		return safeCastUnsignedNumber[N](uint64(v))
+	case uint8:
+		return safeCastUnsignedNumber[N](uint64(v))
+	case uint16:
+		return safeCastUnsignedNumber[N](uint64(v))
+	case uint32:
+		return safeCastUnsignedNumber[N](uint64(v))
+	case uint64:
+		return safeCastUnsignedNumber[N](uint64(v))
 	case string:
-		iv, err := strconv.ParseUint(v, 10, 64)
+		uv, err := strconv.ParseUint(v, 10, 64)
 		if err != nil {
 			var strconvErr *strconv.NumError
 			if errors.As(err, &strconvErr) && isSignedInteger(v) {
@@ -116,19 +105,9 @@ func UnmarshalUint32(v any) (uint32, error) {
 			}
 			return 0, err
 		}
-		return safeCastUint32(iv)
-	case int:
-		if v < 0 {
-			return 0, newUintSignError(strconv.FormatInt(int64(v), 10))
-		}
-		return safeCastUint32(uint64(v))
-	case int64:
-		if v < 0 {
-			return 0, newUintSignError(strconv.FormatInt(v, 10))
-		}
-		return safeCastUint32(uint64(v))
+		return safeCastUnsignedNumber[N](uv)
 	case json.Number:
-		iv, err := strconv.ParseUint(string(v), 10, 64)
+		uv, err := strconv.ParseUint(string(v), 10, 64)
 		if err != nil {
 			var strconvErr *strconv.NumError
 			if errors.As(err, &strconvErr) && isSignedInteger(string(v)) {
@@ -136,11 +115,11 @@ func UnmarshalUint32(v any) (uint32, error) {
 			}
 			return 0, err
 		}
-		return safeCastUint32(iv)
+		return safeCastUnsignedNumber[N](uv)
 	case nil:
 		return 0, nil
 	default:
-		return 0, fmt.Errorf("%T is not an uint", v)
+		return 0, fmt.Errorf("%T is not an %T", v, N(0))
 	}
 }
 
@@ -160,6 +139,32 @@ func (e *UintSignError) Unwrap() error {
 	return e.IntegerError
 }
 
+// safeCastUnsignedNumber converts an uint64 to a number of type N.
+func safeCastUnsignedNumber[N number](val uint64) (N, error) {
+	bitsize := fmt.Sprintf("%T", N(0))
+	switch bitsize {
+	case "int8", "uint8":
+		if val > math.MaxUint8 {
+			return 0, newNumberOverflowError[uint64](val, 8)
+		}
+		return N(val), nil
+	case "int16", "uint16":
+		if val > math.MaxUint16 {
+			return 0, newNumberOverflowError[uint64](val, 16)
+		}
+		return N(val), nil
+	case "int32", "uint32":
+		if val > math.MaxUint32 {
+			return 0, newNumberOverflowError[uint64](val, 32)
+		}
+		return N(val), nil
+	case "int64", "int", "uint64", "uint":
+		return N(val), nil
+	default:
+		return 0, fmt.Errorf("invalid bitsize %s", bitsize)
+	}
+}
+
 func isSignedInteger(v string) bool {
 	if v == "" {
 		return false
@@ -171,29 +176,4 @@ func isSignedInteger(v string) bool {
 		return true
 	}
 	return false
-}
-
-type Uint32OverflowError struct {
-	Value uint64
-	*IntegerError
-}
-
-func newUint32OverflowError(i uint64) *Uint32OverflowError {
-	return &Uint32OverflowError{
-		Value: i,
-		IntegerError: &IntegerError{
-			Message: fmt.Sprintf("%d overflows unsigned 32-bit integer", i),
-		},
-	}
-}
-
-func (e *Uint32OverflowError) Unwrap() error {
-	return e.IntegerError
-}
-
-func safeCastUint32(i uint64) (uint32, error) {
-	if i > math.MaxUint32 {
-		return 0, newUint32OverflowError(i)
-	}
-	return uint32(i), nil
 }

--- a/graphql/uint.go
+++ b/graphql/uint.go
@@ -62,7 +62,7 @@ func UnmarshalUint64(v any) (uint64, error) {
 
 func interfaceToUnsignedNumber[N number](v any) (N, error) {
 	switch v := v.(type) {
-	case int, int8, int16, int32, int64:
+	case int, int64:
 		if reflect.ValueOf(v).Int() < 0 {
 			return 0, newUintSignError(strconv.FormatInt(reflect.ValueOf(v).Int(), 10))
 		}
@@ -116,31 +116,19 @@ func (e *UintSignError) Unwrap() error {
 func safeCastUnsignedNumber[N number](val uint64) (N, error) {
 	var zero N
 	switch any(zero).(type) {
-	case int8:
-		if val > math.MaxInt8 {
-			return 0, newNumberOverflowError[uint64](val, 8)
-		}
 	case uint8:
 		if val > math.MaxUint8 {
 			return 0, newNumberOverflowError[uint64](val, 8)
-		}
-	case int16:
-		if val > math.MaxInt16 {
-			return 0, newNumberOverflowError[uint64](val, 16)
 		}
 	case uint16:
 		if val > math.MaxUint16 {
 			return 0, newNumberOverflowError[uint64](val, 16)
 		}
-	case int32:
-		if val > math.MaxInt32 {
-			return 0, newNumberOverflowError[uint64](val, 32)
-		}
 	case uint32:
 		if val > math.MaxUint32 {
 			return 0, newNumberOverflowError[uint64](val, 32)
 		}
-	case int64, int, uint64, uint:
+	case uint64, uint, int:
 	default:
 		return 0, fmt.Errorf("invalid type %T", zero)
 	}

--- a/graphql/uint.go
+++ b/graphql/uint.go
@@ -83,7 +83,7 @@ func interfaceToUnsignedNumber[N number](v any) (N, error) {
 		return safeCastUnsignedNumber[N](uint64(v))
 	case int64:
 		if v < 0 {
-			return 0, newUintSignError(strconv.FormatInt(int64(v), 10))
+			return 0, newUintSignError(strconv.FormatInt(v, 10))
 		}
 		return safeCastUnsignedNumber[N](uint64(v))
 	case uint:
@@ -95,7 +95,7 @@ func interfaceToUnsignedNumber[N number](v any) (N, error) {
 	case uint32:
 		return safeCastUnsignedNumber[N](uint64(v))
 	case uint64:
-		return safeCastUnsignedNumber[N](uint64(v))
+		return safeCastUnsignedNumber[N](v)
 	case string:
 		uv, err := strconv.ParseUint(v, 10, 64)
 		if err != nil {

--- a/graphql/uint_test.go
+++ b/graphql/uint_test.go
@@ -79,6 +79,188 @@ func mustUnmarshalUint(v any) uint {
 	return res
 }
 
+func TestUint8(t *testing.T) {
+	t.Run("marshal", func(t *testing.T) {
+		assert.Equal(t, "123", m2s(MarshalUint8(123)))
+		assert.Equal(t, "255", m2s(MarshalUint8(math.MaxUint8)))
+	})
+
+	t.Run("unmarshal", func(t *testing.T) {
+		assert.Equal(t, uint8(0), mustUnmarshalUint8(nil))
+		assert.Equal(t, uint8(123), mustUnmarshalUint8(123))
+		assert.Equal(t, uint8(123), mustUnmarshalUint8(int64(123)))
+		assert.Equal(t, uint8(123), mustUnmarshalUint8(json.Number("123")))
+		assert.Equal(t, uint8(123), mustUnmarshalUint8("123"))
+		assert.Equal(t, uint8(255), mustUnmarshalUint8("255"))
+	})
+
+	t.Run("can't unmarshal negative numbers", func(t *testing.T) {
+		cases := []struct {
+			name string
+			v    any
+			err  string
+		}{
+			{"negative int", -1, "-1 is an invalid unsigned integer: includes sign"},
+			{"negative int64", int64(-1), "-1 is an invalid unsigned integer: includes sign"},
+			{"negative json.Number", json.Number("-1"), "-1 is an invalid unsigned integer: includes sign"},
+			{"negative string", "-1", "-1 is an invalid unsigned integer: includes sign"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				var uintSignErr *UintSignError
+				var intErr *IntegerError
+
+				res, err := UnmarshalUint8(tc.v)
+				assert.EqualError(t, err, tc.err)    //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &uintSignErr) //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &intErr)      //nolint:testifylint // An error assertion makes more sense.
+				assert.Equal(t, uint8(0), res)
+			})
+		}
+	})
+
+	t.Run("invalid string numbers are not integer errors", func(t *testing.T) {
+		var uintSignErr *UintSignError
+		var intErr *IntegerError
+
+		res, err := UnmarshalUint8("-1.03")
+		assert.EqualError(t, err, "strconv.ParseUint: parsing \"-1.03\": invalid syntax") //nolint:testifylint // An error assertion makes more sense.
+		assert.NotErrorAs(t, err, &uintSignErr)
+		assert.NotErrorAs(t, err, &intErr)
+		assert.Equal(t, uint8(0), res)
+
+		res, err = UnmarshalUint8(json.Number(" 1"))
+		assert.EqualError(t, err, "strconv.ParseUint: parsing \" 1\": invalid syntax") //nolint:testifylint // An error assertion makes more sense.
+		assert.NotErrorAs(t, err, &uintSignErr)
+		assert.NotErrorAs(t, err, &intErr)
+		assert.Equal(t, uint8(0), res)
+	})
+
+	t.Run("overflow", func(t *testing.T) {
+		cases := []struct {
+			name string
+			v    any
+			err  string
+		}{
+			{"int overflow", math.MaxUint8 + 1, "256 overflows unsigned 8-bit integer"},
+			{"int64 overflow", int64(math.MaxUint8 + 1), "256 overflows unsigned 8-bit integer"},
+			{"json.Number overflow", json.Number("256"), "256 overflows unsigned 8-bit integer"},
+			{"string overflow", "256", "256 overflows unsigned 8-bit integer"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				var numberOverflowErr *NumberOverflowError
+				var intErr *IntegerError
+
+				res, err := UnmarshalUint8(tc.v)
+				assert.EqualError(t, err, tc.err)          //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &numberOverflowErr) //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &intErr)            //nolint:testifylint // An error assertion makes more sense.
+				assert.Equal(t, uint8(0), res)
+			})
+		}
+	})
+}
+
+func mustUnmarshalUint8(v any) uint8 {
+	res, err := UnmarshalUint8(v)
+	if err != nil {
+		panic(err)
+	}
+	return res
+}
+
+func TestUint16(t *testing.T) {
+	t.Run("marshal", func(t *testing.T) {
+		assert.Equal(t, "123", m2s(MarshalUint16(123)))
+		assert.Equal(t, "65535", m2s(MarshalUint16(math.MaxUint16)))
+	})
+
+	t.Run("unmarshal", func(t *testing.T) {
+		assert.Equal(t, uint16(0), mustUnmarshalUint16(nil))
+		assert.Equal(t, uint16(123), mustUnmarshalUint16(123))
+		assert.Equal(t, uint16(123), mustUnmarshalUint16(int64(123)))
+		assert.Equal(t, uint16(123), mustUnmarshalUint16(json.Number("123")))
+		assert.Equal(t, uint16(123), mustUnmarshalUint16("123"))
+		assert.Equal(t, uint16(65535), mustUnmarshalUint16("65535"))
+	})
+
+	t.Run("can't unmarshal negative numbers", func(t *testing.T) {
+		cases := []struct {
+			name string
+			v    any
+			err  string
+		}{
+			{"negative int", -1, "-1 is an invalid unsigned integer: includes sign"},
+			{"negative int64", int64(-1), "-1 is an invalid unsigned integer: includes sign"},
+			{"negative json.Number", json.Number("-1"), "-1 is an invalid unsigned integer: includes sign"},
+			{"negative string", "-1", "-1 is an invalid unsigned integer: includes sign"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				var uintSignErr *UintSignError
+				var intErr *IntegerError
+
+				res, err := UnmarshalUint16(tc.v)
+				assert.EqualError(t, err, tc.err)    //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &uintSignErr) //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &intErr)      //nolint:testifylint // An error assertion makes more sense.
+				assert.Equal(t, uint16(0), res)
+			})
+		}
+	})
+
+	t.Run("invalid string numbers are not integer errors", func(t *testing.T) {
+		var uintSignErr *UintSignError
+		var intErr *IntegerError
+
+		res, err := UnmarshalUint16("-1.03")
+		assert.EqualError(t, err, "strconv.ParseUint: parsing \"-1.03\": invalid syntax") //nolint:testifylint // An error assertion makes more sense.
+		assert.NotErrorAs(t, err, &uintSignErr)
+		assert.NotErrorAs(t, err, &intErr)
+		assert.Equal(t, uint16(0), res)
+
+		res, err = UnmarshalUint16(json.Number(" 1"))
+		assert.EqualError(t, err, "strconv.ParseUint: parsing \" 1\": invalid syntax") //nolint:testifylint // An error assertion makes more sense.
+		assert.NotErrorAs(t, err, &uintSignErr)
+		assert.NotErrorAs(t, err, &intErr)
+		assert.Equal(t, uint16(0), res)
+	})
+
+	t.Run("overflow", func(t *testing.T) {
+		cases := []struct {
+			name string
+			v    any
+			err  string
+		}{
+			{"int overflow", math.MaxUint16 + 1, "65536 overflows unsigned 16-bit integer"},
+			{"int64 overflow", int64(math.MaxUint16 + 1), "65536 overflows unsigned 16-bit integer"},
+			{"json.Number overflow", json.Number("65536"), "65536 overflows unsigned 16-bit integer"},
+			{"string overflow", "65536", "65536 overflows unsigned 16-bit integer"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				var numberOverflowErr *NumberOverflowError
+				var intErr *IntegerError
+
+				res, err := UnmarshalUint16(tc.v)
+				assert.EqualError(t, err, tc.err)          //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &numberOverflowErr) //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &intErr)            //nolint:testifylint // An error assertion makes more sense.
+				assert.Equal(t, uint16(0), res)
+			})
+		}
+	})
+}
+
+func mustUnmarshalUint16(v any) uint16 {
+	res, err := UnmarshalUint16(v)
+	if err != nil {
+		panic(err)
+	}
+	return res
+}
+
 func TestUint32(t *testing.T) {
 	t.Run("marshal", func(t *testing.T) {
 		assert.Equal(t, "123", m2s(MarshalUint32(123)))
@@ -149,12 +331,12 @@ func TestUint32(t *testing.T) {
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
-				var uint32OverflowErr *Uint32OverflowError
+				var numberOverflowErr *NumberOverflowError
 				var intErr *IntegerError
 
 				res, err := UnmarshalUint32(tc.v)
 				assert.EqualError(t, err, tc.err)          //nolint:testifylint // An error assertion makes more sense.
-				assert.ErrorAs(t, err, &uint32OverflowErr) //nolint:testifylint // An error assertion makes more sense.
+				assert.ErrorAs(t, err, &numberOverflowErr) //nolint:testifylint // An error assertion makes more sense.
 				assert.ErrorAs(t, err, &intErr)            //nolint:testifylint // An error assertion makes more sense.
 				assert.Equal(t, uint32(0), res)
 			})


### PR DESCRIPTION
Add support for all signed and unsigned integer types in GraphQL marshalling/unmarshalling and consolidate conversion logic into generic functions.

## New Features:
- Introduce Marshal and Unmarshal functions for int8, int16, int32, int64, uint8, uint16, and uint32 types.
- Add generic interfaceToSignedNumber and interfaceToUnsignedNumber functions to convert any numeric input to the target type.

## Enhancements:
- Centralize overflow checks into safeCastSignedNumber and safeCastUnsignedNumber with a unified NumberOverflowError type.
- Simplify existing int and uint conversion logic by replacing per-type implementations with generic handlers.

## Documentation:
- Update documentation to reflect extended support for all signed and unsigned integer types.

## Tests:
- Add comprehensive tests for marshalling, unmarshalling, sign errors, invalid inputs, and overflow conditions across all integer types.

### Generic Integer Unmarshaling Flow

```mermaid
sequenceDiagram
    participant Caller
    participant UnmarshalFunc
    participant GenericHelper
    participant ErrorHandler

    Caller->>UnmarshalFunc: UnmarshalInt8/16/32/64(value)
    UnmarshalFunc->>GenericHelper: interfaceToSignedNumber[N](value)
    GenericHelper->>GenericHelper: Type switch & conversion
    alt Overflow or type error
        GenericHelper->>ErrorHandler: newNumberOverflowError or type error
        ErrorHandler-->>GenericHelper: Error
    end
    GenericHelper-->>UnmarshalFunc: intN value or error
    UnmarshalFunc-->>Caller: Result or error
```

### Generic Unsigned Integer Unmarshaling Flow

```mermaid
sequenceDiagram
    participant Caller
    participant UnmarshalFunc
    participant GenericHelper
    participant ErrorHandler

    Caller->>UnmarshalFunc: UnmarshalUint8/16/32/64(value)
    UnmarshalFunc->>GenericHelper: interfaceToUnsignedNumber[N](value)
    GenericHelper->>GenericHelper: Type switch & conversion
    alt Negative value
        GenericHelper->>ErrorHandler: UintSignError
        ErrorHandler-->>GenericHelper: Error
    else Overflow
        GenericHelper->>ErrorHandler: newNumberOverflowError
        ErrorHandler-->>GenericHelper: Error
    end
    GenericHelper-->>UnmarshalFunc: uintN value or error
    UnmarshalFunc-->>Caller: Result or error
```

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
