### PR TITLE
Set Executor DispatchOperation inner context to default to avoid nil pointer in InterceptOperation extensions

### DIFF
--- a/graphql/executor/executor.go
+++ b/graphql/executor/executor.go
@@ -119,10 +119,9 @@ func (e *Executor) DispatchOperation(
 	ctx context.Context,
 	opCtx *graphql.OperationContext,
 ) (graphql.ResponseHandler, context.Context) {
-	ctx = graphql.WithOperationContext(ctx, opCtx)
+	innerCtx := graphql.WithOperationContext(ctx, opCtx)
 
-	var innerCtx context.Context
-	res := e.ext.operationMiddleware(ctx, func(ctx context.Context) graphql.ResponseHandler {
+	res := e.ext.operationMiddleware(innerCtx, func(ctx context.Context) graphql.ResponseHandler {
 		innerCtx = ctx
 
 		tmpResponseContext := graphql.WithResponseContext(ctx, e.errorPresenter, e.recoverFunc)


### PR DESCRIPTION
Fix #2690: InterceptOperation extensions returned ResponseHandlers see nil context until `next()` has been called 

@jlautman Years ago (sorry!) reported that the lack of a default context was causing nil pointer exceptions for interceptOperation extensions when they skipped execution of non-relevant nested middleware if the result from that middleware wasn't needed to service the request.

```
	//  +--- REQUEST   POST /graphql --------------------------------------------+
	//  | +- OPERATION query OpName { viewer { name } } -----------------------+ |
	//  | |  RESPONSE  { "data": { "viewer": { "name": "bob" } } }             | |
	//  | +- OPERATION subscription OpName2 { chat { message } } --------------+ |
	//  | |  RESPONSE  { "data": { "chat": { "message": "hello" } } }          | |
	//  | |  RESPONSE  { "data": { "chat": { "message": "byee" } } }           | |
	//  | +--------------------------------------------------------------------+ |
	//  +------------------------------------------------------------------------+
```

A middleware that _**incorrectly**_ fails to call "next()" would be problematic and potentially affect this context result, but forcing every middleware to call every other middleware in the chain all the time also seems wrong. 

Signed-off-by: Steve Coffman <steve@khanacademy.org>
