### PR TITLE
fix: do not use if-else scoped var in type assertion

### DIFF
--- a/codegen/interface.gotpl
+++ b/codegen/interface.gotpl
@@ -24,8 +24,8 @@ func (ec *executionContext) _{{$interface.Name}}(ctx context.Context, sel ast.Se
 			{{- end }}
 	{{- end }}
 	default:
-		if obj, ok := obj.(graphql.Marshaler); ok {
-			return obj
+		if typedObj, ok := obj.(graphql.Marshaler); ok {
+			return typedObj
 		} else {
 			panic(fmt.Errorf("unexpected type %T; non-generated variants of {{$interface.Name}} must implement graphql.Marshaler", obj))
 		}


### PR DESCRIPTION
The variable `obj` is redeclared in the `if` block, so the `else` statement is using the locally scoped `obj` instead of one the one that was being evaluated in the switch statement for a type assertion. Change the variable name so that it doesn't shadow the original `obj` definition.

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
