### PR TITLE
feat(resolveField): allow field middlewares to return a marshaler directly

### DIFF
--- a/graphql/resolve_field.go
+++ b/graphql/resolve_field.go
@@ -126,17 +126,20 @@ func resolveField[T, R any](
 		}
 		return defaultResult
 	}
-	res, ok := resTmp.(T)
-	if !ok {
-		var t T
-		oc.Errorf(
-			ctx,
-			`unexpected type %T from middleware/directive chain, should be %T`,
-			resTmp,
-			t,
-		)
-		return defaultResult
+	if res, ok := resTmp.(T); ok {
+		fc.Result = res
+		return result(ctx, res)
 	}
-	fc.Result = res
-	return result(ctx, res)
+	if res, ok := resTmp.(R); ok {
+		fc.Result = res
+		return res
+	}
+	var t T
+	oc.Errorf(
+		ctx,
+		`unexpected type %T from middleware/directive chain, should be %T`,
+		resTmp,
+		t,
+	)
+	return defaultResult
 }


### PR DESCRIPTION
In some specific cases, we'd like the ability from a field resolver to return a marshaler directly. This is needed for specific performance-sensitive codepaths we have in our application, where part of the request might already be resolved and we don't want to resolve it again, as the performance hit from doing so would be too high.

This shouldn't impact any already existing usecase, and only make those field middlewares more capable.

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
