### PR TITLE
fix generating enum maps for slices

### DIFF
--- a/codegen/testserver/usefunctionsyntaxforexecutioncontext/generated.go
+++ b/codegen/testserver/usefunctionsyntaxforexecutioncontext/generated.go
@@ -5079,19 +5079,6 @@ func marshalORole2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋ
 	return ret
 }
 
-var (
-	unmarshalORole2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModelᚄF = map[string]RoleModel{
-		"ADMIN": RoleModelAdmin,
-		"USER":  RoleModelUser,
-		"GUEST": RoleModelGuest,
-	}
-	marshalORole2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModelᚄF = map[RoleModel]string{
-		RoleModelAdmin: "ADMIN",
-		RoleModelUser:  "USER",
-		RoleModelGuest: "GUEST",
-	}
-)
-
 func unmarshalORole2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋusefunctionsyntaxforexecutioncontextᚐRoleModel(ctx context.Context, ec *executionContext, v any) (*RoleModel, error) {
 	if v == nil {
 		return nil, nil

--- a/codegen/type.gotpl
+++ b/codegen/type.gotpl
@@ -288,7 +288,7 @@
 		}
 	{{- end }}
 
-	{{- if $type.HasEnumValues }}
+	{{- if and $type.HasEnumValues (not $type.IsSlice) }}
 	{{- $enum := $type.GO }}
 	{{- if $type.IsNilable }}
 		{{- $enum = $type.GO.Elem }}


### PR DESCRIPTION
Previously this would generate the enum lookup maps for the underlying types of slices, though these functions were not used.

In the case where an enum type is used as an optional field, required field, and optional array field, the generated maps would be invalid (missing the appropriate dereference). Because these maps are not needed, removing them is better.

I didn't update the tests because I couldn't find a great way to have coverage for this.

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
