### PR TITLE
fix: allow error presenter to silence errors

### DIFF
--- a/graphql/context_response.go
+++ b/graphql/context_response.go
@@ -57,6 +57,9 @@ func AddError(ctx context.Context, err error) {
 	c := getResponseContext(ctx)
 
 	presentedError := c.errorPresenter(ctx, ErrorOnPath(ctx, err))
+	if presentedError == nil {
+		return
+	}
 
 	c.errorsMu.Lock()
 	defer c.errorsMu.Unlock()

--- a/graphql/context_response_test.go
+++ b/graphql/context_response_test.go
@@ -11,6 +11,12 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
+func nilUserPresenter(ctx context.Context, err error) *gqlerror.Error {
+	return nil
+}
+
+var _ ErrorPresenterFunc = nilUserPresenter
+
 func TestAddError(t *testing.T) {
 	ctx := WithResponseContext(context.Background(), DefaultErrorPresenter, nil)
 
@@ -78,6 +84,23 @@ func TestAddError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAddError_NilUserPresenter(t *testing.T) {
+	ctx := WithResponseContext(context.Background(), nilUserPresenter, nil)
+	nilUserPresenterRoot := &FieldContext{
+		Field: CollectedField{
+			Field: &ast.Field{
+				Alias: "foo",
+			},
+		},
+	}
+	ctx = WithFieldContext(ctx, nilUserPresenterRoot)
+	AddError(ctx, errors.New("foo"))
+	AddError(ctx, errors.New("bar"))
+
+	errList := GetFieldErrors(ctx, nilUserPresenterRoot)
+	require.Empty(t, errList)
 }
 
 func TestGetErrorFromPresenter(t *testing.T) {


### PR DESCRIPTION
The `ErrorPresenterFunc` might return `nil` in some cases, if we want to silence the errors. This isn't handled properly, and causes panics when we go over the errors later in this file. We need to keep this ability, as the default error presenter can return nil too (though unlikely, as it only does it when err is nil).

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
