### PR TITLE
disable prealloc linter for now

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,7 +53,6 @@ linters:
     - nakedret
     - nolintlint
     - perfsprint
-    - prealloc
     - reassign
     - revive
     - staticcheck
@@ -65,6 +64,7 @@ linters:
     - usestdlibvars
     - usetesting
     - wastedassign
+#    - prealloc # disabled because it is a huge pain
   settings:
     errcheck:
       exclude-functions:


### PR DESCRIPTION
I'm disabling the prealloc linter for now. I understand that it can be a substantial performance benefit in _some_ hot paths, but it's a real bother to adjust all the code since the linter does not provide TextEdits for SuggestedFixes (so it can automatically fix what it warns about).

Signed-off-by: Steve Coffman <steve@khanacademy.org>
