### PR TITLE
Add nolint to avoid static check deprecation lint failure

### DIFF
--- a/api/generate.go
+++ b/api/generate.go
@@ -63,6 +63,7 @@ func Generate(cfg *config.Config, option ...Option) error {
 	}
 
 	for _, p := range plugins {
+		//nolint:staticcheck // for backwards compatibility only
 		if inj, ok := p.(plugin.EarlySourceInjector); ok {
 			if s := inj.InjectSourceEarly(); s != nil {
 				cfg.Sources = append(cfg.Sources, s)


### PR DESCRIPTION
Signed-off-by: Steve Coffman <steve@khanacademy.org>
