### PR TITLE
feat(exec): batch-only resolver generation (blocked by #4007)

### DIFF
--- a/_examples/batchresolver/batchresolver_test.go
+++ b/_examples/batchresolver/batchresolver_test.go
@@ -1,0 +1,446 @@
+package batchresolver
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/99designs/gqlgen/client"
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+)
+
+type gqlError struct {
+	Message string `json:"message"`
+	Path    []any  `json:"path"`
+}
+
+func newTestClient(r *Resolver) *client.Client {
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: r}))
+	srv.AddTransport(transport.POST{})
+	return client.New(srv)
+}
+
+func marshalJSON(t *testing.T, v any) string {
+	t.Helper()
+	blob, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(blob)
+}
+
+func requireErrorJSON(t *testing.T, err error, expected string) {
+	t.Helper()
+	require.Error(t, err)
+	actual := normalizeErrorJSON(t, err.Error())
+	expectedNorm := normalizeErrorJSON(t, expected)
+	require.Equal(t, expectedNorm, actual)
+}
+
+func normalizeErrorJSON(t *testing.T, jsonStr string) string {
+	t.Helper()
+	if jsonStr == "" {
+		return ""
+	}
+	var list []gqlError
+	require.NoError(t, json.Unmarshal([]byte(jsonStr), &list))
+	sort.Slice(list, func(i, j int) bool {
+		return errorKey(t, list[i]) < errorKey(t, list[j])
+	})
+	blob, err := json.Marshal(list)
+	require.NoError(t, err)
+	return string(blob)
+}
+
+func errorKey(t *testing.T, err gqlError) string {
+	t.Helper()
+	blob, marshalErr := json.Marshal(err.Path)
+	require.NoError(t, marshalErr)
+	return err.Message + "|" + string(blob)
+}
+
+func TestBatchResolver_Parity_NoError(t *testing.T) {
+	resolver := &Resolver{
+		users:         []*User{{}, {}},
+		profiles:      []*Profile{{ID: "p1"}, {ID: "p2"}},
+		profileErrIdx: -1,
+	}
+
+	c := newTestClient(resolver)
+	var resp struct {
+		Users []struct {
+			NullableBatch *struct {
+				ID string `json:"id"`
+			} `json:"nullableBatch"`
+			NullableNonBatch *struct {
+				ID string `json:"id"`
+			} `json:"nullableNonBatch"`
+		} `json:"users"`
+	}
+
+	err := c.Post(`query { users { nullableBatch { id } nullableNonBatch { id } } }`, &resp)
+	require.NoError(t, err)
+	require.JSONEq(
+		t,
+		`{"users":[{"nullableBatch":{"id":"p1"},"nullableNonBatch":{"id":"p1"}},{"nullableBatch":{"id":"p2"},"nullableNonBatch":{"id":"p2"}}]}`,
+		marshalJSON(t, resp),
+	)
+}
+
+func TestBatchResolver_Parity_WithArgs(t *testing.T) {
+	resolver := &Resolver{
+		users:         []*User{{}, {}},
+		profiles:      []*Profile{{ID: "p1"}, {ID: "p2"}, {ID: "p3"}},
+		profileErrIdx: -1,
+	}
+
+	c := newTestClient(resolver)
+	var resp struct {
+		Users []struct {
+			NullableBatchWithArg *struct {
+				ID string `json:"id"`
+			} `json:"nullableBatchWithArg"`
+			NullableNonBatchWithArg *struct {
+				ID string `json:"id"`
+			} `json:"nullableNonBatchWithArg"`
+		} `json:"users"`
+	}
+
+	err := c.Post(`
+query {
+  users {
+    nullableBatchWithArg(offset: 1) { id }
+    nullableNonBatchWithArg(offset: 1) { id }
+  }
+}`, &resp)
+	require.NoError(t, err)
+	require.JSONEq(
+		t,
+		`{"users":[{"nullableBatchWithArg":{"id":"p2"},"nullableNonBatchWithArg":{"id":"p2"}},{"nullableBatchWithArg":{"id":"p3"},"nullableNonBatchWithArg":{"id":"p3"}}]}`,
+		marshalJSON(t, resp),
+	)
+}
+
+func TestBatchResolver_Parity_Error(t *testing.T) {
+	resolver := &Resolver{
+		users:         []*User{{}, {}},
+		profiles:      []*Profile{{ID: "p1"}, {ID: "p2"}},
+		profileErrIdx: 1,
+	}
+
+	c := newTestClient(resolver)
+	var resp struct {
+		Users []struct {
+			NullableBatch *struct {
+				ID string `json:"id"`
+			} `json:"nullableBatch"`
+			NullableNonBatch *struct {
+				ID string `json:"id"`
+			} `json:"nullableNonBatch"`
+		} `json:"users"`
+	}
+
+	err := c.Post(`query { users { nullableBatch { id } nullableNonBatch { id } } }`, &resp)
+	requireErrorJSON(t, err, `[
+		{"message":"profile error at index 1","path":["users",1,"nullableBatch"]},
+		{"message":"profile error at index 1","path":["users",1,"nullableNonBatch"]}
+	]`)
+	require.JSONEq(
+		t,
+		`{"users":[{"nullableBatch":{"id":"p1"},"nullableNonBatch":{"id":"p1"}},{"nullableBatch":null,"nullableNonBatch":null}]}`,
+		marshalJSON(t, resp),
+	)
+}
+
+func TestBatchResolver_Parity_GqlErrorList(t *testing.T) {
+	resolver := &Resolver{
+		users:              []*User{{}, {}},
+		profiles:           []*Profile{{ID: "p1"}, {ID: "p2"}},
+		profileErrListIdxs: map[int]struct{}{0: {}},
+		profileErrIdx:      -1,
+	}
+
+	c := newTestClient(resolver)
+	var resp struct {
+		Users []struct {
+			NullableBatch *struct {
+				ID string `json:"id"`
+			} `json:"nullableBatch"`
+			NullableNonBatch *struct {
+				ID string `json:"id"`
+			} `json:"nullableNonBatch"`
+		} `json:"users"`
+	}
+
+	err := c.Post(`query { users { nullableBatch { id } nullableNonBatch { id } } }`, &resp)
+	requireErrorJSON(t, err, `[
+		{"message":"profile list error 1 at index 0","path":["users",0,"nullableBatch"]},
+		{"message":"profile list error 2 at index 0","path":["users",0,"nullableBatch"]},
+		{"message":"profile list error 1 at index 0","path":["users",0,"nullableNonBatch"]},
+		{"message":"profile list error 2 at index 0","path":["users",0,"nullableNonBatch"]}
+	]`)
+	require.JSONEq(
+		t,
+		`{"users":[{"nullableBatch":null,"nullableNonBatch":null},{"nullableBatch":{"id":"p2"},"nullableNonBatch":{"id":"p2"}}]}`,
+		marshalJSON(t, resp),
+	)
+}
+
+func TestBatchResolver_Parity_GqlErrorPathNil(t *testing.T) {
+	resolver := &Resolver{
+		users:                   []*User{{}, {}},
+		profiles:                []*Profile{{ID: "p1"}, {ID: "p2"}},
+		profileGqlErrNoPathIdxs: map[int]struct{}{0: {}},
+		profileErrIdx:           -1,
+	}
+
+	c := newTestClient(resolver)
+	var resp struct {
+		Users []struct {
+			NullableBatch *struct {
+				ID string `json:"id"`
+			} `json:"nullableBatch"`
+			NullableNonBatch *struct {
+				ID string `json:"id"`
+			} `json:"nullableNonBatch"`
+		} `json:"users"`
+	}
+
+	err := c.Post(`query { users { nullableBatch { id } nullableNonBatch { id } } }`, &resp)
+	requireErrorJSON(t, err, `[
+		{"message":"profile gqlerror path nil at index 0","path":["users",0,"nullableBatch"]},
+		{"message":"profile gqlerror path nil at index 0","path":["users",0,"nullableNonBatch"]}
+	]`)
+	require.JSONEq(
+		t,
+		`{"users":[{"nullableBatch":null,"nullableNonBatch":null},{"nullableBatch":{"id":"p2"},"nullableNonBatch":{"id":"p2"}}]}`,
+		marshalJSON(t, resp),
+	)
+}
+
+func TestBatchResolver_Parity_GqlErrorPathSet(t *testing.T) {
+	resolver := &Resolver{
+		users:                 []*User{{}, {}},
+		profiles:              []*Profile{{ID: "p1"}, {ID: "p2"}},
+		profileGqlErrPathIdxs: map[int]struct{}{0: {}},
+		profileErrIdx:         -1,
+	}
+
+	c := newTestClient(resolver)
+	var resp struct {
+		Users []struct {
+			NullableBatch *struct {
+				ID string `json:"id"`
+			} `json:"nullableBatch"`
+			NullableNonBatch *struct {
+				ID string `json:"id"`
+			} `json:"nullableNonBatch"`
+		} `json:"users"`
+	}
+
+	err := c.Post(`query { users { nullableBatch { id } nullableNonBatch { id } } }`, &resp)
+	requireErrorJSON(t, err, `[
+		{"message":"profile gqlerror path set at index 0","path":["custom",0]},
+		{"message":"profile gqlerror path set at index 0","path":["custom",0]}
+	]`)
+	require.JSONEq(
+		t,
+		`{"users":[{"nullableBatch":null,"nullableNonBatch":null},{"nullableBatch":{"id":"p2"},"nullableNonBatch":{"id":"p2"}}]}`,
+		marshalJSON(t, resp),
+	)
+}
+
+func TestBatchResolver_Parity_PartialResponseWithErrValue(t *testing.T) {
+	resolver := &Resolver{
+		users:                   []*User{{}, {}},
+		profiles:                []*Profile{{ID: "p1"}, {ID: "p2"}},
+		profileErrWithValueIdxs: map[int]struct{}{0: {}},
+		profileErrIdx:           -1,
+	}
+
+	c := newTestClient(resolver)
+	var resp struct {
+		Users []struct {
+			NullableBatch *struct {
+				ID string `json:"id"`
+			} `json:"nullableBatch"`
+			NullableNonBatch *struct {
+				ID string `json:"id"`
+			} `json:"nullableNonBatch"`
+		} `json:"users"`
+	}
+
+	err := c.Post(`query { users { nullableBatch { id } nullableNonBatch { id } } }`, &resp)
+	requireErrorJSON(t, err, `[
+		{"message":"profile error with value at index 0","path":["users",0,"nullableBatch"]},
+		{"message":"profile error with value at index 0","path":["users",0,"nullableNonBatch"]}
+	]`)
+	require.JSONEq(
+		t,
+		`{"users":[{"nullableBatch":null,"nullableNonBatch":null},{"nullableBatch":{"id":"p2"},"nullableNonBatch":{"id":"p2"}}]}`,
+		marshalJSON(t, resp),
+	)
+}
+
+func TestBatchResolver_Parity_NonNullPropagation(t *testing.T) {
+	resolver := &Resolver{
+		users:         []*User{{}, {}},
+		profiles:      []*Profile{{ID: "p1"}, {ID: "p2"}},
+		profileErrIdx: 0,
+	}
+
+	c := newTestClient(resolver)
+	var resp struct {
+		Users []struct {
+			NonNullableBatch *struct {
+				ID string `json:"id"`
+			} `json:"nonNullableBatch"`
+			NonNullableNonBatch *struct {
+				ID string `json:"id"`
+			} `json:"nonNullableNonBatch"`
+		} `json:"users"`
+	}
+
+	err := c.Post(`query { users { nonNullableBatch { id } nonNullableNonBatch { id } } }`, &resp)
+	requireErrorJSON(t, err, `[
+		{"message":"profile error at index 0","path":["users",0,"nonNullableBatch"]},
+		{"message":"profile error at index 0","path":["users",0,"nonNullableNonBatch"]}
+	]`)
+	require.JSONEq(
+		t,
+		`{"users":null}`,
+		marshalJSON(t, resp),
+	)
+}
+
+func TestBatchResolver_InvalidLen_AddsErrorPerParent(t *testing.T) {
+	resolver := &Resolver{
+		users:           []*User{{}, {}},
+		profiles:        []*Profile{{ID: "p1"}, {ID: "p2"}},
+		profileErrIdx:   -1,
+		profileWrongLen: true,
+	}
+
+	c := newTestClient(resolver)
+	var resp struct {
+		Users []struct {
+			NullableBatch *struct {
+				ID string `json:"id"`
+			} `json:"nullableBatch"`
+		} `json:"users"`
+	}
+
+	err := c.Post(`query { users { nullableBatch { id } } }`, &resp)
+	requireErrorJSON(t, err, `[
+		{"message":"index 0: batch resolver User.nullableBatch returned 1 results for 2 parents","path":["users",0,"nullableBatch"]},
+		{"message":"index 1: batch resolver User.nullableBatch returned 1 results for 2 parents","path":["users",1,"nullableBatch"]}
+	]`)
+	require.JSONEq(
+		t,
+		`{"users":[{"nullableBatch":null},{"nullableBatch":null}]}`,
+		marshalJSON(t, resp),
+	)
+}
+
+func TestBatchResolver_BatchErrors_ErrLenMismatch_AddsErrorPerParent(t *testing.T) {
+	cases := []struct {
+		name   string
+		errLen int
+	}{
+		{name: "len1", errLen: 1},
+		{name: "len0", errLen: 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resolver := &Resolver{
+				users:             []*User{{}, {}},
+				profiles:          []*Profile{{ID: "p1"}, {ID: "p2"}},
+				profileErrIdx:     -1,
+				batchErrsWrongLen: true,
+				batchErrsLen:      tc.errLen,
+			}
+
+			c := newTestClient(resolver)
+			var resp struct {
+				Users []struct {
+					NullableBatch *struct {
+						ID string `json:"id"`
+					} `json:"nullableBatch"`
+				} `json:"users"`
+			}
+
+			err := c.Post(`query { users { nullableBatch { id } } }`, &resp)
+			requireErrorJSON(t, err, fmt.Sprintf(`[
+				{"message":"index 0: batch resolver User.nullableBatch returned %d errors for 2 parents","path":["users",0,"nullableBatch"]},
+				{"message":"index 1: batch resolver User.nullableBatch returned %d errors for 2 parents","path":["users",1,"nullableBatch"]}
+			]`, tc.errLen, tc.errLen))
+			require.JSONEq(
+				t,
+				`{"users":[{"nullableBatch":null},{"nullableBatch":null}]}`,
+				marshalJSON(t, resp),
+			)
+		})
+	}
+}
+
+func TestBatchResolver_BatchErrors_ResultLenMismatch_AddsErrorPerParent(t *testing.T) {
+	resolver := &Resolver{
+		users:                []*User{{}, {}},
+		profiles:             []*Profile{{ID: "p1"}, {ID: "p2"}},
+		profileErrIdx:        -1,
+		batchResultsWrongLen: true,
+		batchResultsLen:      1,
+	}
+
+	c := newTestClient(resolver)
+	var resp struct {
+		Users []struct {
+			NullableBatch *struct {
+				ID string `json:"id"`
+			} `json:"nullableBatch"`
+		} `json:"users"`
+	}
+
+	err := c.Post(`query { users { nullableBatch { id } } }`, &resp)
+	requireErrorJSON(t, err, `[
+		{"message":"index 0: batch resolver User.nullableBatch returned 1 results for 2 parents","path":["users",0,"nullableBatch"]},
+		{"message":"index 1: batch resolver User.nullableBatch returned 1 results for 2 parents","path":["users",1,"nullableBatch"]}
+	]`)
+	require.JSONEq(
+		t,
+		`{"users":[{"nullableBatch":null},{"nullableBatch":null}]}`,
+		marshalJSON(t, resp),
+	)
+}
+
+func TestBatchResolver_BatchErrors_ListPerIndex_AddsMultipleErrors(t *testing.T) {
+	resolver := &Resolver{
+		users:            []*User{{}, {}},
+		profiles:         []*Profile{{ID: "p1"}, {ID: "p2"}},
+		profileErrIdx:    -1,
+		batchErrListIdxs: map[int]struct{}{0: {}},
+	}
+
+	c := newTestClient(resolver)
+	var resp struct {
+		Users []struct {
+			NullableBatch *struct {
+				ID string `json:"id"`
+			} `json:"nullableBatch"`
+		} `json:"users"`
+	}
+
+	err := c.Post(`query { users { nullableBatch { id } } }`, &resp)
+	requireErrorJSON(t, err, `[
+		{"message":"batch list error 1 at index 0","path":["users",0,"nullableBatch"]},
+		{"message":"batch list error 2 at index 0","path":["users",0,"nullableBatch"]}
+	]`)
+	require.JSONEq(
+		t,
+		`{"users":[{"nullableBatch":null},{"nullableBatch":{"id":"p2"}}]}`,
+		marshalJSON(t, resp),
+	)
+}

--- a/_examples/batchresolver/gqlgen.yml
+++ b/_examples/batchresolver/gqlgen.yml
@@ -22,6 +22,11 @@ models:
         batch: true
       nullableNonBatch:
         resolver: true
+      nullableBatchWithArg:
+        resolver: true
+        batch: true
+      nullableNonBatchWithArg:
+        resolver: true
       nonNullableBatch:
         resolver: true
         batch: true

--- a/_examples/batchresolver/models_gen.go
+++ b/_examples/batchresolver/models_gen.go
@@ -10,8 +10,10 @@ type Query struct {
 }
 
 type User struct {
-	NullableBatch       *Profile `json:"nullableBatch,omitempty"`
-	NullableNonBatch    *Profile `json:"nullableNonBatch,omitempty"`
-	NonNullableBatch    *Profile `json:"nonNullableBatch"`
-	NonNullableNonBatch *Profile `json:"nonNullableNonBatch"`
+	NullableBatch           *Profile `json:"nullableBatch,omitempty"`
+	NullableNonBatch        *Profile `json:"nullableNonBatch,omitempty"`
+	NullableBatchWithArg    *Profile `json:"nullableBatchWithArg,omitempty"`
+	NullableNonBatchWithArg *Profile `json:"nullableNonBatchWithArg,omitempty"`
+	NonNullableBatch        *Profile `json:"nonNullableBatch"`
+	NonNullableNonBatch     *Profile `json:"nonNullableNonBatch"`
 }

--- a/_examples/batchresolver/resolver.go
+++ b/_examples/batchresolver/resolver.go
@@ -5,4 +5,30 @@ package batchresolver
 // It serves as dependency injection for your app, add any dependencies you require
 // here.
 
-type Resolver struct{}
+type Resolver struct {
+	users                   []*User
+	profiles                []*Profile
+	profileErrIdx           int
+	profileErrWithValueIdxs map[int]struct{}
+	profileErrListIdxs      map[int]struct{}
+	profileGqlErrNoPathIdxs map[int]struct{}
+	profileGqlErrPathIdxs   map[int]struct{}
+	profileWrongLen         bool
+	batchErrsWrongLen       bool
+	batchErrsLen            int
+	batchResultsWrongLen    bool
+	batchResultsLen         int
+	batchErrListIdxs        map[int]struct{}
+}
+
+func (r *Resolver) userIndex(obj *User) int {
+	if obj == nil {
+		return -1
+	}
+	for i := range r.users {
+		if r.users[i] == obj {
+			return i
+		}
+	}
+	return -1
+}

--- a/_examples/batchresolver/resolver_helpers.go
+++ b/_examples/batchresolver/resolver_helpers.go
@@ -1,0 +1,48 @@
+package batchresolver
+
+import (
+	"fmt"
+
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+)
+
+func resolveProfile(r *Resolver, idx int) (*Profile, error) {
+	if r.profileGqlErrPathIdxs != nil {
+		if _, ok := r.profileGqlErrPathIdxs[idx]; ok {
+			return nil, &gqlerror.Error{
+				Message: fmt.Sprintf("profile gqlerror path set at index %d", idx),
+				Path:    ast.Path{ast.PathName("custom"), ast.PathIndex(idx)},
+			}
+		}
+	}
+	if r.profileGqlErrNoPathIdxs != nil {
+		if _, ok := r.profileGqlErrNoPathIdxs[idx]; ok {
+			return nil, gqlerror.Errorf("profile gqlerror path nil at index %d", idx)
+		}
+	}
+	if r.profileErrListIdxs != nil {
+		if _, ok := r.profileErrListIdxs[idx]; ok {
+			return nil, gqlerror.List{
+				gqlerror.Errorf("profile list error 1 at index %d", idx),
+				gqlerror.Errorf("profile list error 2 at index %d", idx),
+			}
+		}
+	}
+	if r.profileErrWithValueIdxs != nil {
+		if _, ok := r.profileErrWithValueIdxs[idx]; ok {
+			var value *Profile
+			if idx >= 0 && idx < len(r.profiles) {
+				value = r.profiles[idx]
+			}
+			return value, fmt.Errorf("profile error with value at index %d", idx)
+		}
+	}
+	if idx == r.profileErrIdx {
+		return nil, fmt.Errorf("profile error at index %d", idx)
+	}
+	if idx < 0 || idx >= len(r.profiles) {
+		return nil, fmt.Errorf("profile not set at index %d", idx)
+	}
+	return r.profiles[idx], nil
+}

--- a/_examples/batchresolver/schema.graphql
+++ b/_examples/batchresolver/schema.graphql
@@ -5,6 +5,8 @@ type Query {
 type User {
     nullableBatch: Profile
     nullableNonBatch: Profile
+    nullableBatchWithArg(offset: Int!): Profile
+    nullableNonBatchWithArg(offset: Int!): Profile
     nonNullableBatch: Profile!
     nonNullableNonBatch: Profile!
 }

--- a/_examples/batchresolver/schema.resolvers.go
+++ b/_examples/batchresolver/schema.resolvers.go
@@ -7,32 +7,150 @@ package batchresolver
 
 import (
 	"context"
-	"fmt"
+	"errors"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // Users is the resolver for the users field.
 func (r *queryResolver) Users(ctx context.Context) ([]*User, error) {
-	panic(fmt.Errorf("not implemented: Users - users"))
+	if r.users == nil {
+		return nil, errors.New("users not set")
+	}
+	return r.users, nil
 }
 
 // NullableBatch is the batch resolver for the nullableBatch field.
-func (r *userResolver) NullableBatch(ctx context.Context, objs []*User) ([]*Profile, []error) {
-	panic("not implemented: NullableBatch - nullableBatch")
+func (r *userResolver) NullableBatch(ctx context.Context, objs []*User) ([]*Profile, error) {
+	if r.batchResultsWrongLen {
+		results := make([]*Profile, r.batchResultsLen)
+		errs := make([]error, len(objs))
+		return results, graphql.BatchErrorList(errs)
+	}
+	if r.batchErrsWrongLen {
+		results := make([]*Profile, len(objs))
+		errs := make([]error, r.batchErrsLen)
+		return results, graphql.BatchErrorList(errs)
+	}
+	if r.batchErrListIdxs != nil {
+		results := make([]*Profile, len(objs))
+		errs := make([]error, len(objs))
+		for i, obj := range objs {
+			idx := r.userIndex(obj)
+			if idx >= 0 && idx < len(r.profiles) {
+				results[i] = r.profiles[idx]
+			}
+			if _, ok := r.batchErrListIdxs[idx]; ok {
+				errs[i] = gqlerror.List{
+					gqlerror.Errorf("batch list error 1 at index %d", idx),
+					gqlerror.Errorf("batch list error 2 at index %d", idx),
+				}
+			}
+		}
+		return results, graphql.BatchErrorList(errs)
+	}
+	if r.profileWrongLen {
+		if len(objs) == 0 {
+			return nil, nil
+		}
+		idx := r.userIndex(objs[0])
+		value, _ := resolveProfile(r.Resolver, idx)
+		return []*Profile{value}, nil
+	}
+
+	results := make([]*Profile, len(objs))
+	errs := make([]error, len(objs))
+	hasErr := false
+	for i, obj := range objs {
+		idx := r.userIndex(obj)
+		value, err := resolveProfile(r.Resolver, idx)
+		results[i] = value
+		errs[i] = err
+		if err != nil {
+			hasErr = true
+		}
+	}
+	if hasErr {
+		return results, graphql.BatchErrorList(errs)
+	}
+	return results, nil
 }
 
 // NullableNonBatch is the resolver for the nullableNonBatch field.
 func (r *userResolver) NullableNonBatch(ctx context.Context, obj *User) (*Profile, error) {
-	panic("not implemented")
+	idx := r.userIndex(obj)
+	return resolveProfile(r.Resolver, idx)
+}
+
+// NullableBatchWithArg is the batch resolver for the nullableBatchWithArg field.
+func (r *userResolver) NullableBatchWithArg(ctx context.Context, objs []*User, offset int) ([]*Profile, error) {
+	if r.profileWrongLen {
+		if len(objs) == 0 {
+			return nil, nil
+		}
+		idx := r.userIndex(objs[0]) + offset
+		value, _ := resolveProfile(r.Resolver, idx)
+		return []*Profile{value}, nil
+	}
+
+	results := make([]*Profile, len(objs))
+	errs := make([]error, len(objs))
+	hasErr := false
+	for i, obj := range objs {
+		idx := r.userIndex(obj) + offset
+		value, err := resolveProfile(r.Resolver, idx)
+		results[i] = value
+		errs[i] = err
+		if err != nil {
+			hasErr = true
+		}
+	}
+	if hasErr {
+		return results, graphql.BatchErrorList(errs)
+	}
+	return results, nil
+}
+
+// NullableNonBatchWithArg is the resolver for the nullableNonBatchWithArg field.
+func (r *userResolver) NullableNonBatchWithArg(ctx context.Context, obj *User, offset int) (*Profile, error) {
+	idx := r.userIndex(obj) + offset
+	return resolveProfile(r.Resolver, idx)
 }
 
 // NonNullableBatch is the batch resolver for the nonNullableBatch field.
-func (r *userResolver) NonNullableBatch(ctx context.Context, objs []*User) ([]*Profile, []error) {
-	panic("not implemented: NonNullableBatch - nonNullableBatch")
+func (r *userResolver) NonNullableBatch(ctx context.Context, objs []*User) ([]*Profile, error) {
+	if r.profileWrongLen {
+		if len(objs) == 0 {
+			return nil, nil
+		}
+		idx := r.userIndex(objs[0])
+		value, _ := resolveProfile(r.Resolver, idx)
+		return []*Profile{value}, nil
+	}
+
+	results := make([]*Profile, len(objs))
+	errs := make([]error, len(objs))
+	hasErr := false
+	for i, obj := range objs {
+		idx := r.userIndex(obj)
+		value, err := resolveProfile(r.Resolver, idx)
+		results[i] = value
+		errs[i] = err
+		if err != nil {
+			hasErr = true
+		}
+	}
+	if hasErr {
+		return results, graphql.BatchErrorList(errs)
+	}
+	return results, nil
 }
 
 // NonNullableNonBatch is the resolver for the nonNullableNonBatch field.
 func (r *userResolver) NonNullableNonBatch(ctx context.Context, obj *User) (*Profile, error) {
-	panic("not implemented")
+	idx := r.userIndex(obj)
+	return resolveProfile(r.Resolver, idx)
 }
 
 // Query returns QueryResolver implementation.

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -589,8 +589,9 @@ type TypeMapField struct {
 
 	// Batch enables batch resolver generation for this field.
 	// When true, a batch resolver method (e.g., PostsBatch) will be generated
-	// that accepts multiple parent objects and returns results for all of them
-	// in a single call, reducing N+1 query problems.
+	// that accepts multiple parent objects and returns ([]T, error) for all of them
+	// in a single call, reducing N+1 query problems. For partial failures, return
+	// a graphql.BatchErrors implementation as the error.
 	Batch bool `yaml:"batch,omitempty"`
 	// ForceGenerate forces the field to be generated in the model struct
 	// even when OmitResolverFields is enabled and the field has forceResolver: true.

--- a/codegen/data.go
+++ b/codegen/data.go
@@ -49,6 +49,20 @@ func (d *Data) HasEmbeddableSources() bool {
 	return hasEmbeddableSources
 }
 
+func (d *Data) HasBatchResolverFields() bool {
+	for _, obj := range d.Objects {
+		if obj.Root {
+			continue
+		}
+		for _, field := range obj.Fields {
+			if field.IsBatch() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // AugmentedSource contains extra information about graphql schema files which is not known directly
 // from the Config.Sources data
 type AugmentedSource struct {

--- a/codegen/field.gotpl
+++ b/codegen/field.gotpl
@@ -138,25 +138,59 @@ func (ec *executionContext) {{ $field.FieldContextFunc }}({{ if not $field.Args 
 	return fc, nil
 }
 
+{{- if and $field.IsBatch (not $object.Root) }}
+func (ec *executionContext) resolveBatch_{{$object.Name}}_{{$field.Name}}(ctx context.Context, field graphql.CollectedField, obj {{$object.Reference | ref}}) (any, error) {
+	resolver := ec.resolvers.{{ ucFirst $object.Name }}()
+	{{- if $field.Args }}
+	fc := graphql.GetFieldContext(ctx)
+	{{- end }}
+	group := graphql.GetBatchParentGroup(ctx, {{ $object.Name | quote }})
+	if group != nil {
+		parents, ok := group.Parents.([]{{$object.Reference | ref}})
+		if ok {
+			idx, ok := graphql.BatchParentIndex(ctx)
+			if ok {
+				key := field.Alias
+				if key == "" {
+					key = field.Name
+				}
+				{{/* TODO: resolveBatch_* runs per parent even when grouped; consider a single
+				dispatch per field if the execution flow can support it. */ -}}
+				result := group.GetFieldResult(key, func() (any, error) {
+					return resolver.{{ $field.GoFieldName }}({{ $field.BatchCallArgs "parents" }})
+				})
+				return graphql.ResolveBatchGroupResult[{{ $field.TypeReference.GO | ref }}](
+					ctx,
+					idx,
+					len(parents),
+					result,
+					{{ printf "%s.%s" $object.Name $field.Name | quote }},
+				)
+			}
+		}
+	}
+
+	results, err := resolver.{{ $field.GoFieldName }}({{ $field.BatchCallArgs (printf "[]%s{obj}" ($object.Reference | ref)) }})
+	return graphql.ResolveBatchSingleResult[{{ $field.TypeReference.GO | ref }}](
+		ctx,
+		results,
+		err,
+		{{ printf "%s.%s" $object.Name $field.Name | quote }},
+	)
+}
+{{- end }}
+
 {{- end }}{{- end}}
 
 {{ define "fieldDefinition" }}
 	{{- if and .IsBatch (not .Object.Root) }}
-		resolver := ec.resolvers.{{ ucFirst .Object.Name }}()
-		results, errs := resolver.{{ .GoFieldName }}(ctx, []{{ .Object.Reference | ref }}{obj})
-		if errs == nil {
-			errs = make([]error, len(results))
-		}
-		if len(results) != 1 || len(errs) != 1 {
-			return nil, fmt.Errorf(
-				"batch resolver {{ .Object.Name }}.{{ .Name }} returned %d results and %d errors for %d parents",
-				len(results),
-				len(errs),
-				1,
-			)
-		}
-		return results[0], errs[0]
+		return ec.resolveBatch_{{ .Object.Name }}_{{ .Name }}(ctx, field, obj)
 	{{- else }}
+		{{- template "singleFieldDefinition" . }}
+	{{- end }}
+{{- end }}
+
+{{ define "singleFieldDefinition" }}
 	{{- if or .IsResolver .IsMethod -}}
 	{{- if gt (len .Args) 0 -}}
 	fc := graphql.GetFieldContext(ctx)
@@ -201,4 +235,3 @@ func (ec *executionContext) {{ $field.FieldContextFunc }}({{ if not $field.Args 
 		return {{.GoReceiverName}}.{{.GoFieldName}}, nil
 	{{- end }}
 	{{- end }}
-{{- end }}

--- a/codegen/generated!.gotpl
+++ b/codegen/generated!.gotpl
@@ -285,15 +285,16 @@
 		}
 	}
 
-	type executionContext struct {
-		*graphql.OperationContext
-		*executableSchema
-		deferred        int32
-		pendingDeferred int32
-		deferredResults chan graphql.DeferredResult
-	}
+type executionContext struct {
+	*graphql.OperationContext
+	*executableSchema
+	deferred        int32
+	pendingDeferred int32
+	deferredResults chan graphql.DeferredResult
+}
 
-	func (ec *executionContext) processDeferredGroup(dg graphql.DeferredGroup) {
+
+func (ec *executionContext) processDeferredGroup(dg graphql.DeferredGroup) {
 		atomic.AddInt32(&ec.pendingDeferred, 1)
 		go func () {
 			ctx := graphql.WithFreshResponseContext(dg.Context)

--- a/codegen/object.go
+++ b/codegen/object.go
@@ -107,7 +107,7 @@ func (o *Object) Implementors() string {
 
 func (o *Object) HasResolvers() bool {
 	for _, f := range o.Fields {
-		if f.IsResolver {
+		if f.IsResolver || f.IsBatch() {
 			return true
 		}
 	}

--- a/codegen/root_.gotpl
+++ b/codegen/root_.gotpl
@@ -263,6 +263,7 @@ type executionContext struct {
 	deferredResults chan graphql.DeferredResult
 }
 
+
 func (ec *executionContext) processDeferredGroup(dg graphql.DeferredGroup) {
 	atomic.AddInt32(&ec.pendingDeferred, 1)
 	go func () {

--- a/codegen/type.gotpl
+++ b/codegen/type.gotpl
@@ -130,6 +130,9 @@
 					}
 				{{- end }}
 				ret := make(graphql.Array, len(v))
+				{{- if and $.HasBatchResolverFields (not $type.IsScalar) (eq $type.Elem.Definition.Kind "OBJECT") }}
+				ctx = graphql.WithBatchParents(ctx, {{ $type.Elem.Definition.Name | quote }}, v)
+				{{- end }}
 				{{- if not $type.IsScalar }}
 					var wg sync.WaitGroup
 					{{- if gt $.Config.Exec.WorkerLimit 0 }}

--- a/graphql/batch.go
+++ b/graphql/batch.go
@@ -1,0 +1,306 @@
+package graphql
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"sync"
+
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+)
+
+// BatchErrors represents per-item errors from a batch resolver.
+// The returned slice must be the same length as the results slice, with nils for successes.
+type BatchErrors interface {
+	error
+	Errors() []error
+}
+
+// BatchErrorList is a simple BatchErrors implementation backed by a slice.
+type BatchErrorList []error
+
+func (e BatchErrorList) Error() string   { return "batch resolver returned errors" }
+func (e BatchErrorList) Errors() []error { return []error(e) }
+func (e BatchErrorList) Unwrap() []error {
+	if len(e) == 0 {
+		return nil
+	}
+	out := make([]error, 0, len(e))
+	for _, err := range e {
+		if err != nil {
+			out = append(out, err)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+type batchContextKey struct{}
+
+// BatchParentState holds the batch parent groups for the current context.
+type BatchParentState struct {
+	groups map[string]*BatchParentGroup
+}
+
+// BatchParentGroup represents a group of parent objects being resolved together.
+type BatchParentGroup struct {
+	Parents any
+	fields  sync.Map
+}
+
+// BatchFieldResult represents the cached result of a batch field resolution.
+type BatchFieldResult struct {
+	once    sync.Once
+	done    chan struct{}
+	Results any
+	Err     error
+}
+
+// WithBatchParents adds a batch parent group to the context.
+func WithBatchParents(ctx context.Context, typeName string, parents any) context.Context {
+	prev, _ := ctx.Value(batchContextKey{}).(*BatchParentState)
+	var groups map[string]*BatchParentGroup
+	if prev != nil {
+		groups = make(map[string]*BatchParentGroup, len(prev.groups)+1)
+		maps.Copy(groups, prev.groups)
+	} else {
+		groups = make(map[string]*BatchParentGroup, 1)
+	}
+	groups[typeName] = &BatchParentGroup{Parents: parents}
+
+	return context.WithValue(ctx, batchContextKey{}, &BatchParentState{groups: groups})
+}
+
+// GetBatchParentGroup retrieves the batch parent group for a given type name from context.
+func GetBatchParentGroup(ctx context.Context, typeName string) *BatchParentGroup {
+	state, _ := ctx.Value(batchContextKey{}).(*BatchParentState)
+	if state == nil {
+		return nil
+	}
+	return state.groups[typeName]
+}
+
+// GetFieldResult retrieves or computes the result for a batch field.
+func (g *BatchParentGroup) GetFieldResult(
+	key string,
+	resolve func() (any, error),
+) *BatchFieldResult {
+	if g == nil {
+		return nil
+	}
+	res, _ := g.fields.LoadOrStore(key, &BatchFieldResult{done: make(chan struct{})})
+	result := res.(*BatchFieldResult)
+	result.once.Do(func() {
+		defer close(result.done)
+		result.Results, result.Err = resolve()
+	})
+	<-result.done
+	return result
+}
+
+// BatchParentIndex returns the index of the current parent in the batch from the path.
+func BatchParentIndex(ctx context.Context) (ast.PathIndex, bool) {
+	path := GetPath(ctx)
+	if len(path) < 2 {
+		return 0, false
+	}
+	if idx, ok := path[len(path)-2].(ast.PathIndex); ok {
+		return idx, true
+	}
+	return 0, false
+}
+
+// BatchPathWithIndex returns a copy of the current path with the parent index replaced.
+func BatchPathWithIndex(ctx context.Context, index int) ast.Path {
+	path := GetPath(ctx)
+	if len(path) < 2 {
+		return path
+	}
+	if _, ok := path[len(path)-2].(ast.PathIndex); !ok {
+		return path
+	}
+	copied := make(ast.Path, len(path))
+	copy(copied, path)
+	copied[len(path)-2] = ast.PathIndex(index)
+	return copied
+}
+
+// AddBatchError adds an error for a specific index in a batch operation.
+func AddBatchError(ctx context.Context, index int, err error) {
+	if err == nil {
+		return
+	}
+	path := BatchPathWithIndex(ctx, index)
+	if list, ok := err.(gqlerror.List); ok {
+		for _, item := range list {
+			if item == nil {
+				continue
+			}
+			if item.Path == nil {
+				cloned := *item
+				cloned.Path = path
+				AddError(ctx, &cloned)
+				continue
+			}
+			AddError(ctx, item)
+		}
+		return
+	}
+	var gqlErr *gqlerror.Error
+	if errors.As(err, &gqlErr) {
+		if gqlErr.Path == nil {
+			cloned := *gqlErr
+			cloned.Path = path
+			AddError(ctx, &cloned)
+			return
+		}
+		AddError(ctx, gqlErr)
+		return
+	}
+	AddError(ctx, gqlerror.WrapPath(path, err))
+}
+
+// ResolveBatchGroupResult handles batch resolver results for grouped parents.
+func ResolveBatchGroupResult[T any](
+	ctx context.Context,
+	idx ast.PathIndex,
+	parentsLen int,
+	result *BatchFieldResult,
+	fieldName string,
+) (any, error) {
+	idxInt := int(idx)
+	if result.Err != nil {
+		if batchErrs, ok := result.Err.(BatchErrors); ok {
+			results, ok := result.Results.([]T)
+			if !ok {
+				AddBatchError(ctx, idxInt, fmt.Errorf(
+					"batch resolver %s returned unexpected result type (index %d)",
+					fieldName,
+					idx,
+				))
+				return nil, nil
+			}
+			errs := batchErrs.Errors()
+			if len(results) != parentsLen {
+				AddBatchError(ctx, idxInt, fmt.Errorf(
+					"index %d: batch resolver %s returned %d results for %d parents",
+					idx,
+					fieldName,
+					len(results),
+					parentsLen,
+				))
+				return nil, nil
+			}
+			if len(errs) != parentsLen {
+				AddBatchError(ctx, idxInt, fmt.Errorf(
+					"index %d: batch resolver %s returned %d errors for %d parents",
+					idx,
+					fieldName,
+					len(errs),
+					parentsLen,
+				))
+				return nil, nil
+			}
+			if idxInt < 0 || idxInt >= len(results) {
+				AddBatchError(ctx, idxInt, fmt.Errorf(
+					"batch resolver %s could not resolve parent index %d",
+					fieldName,
+					idx,
+				))
+				return nil, nil
+			}
+			if err := errs[idxInt]; err != nil {
+				AddBatchError(ctx, idxInt, err)
+				return nil, nil
+			}
+			return results[idxInt], nil
+		}
+		AddBatchError(ctx, idxInt, result.Err)
+		return nil, nil
+	}
+
+	results, ok := result.Results.([]T)
+	if !ok {
+		AddBatchError(ctx, idxInt, fmt.Errorf(
+			"batch resolver %s returned unexpected result type (index %d)",
+			fieldName,
+			idx,
+		))
+		return nil, nil
+	}
+	if len(results) != parentsLen {
+		AddBatchError(ctx, idxInt, fmt.Errorf(
+			"index %d: batch resolver %s returned %d results for %d parents",
+			idx,
+			fieldName,
+			len(results),
+			parentsLen,
+		))
+		return nil, nil
+	}
+	if idxInt < 0 || idxInt >= len(results) {
+		AddBatchError(ctx, idxInt, fmt.Errorf(
+			"batch resolver %s could not resolve parent index %d",
+			fieldName,
+			idx,
+		))
+		return nil, nil
+	}
+	return results[idxInt], nil
+}
+
+// ResolveBatchSingleResult handles batch resolver results for a single parent.
+func ResolveBatchSingleResult[T any](
+	ctx context.Context,
+	results []T,
+	err error,
+	fieldName string,
+) (any, error) {
+	if err != nil {
+		if batchErrs, ok := err.(BatchErrors); ok {
+			errs := batchErrs.Errors()
+			if len(results) != 1 {
+				AddBatchError(ctx, 0, fmt.Errorf(
+					"batch resolver %s returned %d results for %d parents (index %d)",
+					fieldName,
+					len(results),
+					1,
+					0,
+				))
+				return nil, nil
+			}
+			if len(errs) != 1 {
+				AddBatchError(ctx, 0, fmt.Errorf(
+					"batch resolver %s returned %d errors for %d parents (index %d)",
+					fieldName,
+					len(errs),
+					1,
+					0,
+				))
+				return nil, nil
+			}
+			if errs[0] != nil {
+				AddBatchError(ctx, 0, errs[0])
+				return nil, nil
+			}
+			return results[0], nil
+		}
+		AddBatchError(ctx, 0, err)
+		return nil, nil
+	}
+	if len(results) != 1 {
+		AddBatchError(ctx, 0, fmt.Errorf(
+			"batch resolver %s returned %d results for %d parents (index %d)",
+			fieldName,
+			len(results),
+			1,
+			0,
+		))
+		return nil, nil
+	}
+	return results[0], nil
+}

--- a/graphql/batch_test.go
+++ b/graphql/batch_test.go
@@ -1,0 +1,141 @@
+package graphql
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+func TestBatchErrorList_UnwrapFiltersNil(t *testing.T) {
+	sentinel := errors.New("sentinel")
+	list := BatchErrorList{nil, sentinel, nil}
+
+	type unwrapper interface {
+		Unwrap() []error
+	}
+	u, ok := any(list).(unwrapper)
+	require.True(t, ok)
+
+	got := u.Unwrap()
+	require.Len(t, got, 1)
+	require.Equal(t, sentinel, got[0])
+}
+
+func TestBatchErrorList_ErrorsIs(t *testing.T) {
+	sentinel := errors.New("sentinel")
+	other := errors.New("other")
+	list := BatchErrorList{nil, sentinel, other}
+
+	require.ErrorIs(t, list, sentinel)
+	require.ErrorIs(t, list, other)
+	require.NotErrorIs(t, list, errors.New("missing"))
+}
+
+func TestBatchErrorList_ErrorsIsWithAllNil(t *testing.T) {
+	list := BatchErrorList{nil, nil}
+
+	require.NotErrorIs(t, list, errors.New("missing"))
+}
+
+func newBatchTestContext() context.Context {
+	ctx := WithResponseContext(context.Background(), DefaultErrorPresenter, nil)
+	ctx = WithPathContext(ctx, NewPathWithField("users"))
+	ctx = WithPathContext(ctx, NewPathWithIndex(0))
+	ctx = WithPathContext(ctx, NewPathWithField("profile"))
+	return ctx
+}
+
+func TestResolveBatchGroupResult_Success(t *testing.T) {
+	ctx := newBatchTestContext()
+	result := &BatchFieldResult{
+		Results: []string{"a", "b"},
+	}
+
+	got, err := ResolveBatchGroupResult[string](
+		ctx,
+		ast.PathIndex(1),
+		2,
+		result,
+		"User.profile",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "b", got)
+	require.Empty(t, GetErrors(ctx))
+}
+
+func TestResolveBatchGroupResult_ResultLenMismatch(t *testing.T) {
+	ctx := newBatchTestContext()
+	result := &BatchFieldResult{
+		Results: []string{"a"},
+	}
+
+	got, err := ResolveBatchGroupResult[string](
+		ctx,
+		ast.PathIndex(1),
+		2,
+		result,
+		"User.profile",
+	)
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	errs := GetErrors(ctx)
+	require.Len(t, errs, 1)
+	require.Equal(
+		t,
+		"index 1: batch resolver User.profile returned 1 results for 2 "+
+			"parents",
+		errs[0].Message,
+	)
+	require.Equal(
+		t,
+		ast.Path{
+			ast.PathName("users"),
+			ast.PathIndex(1),
+			ast.PathName("profile"),
+		},
+		errs[0].Path,
+	)
+}
+
+func TestResolveBatchSingleResult_BatchErrors(t *testing.T) {
+	ctx := newBatchTestContext()
+
+	got, err := ResolveBatchSingleResult[string](
+		ctx,
+		[]string{"a"},
+		BatchErrorList{errors.New("boom")},
+		"User.profile",
+	)
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	errs := GetErrors(ctx)
+	require.Len(t, errs, 1)
+	require.Equal(t, "boom", errs[0].Message)
+}
+
+func TestResolveBatchSingleResult_ErrorLenMismatch(t *testing.T) {
+	ctx := newBatchTestContext()
+
+	got, err := ResolveBatchSingleResult[string](
+		ctx,
+		[]string{"a"},
+		BatchErrorList{},
+		"User.profile",
+	)
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	errs := GetErrors(ctx)
+	require.Len(t, errs, 1)
+	require.Equal(
+		t,
+		"batch resolver User.profile returned 0 errors for 1 "+
+			"parents (index 0)",
+		errs[0].Message,
+	)
+}


### PR DESCRIPTION
## Goal

This series adds first-class batch resolver support to gqlgen, letting you solve the GraphQL N+1 problem without external libraries.
The N+1 problem happens when a single query fans out into many individual DB/API calls, killing performance. Today most people solve this with dataloader libraries; this makes it possible to handle it in gqlgen directly.
Since the behavior is opt-in and doesn't affect existing users, shipping it as **experimental** still provides clear value.

This PR alone might not give you the full picture, so take a look at the `_examples/batchresolver` directory on the `performance-enhancement-4` branch (https://github.com/99designs/gqlgen/pull/4008). Checking the test files, `generated.go`, and `schema.resolvers.go` should make the difference from existing non-batch resolvers clear.  The output itself doesn't change, and there are tests to prove it.

## Configuration and generated resolver shape

To enable batch resolvers, mark fields explicitly in the config:

```yaml
models:
  User:
    fields:
      posts:
        resolver: true
        batch: true # <- new!!!
```

When `batch: true` is set, gqlgen generates a batch resolver method that receives multiple parents and returns per‑parent results:

```go
// PostsBatch is the batch resolver for the posts field.
func (r *userResolver) PostsBatch(ctx context.Context, objs []*User) []BatchResult[[]*Post]
```

If batch is not set, gqlgen generates the standard per‑object resolver:

```go
func (r *userResolver) Posts(ctx context.Context, obj *User) ([]*Post, error)
```

Only fields with `batch: true` are affected. All other resolvers remain unchanged.

## Preconditions and approach

- Nothing is enabled unless batch: true is set
    - This is fully opt‑in, so existing users are unaffected.
- Same error handling, partial response behavior, and non‑null propagation as non‑batch
    - These invariants are covered by tests to prevent behavioral drift.
- PRs are split in dependency order so reviewers can follow the whole story linearly
    - Settings → internal data model → stub generation → runtime logic and tests.

## Role of each PR

### `performance‑enhancement‑1` branch

https://github.com/99designs/gqlgen/pull/4005

Allow batch to be declared in config

- Add batch: true to TypeMapField
- Make batch‑enabled fields explicit in schema config

### `performance‑enhancement‑2` branch based on `performance‑enhancement‑1`

https://github.com/99designs/gqlgen/pull/4006

Propagate the batch flag into codegen

- Add Batch flag to Field
- Let templates and generators branch correctly on batch vs non‑batch

### `performance‑enhancement‑3` branch based on `performance‑enhancement‑2`

https://github.com/99designs/gqlgen/pull/4007

Generate batch resolver stubs

- Auto‑generate batch resolver method stubs

### `performance‑enhancement‑4` branch based on `performance‑enhancement‑3`

https://github.com/99designs/gqlgen/pull/4008

Add runtime support and verification

- Implement batch execution logic
- Add example tests comparing batch vs non‑batch behavior
- Preserve batch implementations across regeneration

---

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))