### PR TITLE
Add functional options to control complexity calculation

### DIFF
--- a/complexity/option.go
+++ b/complexity/option.go
@@ -1,0 +1,28 @@
+package complexity
+
+type Option func(*complexityOptions)
+
+type complexityOptions struct {
+	fixedScalarValue int
+	ignoreFields     map[string]struct{}
+}
+
+var defaultOptions = complexityOptions{
+	fixedScalarValue: 1,
+	ignoreFields:     nil,
+}
+
+// WithFixedScalarValue sets the default value attributed to scalar and enum fields.
+func WithFixedScalarValue(v int) Option {
+	return func(o *complexityOptions) {
+		o.fixedScalarValue = v
+	}
+}
+
+// WithIgnoreFields specifies which fields are ignored in the complexity calculation.
+// It's equivalent to setting the value of these fields to zero.
+func WithIgnoreFields(m map[string]struct{}) Option {
+	return func(o *complexityOptions) {
+		o.ignoreFields = m
+	}
+}

--- a/docs/content/reference/complexity.md
+++ b/docs/content/reference/complexity.md
@@ -60,6 +60,21 @@ func main() {
 
 Now any query with complexity greater than 5 is rejected by the API. By default, each field and level of depth adds one to the overall query complexity. You can also use `extension.ComplexityLimit` to dynamically configure the complexity limit per request.
 
+To set a custom complexity value for scalars and enums, use `extension.FixedComplexityLimit` with the `WithFixedScalarValue` functional option:
+
+```go
+srv.Use(extension.FixedComplexityLimit(5, complexity.WithFixedScalarValue(0)))
+```
+You can also specify which fields to ignore with the `WithIgnoreFields` functional option. The expected argument is a set of the field names:
+
+```go
+ignore := map[string]struct{}{
+	"Query.foo": {}, // ignore top-level 'foo' field
+	"Item.name": {}, // ignore the 'name' field of the 'Item' object.
+}
+srv.Use(extension.FixedComplexityLimit(5, complexity.WithIgnoreFields(ignore)))
+```
+
 This helps, but we still have a problem: the `posts` and `related` fields, which return arrays, are much more expensive to resolve than the scalar `title` and `text` fields. However, the default complexity calculation weights them equally. It would make more sense to apply a higher cost to the array fields.
 
 ## Custom Complexity Calculation

--- a/graphql/handler/extension/complexity.go
+++ b/graphql/handler/extension/complexity.go
@@ -19,7 +19,8 @@ const errComplexityLimit = "COMPLEXITY_LIMIT_EXCEEDED"
 type ComplexityLimit struct {
 	Func func(ctx context.Context, opCtx *graphql.OperationContext) int
 
-	es graphql.ExecutableSchema
+	es   graphql.ExecutableSchema
+	opts []complexity.Option
 }
 
 var _ interface {
@@ -38,11 +39,12 @@ type ComplexityStats struct {
 }
 
 // FixedComplexityLimit sets a complexity limit that does not change
-func FixedComplexityLimit(limit int) *ComplexityLimit {
+func FixedComplexityLimit(limit int, opts ...complexity.Option) *ComplexityLimit {
 	return &ComplexityLimit{
 		Func: func(ctx context.Context, opCtx *graphql.OperationContext) int {
 			return limit
 		},
+		opts: opts,
 	}
 }
 
@@ -63,7 +65,7 @@ func (c ComplexityLimit) MutateOperationContext(
 	opCtx *graphql.OperationContext,
 ) *gqlerror.Error {
 	op := opCtx.Doc.Operations.ForName(opCtx.OperationName)
-	complexityCalcs := complexity.Calculate(ctx, c.es, op, opCtx.Variables)
+	complexityCalcs := complexity.Calculate(ctx, c.es, op, opCtx.Variables, c.opts...)
 
 	limit := c.Func(ctx, opCtx)
 


### PR DESCRIPTION
No AI was ever involved in the creation of this PR.

The PR adds functional options to `complexity.Calculate` and `extension.FixedComplexityLimit`. Clients can control what complexity value scalars and enums should have (in some literature that's expected to be 0, despite gqlgen defaulting to 1). Clients can also control which fields to outright ignore (this helps with graphql clients that automatically add fields to each request, such as Apollo adding `__typename` fields).

Changes:
- Add `Option` type to `complexity` package
- Add `WithFixedScalarValue` option to control complexity value of scalars and enums
- Add `WithIgnoreFields` option to control which fields should not contribute to the complexity calculation
- Add vararg `...Option` to `complexity.Calculate`. Usage of varargs allows to preserve the behavior of existing call sites.
- Add check for fields to ignore in `selectionSetComplexity`
- Add scalar and enum default complexity evaluation in `complexityWalker.fieldComplexity`. When no option is supplied, it defaults to `1` to maintain backward compatibility
- Add vararg `...complexity.Option` to `extension.FixedComplexityLimit`. The options are passed to `complexity.Calculate`

I have also:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
