### PR TITLE
fix(modelgen): use ToGoModelName in generateGetters

### DIFF
--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -254,7 +254,7 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 		}
 		goType := templates.CurrentImports.LookupType(field.Type)
 		if strings.HasPrefix(goType, "[]") {
-			getter := fmt.Sprintf("func (this %s) Get%s() %s {\n", templates.ToGo(model.Name), field.GoName, goType)
+			getter := fmt.Sprintf("func (this %s) Get%s() %s {\n", templates.ToGoModelName(model.Name), field.GoName, goType)
 			getter += fmt.Sprintf("\tif this.%s == nil { return nil }\n", field.GoName)
 			getter += fmt.Sprintf("\tinterfaceSlice := make(%s, 0, len(this.%s))\n", goType, field.GoName)
 			getter += fmt.Sprintf("\tfor _, concrete := range this.%s { interfaceSlice = append(interfaceSlice, ", field.GoName)
@@ -268,7 +268,7 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 			getter += "}"
 			return getter
 		}
-		getter := fmt.Sprintf("func (this %s) Get%s() %s { return ", templates.ToGo(model.Name), field.GoName, goType)
+		getter := fmt.Sprintf("func (this %s) Get%s() %s { return ", templates.ToGoModelName(model.Name), field.GoName, goType)
 
 		if interfaceFieldTypeIsPointer && !structFieldTypeIsPointer && cfg.OmitEmbeddedStructs {
 			getter += "&"


### PR DESCRIPTION
This is a follow-up from #3865

This diff made it so that we use `templates.ToGoModelName` instead of `templates.ToGo`. This should also be done in the modelgen functions, as if we enrich a model with interfaces that generate more getters, those will never use the model name with the number appended to it.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
