### PR TITLE
fix(introspection): support @deprecated directive on field arguments

### DIFF
--- a/codegen/testserver/followschema/resolver.go
+++ b/codegen/testserver/followschema/resolver.go
@@ -192,6 +192,11 @@ func (r *queryResolver) DeprecatedField(ctx context.Context) (string, error) {
 	panic("not implemented")
 }
 
+// FieldWithDeprecatedArg is the resolver for the fieldWithDeprecatedArg field.
+func (r *queryResolver) FieldWithDeprecatedArg(ctx context.Context, oldArg *int, newArg *int) (*string, error) {
+	panic("not implemented")
+}
+
 // Overlapping is the resolver for the overlapping field.
 func (r *queryResolver) Overlapping(ctx context.Context) (*OverlappingFields, error) {
 	panic("not implemented")

--- a/codegen/testserver/followschema/root_.generated.go
+++ b/codegen/testserver/followschema/root_.generated.go
@@ -350,6 +350,7 @@ type ComplexityRoot struct {
 		ErrorList                        func(childComplexity int) int
 		Errors                           func(childComplexity int) int
 		Fallback                         func(childComplexity int, arg FallbackToStringEncoding) int
+		FieldWithDeprecatedArg           func(childComplexity int, oldArg *int, newArg *int) int
 		FilterProducts                   func(childComplexity int, query *string, category *string, minPrice *int) int
 		FindProducts                     func(childComplexity int, query *string, category *string, minPrice *int) int
 		Infinity                         func(childComplexity int) int
@@ -1525,6 +1526,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.Fallback(childComplexity, args["arg"].(FallbackToStringEncoding)), true
+
+	case "Query.fieldWithDeprecatedArg":
+		if e.complexity.Query.FieldWithDeprecatedArg == nil {
+			break
+		}
+
+		args, err := ec.field_Query_fieldWithDeprecatedArg_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.FieldWithDeprecatedArg(childComplexity, args["oldArg"].(*int), args["newArg"].(*int)), true
 
 	case "Query.filterProducts":
 		if e.complexity.Query.FilterProducts == nil {
@@ -2772,6 +2785,7 @@ type Query {
 	shapeUnion: ShapeUnion!
 	autobind: Autobind
 	deprecatedField: String! @deprecated(reason: "test deprecated directive")
+	fieldWithDeprecatedArg(oldArg: Int @deprecated(reason: "old arg"), newArg: Int): String
 	overlapping: OverlappingFields
 	defaultParameters(falsyBoolean: Boolean = false, truthyBoolean: Boolean = true): DefaultParametersMirror!
 	deferSingle: DeferModel

--- a/codegen/testserver/followschema/schema.generated.go
+++ b/codegen/testserver/followschema/schema.generated.go
@@ -45,6 +45,7 @@ type QueryResolver interface {
 	ShapeUnion(ctx context.Context) (ShapeUnion, error)
 	Autobind(ctx context.Context) (*Autobind, error)
 	DeprecatedField(ctx context.Context) (string, error)
+	FieldWithDeprecatedArg(ctx context.Context, oldArg *int, newArg *int) (*string, error)
 	Overlapping(ctx context.Context) (*OverlappingFields, error)
 	DefaultParameters(ctx context.Context, falsyBoolean *bool, truthyBoolean *bool) (*DefaultParametersMirror, error)
 	DeferSingle(ctx context.Context) (*DeferModel, error)
@@ -598,6 +599,22 @@ func (ec *executionContext) field_Query_fallback_args(ctx context.Context, rawAr
 		return nil, err
 	}
 	args["arg"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_fieldWithDeprecatedArg_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "oldArg", ec.unmarshalOInt2ᚖint)
+	if err != nil {
+		return nil, err
+	}
+	args["oldArg"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "newArg", ec.unmarshalOInt2ᚖint)
+	if err != nil {
+		return nil, err
+	}
+	args["newArg"] = arg1
 	return args, nil
 }
 
@@ -2281,6 +2298,49 @@ func (ec *executionContext) fieldContext_Query_deprecatedField(_ context.Context
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_fieldWithDeprecatedArg(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_fieldWithDeprecatedArg,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Query().FieldWithDeprecatedArg(ctx, fc.Args["oldArg"].(*int), fc.Args["newArg"].(*int))
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			return ec._fieldMiddleware(ctx, nil, next)
+		},
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_fieldWithDeprecatedArg(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_fieldWithDeprecatedArg_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -6599,6 +6659,25 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "fieldWithDeprecatedArg":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_fieldWithDeprecatedArg(ctx, field)
 				return res
 			}
 

--- a/codegen/testserver/followschema/schema.graphql
+++ b/codegen/testserver/followschema/schema.graphql
@@ -29,6 +29,7 @@ type Query {
     shapeUnion: ShapeUnion!
     autobind: Autobind
     deprecatedField: String! @deprecated(reason: "test deprecated directive")
+    fieldWithDeprecatedArg(oldArg: Int @deprecated(reason: "old arg"), newArg: Int): String
 }
 
 type Subscription {

--- a/codegen/testserver/followschema/stub.go
+++ b/codegen/testserver/followschema/stub.go
@@ -70,6 +70,7 @@ type Stub struct {
 		ShapeUnion                       func(ctx context.Context) (ShapeUnion, error)
 		Autobind                         func(ctx context.Context) (*Autobind, error)
 		DeprecatedField                  func(ctx context.Context) (string, error)
+		FieldWithDeprecatedArg           func(ctx context.Context, oldArg *int, newArg *int) (*string, error)
 		Overlapping                      func(ctx context.Context) (*OverlappingFields, error)
 		DefaultParameters                func(ctx context.Context, falsyBoolean *bool, truthyBoolean *bool) (*DefaultParametersMirror, error)
 		DeferSingle                      func(ctx context.Context) (*DeferModel, error)
@@ -358,6 +359,9 @@ func (r *stubQuery) Autobind(ctx context.Context) (*Autobind, error) {
 }
 func (r *stubQuery) DeprecatedField(ctx context.Context) (string, error) {
 	return r.QueryResolver.DeprecatedField(ctx)
+}
+func (r *stubQuery) FieldWithDeprecatedArg(ctx context.Context, oldArg *int, newArg *int) (*string, error) {
+	return r.QueryResolver.FieldWithDeprecatedArg(ctx, oldArg, newArg)
 }
 func (r *stubQuery) Overlapping(ctx context.Context) (*OverlappingFields, error) {
 	return r.QueryResolver.Overlapping(ctx)

--- a/codegen/testserver/singlefile/generated.go
+++ b/codegen/testserver/singlefile/generated.go
@@ -359,6 +359,7 @@ type ComplexityRoot struct {
 		ErrorList                        func(childComplexity int) int
 		Errors                           func(childComplexity int) int
 		Fallback                         func(childComplexity int, arg FallbackToStringEncoding) int
+		FieldWithDeprecatedArg           func(childComplexity int, oldArg *int, newArg *int) int
 		FilterProducts                   func(childComplexity int, query *string, category *string, minPrice *int) int
 		FindProducts                     func(childComplexity int, query *string, category *string, minPrice *int) int
 		Infinity                         func(childComplexity int) int
@@ -565,6 +566,7 @@ type QueryResolver interface {
 	ShapeUnion(ctx context.Context) (ShapeUnion, error)
 	Autobind(ctx context.Context) (*Autobind, error)
 	DeprecatedField(ctx context.Context) (string, error)
+	FieldWithDeprecatedArg(ctx context.Context, oldArg *int, newArg *int) (*string, error)
 	Overlapping(ctx context.Context) (*OverlappingFields, error)
 	DefaultParameters(ctx context.Context, falsyBoolean *bool, truthyBoolean *bool) (*DefaultParametersMirror, error)
 	DeferSingle(ctx context.Context) (*DeferModel, error)
@@ -1607,6 +1609,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.Fallback(childComplexity, args["arg"].(FallbackToStringEncoding)), true
+	case "Query.fieldWithDeprecatedArg":
+		if e.complexity.Query.FieldWithDeprecatedArg == nil {
+			break
+		}
+
+		args, err := ec.field_Query_fieldWithDeprecatedArg_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.FieldWithDeprecatedArg(childComplexity, args["oldArg"].(*int), args["newArg"].(*int)), true
 	case "Query.filterProducts":
 		if e.complexity.Query.FilterProducts == nil {
 			break
@@ -2780,6 +2793,7 @@ type Query {
 	shapeUnion: ShapeUnion!
 	autobind: Autobind
 	deprecatedField: String! @deprecated(reason: "test deprecated directive")
+	fieldWithDeprecatedArg(oldArg: Int @deprecated(reason: "old arg"), newArg: Int): String
 	overlapping: OverlappingFields
 	defaultParameters(falsyBoolean: Boolean = false, truthyBoolean: Boolean = true): DefaultParametersMirror!
 	deferSingle: DeferModel
@@ -3644,6 +3658,22 @@ func (ec *executionContext) field_Query_fallback_args(ctx context.Context, rawAr
 		return nil, err
 	}
 	args["arg"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_fieldWithDeprecatedArg_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "oldArg", ec.unmarshalOInt2ᚖint)
+	if err != nil {
+		return nil, err
+	}
+	args["oldArg"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "newArg", ec.unmarshalOInt2ᚖint)
+	if err != nil {
+		return nil, err
+	}
+	args["newArg"] = arg1
 	return args, nil
 }
 
@@ -8528,6 +8558,49 @@ func (ec *executionContext) fieldContext_Query_deprecatedField(_ context.Context
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_fieldWithDeprecatedArg(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_fieldWithDeprecatedArg,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Query().FieldWithDeprecatedArg(ctx, fc.Args["oldArg"].(*int), fc.Args["newArg"].(*int))
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			return ec._fieldMiddleware(ctx, nil, next)
+		},
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_fieldWithDeprecatedArg(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_fieldWithDeprecatedArg_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -18583,6 +18656,25 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "fieldWithDeprecatedArg":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_fieldWithDeprecatedArg(ctx, field)
 				return res
 			}
 

--- a/codegen/testserver/singlefile/introspection_test.go
+++ b/codegen/testserver/singlefile/introspection_test.go
@@ -68,6 +68,45 @@ func TestIntrospection(t *testing.T) {
 			require.Equal(t, "id", resp.Type.Fields[0].Name)
 			require.Nil(t, resp.Type.Fields[0].DeprecationReason)
 		})
+
+		t.Run("deprecated arguments", func(t *testing.T) {
+			var resp struct {
+				Type struct {
+					Fields []struct {
+						Name string
+						Args []struct {
+							Name              string
+							DeprecationReason *string
+						}
+					}
+				} `json:"__type"`
+			}
+
+			err := c.Post(
+				`{ __type(name:"Query") { fields { name args { name deprecationReason }}}}`,
+				&resp,
+			)
+			require.NoError(t, err)
+
+			var args []struct {
+				Name              string
+				DeprecationReason *string
+			}
+			for _, f := range resp.Type.Fields {
+				if f.Name == "fieldWithDeprecatedArg" {
+					args = f.Args
+					break
+				}
+			}
+
+			require.Len(t, args, 2)
+			require.Equal(t, "oldArg", args[0].Name)
+			require.NotNil(t, args[0].DeprecationReason)
+			require.Equal(t, "old arg", *args[0].DeprecationReason)
+
+			require.Equal(t, "newArg", args[1].Name)
+			require.Nil(t, args[1].DeprecationReason)
+		})
 	})
 
 	t.Run("disabled by middleware", func(t *testing.T) {

--- a/codegen/testserver/singlefile/resolver.go
+++ b/codegen/testserver/singlefile/resolver.go
@@ -192,6 +192,11 @@ func (r *queryResolver) DeprecatedField(ctx context.Context) (string, error) {
 	panic("not implemented")
 }
 
+// FieldWithDeprecatedArg is the resolver for the fieldWithDeprecatedArg field.
+func (r *queryResolver) FieldWithDeprecatedArg(ctx context.Context, oldArg *int, newArg *int) (*string, error) {
+	panic("not implemented")
+}
+
 // Overlapping is the resolver for the overlapping field.
 func (r *queryResolver) Overlapping(ctx context.Context) (*OverlappingFields, error) {
 	panic("not implemented")

--- a/codegen/testserver/singlefile/schema.graphql
+++ b/codegen/testserver/singlefile/schema.graphql
@@ -29,6 +29,7 @@ type Query {
     shapeUnion: ShapeUnion!
     autobind: Autobind
     deprecatedField: String! @deprecated(reason: "test deprecated directive")
+    fieldWithDeprecatedArg(oldArg: Int @deprecated(reason: "old arg"), newArg: Int): String
 }
 
 type Subscription {

--- a/codegen/testserver/singlefile/stub.go
+++ b/codegen/testserver/singlefile/stub.go
@@ -70,6 +70,7 @@ type Stub struct {
 		ShapeUnion                       func(ctx context.Context) (ShapeUnion, error)
 		Autobind                         func(ctx context.Context) (*Autobind, error)
 		DeprecatedField                  func(ctx context.Context) (string, error)
+		FieldWithDeprecatedArg           func(ctx context.Context, oldArg *int, newArg *int) (*string, error)
 		Overlapping                      func(ctx context.Context) (*OverlappingFields, error)
 		DefaultParameters                func(ctx context.Context, falsyBoolean *bool, truthyBoolean *bool) (*DefaultParametersMirror, error)
 		DeferSingle                      func(ctx context.Context) (*DeferModel, error)
@@ -358,6 +359,9 @@ func (r *stubQuery) Autobind(ctx context.Context) (*Autobind, error) {
 }
 func (r *stubQuery) DeprecatedField(ctx context.Context) (string, error) {
 	return r.QueryResolver.DeprecatedField(ctx)
+}
+func (r *stubQuery) FieldWithDeprecatedArg(ctx context.Context, oldArg *int, newArg *int) (*string, error) {
+	return r.QueryResolver.FieldWithDeprecatedArg(ctx, oldArg, newArg)
 }
 func (r *stubQuery) Overlapping(ctx context.Context) (*OverlappingFields, error) {
 	return r.QueryResolver.Overlapping(ctx)

--- a/graphql/introspection/type.go
+++ b/graphql/introspection/type.go
@@ -81,7 +81,7 @@ func (t *Type) Fields(includeDeprecated bool) []Field {
 				Name:         arg.Name,
 				description:  arg.Description,
 				DefaultValue: defaultValue(arg.DefaultValue),
-				deprecation:  f.Directives.ForName("deprecated"),
+				deprecation:  arg.Directives.ForName("deprecated"),
 			})
 		}
 


### PR DESCRIPTION
Field arguments are currently not introspected as deprecated due to a typo in the field arguments definition in the introspection code. It uses the directives from the field instead of the directives on the field argument:
```diff
		for _, arg := range f.Arguments {
			args = append(args, InputValue{
				Type:         WrapTypeFromType(t.schema, arg.Type),
				Name:         arg.Name,
				description:  arg.Description,
				DefaultValue: defaultValue(arg.DefaultValue),
-				deprecation:  f.Directives.ForName("deprecated"),
+				deprecation:  arg.Directives.ForName("deprecated"),
			})
```

The **[GraphQL spec was updated in September](https://spec.graphql.org/September2025/#sec--deprecated)** to allow deprecation on field arguments, and gqlgen seems to have followed, though not working due to the above typo.

I have also added tests, although I must admit I am not entirely sure what the difference is between `testserver/singlefile` and `testserver/followschema`. However, I mimicked what I saw from other tests.

I also added introspection tests in the `integration/` folder, but running the GraphQL codegen generated code that was unrelated to my changes (perhaps these have not been re-generated for a while, and GraphQL codegen changed?), so I have not included that. I'm open to add those changes to this PR if you're OK with extra stuff being added by codegen.


I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
