### PR TITLE
refactor: fix modernize.slicescontains lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,6 +50,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - modernize
     - nakedret
     - nolintlint
     - perfsprint
@@ -91,6 +92,18 @@ linters:
         - shadow
         - unusedwrite
       enable-all: true
+    modernize:
+      disable:
+        - any
+        - bloop
+        - fmtappendf
+        - minmax
+        - rangeint
+        - reflecttypefor
+        - stditerators
+        - stringscut
+        - stringscutprefix
+        - stringsseq
     perfsprint:
       int-conversion: false
       err-error: false

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -598,12 +599,7 @@ func (a *StringList) UnmarshalYAML(unmarshal func(any) error) error {
 }
 
 func (a StringList) Has(file string) bool {
-	for _, existing := range a {
-		if existing == file {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(a, file)
 }
 
 func (c *Config) check() error {
@@ -747,7 +743,7 @@ func (tm TypeMap) ReferencedPackages() []string {
 				continue
 			}
 			pkg, _ := code.PkgAndType(model)
-			if pkg == "" || inStrSlice(pkgs, pkg) {
+			if pkg == "" || slices.Contains(pkgs, pkg) {
 				continue
 			}
 			pkgs = append(pkgs, code.QualifyPackagePath(pkg))
@@ -785,16 +781,6 @@ type DirectiveConfig struct {
 	// func(ctx context.Context, obj any, next graphql.Resolver[, directive arguments if any]) (res
 	// any, err error)
 	Implementation *string
-}
-
-func inStrSlice(haystack []string, needle string) bool {
-	for _, v := range haystack {
-		if needle == v {
-			return true
-		}
-	}
-
-	return false
 }
 
 // findCfg searches for the config file in this directory and all parents up the tree

--- a/codegen/directive.go
+++ b/codegen/directive.go
@@ -2,6 +2,7 @@ package codegen
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/vektah/gqlparser/v2/ast"
@@ -28,10 +29,8 @@ type Directive struct {
 // IsLocation check location directive
 func (d *Directive) IsLocation(location ...ast.DirectiveLocation) bool {
 	for _, l := range d.Locations {
-		for _, a := range location {
-			if l == a {
-				return true
-			}
+		if slices.Contains(location, l) {
+			return true
 		}
 	}
 

--- a/codegen/field.go
+++ b/codegen/field.go
@@ -7,6 +7,7 @@ import (
 	"go/types"
 	"log"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -627,15 +628,6 @@ func (f *Field) IsRoot() bool {
 	return f.Object.Root
 }
 
-func contains(slice []string, str string) bool {
-	for _, s := range slice {
-		if s == str {
-			return true
-		}
-	}
-	return false
-}
-
 func formatGoType(goType string) string {
 	if strings.Contains(goType, "/") {
 		lastDot := strings.LastIndex(goType, ".")
@@ -687,7 +679,7 @@ func (f *Field) ShortResolverSignature(ft *goast.FuncType) string {
 		resSb540.WriteString(fmt.Sprintf(", %s %s", inlineInfo.OriginalArgName, goType))
 
 		for _, arg := range f.Args {
-			if !contains(inlineInfo.ExpandedArgs, arg.Name) {
+			if !slices.Contains(inlineInfo.ExpandedArgs, arg.Name) {
 				resSb540.WriteString(
 					fmt.Sprintf(
 						", %s %s",
@@ -816,7 +808,7 @@ func (f *Field) CallArgs() string {
 		args = append(args, bundled)
 
 		for _, arg := range f.Args {
-			if !contains(inlineInfo.ExpandedArgs, arg.Name) {
+			if !slices.Contains(inlineInfo.ExpandedArgs, arg.Name) {
 				tmp := "fc.Args[" + strconv.Quote(
 					arg.Name,
 				) + "].(" + templates.CurrentImports.LookupType(
@@ -872,7 +864,7 @@ func (f *Field) StubCallArgs() string {
 		args = append(args, inlineInfo.OriginalArgName)
 
 		for _, arg := range f.Args {
-			if !contains(inlineInfo.ExpandedArgs, arg.Name) {
+			if !slices.Contains(inlineInfo.ExpandedArgs, arg.Name) {
 				args = append(args, arg.VarName)
 			}
 		}

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"go/types"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -78,9 +80,7 @@ func Render(cfg Options) error {
 	CurrentImports = &Imports{packages: cfg.Packages, destDir: filepath.Dir(cfg.Filename)}
 
 	funcs := Funcs()
-	for n, f := range cfg.Funcs {
-		funcs[n] = f
-	}
+	maps.Copy(funcs, cfg.Funcs)
 
 	t := template.New("").Funcs(funcs)
 	t, err := parseTemplates(cfg, t)
@@ -596,10 +596,8 @@ var keywords = []string{
 
 // sanitizeKeywords prevents collisions with go keywords for arguments to resolver functions
 func sanitizeKeywords(name string) string {
-	for _, k := range keywords {
-		if name == k {
-			return name + "Arg"
-		}
+	if slices.Contains(keywords, name) {
+		return name + "Arg"
 	}
 	return name
 }

--- a/graphql/executable_schema.go
+++ b/graphql/executable_schema.go
@@ -5,6 +5,7 @@ package graphql
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/vektah/gqlparser/v2/ast"
 )
@@ -148,12 +149,7 @@ func doesFragmentConditionMatch(typeCondition string, satisfies []string) bool {
 
 	// To handle abstract types we pass in a list of all known types that the current
 	// type will satisfy.
-	for _, satisfyingType := range satisfies {
-		if typeCondition == satisfyingType {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(satisfies, typeCondition)
 }
 
 func getOrCreateAndAppendField(
@@ -176,15 +172,11 @@ func getOrCreateAndAppendField(
 				return &(*c)[i]
 			}
 
-			for _, ifc := range objectDefinition.Interfaces {
-				if ifc == cf.ObjectDefinition.Name {
-					return &(*c)[i]
-				}
+			if slices.Contains(objectDefinition.Interfaces, cf.ObjectDefinition.Name) {
+				return &(*c)[i]
 			}
-			for _, ifc := range cf.ObjectDefinition.Interfaces {
-				if ifc == objectDefinition.Name {
-					return &(*c)[i]
-				}
+			if slices.Contains(cf.ObjectDefinition.Interfaces, objectDefinition.Name) {
+				return &(*c)[i]
 			}
 		}
 	}

--- a/graphql/handler/transport/headers.go
+++ b/graphql/handler/transport/headers.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"maps"
 	"mime"
 	"net/http"
 	"strings"
@@ -69,11 +70,7 @@ func writeHeaders(w http.ResponseWriter, headers map[string][]string) {
 
 func mergeHeaders(baseHeaders, additionalHeaders map[string][]string) map[string][]string {
 	result := make(map[string][]string)
-	for k, v := range baseHeaders {
-		result[k] = v
-	}
-	for key, values := range additionalHeaders {
-		result[key] = values
-	}
+	maps.Copy(result, baseHeaders)
+	maps.Copy(result, additionalHeaders)
 	return result
 }

--- a/graphql/handler/transport/websocket_subprotocol.go
+++ b/graphql/handler/transport/websocket_subprotocol.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"encoding/json"
 	"errors"
+	"slices"
 
 	"github.com/gorilla/websocket"
 )
@@ -78,16 +79,6 @@ func (t messageType) String() string {
 	return text
 }
 
-func contains(list []string, elem string) bool {
-	for _, e := range list {
-		if e == elem {
-			return true
-		}
-	}
-
-	return false
-}
-
 func (t *Websocket) injectGraphQLWSSubprotocols() {
 	// the list of subprotocols is specified by the consumer of the Websocket struct,
 	// in order to preserve backward compatibility, we inject the graphql specific subprotocols
@@ -98,7 +89,7 @@ func (t *Websocket) injectGraphQLWSSubprotocols() {
 		}()
 
 		for _, subprotocol := range supportedSubprotocols {
-			if !contains(t.Upgrader.Subprotocols, subprotocol) {
+			if !slices.Contains(t.Upgrader.Subprotocols, subprotocol) {
 				t.Upgrader.Subprotocols = append(t.Upgrader.Subprotocols, subprotocol)
 			}
 		}

--- a/plugin/federation/entity.go
+++ b/plugin/federation/entity.go
@@ -2,6 +2,7 @@ package federation
 
 import (
 	"go/types"
+	"slices"
 
 	"github.com/vektah/gqlparser/v2/ast"
 
@@ -97,12 +98,7 @@ func (e *Entity) isResolvable() bool {
 
 // Determine if a field is part of the entities key.
 func (e *Entity) isKeyField(field *ast.FieldDefinition) bool {
-	for _, keyField := range e.keyFields() {
-		if keyField == field.Name {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(e.keyFields(), field.Name)
 }
 
 // Get the key fields for this entity.


### PR DESCRIPTION
This PR enables the `modernize` linter and fixes all `slicescontains` and `mapsloop` issues. This significantly reduces boilerplate.