### PR TITLE
feat(codegen): add Batch flag to Field struct (blocked by #4005)

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -592,6 +592,7 @@ type TypeMapField struct {
 	// that accepts multiple parent objects and returns results for all of them
 	// in a single call, reducing N+1 query problems.
 	Batch bool `yaml:"batch,omitempty"`
+
 	// ForceGenerate forces the field to be generated in the model struct
 	// even when OmitResolverFields is enabled and the field has forceResolver: true.
 	ForceGenerate bool `yaml:"forceGenerate"`

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -592,7 +592,6 @@ type TypeMapField struct {
 	// that accepts multiple parent objects and returns results for all of them
 	// in a single call, reducing N+1 query problems.
 	Batch bool `yaml:"batch,omitempty"`
-
 	// ForceGenerate forces the field to be generated in the model struct
 	// even when OmitResolverFields is enabled and the field has forceResolver: true.
 	ForceGenerate bool `yaml:"forceGenerate"`

--- a/codegen/field.go
+++ b/codegen/field.go
@@ -38,6 +38,7 @@ type Field struct {
 	Directives       []*Directive
 	HasHaser         bool   // Whether a haser method is available (e.g., HasName())
 	HaserMethodName  string // Name of the haser method
+	Batch            bool   // Enable batch resolver for this field
 }
 
 func (b *builder) buildField(obj *Object, field *ast.FieldDefinition) (*Field, error) {
@@ -82,6 +83,13 @@ func (b *builder) buildField(obj *Object, field *ast.FieldDefinition) (*Field, e
 	if f.IsResolver && b.Config.ResolversAlwaysReturnPointers && !f.TypeReference.IsPtr() &&
 		f.TypeReference.IsStruct() {
 		f.TypeReference = b.Binder.PointerTo(f.TypeReference)
+	}
+
+	// Set Batch flag from config (independent of resolver setting)
+	if fieldCfg, ok := b.Config.Models[obj.Name]; ok {
+		if fieldEntry, ok := fieldCfg.Fields[field.Name]; ok {
+			f.Batch = fieldEntry.Batch
+		}
 	}
 
 	return &f, nil

--- a/codegen/field_test.go
+++ b/codegen/field_test.go
@@ -131,6 +131,18 @@ func TestEqualFieldName(t *testing.T) {
 	}
 }
 
+func TestField_Batch(t *testing.T) {
+	t.Run("Batch flag defaults to false", func(t *testing.T) {
+		f := Field{}
+		require.False(t, f.Batch)
+	})
+
+	t.Run("Batch flag can be set", func(t *testing.T) {
+		f := Field{Batch: true}
+		require.True(t, f.Batch)
+	})
+}
+
 func TestField_CallArgs(t *testing.T) {
 	tt := []struct {
 		Name string


### PR DESCRIPTION
## Goal

This series adds first-class batch resolver support to gqlgen, letting you solve the GraphQL N+1 problem without external libraries.
The N+1 problem happens when a single query fans out into many individual DB/API calls, killing performance. Today most people solve this with dataloader libraries; this makes it possible to handle it in gqlgen directly.
Since the behavior is opt-in and doesn't affect existing users, shipping it as **experimental** still provides clear value.

This PR alone might not give you the full picture, so take a look at the `_examples/batchresolver` directory on the `performance-enhancement-4` branch (https://github.com/99designs/gqlgen/pull/4008). Checking the test files, `generated.go`, and `schema.resolvers.go` should make the difference from existing non-batch resolvers clear.  The output itself doesn't change, and there are tests to prove it.

## Configuration and generated resolver shape

To enable batch resolvers, mark fields explicitly in the config:

```yaml
models:
  User:
    fields:
      posts:
        resolver: true
        batch: true # <- new!!!
```

When `batch: true` is set, gqlgen generates a batch resolver method that receives multiple parents and returns per‑parent results:

```go
// PostsBatch is the batch resolver for the posts field.
func (r *userResolver) PostsBatch(ctx context.Context, objs []*User) []BatchResult[[]*Post]
```

If batch is not set, gqlgen generates the standard per‑object resolver:

```go
func (r *userResolver) Posts(ctx context.Context, obj *User) ([]*Post, error)
```

Only fields with `batch: true` are affected. All other resolvers remain unchanged.

## Preconditions and approach

- Nothing is enabled unless batch: true is set
    - This is fully opt‑in, so existing users are unaffected.
- Same error handling, partial response behavior, and non‑null propagation as non‑batch
    - These invariants are covered by tests to prevent behavioral drift.
- PRs are split in dependency order so reviewers can follow the whole story linearly
    - Settings → internal data model → stub generation → runtime logic and tests.

## Role of each PR

### `performance‑enhancement‑1` branch

https://github.com/99designs/gqlgen/pull/4005

Allow batch to be declared in config

- Add batch: true to TypeMapField
- Make batch‑enabled fields explicit in schema config

### `performance‑enhancement‑2` branch based on `performance‑enhancement‑1`

https://github.com/99designs/gqlgen/pull/4006

Propagate the batch flag into codegen

- Add Batch flag to Field
- Let templates and generators branch correctly on batch vs non‑batch

### `performance‑enhancement‑3` branch based on `performance‑enhancement‑2`

https://github.com/99designs/gqlgen/pull/4007

Generate batch resolver stubs

- Auto‑generate batch resolver method stubs

### `performance‑enhancement‑4` branch based on `performance‑enhancement‑3`

https://github.com/99designs/gqlgen/pull/4008

Add runtime support and verification

- Implement batch execution logic
- Add example tests comparing batch vs non‑batch behavior
- Preserve batch implementations across regeneration

---

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))