### PR TITLE
fix: handle nil-return from field hooks to omit a field from code generation

### DIFF
--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -441,6 +441,12 @@ func (m *Plugin) generateField(
 		if err != nil {
 			return nil, fmt.Errorf("generror: field %v.%v: %w", schemaType.Name, field.Name, err)
 		}
+
+		if mf == nil {
+			// the field hook wants to omit the field
+			return nil, nil
+		}
+
 		f = mf
 	}
 


### PR DESCRIPTION
A field hook may return nil which results in a nil-pointer deref later on. This checks for nil and returns immediately to avoid this and effectively allow field hooks to omit a field entirely.

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
