### PR TITLE
feat(dataloader): handle thunk resolvers

### DIFF
--- a/_examples/dataloader/.gqlgen.yml
+++ b/_examples/dataloader/.gqlgen.yml
@@ -3,3 +3,6 @@ models:
     model: github.com/99designs/gqlgen/_examples/dataloader.Order
   Customer:
     model: github.com/99designs/gqlgen/_examples/dataloader.Customer
+
+resolver:
+  thunk_resolvers: true

--- a/_examples/dataloader/generated.go
+++ b/_examples/dataloader/generated.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -80,16 +79,16 @@ type ComplexityRoot struct {
 }
 
 type CustomerResolver interface {
-	Address(ctx context.Context, obj *Customer) (*Address, error)
-	Orders(ctx context.Context, obj *Customer) ([]*Order, error)
+	Address(ctx context.Context, obj *Customer) (func() (*Address, error), error)
+	Orders(ctx context.Context, obj *Customer) (func() ([]*Order, error), error)
 }
 type OrderResolver interface {
-	Items(ctx context.Context, obj *Order) ([]*Item, error)
+	Items(ctx context.Context, obj *Order) (func() ([]*Item, error), error)
 }
 type QueryResolver interface {
-	Customers(ctx context.Context) ([]*Customer, error)
-	Torture1d(ctx context.Context, customerIds []int) ([]*Customer, error)
-	Torture2d(ctx context.Context, customerIds [][]int) ([][]*Customer, error)
+	Customers(ctx context.Context) (func() ([]*Customer, error), error)
+	Torture1d(ctx context.Context, customerIds []int) (func() ([]*Customer, error), error)
+	Torture2d(ctx context.Context, customerIds [][]int) (func() ([][]*Customer, error), error)
 }
 
 type executableSchema struct {
@@ -3320,11 +3319,6 @@ func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlge
 
 func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Directive) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
 	for i := range v {
 		i := i
 		fc := &graphql.FieldContext{
@@ -3339,19 +3333,11 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 					ret = nil
 				}
 			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
 			ret[i] = ec.marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx, sel, v[i])
 		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
+		f(i)
 
 	}
-	wg.Wait()
 
 	for _, e := range ret {
 		if e == graphql.Null {
@@ -3395,11 +3381,6 @@ func (ec *executionContext) unmarshalN__DirectiveLocation2ᚕstringᚄ(ctx conte
 
 func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
 	for i := range v {
 		i := i
 		fc := &graphql.FieldContext{
@@ -3414,19 +3395,11 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context
 					ret = nil
 				}
 			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
 			ret[i] = ec.marshalN__DirectiveLocation2string(ctx, sel, v[i])
 		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
+		f(i)
 
 	}
-	wg.Wait()
 
 	for _, e := range ret {
 		if e == graphql.Null {
@@ -3451,11 +3424,6 @@ func (ec *executionContext) marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlg
 
 func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
 	for i := range v {
 		i := i
 		fc := &graphql.FieldContext{
@@ -3470,19 +3438,11 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 					ret = nil
 				}
 			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
+		f(i)
 
 	}
-	wg.Wait()
 
 	for _, e := range ret {
 		if e == graphql.Null {
@@ -3499,11 +3459,6 @@ func (ec *executionContext) marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋg
 
 func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
 	for i := range v {
 		i := i
 		fc := &graphql.FieldContext{
@@ -3518,19 +3473,11 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 					ret = nil
 				}
 			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
+		f(i)
 
 	}
-	wg.Wait()
 
 	for _, e := range ret {
 		if e == graphql.Null {
@@ -3609,11 +3556,6 @@ func (ec *executionContext) marshalOCustomer2ᚕᚕᚖgithubᚗcomᚋ99designs�
 		return graphql.Null
 	}
 	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
 	for i := range v {
 		i := i
 		fc := &graphql.FieldContext{
@@ -3628,19 +3570,11 @@ func (ec *executionContext) marshalOCustomer2ᚕᚕᚖgithubᚗcomᚋ99designs�
 					ret = nil
 				}
 			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
 			ret[i] = ec.marshalOCustomer2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋdataloaderᚐCustomerᚄ(ctx, sel, v[i])
 		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
+		f(i)
 
 	}
-	wg.Wait()
 
 	return ret
 }
@@ -3650,11 +3584,6 @@ func (ec *executionContext) marshalOCustomer2ᚕᚖgithubᚗcomᚋ99designsᚋgq
 		return graphql.Null
 	}
 	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
 	for i := range v {
 		i := i
 		fc := &graphql.FieldContext{
@@ -3669,19 +3598,11 @@ func (ec *executionContext) marshalOCustomer2ᚕᚖgithubᚗcomᚋ99designsᚋgq
 					ret = nil
 				}
 			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
 			ret[i] = ec.marshalNCustomer2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋdataloaderᚐCustomer(ctx, sel, v[i])
 		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
+		f(i)
 
 	}
-	wg.Wait()
 
 	for _, e := range ret {
 		if e == graphql.Null {
@@ -3763,11 +3684,6 @@ func (ec *executionContext) marshalOItem2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 		return graphql.Null
 	}
 	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
 	for i := range v {
 		i := i
 		fc := &graphql.FieldContext{
@@ -3782,19 +3698,11 @@ func (ec *executionContext) marshalOItem2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgen
 					ret = nil
 				}
 			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
 			ret[i] = ec.marshalNItem2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋdataloaderᚐItem(ctx, sel, v[i])
 		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
+		f(i)
 
 	}
-	wg.Wait()
 
 	for _, e := range ret {
 		if e == graphql.Null {
@@ -3810,11 +3718,6 @@ func (ec *executionContext) marshalOOrder2ᚕᚖgithubᚗcomᚋ99designsᚋgqlge
 		return graphql.Null
 	}
 	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
 	for i := range v {
 		i := i
 		fc := &graphql.FieldContext{
@@ -3829,19 +3732,11 @@ func (ec *executionContext) marshalOOrder2ᚕᚖgithubᚗcomᚋ99designsᚋgqlge
 					ret = nil
 				}
 			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
 			ret[i] = ec.marshalNOrder2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋdataloaderᚐOrder(ctx, sel, v[i])
 		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
+		f(i)
 
 	}
-	wg.Wait()
 
 	for _, e := range ret {
 		if e == graphql.Null {
@@ -3875,11 +3770,6 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 		return graphql.Null
 	}
 	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
 	for i := range v {
 		i := i
 		fc := &graphql.FieldContext{
@@ -3894,19 +3784,11 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 					ret = nil
 				}
 			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
 			ret[i] = ec.marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx, sel, v[i])
 		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
+		f(i)
 
 	}
-	wg.Wait()
 
 	for _, e := range ret {
 		if e == graphql.Null {
@@ -3922,11 +3804,6 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 		return graphql.Null
 	}
 	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
 	for i := range v {
 		i := i
 		fc := &graphql.FieldContext{
@@ -3941,19 +3818,11 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 					ret = nil
 				}
 			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
 			ret[i] = ec.marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx, sel, v[i])
 		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
+		f(i)
 
 	}
-	wg.Wait()
 
 	for _, e := range ret {
 		if e == graphql.Null {
@@ -3969,11 +3838,6 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 		return graphql.Null
 	}
 	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
 	for i := range v {
 		i := i
 		fc := &graphql.FieldContext{
@@ -3988,19 +3852,11 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 					ret = nil
 				}
 			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
 			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
+		f(i)
 
 	}
-	wg.Wait()
 
 	for _, e := range ret {
 		if e == graphql.Null {
@@ -4023,11 +3879,6 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 		return graphql.Null
 	}
 	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
 	for i := range v {
 		i := i
 		fc := &graphql.FieldContext{
@@ -4042,19 +3893,11 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 					ret = nil
 				}
 			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
 			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
+		f(i)
 
 	}
-	wg.Wait()
 
 	for _, e := range ret {
 		if e == graphql.Null {

--- a/codegen/config/resolver.go
+++ b/codegen/config/resolver.go
@@ -20,6 +20,7 @@ type ResolverConfig struct {
 	OmitTemplateComment bool           `yaml:"omit_template_comment,omitempty"`
 	ResolverTemplate    string         `yaml:"resolver_template,omitempty"`
 	PreserveResolver    bool           `yaml:"preserve_resolver,omitempty"`
+	ThunkResolvers      bool           `yaml:"thunk_resolvers,omitempty"`
 }
 
 type ResolverLayout string

--- a/codegen/field.go
+++ b/codegen/field.go
@@ -34,6 +34,7 @@ type Field struct {
 	Object           *Object          // A link back to the parent object
 	Default          any              // The default value
 	Stream           bool             // does this field return a channel?
+	ThunkResolver    bool             // does this field return a thunk resolver?
 	Directives       []*Directive
 }
 
@@ -107,6 +108,7 @@ func (b *builder) bindField(obj *Object, f *Field) (errret error) {
 	}()
 
 	f.Stream = obj.Stream
+	f.ThunkResolver = b.Config.Resolver.ThunkResolvers
 
 	switch {
 	case f.Name == "__schema":
@@ -554,6 +556,9 @@ func (f *Field) ShortResolverSignature(ft *goast.FuncType) string {
 		if ft.Results != nil && len(ft.Results.List) > 1 && len(ft.Results.List[1].Names) > 0 {
 			namedE = ft.Results.List[1].Names[0].Name
 		}
+	}
+	if f.ThunkResolver {
+		result = fmt.Sprintf("func() (%s, error)", result)
 	}
 	res += fmt.Sprintf(") (%s %s, %s error)", namedV, result, namedE)
 	return res

--- a/codegen/type.gotpl
+++ b/codegen/type.gotpl
@@ -130,7 +130,7 @@
 					}
 				{{- end }}
 				ret := make(graphql.Array, len(v))
-				{{- if not $type.IsScalar }}
+				{{- if and (not $type.IsScalar) (not $.Config.Resolver.ThunkResolvers) }}
 					var wg sync.WaitGroup
 					{{- if gt $.Config.Exec.WorkerLimit 0 }}
 						sm := semaphore.NewWeighted({{ $.Config.Exec.WorkerLimit }})
@@ -157,6 +157,7 @@
 								}
 							}()
 							{{- end }}
+							{{- if not $.Config.Resolver.ThunkResolvers }}
 							if !isLen1 {
 								{{- if gt $.Config.Exec.WorkerLimit 0 }}
 									defer func(){
@@ -167,12 +168,16 @@
 									defer wg.Done()
 								{{- end }}
 							}
+							{{- end }}
 							{{ if $useFunctionSyntaxForExecutionContext -}}
 							ret[i] = {{ $type.Elem.MarshalFunc }}(ctx, ec, sel, v[i])
 							{{- else -}}
 							ret[i] = ec.{{ $type.Elem.MarshalFunc }}(ctx, sel, v[i])
 							{{- end }}
 						}
+						{{- if $.Config.Resolver.ThunkResolvers }}
+						f(i)
+						{{- else }}
 						if isLen1 {
 							f(i)
 						} else {
@@ -186,6 +191,7 @@
 								go f(i)
 							{{- end }}
 						}
+						{{- end }}
 					{{ else }}
 						{{ if $useFunctionSyntaxForExecutionContext -}}
 						ret[i] = {{ $type.Elem.MarshalFunc }}(ctx, ec, sel, v[i])
@@ -194,7 +200,9 @@
 						{{- end }}
 					{{- end }}
 				}
-				{{ if not $type.IsScalar }} wg.Wait() {{ end }}
+				{{- if and (not $type.IsScalar) (not $.Config.Resolver.ThunkResolvers) }}
+				wg.Wait()
+				{{- end }}
 				{{ if $type.Elem.GQL.NonNull }}
 					for _, e := range ret {
 						if e == graphql.Null {


### PR DESCRIPTION
With how dataloadgen works, we don't need to create as many goroutines, and we can let it handle all the batching for us, and use their "thunk" function, that will resolve when the batch of data resolved.

This commit adds a new resolver configuration, "thunk_resolvers", that changes the return type of resolvers from `(T, error)` to `(func() (T, error), error)`. This allows us to implement resolvers using `LoadThunk` instead of `Load`, thus using the whole potential of dataloadgen.

This will end up creating a lot less goroutines in heavy setups that rely on dataloading, and should greatly improve performance.

This setting could also be enabled for anyone that wants it, without the need to rely on dataloadgen. Effectively, it gives control to the engineer writing the implementation of how they handle their goroutines.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
