### PR TITLE
refactor(codegen): add `graphql.ExecutableSchemaState` as shared schema dependency holder

### DIFF
--- a/_examples/batchresolver/generated.go
+++ b/_examples/batchresolver/generated.go
@@ -22,12 +22,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -71,16 +66,11 @@ type UserResolver interface {
 	NonNullableNonBatch(ctx context.Context, obj *User) (*Profile, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -91,39 +81,39 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "Profile.id":
-		if e.complexity.Profile.ID == nil {
+		if e.ComplexityRoot.Profile.ID == nil {
 			break
 		}
 
-		return e.complexity.Profile.ID(childComplexity), true
+		return e.ComplexityRoot.Profile.ID(childComplexity), true
 
 	case "Query.users":
-		if e.complexity.Query.Users == nil {
+		if e.ComplexityRoot.Query.Users == nil {
 			break
 		}
 
-		return e.complexity.Query.Users(childComplexity), true
+		return e.ComplexityRoot.Query.Users(childComplexity), true
 
 	case "User.nonNullableBatch":
-		if e.complexity.User.NonNullableBatch == nil {
+		if e.ComplexityRoot.User.NonNullableBatch == nil {
 			break
 		}
 
-		return e.complexity.User.NonNullableBatch(childComplexity), true
+		return e.ComplexityRoot.User.NonNullableBatch(childComplexity), true
 	case "User.nonNullableNonBatch":
-		if e.complexity.User.NonNullableNonBatch == nil {
+		if e.ComplexityRoot.User.NonNullableNonBatch == nil {
 			break
 		}
 
-		return e.complexity.User.NonNullableNonBatch(childComplexity), true
+		return e.ComplexityRoot.User.NonNullableNonBatch(childComplexity), true
 	case "User.nullableBatch":
-		if e.complexity.User.NullableBatch == nil {
+		if e.ComplexityRoot.User.NullableBatch == nil {
 			break
 		}
 
-		return e.complexity.User.NullableBatch(childComplexity), true
+		return e.ComplexityRoot.User.NullableBatch(childComplexity), true
 	case "User.nullableBatchWithArg":
-		if e.complexity.User.NullableBatchWithArg == nil {
+		if e.ComplexityRoot.User.NullableBatchWithArg == nil {
 			break
 		}
 
@@ -132,15 +122,15 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.User.NullableBatchWithArg(childComplexity, args["offset"].(int)), true
+		return e.ComplexityRoot.User.NullableBatchWithArg(childComplexity, args["offset"].(int)), true
 	case "User.nullableNonBatch":
-		if e.complexity.User.NullableNonBatch == nil {
+		if e.ComplexityRoot.User.NullableNonBatch == nil {
 			break
 		}
 
-		return e.complexity.User.NullableNonBatch(childComplexity), true
+		return e.ComplexityRoot.User.NullableNonBatch(childComplexity), true
 	case "User.nullableNonBatchWithArg":
-		if e.complexity.User.NullableNonBatchWithArg == nil {
+		if e.ComplexityRoot.User.NullableNonBatchWithArg == nil {
 			break
 		}
 
@@ -149,7 +139,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.User.NullableNonBatchWithArg(childComplexity, args["offset"].(int)), true
+		return e.ComplexityRoot.User.NullableNonBatchWithArg(childComplexity, args["offset"].(int)), true
 
 	}
 	return 0, false
@@ -380,7 +370,7 @@ func (ec *executionContext) _Query_users(ctx context.Context, field graphql.Coll
 		field,
 		ec.fieldContext_Query_users,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Users(ctx)
+			return ec.Resolvers.Query().Users(ctx)
 		},
 		nil,
 		ec.marshalNUser2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐUserᚄ,
@@ -557,7 +547,7 @@ func (ec *executionContext) fieldContext_User_nullableBatch(_ context.Context, f
 	return fc, nil
 }
 func (ec *executionContext) resolveBatch_User_nullableBatch(ctx context.Context, field graphql.CollectedField, obj *User) (any, error) {
-	resolver := ec.resolvers.User()
+	resolver := ec.Resolvers.User()
 	group := graphql.GetBatchParentGroup(ctx, "User")
 	if group != nil {
 		parents, ok := group.Parents.([]*User)
@@ -598,7 +588,7 @@ func (ec *executionContext) _User_nullableNonBatch(ctx context.Context, field gr
 		field,
 		ec.fieldContext_User_nullableNonBatch,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.User().NullableNonBatch(ctx, obj)
+			return ec.Resolvers.User().NullableNonBatch(ctx, obj)
 		},
 		nil,
 		ec.marshalOProfile2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfile,
@@ -668,7 +658,7 @@ func (ec *executionContext) fieldContext_User_nullableBatchWithArg(ctx context.C
 	return fc, nil
 }
 func (ec *executionContext) resolveBatch_User_nullableBatchWithArg(ctx context.Context, field graphql.CollectedField, obj *User) (any, error) {
-	resolver := ec.resolvers.User()
+	resolver := ec.Resolvers.User()
 	fc := graphql.GetFieldContext(ctx)
 	group := graphql.GetBatchParentGroup(ctx, "User")
 	if group != nil {
@@ -711,7 +701,7 @@ func (ec *executionContext) _User_nullableNonBatchWithArg(ctx context.Context, f
 		ec.fieldContext_User_nullableNonBatchWithArg,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.User().NullableNonBatchWithArg(ctx, obj, fc.Args["offset"].(int))
+			return ec.Resolvers.User().NullableNonBatchWithArg(ctx, obj, fc.Args["offset"].(int))
 		},
 		nil,
 		ec.marshalOProfile2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfile,
@@ -781,7 +771,7 @@ func (ec *executionContext) fieldContext_User_nonNullableBatch(_ context.Context
 	return fc, nil
 }
 func (ec *executionContext) resolveBatch_User_nonNullableBatch(ctx context.Context, field graphql.CollectedField, obj *User) (any, error) {
-	resolver := ec.resolvers.User()
+	resolver := ec.Resolvers.User()
 	group := graphql.GetBatchParentGroup(ctx, "User")
 	if group != nil {
 		parents, ok := group.Parents.([]*User)
@@ -822,7 +812,7 @@ func (ec *executionContext) _User_nonNullableNonBatch(ctx context.Context, field
 		field,
 		ec.fieldContext_User_nonNullableNonBatch,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.User().NonNullableNonBatch(ctx, obj)
+			return ec.Resolvers.User().NonNullableNonBatch(ctx, obj)
 		},
 		nil,
 		ec.marshalNProfile2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfile,

--- a/_examples/config/generated.go
+++ b/_examples/config/generated.go
@@ -22,12 +22,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -85,16 +80,11 @@ type RoleResolver interface {
 	Name(ctx context.Context, obj *UserRole) (string, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -105,7 +95,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "Mutation.createTodo":
-		if e.complexity.Mutation.CreateTodo == nil {
+		if e.ComplexityRoot.Mutation.CreateTodo == nil {
 			break
 		}
 
@@ -114,83 +104,83 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.CreateTodo(childComplexity, args["input"].(NewTodo)), true
+		return e.ComplexityRoot.Mutation.CreateTodo(childComplexity, args["input"].(NewTodo)), true
 
 	case "Query.todos":
-		if e.complexity.Query.Todos == nil {
+		if e.ComplexityRoot.Query.Todos == nil {
 			break
 		}
 
-		return e.complexity.Query.Todos(childComplexity), true
+		return e.ComplexityRoot.Query.Todos(childComplexity), true
 
 	case "Todo.databaseId":
-		if e.complexity.Todo.DatabaseID == nil {
+		if e.ComplexityRoot.Todo.DatabaseID == nil {
 			break
 		}
 
-		return e.complexity.Todo.DatabaseID(childComplexity), true
+		return e.ComplexityRoot.Todo.DatabaseID(childComplexity), true
 	case "Todo.text":
-		if e.complexity.Todo.Description == nil {
+		if e.ComplexityRoot.Todo.Description == nil {
 			break
 		}
 
-		return e.complexity.Todo.Description(childComplexity), true
+		return e.ComplexityRoot.Todo.Description(childComplexity), true
 	case "Todo.done":
-		if e.complexity.Todo.Done == nil {
+		if e.ComplexityRoot.Todo.Done == nil {
 			break
 		}
 
-		return e.complexity.Todo.Done(childComplexity), true
+		return e.ComplexityRoot.Todo.Done(childComplexity), true
 	case "Todo.id":
-		if e.complexity.Todo.ID == nil {
+		if e.ComplexityRoot.Todo.ID == nil {
 			break
 		}
 
-		return e.complexity.Todo.ID(childComplexity), true
+		return e.ComplexityRoot.Todo.ID(childComplexity), true
 	case "Todo.mutation":
-		if e.complexity.Todo.Mutation == nil {
+		if e.ComplexityRoot.Todo.Mutation == nil {
 			break
 		}
 
-		return e.complexity.Todo.Mutation(childComplexity), true
+		return e.ComplexityRoot.Todo.Mutation(childComplexity), true
 	case "Todo.query":
-		if e.complexity.Todo.Query == nil {
+		if e.ComplexityRoot.Todo.Query == nil {
 			break
 		}
 
-		return e.complexity.Todo.Query(childComplexity), true
+		return e.ComplexityRoot.Todo.Query(childComplexity), true
 	case "Todo.user":
-		if e.complexity.Todo.User == nil {
+		if e.ComplexityRoot.Todo.User == nil {
 			break
 		}
 
-		return e.complexity.Todo.User(childComplexity), true
+		return e.ComplexityRoot.Todo.User(childComplexity), true
 
 	case "User.name":
-		if e.complexity.User.FullName == nil {
+		if e.ComplexityRoot.User.FullName == nil {
 			break
 		}
 
-		return e.complexity.User.FullName(childComplexity), true
+		return e.ComplexityRoot.User.FullName(childComplexity), true
 	case "User.id":
-		if e.complexity.User.ID == nil {
+		if e.ComplexityRoot.User.ID == nil {
 			break
 		}
 
-		return e.complexity.User.ID(childComplexity), true
+		return e.ComplexityRoot.User.ID(childComplexity), true
 	case "User.role":
-		if e.complexity.User.Role == nil {
+		if e.ComplexityRoot.User.Role == nil {
 			break
 		}
 
-		return e.complexity.User.Role(childComplexity), true
+		return e.ComplexityRoot.User.Role(childComplexity), true
 
 	case "role.name":
-		if e.complexity.Role.Name == nil {
+		if e.ComplexityRoot.Role.Name == nil {
 			break
 		}
 
-		return e.complexity.Role.Name(childComplexity), true
+		return e.ComplexityRoot.Role.Name(childComplexity), true
 
 	}
 	return 0, false
@@ -401,7 +391,7 @@ func (ec *executionContext) _Mutation_createTodo(ctx context.Context, field grap
 		ec.fieldContext_Mutation_createTodo,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().CreateTodo(ctx, fc.Args["input"].(NewTodo))
+			return ec.Resolvers.Mutation().CreateTodo(ctx, fc.Args["input"].(NewTodo))
 		},
 		nil,
 		ec.marshalNTodo2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋconfigᚐTodo,
@@ -457,7 +447,7 @@ func (ec *executionContext) _Query_todos(ctx context.Context, field graphql.Coll
 		field,
 		ec.fieldContext_Query_todos,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Todos(ctx)
+			return ec.Resolvers.Query().Todos(ctx)
 		},
 		nil,
 		ec.marshalNTodo2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋconfigᚐTodoᚄ,
@@ -610,7 +600,7 @@ func (ec *executionContext) _Todo_id(ctx context.Context, field graphql.Collecte
 		field,
 		ec.fieldContext_Todo_id,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Todo().ID(ctx, obj)
+			return ec.Resolvers.Todo().ID(ctx, obj)
 		},
 		nil,
 		ec.marshalNID2string,
@@ -2368,7 +2358,7 @@ func (ec *executionContext) _role_name(ctx context.Context, field graphql.Collec
 		field,
 		ec.fieldContext_role_name,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Role().Name(ctx, obj)
+			return ec.Resolvers.Role().Name(ctx, obj)
 		},
 		nil,
 		ec.marshalNString2string,

--- a/_examples/contextpropagation/generated.go
+++ b/_examples/contextpropagation/generated.go
@@ -22,12 +22,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -63,16 +58,11 @@ type TodoContextResolver interface {
 	Value(ctx context.Context, obj *TodoContext) (*string, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -83,31 +73,31 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "Query.testTodo":
-		if e.complexity.Query.TestTodo == nil {
+		if e.ComplexityRoot.Query.TestTodo == nil {
 			break
 		}
 
-		return e.complexity.Query.TestTodo(childComplexity), true
+		return e.ComplexityRoot.Query.TestTodo(childComplexity), true
 
 	case "Todo.context":
-		if e.complexity.Todo.Context == nil {
+		if e.ComplexityRoot.Todo.Context == nil {
 			break
 		}
 
-		return e.complexity.Todo.Context(childComplexity), true
+		return e.ComplexityRoot.Todo.Context(childComplexity), true
 	case "Todo.text":
-		if e.complexity.Todo.Text == nil {
+		if e.ComplexityRoot.Todo.Text == nil {
 			break
 		}
 
-		return e.complexity.Todo.Text(childComplexity), true
+		return e.ComplexityRoot.Todo.Text(childComplexity), true
 
 	case "TodoContext.value":
-		if e.complexity.TodoContext.Value == nil {
+		if e.ComplexityRoot.TodoContext.Value == nil {
 			break
 		}
 
-		return e.complexity.TodoContext.Value(childComplexity), true
+		return e.ComplexityRoot.TodoContext.Value(childComplexity), true
 
 	}
 	return 0, false
@@ -298,7 +288,7 @@ func (ec *executionContext) _Query_testTodo(ctx context.Context, field graphql.C
 		field,
 		ec.fieldContext_Query_testTodo,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().TestTodo(ctx)
+			return ec.Resolvers.Query().TestTodo(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
@@ -309,11 +299,11 @@ func (ec *executionContext) _Query_testTodo(ctx context.Context, field graphql.C
 					var zeroVal *Todo
 					return zeroVal, err
 				}
-				if ec.directives.WithContext == nil {
+				if ec.Directives.WithContext == nil {
 					var zeroVal *Todo
 					return zeroVal, errors.New("directive withContext is not implemented")
 				}
-				return ec.directives.WithContext(ctx, nil, directive0, value)
+				return ec.Directives.WithContext(ctx, nil, directive0, value)
 			}
 
 			next = directive1
@@ -521,7 +511,7 @@ func (ec *executionContext) _TodoContext_value(ctx context.Context, field graphq
 		field,
 		ec.fieldContext_TodoContext_value,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.TodoContext().Value(ctx, obj)
+			return ec.Resolvers.TodoContext().Value(ctx, obj)
 		},
 		nil,
 		ec.marshalOString2ᚖstring,

--- a/_examples/dataloader/generated.go
+++ b/_examples/dataloader/generated.go
@@ -23,12 +23,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -87,16 +82,11 @@ type QueryResolver interface {
 	Torture2d(ctx context.Context, customerIds [][]int) ([][]*Customer, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -107,89 +97,89 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "Address.country":
-		if e.complexity.Address.Country == nil {
+		if e.ComplexityRoot.Address.Country == nil {
 			break
 		}
 
-		return e.complexity.Address.Country(childComplexity), true
+		return e.ComplexityRoot.Address.Country(childComplexity), true
 	case "Address.id":
-		if e.complexity.Address.ID == nil {
+		if e.ComplexityRoot.Address.ID == nil {
 			break
 		}
 
-		return e.complexity.Address.ID(childComplexity), true
+		return e.ComplexityRoot.Address.ID(childComplexity), true
 	case "Address.street":
-		if e.complexity.Address.Street == nil {
+		if e.ComplexityRoot.Address.Street == nil {
 			break
 		}
 
-		return e.complexity.Address.Street(childComplexity), true
+		return e.ComplexityRoot.Address.Street(childComplexity), true
 
 	case "Customer.address":
-		if e.complexity.Customer.Address == nil {
+		if e.ComplexityRoot.Customer.Address == nil {
 			break
 		}
 
-		return e.complexity.Customer.Address(childComplexity), true
+		return e.ComplexityRoot.Customer.Address(childComplexity), true
 	case "Customer.id":
-		if e.complexity.Customer.ID == nil {
+		if e.ComplexityRoot.Customer.ID == nil {
 			break
 		}
 
-		return e.complexity.Customer.ID(childComplexity), true
+		return e.ComplexityRoot.Customer.ID(childComplexity), true
 	case "Customer.name":
-		if e.complexity.Customer.Name == nil {
+		if e.ComplexityRoot.Customer.Name == nil {
 			break
 		}
 
-		return e.complexity.Customer.Name(childComplexity), true
+		return e.ComplexityRoot.Customer.Name(childComplexity), true
 	case "Customer.orders":
-		if e.complexity.Customer.Orders == nil {
+		if e.ComplexityRoot.Customer.Orders == nil {
 			break
 		}
 
-		return e.complexity.Customer.Orders(childComplexity), true
+		return e.ComplexityRoot.Customer.Orders(childComplexity), true
 
 	case "Item.name":
-		if e.complexity.Item.Name == nil {
+		if e.ComplexityRoot.Item.Name == nil {
 			break
 		}
 
-		return e.complexity.Item.Name(childComplexity), true
+		return e.ComplexityRoot.Item.Name(childComplexity), true
 
 	case "Order.amount":
-		if e.complexity.Order.Amount == nil {
+		if e.ComplexityRoot.Order.Amount == nil {
 			break
 		}
 
-		return e.complexity.Order.Amount(childComplexity), true
+		return e.ComplexityRoot.Order.Amount(childComplexity), true
 	case "Order.date":
-		if e.complexity.Order.Date == nil {
+		if e.ComplexityRoot.Order.Date == nil {
 			break
 		}
 
-		return e.complexity.Order.Date(childComplexity), true
+		return e.ComplexityRoot.Order.Date(childComplexity), true
 	case "Order.id":
-		if e.complexity.Order.ID == nil {
+		if e.ComplexityRoot.Order.ID == nil {
 			break
 		}
 
-		return e.complexity.Order.ID(childComplexity), true
+		return e.ComplexityRoot.Order.ID(childComplexity), true
 	case "Order.items":
-		if e.complexity.Order.Items == nil {
+		if e.ComplexityRoot.Order.Items == nil {
 			break
 		}
 
-		return e.complexity.Order.Items(childComplexity), true
+		return e.ComplexityRoot.Order.Items(childComplexity), true
 
 	case "Query.customers":
-		if e.complexity.Query.Customers == nil {
+		if e.ComplexityRoot.Query.Customers == nil {
 			break
 		}
 
-		return e.complexity.Query.Customers(childComplexity), true
+		return e.ComplexityRoot.Query.Customers(childComplexity), true
 	case "Query.torture1d":
-		if e.complexity.Query.Torture1d == nil {
+		if e.ComplexityRoot.Query.Torture1d == nil {
 			break
 		}
 
@@ -198,9 +188,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Torture1d(childComplexity, args["customerIds"].([]int)), true
+		return e.ComplexityRoot.Query.Torture1d(childComplexity, args["customerIds"].([]int)), true
 	case "Query.torture2d":
-		if e.complexity.Query.Torture2d == nil {
+		if e.ComplexityRoot.Query.Torture2d == nil {
 			break
 		}
 
@@ -209,7 +199,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Torture2d(childComplexity, args["customerIds"].([][]int)), true
+		return e.ComplexityRoot.Query.Torture2d(childComplexity, args["customerIds"].([][]int)), true
 
 	}
 	return 0, false
@@ -556,7 +546,7 @@ func (ec *executionContext) _Customer_address(ctx context.Context, field graphql
 		field,
 		ec.fieldContext_Customer_address,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Customer().Address(ctx, obj)
+			return ec.Resolvers.Customer().Address(ctx, obj)
 		},
 		nil,
 		ec.marshalOAddress2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋdataloaderᚐAddress,
@@ -593,7 +583,7 @@ func (ec *executionContext) _Customer_orders(ctx context.Context, field graphql.
 		field,
 		ec.fieldContext_Customer_orders,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Customer().Orders(ctx, obj)
+			return ec.Resolvers.Customer().Orders(ctx, obj)
 		},
 		nil,
 		ec.marshalOOrder2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋdataloaderᚐOrderᚄ,
@@ -748,7 +738,7 @@ func (ec *executionContext) _Order_items(ctx context.Context, field graphql.Coll
 		field,
 		ec.fieldContext_Order_items,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Order().Items(ctx, obj)
+			return ec.Resolvers.Order().Items(ctx, obj)
 		},
 		nil,
 		ec.marshalOItem2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋdataloaderᚐItemᚄ,
@@ -781,7 +771,7 @@ func (ec *executionContext) _Query_customers(ctx context.Context, field graphql.
 		field,
 		ec.fieldContext_Query_customers,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Customers(ctx)
+			return ec.Resolvers.Query().Customers(ctx)
 		},
 		nil,
 		ec.marshalOCustomer2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋdataloaderᚐCustomerᚄ,
@@ -821,7 +811,7 @@ func (ec *executionContext) _Query_torture1d(ctx context.Context, field graphql.
 		ec.fieldContext_Query_torture1d,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Torture1d(ctx, fc.Args["customerIds"].([]int))
+			return ec.Resolvers.Query().Torture1d(ctx, fc.Args["customerIds"].([]int))
 		},
 		nil,
 		ec.marshalOCustomer2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋdataloaderᚐCustomerᚄ,
@@ -872,7 +862,7 @@ func (ec *executionContext) _Query_torture2d(ctx context.Context, field graphql.
 		ec.fieldContext_Query_torture2d,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Torture2d(ctx, fc.Args["customerIds"].([][]int))
+			return ec.Resolvers.Query().Torture2d(ctx, fc.Args["customerIds"].([][]int))
 		},
 		nil,
 		ec.marshalOCustomer2ᚕᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋdataloaderᚐCustomer,

--- a/_examples/embedding/subdir/gendir/generated.go
+++ b/_examples/embedding/subdir/gendir/generated.go
@@ -22,12 +22,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -58,16 +53,11 @@ type QueryResolver interface {
 	Subdir(ctx context.Context) (string, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -78,36 +68,36 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "Query.inSchemadir":
-		if e.complexity.Query.InSchemadir == nil {
+		if e.ComplexityRoot.Query.InSchemadir == nil {
 			break
 		}
 
-		return e.complexity.Query.InSchemadir(childComplexity), true
+		return e.ComplexityRoot.Query.InSchemadir(childComplexity), true
 	case "Query.parentdir":
-		if e.complexity.Query.Parentdir == nil {
+		if e.ComplexityRoot.Query.Parentdir == nil {
 			break
 		}
 
-		return e.complexity.Query.Parentdir(childComplexity), true
+		return e.ComplexityRoot.Query.Parentdir(childComplexity), true
 	case "Query.subdir":
-		if e.complexity.Query.Subdir == nil {
+		if e.ComplexityRoot.Query.Subdir == nil {
 			break
 		}
 
-		return e.complexity.Query.Subdir(childComplexity), true
+		return e.ComplexityRoot.Query.Subdir(childComplexity), true
 	case "Query._service":
-		if e.complexity.Query.__resolve__service == nil {
+		if e.ComplexityRoot.Query.__resolve__service == nil {
 			break
 		}
 
-		return e.complexity.Query.__resolve__service(childComplexity), true
+		return e.ComplexityRoot.Query.__resolve__service(childComplexity), true
 
 	case "_Service.sdl":
-		if e.complexity._Service.SDL == nil {
+		if e.ComplexityRoot._Service.SDL == nil {
 			break
 		}
 
-		return e.complexity._Service.SDL(childComplexity), true
+		return e.ComplexityRoot._Service.SDL(childComplexity), true
 
 	}
 	return 0, false
@@ -305,7 +295,7 @@ func (ec *executionContext) _Query_inSchemadir(ctx context.Context, field graphq
 		field,
 		ec.fieldContext_Query_inSchemadir,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().InSchemadir(ctx)
+			return ec.Resolvers.Query().InSchemadir(ctx)
 		},
 		nil,
 		ec.marshalNString2string,
@@ -334,7 +324,7 @@ func (ec *executionContext) _Query_parentdir(ctx context.Context, field graphql.
 		field,
 		ec.fieldContext_Query_parentdir,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Parentdir(ctx)
+			return ec.Resolvers.Query().Parentdir(ctx)
 		},
 		nil,
 		ec.marshalNString2string,
@@ -363,7 +353,7 @@ func (ec *executionContext) _Query_subdir(ctx context.Context, field graphql.Col
 		field,
 		ec.fieldContext_Query_subdir,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Subdir(ctx)
+			return ec.Resolvers.Query().Subdir(ctx)
 		},
 		nil,
 		ec.marshalNString2string,

--- a/_examples/embedding/subdir/root.generated.go
+++ b/_examples/embedding/subdir/root.generated.go
@@ -51,7 +51,7 @@ func (ec *executionContext) _Query_inSchemadir(ctx context.Context, field graphq
 		field,
 		ec.fieldContext_Query_inSchemadir,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().InSchemadir(ctx)
+			return ec.Resolvers.Query().InSchemadir(ctx)
 		},
 		nil,
 		ec.marshalNString2string,
@@ -80,7 +80,7 @@ func (ec *executionContext) _Query_parentdir(ctx context.Context, field graphql.
 		field,
 		ec.fieldContext_Query_parentdir,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Parentdir(ctx)
+			return ec.Resolvers.Query().Parentdir(ctx)
 		},
 		nil,
 		ec.marshalNString2string,
@@ -109,7 +109,7 @@ func (ec *executionContext) _Query_subdir(ctx context.Context, field graphql.Col
 		field,
 		ec.fieldContext_Query_subdir,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Subdir(ctx)
+			return ec.Resolvers.Query().Subdir(ctx)
 		},
 		nil,
 		ec.marshalNString2string,

--- a/_examples/embedding/subdir/root_.generated.go
+++ b/_examples/embedding/subdir/root_.generated.go
@@ -18,12 +18,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -48,16 +43,11 @@ type ComplexityRoot struct {
 	}
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -68,39 +58,39 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "Query.inSchemadir":
-		if e.complexity.Query.InSchemadir == nil {
+		if e.ComplexityRoot.Query.InSchemadir == nil {
 			break
 		}
 
-		return e.complexity.Query.InSchemadir(childComplexity), true
+		return e.ComplexityRoot.Query.InSchemadir(childComplexity), true
 
 	case "Query.parentdir":
-		if e.complexity.Query.Parentdir == nil {
+		if e.ComplexityRoot.Query.Parentdir == nil {
 			break
 		}
 
-		return e.complexity.Query.Parentdir(childComplexity), true
+		return e.ComplexityRoot.Query.Parentdir(childComplexity), true
 
 	case "Query.subdir":
-		if e.complexity.Query.Subdir == nil {
+		if e.ComplexityRoot.Query.Subdir == nil {
 			break
 		}
 
-		return e.complexity.Query.Subdir(childComplexity), true
+		return e.ComplexityRoot.Query.Subdir(childComplexity), true
 
 	case "Query._service":
-		if e.complexity.Query.__resolve__service == nil {
+		if e.ComplexityRoot.Query.__resolve__service == nil {
 			break
 		}
 
-		return e.complexity.Query.__resolve__service(childComplexity), true
+		return e.ComplexityRoot.Query.__resolve__service(childComplexity), true
 
 	case "_Service.sdl":
-		if e.complexity._Service.SDL == nil {
+		if e.ComplexityRoot._Service.SDL == nil {
 			break
 		}
 
-		return e.complexity._Service.SDL(childComplexity), true
+		return e.ComplexityRoot._Service.SDL(childComplexity), true
 
 	}
 	return 0, false

--- a/_examples/enum/api/exec.go
+++ b/_examples/enum/api/exec.go
@@ -22,12 +22,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -77,16 +72,11 @@ type QueryResolver interface {
 	InPackage(ctx context.Context, arg InPackage) (InPackage, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -97,7 +87,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "Query.boolTyped":
-		if e.complexity.Query.BoolTyped == nil {
+		if e.ComplexityRoot.Query.BoolTyped == nil {
 			break
 		}
 
@@ -106,9 +96,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.BoolTyped(childComplexity, args["arg"].(model.BoolTyped)), true
+		return e.ComplexityRoot.Query.BoolTyped(childComplexity, args["arg"].(model.BoolTyped)), true
 	case "Query.boolTypedN":
-		if e.complexity.Query.BoolTypedN == nil {
+		if e.ComplexityRoot.Query.BoolTypedN == nil {
 			break
 		}
 
@@ -117,9 +107,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.BoolTypedN(childComplexity, args["arg"].(*model.BoolTyped)), true
+		return e.ComplexityRoot.Query.BoolTypedN(childComplexity, args["arg"].(*model.BoolTyped)), true
 	case "Query.boolUntyped":
-		if e.complexity.Query.BoolUntyped == nil {
+		if e.ComplexityRoot.Query.BoolUntyped == nil {
 			break
 		}
 
@@ -128,9 +118,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.BoolUntyped(childComplexity, args["arg"].(bool)), true
+		return e.ComplexityRoot.Query.BoolUntyped(childComplexity, args["arg"].(bool)), true
 	case "Query.boolUntypedN":
-		if e.complexity.Query.BoolUntypedN == nil {
+		if e.ComplexityRoot.Query.BoolUntypedN == nil {
 			break
 		}
 
@@ -139,9 +129,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.BoolUntypedN(childComplexity, args["arg"].(*bool)), true
+		return e.ComplexityRoot.Query.BoolUntypedN(childComplexity, args["arg"].(*bool)), true
 	case "Query.inPackage":
-		if e.complexity.Query.InPackage == nil {
+		if e.ComplexityRoot.Query.InPackage == nil {
 			break
 		}
 
@@ -150,9 +140,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.InPackage(childComplexity, args["arg"].(InPackage)), true
+		return e.ComplexityRoot.Query.InPackage(childComplexity, args["arg"].(InPackage)), true
 	case "Query.intTyped":
-		if e.complexity.Query.IntTyped == nil {
+		if e.ComplexityRoot.Query.IntTyped == nil {
 			break
 		}
 
@@ -161,9 +151,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.IntTyped(childComplexity, args["arg"].(model.IntTyped)), true
+		return e.ComplexityRoot.Query.IntTyped(childComplexity, args["arg"].(model.IntTyped)), true
 	case "Query.intTypedN":
-		if e.complexity.Query.IntTypedN == nil {
+		if e.ComplexityRoot.Query.IntTypedN == nil {
 			break
 		}
 
@@ -172,9 +162,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.IntTypedN(childComplexity, args["arg"].(*model.IntTyped)), true
+		return e.ComplexityRoot.Query.IntTypedN(childComplexity, args["arg"].(*model.IntTyped)), true
 	case "Query.intUntyped":
-		if e.complexity.Query.IntUntyped == nil {
+		if e.ComplexityRoot.Query.IntUntyped == nil {
 			break
 		}
 
@@ -183,9 +173,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.IntUntyped(childComplexity, args["arg"].(int)), true
+		return e.ComplexityRoot.Query.IntUntyped(childComplexity, args["arg"].(int)), true
 	case "Query.intUntypedN":
-		if e.complexity.Query.IntUntypedN == nil {
+		if e.ComplexityRoot.Query.IntUntypedN == nil {
 			break
 		}
 
@@ -194,9 +184,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.IntUntypedN(childComplexity, args["arg"].(*int)), true
+		return e.ComplexityRoot.Query.IntUntypedN(childComplexity, args["arg"].(*int)), true
 	case "Query.stringTyped":
-		if e.complexity.Query.StringTyped == nil {
+		if e.ComplexityRoot.Query.StringTyped == nil {
 			break
 		}
 
@@ -205,9 +195,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.StringTyped(childComplexity, args["arg"].(model.StringTyped)), true
+		return e.ComplexityRoot.Query.StringTyped(childComplexity, args["arg"].(model.StringTyped)), true
 	case "Query.stringTypedN":
-		if e.complexity.Query.StringTypedN == nil {
+		if e.ComplexityRoot.Query.StringTypedN == nil {
 			break
 		}
 
@@ -216,9 +206,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.StringTypedN(childComplexity, args["arg"].(*model.StringTyped)), true
+		return e.ComplexityRoot.Query.StringTypedN(childComplexity, args["arg"].(*model.StringTyped)), true
 	case "Query.stringUntyped":
-		if e.complexity.Query.StringUntyped == nil {
+		if e.ComplexityRoot.Query.StringUntyped == nil {
 			break
 		}
 
@@ -227,9 +217,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.StringUntyped(childComplexity, args["arg"].(string)), true
+		return e.ComplexityRoot.Query.StringUntyped(childComplexity, args["arg"].(string)), true
 	case "Query.stringUntypedN":
-		if e.complexity.Query.StringUntypedN == nil {
+		if e.ComplexityRoot.Query.StringUntypedN == nil {
 			break
 		}
 
@@ -238,9 +228,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.StringUntypedN(childComplexity, args["arg"].(*string)), true
+		return e.ComplexityRoot.Query.StringUntypedN(childComplexity, args["arg"].(*string)), true
 	case "Query.varTyped":
-		if e.complexity.Query.VarTyped == nil {
+		if e.ComplexityRoot.Query.VarTyped == nil {
 			break
 		}
 
@@ -249,9 +239,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.VarTyped(childComplexity, args["arg"].(model.VarTyped)), true
+		return e.ComplexityRoot.Query.VarTyped(childComplexity, args["arg"].(model.VarTyped)), true
 	case "Query.varUntyped":
-		if e.complexity.Query.VarUntyped == nil {
+		if e.ComplexityRoot.Query.VarUntyped == nil {
 			break
 		}
 
@@ -260,7 +250,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.VarUntyped(childComplexity, args["arg"].(bool)), true
+		return e.ComplexityRoot.Query.VarUntyped(childComplexity, args["arg"].(bool)), true
 
 	}
 	return 0, false
@@ -670,7 +660,7 @@ func (ec *executionContext) _Query_intTyped(ctx context.Context, field graphql.C
 		ec.fieldContext_Query_intTyped,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().IntTyped(ctx, fc.Args["arg"].(model.IntTyped))
+			return ec.Resolvers.Query().IntTyped(ctx, fc.Args["arg"].(model.IntTyped))
 		},
 		nil,
 		ec.marshalNIntTyped2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋmodelᚐIntTyped,
@@ -711,7 +701,7 @@ func (ec *executionContext) _Query_intUntyped(ctx context.Context, field graphql
 		ec.fieldContext_Query_intUntyped,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().IntUntyped(ctx, fc.Args["arg"].(int))
+			return ec.Resolvers.Query().IntUntyped(ctx, fc.Args["arg"].(int))
 		},
 		nil,
 		ec.marshalNIntUntyped2int,
@@ -752,7 +742,7 @@ func (ec *executionContext) _Query_intTypedN(ctx context.Context, field graphql.
 		ec.fieldContext_Query_intTypedN,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().IntTypedN(ctx, fc.Args["arg"].(*model.IntTyped))
+			return ec.Resolvers.Query().IntTypedN(ctx, fc.Args["arg"].(*model.IntTyped))
 		},
 		nil,
 		ec.marshalOIntTyped2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋmodelᚐIntTyped,
@@ -793,7 +783,7 @@ func (ec *executionContext) _Query_intUntypedN(ctx context.Context, field graphq
 		ec.fieldContext_Query_intUntypedN,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().IntUntypedN(ctx, fc.Args["arg"].(*int))
+			return ec.Resolvers.Query().IntUntypedN(ctx, fc.Args["arg"].(*int))
 		},
 		nil,
 		ec.marshalOIntUntyped2ᚖint,
@@ -834,7 +824,7 @@ func (ec *executionContext) _Query_stringTyped(ctx context.Context, field graphq
 		ec.fieldContext_Query_stringTyped,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().StringTyped(ctx, fc.Args["arg"].(model.StringTyped))
+			return ec.Resolvers.Query().StringTyped(ctx, fc.Args["arg"].(model.StringTyped))
 		},
 		nil,
 		ec.marshalNStringTyped2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋmodelᚐStringTyped,
@@ -875,7 +865,7 @@ func (ec *executionContext) _Query_stringUntyped(ctx context.Context, field grap
 		ec.fieldContext_Query_stringUntyped,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().StringUntyped(ctx, fc.Args["arg"].(string))
+			return ec.Resolvers.Query().StringUntyped(ctx, fc.Args["arg"].(string))
 		},
 		nil,
 		ec.marshalNStringUntyped2string,
@@ -916,7 +906,7 @@ func (ec *executionContext) _Query_stringTypedN(ctx context.Context, field graph
 		ec.fieldContext_Query_stringTypedN,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().StringTypedN(ctx, fc.Args["arg"].(*model.StringTyped))
+			return ec.Resolvers.Query().StringTypedN(ctx, fc.Args["arg"].(*model.StringTyped))
 		},
 		nil,
 		ec.marshalOStringTyped2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋmodelᚐStringTyped,
@@ -957,7 +947,7 @@ func (ec *executionContext) _Query_stringUntypedN(ctx context.Context, field gra
 		ec.fieldContext_Query_stringUntypedN,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().StringUntypedN(ctx, fc.Args["arg"].(*string))
+			return ec.Resolvers.Query().StringUntypedN(ctx, fc.Args["arg"].(*string))
 		},
 		nil,
 		ec.marshalOStringUntyped2ᚖstring,
@@ -998,7 +988,7 @@ func (ec *executionContext) _Query_boolTyped(ctx context.Context, field graphql.
 		ec.fieldContext_Query_boolTyped,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().BoolTyped(ctx, fc.Args["arg"].(model.BoolTyped))
+			return ec.Resolvers.Query().BoolTyped(ctx, fc.Args["arg"].(model.BoolTyped))
 		},
 		nil,
 		ec.marshalNBoolTyped2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋmodelᚐBoolTyped,
@@ -1039,7 +1029,7 @@ func (ec *executionContext) _Query_boolUntyped(ctx context.Context, field graphq
 		ec.fieldContext_Query_boolUntyped,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().BoolUntyped(ctx, fc.Args["arg"].(bool))
+			return ec.Resolvers.Query().BoolUntyped(ctx, fc.Args["arg"].(bool))
 		},
 		nil,
 		ec.marshalNBoolUntyped2bool,
@@ -1080,7 +1070,7 @@ func (ec *executionContext) _Query_boolTypedN(ctx context.Context, field graphql
 		ec.fieldContext_Query_boolTypedN,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().BoolTypedN(ctx, fc.Args["arg"].(*model.BoolTyped))
+			return ec.Resolvers.Query().BoolTypedN(ctx, fc.Args["arg"].(*model.BoolTyped))
 		},
 		nil,
 		ec.marshalOBoolTyped2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋmodelᚐBoolTyped,
@@ -1121,7 +1111,7 @@ func (ec *executionContext) _Query_boolUntypedN(ctx context.Context, field graph
 		ec.fieldContext_Query_boolUntypedN,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().BoolUntypedN(ctx, fc.Args["arg"].(*bool))
+			return ec.Resolvers.Query().BoolUntypedN(ctx, fc.Args["arg"].(*bool))
 		},
 		nil,
 		ec.marshalOBoolUntyped2ᚖbool,
@@ -1162,7 +1152,7 @@ func (ec *executionContext) _Query_varTyped(ctx context.Context, field graphql.C
 		ec.fieldContext_Query_varTyped,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().VarTyped(ctx, fc.Args["arg"].(model.VarTyped))
+			return ec.Resolvers.Query().VarTyped(ctx, fc.Args["arg"].(model.VarTyped))
 		},
 		nil,
 		ec.marshalNVarTyped2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋmodelᚐVarTyped,
@@ -1203,7 +1193,7 @@ func (ec *executionContext) _Query_varUntyped(ctx context.Context, field graphql
 		ec.fieldContext_Query_varUntyped,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().VarUntyped(ctx, fc.Args["arg"].(bool))
+			return ec.Resolvers.Query().VarUntyped(ctx, fc.Args["arg"].(bool))
 		},
 		nil,
 		ec.marshalNVarUntyped2bool,
@@ -1244,7 +1234,7 @@ func (ec *executionContext) _Query_inPackage(ctx context.Context, field graphql.
 		ec.fieldContext_Query_inPackage,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().InPackage(ctx, fc.Args["arg"].(InPackage))
+			return ec.Resolvers.Query().InPackage(ctx, fc.Args["arg"].(InPackage))
 		},
 		nil,
 		ec.marshalNInPackage2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋenumᚋapiᚐInPackage,

--- a/_examples/federation/accounts/graph/federation.go
+++ b/_examples/federation/accounts/graph/federation.go
@@ -165,7 +165,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findEmailHostByID(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindEmailHostByID(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindEmailHostByID(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "EmailHost": %w`, err)
 			}
@@ -184,7 +184,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findUserByID(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindUserByID(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindUserByID(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "User": %w`, err)
 			}

--- a/_examples/federation/accounts/graph/generated.go
+++ b/_examples/federation/accounts/graph/generated.go
@@ -24,12 +24,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -83,16 +78,11 @@ type UserResolver interface {
 	Host(ctx context.Context, obj *model.User) (*model.EmailHost, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -103,20 +93,20 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "EmailHost.id":
-		if e.complexity.EmailHost.ID == nil {
+		if e.ComplexityRoot.EmailHost.ID == nil {
 			break
 		}
 
-		return e.complexity.EmailHost.ID(childComplexity), true
+		return e.ComplexityRoot.EmailHost.ID(childComplexity), true
 	case "EmailHost.name":
-		if e.complexity.EmailHost.Name == nil {
+		if e.ComplexityRoot.EmailHost.Name == nil {
 			break
 		}
 
-		return e.complexity.EmailHost.Name(childComplexity), true
+		return e.ComplexityRoot.EmailHost.Name(childComplexity), true
 
 	case "Entity.findEmailHostByID":
-		if e.complexity.Entity.FindEmailHostByID == nil {
+		if e.ComplexityRoot.Entity.FindEmailHostByID == nil {
 			break
 		}
 
@@ -125,9 +115,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindEmailHostByID(childComplexity, args["id"].(string)), true
+		return e.ComplexityRoot.Entity.FindEmailHostByID(childComplexity, args["id"].(string)), true
 	case "Entity.findUserByID":
-		if e.complexity.Entity.FindUserByID == nil {
+		if e.ComplexityRoot.Entity.FindUserByID == nil {
 			break
 		}
 
@@ -136,22 +126,22 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindUserByID(childComplexity, args["id"].(string)), true
+		return e.ComplexityRoot.Entity.FindUserByID(childComplexity, args["id"].(string)), true
 
 	case "Query.me":
-		if e.complexity.Query.Me == nil {
+		if e.ComplexityRoot.Query.Me == nil {
 			break
 		}
 
-		return e.complexity.Query.Me(childComplexity), true
+		return e.ComplexityRoot.Query.Me(childComplexity), true
 	case "Query._service":
-		if e.complexity.Query.__resolve__service == nil {
+		if e.ComplexityRoot.Query.__resolve__service == nil {
 			break
 		}
 
-		return e.complexity.Query.__resolve__service(childComplexity), true
+		return e.ComplexityRoot.Query.__resolve__service(childComplexity), true
 	case "Query._entities":
-		if e.complexity.Query.__resolve_entities == nil {
+		if e.ComplexityRoot.Query.__resolve_entities == nil {
 			break
 		}
 
@@ -160,39 +150,39 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.__resolve_entities(childComplexity, args["representations"].([]map[string]any)), true
+		return e.ComplexityRoot.Query.__resolve_entities(childComplexity, args["representations"].([]map[string]any)), true
 
 	case "User.email":
-		if e.complexity.User.Email == nil {
+		if e.ComplexityRoot.User.Email == nil {
 			break
 		}
 
-		return e.complexity.User.Email(childComplexity), true
+		return e.ComplexityRoot.User.Email(childComplexity), true
 	case "User.host":
-		if e.complexity.User.Host == nil {
+		if e.ComplexityRoot.User.Host == nil {
 			break
 		}
 
-		return e.complexity.User.Host(childComplexity), true
+		return e.ComplexityRoot.User.Host(childComplexity), true
 	case "User.id":
-		if e.complexity.User.ID == nil {
+		if e.ComplexityRoot.User.ID == nil {
 			break
 		}
 
-		return e.complexity.User.ID(childComplexity), true
+		return e.ComplexityRoot.User.ID(childComplexity), true
 	case "User.username":
-		if e.complexity.User.Username == nil {
+		if e.ComplexityRoot.User.Username == nil {
 			break
 		}
 
-		return e.complexity.User.Username(childComplexity), true
+		return e.ComplexityRoot.User.Username(childComplexity), true
 
 	case "_Service.sdl":
-		if e.complexity._Service.SDL == nil {
+		if e.ComplexityRoot._Service.SDL == nil {
 			break
 		}
 
-		return e.complexity._Service.SDL(childComplexity), true
+		return e.ComplexityRoot._Service.SDL(childComplexity), true
 
 	}
 	return 0, false
@@ -534,7 +524,7 @@ func (ec *executionContext) _Entity_findEmailHostByID(ctx context.Context, field
 		ec.fieldContext_Entity_findEmailHostByID,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindEmailHostByID(ctx, fc.Args["id"].(string))
+			return ec.Resolvers.Entity().FindEmailHostByID(ctx, fc.Args["id"].(string))
 		},
 		nil,
 		ec.marshalNEmailHost2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋaccountsᚋgraphᚋmodelᚐEmailHost,
@@ -581,7 +571,7 @@ func (ec *executionContext) _Entity_findUserByID(ctx context.Context, field grap
 		ec.fieldContext_Entity_findUserByID,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindUserByID(ctx, fc.Args["id"].(string))
+			return ec.Resolvers.Entity().FindUserByID(ctx, fc.Args["id"].(string))
 		},
 		nil,
 		ec.marshalNUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋaccountsᚋgraphᚋmodelᚐUser,
@@ -631,7 +621,7 @@ func (ec *executionContext) _Query_me(ctx context.Context, field graphql.Collect
 		field,
 		ec.fieldContext_Query_me,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Me(ctx)
+			return ec.Resolvers.Query().Me(ctx)
 		},
 		nil,
 		ec.marshalOUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋaccountsᚋgraphᚋmodelᚐUser,
@@ -881,7 +871,7 @@ func (ec *executionContext) _User_host(ctx context.Context, field graphql.Collec
 		field,
 		ec.fieldContext_User_host,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.User().Host(ctx, obj)
+			return ec.Resolvers.User().Host(ctx, obj)
 		},
 		nil,
 		ec.marshalNEmailHost2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋaccountsᚋgraphᚋmodelᚐEmailHost,

--- a/_examples/federation/products/graph/federation.go
+++ b/_examples/federation/products/graph/federation.go
@@ -165,7 +165,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findManufacturerByID(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindManufacturerByID(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindManufacturerByID(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "Manufacturer": %w`, err)
 			}
@@ -188,7 +188,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 1 for findProductByManufacturerIDAndID(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindProductByManufacturerIDAndID(ctx, id0, id1)
+			entity, err := ec.Resolvers.Entity().FindProductByManufacturerIDAndID(ctx, id0, id1)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "Product": %w`, err)
 			}
@@ -199,7 +199,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findProductByUpc(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindProductByUpc(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindProductByUpc(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "Product": %w`, err)
 			}

--- a/_examples/federation/products/graph/generated.go
+++ b/_examples/federation/products/graph/generated.go
@@ -24,12 +24,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -54,16 +49,11 @@ type QueryResolver interface {
 	TopProducts(ctx context.Context, first *int) ([]*model.Product, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -381,7 +371,7 @@ func (ec *executionContext) _Entity_findManufacturerByID(ctx context.Context, fi
 		ec.fieldContext_Entity_findManufacturerByID,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManufacturerByID(ctx, fc.Args["id"].(string))
+			return ec.Resolvers.Entity().FindManufacturerByID(ctx, fc.Args["id"].(string))
 		},
 		nil,
 		ec.marshalNManufacturer2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋproductsᚋgraphᚋmodelᚐManufacturer,
@@ -428,7 +418,7 @@ func (ec *executionContext) _Entity_findProductByManufacturerIDAndID(ctx context
 		ec.fieldContext_Entity_findProductByManufacturerIDAndID,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindProductByManufacturerIDAndID(ctx, fc.Args["manufacturerID"].(string), fc.Args["id"].(string))
+			return ec.Resolvers.Entity().FindProductByManufacturerIDAndID(ctx, fc.Args["manufacturerID"].(string), fc.Args["id"].(string))
 		},
 		nil,
 		ec.marshalNProduct2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋproductsᚋgraphᚋmodelᚐProduct,
@@ -481,7 +471,7 @@ func (ec *executionContext) _Entity_findProductByUpc(ctx context.Context, field 
 		ec.fieldContext_Entity_findProductByUpc,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindProductByUpc(ctx, fc.Args["upc"].(string))
+			return ec.Resolvers.Entity().FindProductByUpc(ctx, fc.Args["upc"].(string))
 		},
 		nil,
 		ec.marshalNProduct2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋproductsᚋgraphᚋmodelᚐProduct,
@@ -743,7 +733,7 @@ func (ec *executionContext) _Query_topProducts(ctx context.Context, field graphq
 		ec.fieldContext_Query_topProducts,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().TopProducts(ctx, fc.Args["first"].(*int))
+			return ec.Resolvers.Query().TopProducts(ctx, fc.Args["first"].(*int))
 		},
 		nil,
 		ec.marshalOProduct2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋproductsᚋgraphᚋmodelᚐProduct,

--- a/_examples/federation/reviews/graph/federation.go
+++ b/_examples/federation/reviews/graph/federation.go
@@ -168,7 +168,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findUserByID(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindUserByID(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindUserByID(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "User": %w`, err)
 			}
@@ -222,7 +222,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyProductByManufacturerIDAndIDs(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyProductByManufacturerIDAndIDs(ctx, typedReps)
 			if err != nil {
 				return err
 			}

--- a/_examples/federation/reviews/graph/generated.go
+++ b/_examples/federation/reviews/graph/generated.go
@@ -24,12 +24,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -83,16 +78,11 @@ var (
 	}
 )
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -510,7 +500,7 @@ func (ec *executionContext) _Entity_findManyProductByManufacturerIDAndIDs(ctx co
 		ec.fieldContext_Entity_findManyProductByManufacturerIDAndIDs,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyProductByManufacturerIDAndIDs(ctx, fc.Args["reps"].([]*model.ProductByManufacturerIDAndIDsInput))
+			return ec.Resolvers.Entity().FindManyProductByManufacturerIDAndIDs(ctx, fc.Args["reps"].([]*model.ProductByManufacturerIDAndIDsInput))
 		},
 		nil,
 		ec.marshalOProduct2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋreviewsᚋgraphᚋmodelᚐProduct,
@@ -561,7 +551,7 @@ func (ec *executionContext) _Entity_findUserByID(ctx context.Context, field grap
 		ec.fieldContext_Entity_findUserByID,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindUserByID(ctx, fc.Args["id"].(string))
+			return ec.Resolvers.Entity().FindUserByID(ctx, fc.Args["id"].(string))
 		},
 		nil,
 		ec.marshalNUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋreviewsᚋgraphᚋmodelᚐUser,
@@ -705,7 +695,7 @@ func (ec *executionContext) _Product_manufacturerID(ctx context.Context, field g
 		ec.fieldContext_Product_manufacturerID,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Product().ManufacturerID(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
+			return ec.Resolvers.Product().ManufacturerID(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
 		},
 		nil,
 		ec.marshalOString2ᚖstring,
@@ -1195,7 +1185,7 @@ func (ec *executionContext) _User_username(ctx context.Context, field graphql.Co
 		field,
 		ec.fieldContext_User_username,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.User().Username(ctx, obj)
+			return ec.Resolvers.User().Username(ctx, obj)
 		},
 		nil,
 		ec.marshalNString2string,
@@ -1225,7 +1215,7 @@ func (ec *executionContext) _User_reviews(ctx context.Context, field graphql.Col
 		ec.fieldContext_User_reviews,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.User().Reviews(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
+			return ec.Resolvers.User().Reviews(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
 		},
 		nil,
 		ec.marshalOReview2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfederationᚋreviewsᚋgraphᚋmodelᚐReview,

--- a/_examples/fileupload/generated.go
+++ b/_examples/fileupload/generated.go
@@ -23,12 +23,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -71,16 +66,11 @@ type QueryResolver interface {
 	Empty(ctx context.Context) (string, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -91,32 +81,32 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "File.content":
-		if e.complexity.File.Content == nil {
+		if e.ComplexityRoot.File.Content == nil {
 			break
 		}
 
-		return e.complexity.File.Content(childComplexity), true
+		return e.ComplexityRoot.File.Content(childComplexity), true
 	case "File.contentType":
-		if e.complexity.File.ContentType == nil {
+		if e.ComplexityRoot.File.ContentType == nil {
 			break
 		}
 
-		return e.complexity.File.ContentType(childComplexity), true
+		return e.ComplexityRoot.File.ContentType(childComplexity), true
 	case "File.id":
-		if e.complexity.File.ID == nil {
+		if e.ComplexityRoot.File.ID == nil {
 			break
 		}
 
-		return e.complexity.File.ID(childComplexity), true
+		return e.ComplexityRoot.File.ID(childComplexity), true
 	case "File.name":
-		if e.complexity.File.Name == nil {
+		if e.ComplexityRoot.File.Name == nil {
 			break
 		}
 
-		return e.complexity.File.Name(childComplexity), true
+		return e.ComplexityRoot.File.Name(childComplexity), true
 
 	case "Mutation.multipleUpload":
-		if e.complexity.Mutation.MultipleUpload == nil {
+		if e.ComplexityRoot.Mutation.MultipleUpload == nil {
 			break
 		}
 
@@ -125,9 +115,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.MultipleUpload(childComplexity, args["files"].([]*graphql.Upload)), true
+		return e.ComplexityRoot.Mutation.MultipleUpload(childComplexity, args["files"].([]*graphql.Upload)), true
 	case "Mutation.multipleUploadWithPayload":
-		if e.complexity.Mutation.MultipleUploadWithPayload == nil {
+		if e.ComplexityRoot.Mutation.MultipleUploadWithPayload == nil {
 			break
 		}
 
@@ -136,9 +126,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.MultipleUploadWithPayload(childComplexity, args["req"].([]*model.UploadFile)), true
+		return e.ComplexityRoot.Mutation.MultipleUploadWithPayload(childComplexity, args["req"].([]*model.UploadFile)), true
 	case "Mutation.singleUpload":
-		if e.complexity.Mutation.SingleUpload == nil {
+		if e.ComplexityRoot.Mutation.SingleUpload == nil {
 			break
 		}
 
@@ -147,9 +137,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.SingleUpload(childComplexity, args["file"].(graphql.Upload)), true
+		return e.ComplexityRoot.Mutation.SingleUpload(childComplexity, args["file"].(graphql.Upload)), true
 	case "Mutation.singleUploadWithPayload":
-		if e.complexity.Mutation.SingleUploadWithPayload == nil {
+		if e.ComplexityRoot.Mutation.SingleUploadWithPayload == nil {
 			break
 		}
 
@@ -158,14 +148,14 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.SingleUploadWithPayload(childComplexity, args["req"].(model.UploadFile)), true
+		return e.ComplexityRoot.Mutation.SingleUploadWithPayload(childComplexity, args["req"].(model.UploadFile)), true
 
 	case "Query.empty":
-		if e.complexity.Query.Empty == nil {
+		if e.ComplexityRoot.Query.Empty == nil {
 			break
 		}
 
-		return e.complexity.Query.Empty(childComplexity), true
+		return e.ComplexityRoot.Query.Empty(childComplexity), true
 
 	}
 	return 0, false
@@ -523,7 +513,7 @@ func (ec *executionContext) _Mutation_singleUpload(ctx context.Context, field gr
 		ec.fieldContext_Mutation_singleUpload,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().SingleUpload(ctx, fc.Args["file"].(graphql.Upload))
+			return ec.Resolvers.Mutation().SingleUpload(ctx, fc.Args["file"].(graphql.Upload))
 		},
 		nil,
 		ec.marshalNFile2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfileuploadᚋmodelᚐFile,
@@ -574,7 +564,7 @@ func (ec *executionContext) _Mutation_singleUploadWithPayload(ctx context.Contex
 		ec.fieldContext_Mutation_singleUploadWithPayload,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().SingleUploadWithPayload(ctx, fc.Args["req"].(model.UploadFile))
+			return ec.Resolvers.Mutation().SingleUploadWithPayload(ctx, fc.Args["req"].(model.UploadFile))
 		},
 		nil,
 		ec.marshalNFile2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfileuploadᚋmodelᚐFile,
@@ -625,7 +615,7 @@ func (ec *executionContext) _Mutation_multipleUpload(ctx context.Context, field 
 		ec.fieldContext_Mutation_multipleUpload,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().MultipleUpload(ctx, fc.Args["files"].([]*graphql.Upload))
+			return ec.Resolvers.Mutation().MultipleUpload(ctx, fc.Args["files"].([]*graphql.Upload))
 		},
 		nil,
 		ec.marshalNFile2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfileuploadᚋmodelᚐFileᚄ,
@@ -676,7 +666,7 @@ func (ec *executionContext) _Mutation_multipleUploadWithPayload(ctx context.Cont
 		ec.fieldContext_Mutation_multipleUploadWithPayload,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().MultipleUploadWithPayload(ctx, fc.Args["req"].([]*model.UploadFile))
+			return ec.Resolvers.Mutation().MultipleUploadWithPayload(ctx, fc.Args["req"].([]*model.UploadFile))
 		},
 		nil,
 		ec.marshalNFile2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋfileuploadᚋmodelᚐFileᚄ,
@@ -726,7 +716,7 @@ func (ec *executionContext) _Query_empty(ctx context.Context, field graphql.Coll
 		field,
 		ec.fieldContext_Query_empty,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Empty(ctx)
+			return ec.Resolvers.Query().Empty(ctx)
 		},
 		nil,
 		ec.marshalNString2string,

--- a/_examples/scalars/generated.go
+++ b/_examples/scalars/generated.go
@@ -25,12 +25,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -80,16 +75,11 @@ type UserResolver interface {
 	CustomResolver(ctx context.Context, obj *model.User) (*model.Point, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -100,20 +90,20 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "Address.id":
-		if e.complexity.Address.ID == nil {
+		if e.ComplexityRoot.Address.ID == nil {
 			break
 		}
 
-		return e.complexity.Address.ID(childComplexity), true
+		return e.ComplexityRoot.Address.ID(childComplexity), true
 	case "Address.location":
-		if e.complexity.Address.Location == nil {
+		if e.ComplexityRoot.Address.Location == nil {
 			break
 		}
 
-		return e.complexity.Address.Location(childComplexity), true
+		return e.ComplexityRoot.Address.Location(childComplexity), true
 
 	case "Query.search":
-		if e.complexity.Query.Search == nil {
+		if e.ComplexityRoot.Query.Search == nil {
 			break
 		}
 
@@ -122,9 +112,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Search(childComplexity, args["input"].(*model.SearchArgs)), true
+		return e.ComplexityRoot.Query.Search(childComplexity, args["input"].(*model.SearchArgs)), true
 	case "Query.user":
-		if e.complexity.Query.User == nil {
+		if e.ComplexityRoot.Query.User == nil {
 			break
 		}
 
@@ -133,9 +123,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.User(childComplexity, args["id"].(external.ObjectID)), true
+		return e.ComplexityRoot.Query.User(childComplexity, args["id"].(external.ObjectID)), true
 	case "Query.userByTier":
-		if e.complexity.Query.UserByTier == nil {
+		if e.ComplexityRoot.Query.UserByTier == nil {
 			break
 		}
 
@@ -144,74 +134,74 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.UserByTier(childComplexity, args["tier"].(model.Tier), args["darkMode"].(*model.Prefs)), true
+		return e.ComplexityRoot.Query.UserByTier(childComplexity, args["tier"].(model.Tier), args["darkMode"].(*model.Prefs)), true
 
 	case "User.address":
-		if e.complexity.User.Address == nil {
+		if e.ComplexityRoot.User.Address == nil {
 			break
 		}
 
-		return e.complexity.User.Address(childComplexity), true
+		return e.ComplexityRoot.User.Address(childComplexity), true
 	case "User.created":
-		if e.complexity.User.Created == nil {
+		if e.ComplexityRoot.User.Created == nil {
 			break
 		}
 
-		return e.complexity.User.Created(childComplexity), true
+		return e.ComplexityRoot.User.Created(childComplexity), true
 	case "User.customResolver":
-		if e.complexity.User.CustomResolver == nil {
+		if e.ComplexityRoot.User.CustomResolver == nil {
 			break
 		}
 
-		return e.complexity.User.CustomResolver(childComplexity), true
+		return e.ComplexityRoot.User.CustomResolver(childComplexity), true
 	case "User.id":
-		if e.complexity.User.ID == nil {
+		if e.ComplexityRoot.User.ID == nil {
 			break
 		}
 
-		return e.complexity.User.ID(childComplexity), true
+		return e.ComplexityRoot.User.ID(childComplexity), true
 	case "User.isBanned":
-		if e.complexity.User.IsBanned == nil {
+		if e.ComplexityRoot.User.IsBanned == nil {
 			break
 		}
 
-		return e.complexity.User.IsBanned(childComplexity), true
+		return e.ComplexityRoot.User.IsBanned(childComplexity), true
 	case "User.modified":
-		if e.complexity.User.Modified == nil {
+		if e.ComplexityRoot.User.Modified == nil {
 			break
 		}
 
-		return e.complexity.User.Modified(childComplexity), true
+		return e.ComplexityRoot.User.Modified(childComplexity), true
 	case "User.name":
-		if e.complexity.User.Name == nil {
+		if e.ComplexityRoot.User.Name == nil {
 			break
 		}
 
-		return e.complexity.User.Name(childComplexity), true
+		return e.ComplexityRoot.User.Name(childComplexity), true
 	case "User.primitiveResolver":
-		if e.complexity.User.PrimitiveResolver == nil {
+		if e.ComplexityRoot.User.PrimitiveResolver == nil {
 			break
 		}
 
-		return e.complexity.User.PrimitiveResolver(childComplexity), true
+		return e.ComplexityRoot.User.PrimitiveResolver(childComplexity), true
 	case "User.ptrPrefs":
-		if e.complexity.User.PtrPrefs == nil {
+		if e.ComplexityRoot.User.PtrPrefs == nil {
 			break
 		}
 
-		return e.complexity.User.PtrPrefs(childComplexity), true
+		return e.ComplexityRoot.User.PtrPrefs(childComplexity), true
 	case "User.tier":
-		if e.complexity.User.Tier == nil {
+		if e.ComplexityRoot.User.Tier == nil {
 			break
 		}
 
-		return e.complexity.User.Tier(childComplexity), true
+		return e.ComplexityRoot.User.Tier(childComplexity), true
 	case "User.valPrefs":
-		if e.complexity.User.ValPrefs == nil {
+		if e.ComplexityRoot.User.ValPrefs == nil {
 			break
 		}
 
-		return e.complexity.User.ValPrefs(childComplexity), true
+		return e.ComplexityRoot.User.ValPrefs(childComplexity), true
 
 	}
 	return 0, false
@@ -490,7 +480,7 @@ func (ec *executionContext) _Query_user(ctx context.Context, field graphql.Colle
 		ec.fieldContext_Query_user,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().User(ctx, fc.Args["id"].(external.ObjectID))
+			return ec.Resolvers.Query().User(ctx, fc.Args["id"].(external.ObjectID))
 		},
 		nil,
 		ec.marshalOUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐUser,
@@ -555,7 +545,7 @@ func (ec *executionContext) _Query_search(ctx context.Context, field graphql.Col
 		ec.fieldContext_Query_search,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Search(ctx, fc.Args["input"].(*model.SearchArgs))
+			return ec.Resolvers.Query().Search(ctx, fc.Args["input"].(*model.SearchArgs))
 		},
 		nil,
 		ec.marshalNUser2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐUserᚄ,
@@ -620,7 +610,7 @@ func (ec *executionContext) _Query_userByTier(ctx context.Context, field graphql
 		ec.fieldContext_Query_userByTier,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().UserByTier(ctx, fc.Args["tier"].(model.Tier), fc.Args["darkMode"].(*model.Prefs))
+			return ec.Resolvers.Query().UserByTier(ctx, fc.Args["tier"].(model.Tier), fc.Args["darkMode"].(*model.Prefs))
 		},
 		nil,
 		ec.marshalNUser2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐUserᚄ,
@@ -995,7 +985,7 @@ func (ec *executionContext) _User_primitiveResolver(ctx context.Context, field g
 		field,
 		ec.fieldContext_User_primitiveResolver,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.User().PrimitiveResolver(ctx, obj)
+			return ec.Resolvers.User().PrimitiveResolver(ctx, obj)
 		},
 		nil,
 		ec.marshalNString2string,
@@ -1024,7 +1014,7 @@ func (ec *executionContext) _User_customResolver(ctx context.Context, field grap
 		field,
 		ec.fieldContext_User_customResolver,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.User().CustomResolver(ctx, obj)
+			return ec.Resolvers.User().CustomResolver(ctx, obj)
 		},
 		nil,
 		ec.marshalNPoint2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋscalarsᚋmodelᚐPoint,

--- a/_examples/selection/generated.go
+++ b/_examples/selection/generated.go
@@ -23,12 +23,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -64,16 +59,11 @@ type QueryResolver interface {
 	Events(ctx context.Context) ([]Event, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -84,61 +74,61 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "Like.collected":
-		if e.complexity.Like.Collected == nil {
+		if e.ComplexityRoot.Like.Collected == nil {
 			break
 		}
 
-		return e.complexity.Like.Collected(childComplexity), true
+		return e.ComplexityRoot.Like.Collected(childComplexity), true
 	case "Like.reaction":
-		if e.complexity.Like.Reaction == nil {
+		if e.ComplexityRoot.Like.Reaction == nil {
 			break
 		}
 
-		return e.complexity.Like.Reaction(childComplexity), true
+		return e.ComplexityRoot.Like.Reaction(childComplexity), true
 	case "Like.selection":
-		if e.complexity.Like.Selection == nil {
+		if e.ComplexityRoot.Like.Selection == nil {
 			break
 		}
 
-		return e.complexity.Like.Selection(childComplexity), true
+		return e.ComplexityRoot.Like.Selection(childComplexity), true
 	case "Like.sent":
-		if e.complexity.Like.Sent == nil {
+		if e.ComplexityRoot.Like.Sent == nil {
 			break
 		}
 
-		return e.complexity.Like.Sent(childComplexity), true
+		return e.ComplexityRoot.Like.Sent(childComplexity), true
 
 	case "Post.collected":
-		if e.complexity.Post.Collected == nil {
+		if e.ComplexityRoot.Post.Collected == nil {
 			break
 		}
 
-		return e.complexity.Post.Collected(childComplexity), true
+		return e.ComplexityRoot.Post.Collected(childComplexity), true
 	case "Post.message":
-		if e.complexity.Post.Message == nil {
+		if e.ComplexityRoot.Post.Message == nil {
 			break
 		}
 
-		return e.complexity.Post.Message(childComplexity), true
+		return e.ComplexityRoot.Post.Message(childComplexity), true
 	case "Post.selection":
-		if e.complexity.Post.Selection == nil {
+		if e.ComplexityRoot.Post.Selection == nil {
 			break
 		}
 
-		return e.complexity.Post.Selection(childComplexity), true
+		return e.ComplexityRoot.Post.Selection(childComplexity), true
 	case "Post.sent":
-		if e.complexity.Post.Sent == nil {
+		if e.ComplexityRoot.Post.Sent == nil {
 			break
 		}
 
-		return e.complexity.Post.Sent(childComplexity), true
+		return e.ComplexityRoot.Post.Sent(childComplexity), true
 
 	case "Query.events":
-		if e.complexity.Query.Events == nil {
+		if e.ComplexityRoot.Query.Events == nil {
 			break
 		}
 
-		return e.complexity.Query.Events(childComplexity), true
+		return e.ComplexityRoot.Query.Events(childComplexity), true
 
 	}
 	return 0, false
@@ -550,7 +540,7 @@ func (ec *executionContext) _Query_events(ctx context.Context, field graphql.Col
 		field,
 		ec.fieldContext_Query_events,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Events(ctx)
+			return ec.Resolvers.Query().Events(ctx)
 		},
 		nil,
 		ec.marshalOEvent2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋselectionᚐEventᚄ,

--- a/_examples/starwars/generated/exec.go
+++ b/_examples/starwars/generated/exec.go
@@ -23,12 +23,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -144,16 +139,11 @@ type StarshipResolver interface {
 	Length(ctx context.Context, obj *models.Starship, unit *models.LengthUnit) (float64, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -164,19 +154,19 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "Droid.appearsIn":
-		if e.complexity.Droid.AppearsIn == nil {
+		if e.ComplexityRoot.Droid.AppearsIn == nil {
 			break
 		}
 
-		return e.complexity.Droid.AppearsIn(childComplexity), true
+		return e.ComplexityRoot.Droid.AppearsIn(childComplexity), true
 	case "Droid.friends":
-		if e.complexity.Droid.Friends == nil {
+		if e.ComplexityRoot.Droid.Friends == nil {
 			break
 		}
 
-		return e.complexity.Droid.Friends(childComplexity), true
+		return e.ComplexityRoot.Droid.Friends(childComplexity), true
 	case "Droid.friendsConnection":
-		if e.complexity.Droid.FriendsConnection == nil {
+		if e.ComplexityRoot.Droid.FriendsConnection == nil {
 			break
 		}
 
@@ -185,78 +175,78 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Droid.FriendsConnection(childComplexity, args["first"].(*int), args["after"].(*string)), true
+		return e.ComplexityRoot.Droid.FriendsConnection(childComplexity, args["first"].(*int), args["after"].(*string)), true
 	case "Droid.id":
-		if e.complexity.Droid.ID == nil {
+		if e.ComplexityRoot.Droid.ID == nil {
 			break
 		}
 
-		return e.complexity.Droid.ID(childComplexity), true
+		return e.ComplexityRoot.Droid.ID(childComplexity), true
 	case "Droid.name":
-		if e.complexity.Droid.Name == nil {
+		if e.ComplexityRoot.Droid.Name == nil {
 			break
 		}
 
-		return e.complexity.Droid.Name(childComplexity), true
+		return e.ComplexityRoot.Droid.Name(childComplexity), true
 	case "Droid.primaryFunction":
-		if e.complexity.Droid.PrimaryFunction == nil {
+		if e.ComplexityRoot.Droid.PrimaryFunction == nil {
 			break
 		}
 
-		return e.complexity.Droid.PrimaryFunction(childComplexity), true
+		return e.ComplexityRoot.Droid.PrimaryFunction(childComplexity), true
 
 	case "FriendsConnection.edges":
-		if e.complexity.FriendsConnection.Edges == nil {
+		if e.ComplexityRoot.FriendsConnection.Edges == nil {
 			break
 		}
 
-		return e.complexity.FriendsConnection.Edges(childComplexity), true
+		return e.ComplexityRoot.FriendsConnection.Edges(childComplexity), true
 	case "FriendsConnection.friends":
-		if e.complexity.FriendsConnection.Friends == nil {
+		if e.ComplexityRoot.FriendsConnection.Friends == nil {
 			break
 		}
 
-		return e.complexity.FriendsConnection.Friends(childComplexity), true
+		return e.ComplexityRoot.FriendsConnection.Friends(childComplexity), true
 	case "FriendsConnection.pageInfo":
-		if e.complexity.FriendsConnection.PageInfo == nil {
+		if e.ComplexityRoot.FriendsConnection.PageInfo == nil {
 			break
 		}
 
-		return e.complexity.FriendsConnection.PageInfo(childComplexity), true
+		return e.ComplexityRoot.FriendsConnection.PageInfo(childComplexity), true
 	case "FriendsConnection.totalCount":
-		if e.complexity.FriendsConnection.TotalCount == nil {
+		if e.ComplexityRoot.FriendsConnection.TotalCount == nil {
 			break
 		}
 
-		return e.complexity.FriendsConnection.TotalCount(childComplexity), true
+		return e.ComplexityRoot.FriendsConnection.TotalCount(childComplexity), true
 
 	case "FriendsEdge.cursor":
-		if e.complexity.FriendsEdge.Cursor == nil {
+		if e.ComplexityRoot.FriendsEdge.Cursor == nil {
 			break
 		}
 
-		return e.complexity.FriendsEdge.Cursor(childComplexity), true
+		return e.ComplexityRoot.FriendsEdge.Cursor(childComplexity), true
 	case "FriendsEdge.node":
-		if e.complexity.FriendsEdge.Node == nil {
+		if e.ComplexityRoot.FriendsEdge.Node == nil {
 			break
 		}
 
-		return e.complexity.FriendsEdge.Node(childComplexity), true
+		return e.ComplexityRoot.FriendsEdge.Node(childComplexity), true
 
 	case "Human.appearsIn":
-		if e.complexity.Human.AppearsIn == nil {
+		if e.ComplexityRoot.Human.AppearsIn == nil {
 			break
 		}
 
-		return e.complexity.Human.AppearsIn(childComplexity), true
+		return e.ComplexityRoot.Human.AppearsIn(childComplexity), true
 	case "Human.friends":
-		if e.complexity.Human.Friends == nil {
+		if e.ComplexityRoot.Human.Friends == nil {
 			break
 		}
 
-		return e.complexity.Human.Friends(childComplexity), true
+		return e.ComplexityRoot.Human.Friends(childComplexity), true
 	case "Human.friendsConnection":
-		if e.complexity.Human.FriendsConnection == nil {
+		if e.ComplexityRoot.Human.FriendsConnection == nil {
 			break
 		}
 
@@ -265,9 +255,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Human.FriendsConnection(childComplexity, args["first"].(*int), args["after"].(*string)), true
+		return e.ComplexityRoot.Human.FriendsConnection(childComplexity, args["first"].(*int), args["after"].(*string)), true
 	case "Human.height":
-		if e.complexity.Human.Height == nil {
+		if e.ComplexityRoot.Human.Height == nil {
 			break
 		}
 
@@ -276,46 +266,46 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Human.Height(childComplexity, args["unit"].(models.LengthUnit)), true
+		return e.ComplexityRoot.Human.Height(childComplexity, args["unit"].(models.LengthUnit)), true
 	case "Human.id":
-		if e.complexity.Human.ID == nil {
+		if e.ComplexityRoot.Human.ID == nil {
 			break
 		}
 
-		return e.complexity.Human.ID(childComplexity), true
+		return e.ComplexityRoot.Human.ID(childComplexity), true
 	case "Human.mass":
-		if e.complexity.Human.Mass == nil {
+		if e.ComplexityRoot.Human.Mass == nil {
 			break
 		}
 
-		return e.complexity.Human.Mass(childComplexity), true
+		return e.ComplexityRoot.Human.Mass(childComplexity), true
 	case "Human.mutation":
-		if e.complexity.Human.Mutation == nil {
+		if e.ComplexityRoot.Human.Mutation == nil {
 			break
 		}
 
-		return e.complexity.Human.Mutation(childComplexity), true
+		return e.ComplexityRoot.Human.Mutation(childComplexity), true
 	case "Human.name":
-		if e.complexity.Human.Name == nil {
+		if e.ComplexityRoot.Human.Name == nil {
 			break
 		}
 
-		return e.complexity.Human.Name(childComplexity), true
+		return e.ComplexityRoot.Human.Name(childComplexity), true
 	case "Human.query":
-		if e.complexity.Human.Query == nil {
+		if e.ComplexityRoot.Human.Query == nil {
 			break
 		}
 
-		return e.complexity.Human.Query(childComplexity), true
+		return e.ComplexityRoot.Human.Query(childComplexity), true
 	case "Human.starships":
-		if e.complexity.Human.Starships == nil {
+		if e.ComplexityRoot.Human.Starships == nil {
 			break
 		}
 
-		return e.complexity.Human.Starships(childComplexity), true
+		return e.ComplexityRoot.Human.Starships(childComplexity), true
 
 	case "Mutation.createReview":
-		if e.complexity.Mutation.CreateReview == nil {
+		if e.ComplexityRoot.Mutation.CreateReview == nil {
 			break
 		}
 
@@ -324,29 +314,29 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.CreateReview(childComplexity, args["episode"].(models.Episode), args["review"].(models.Review)), true
+		return e.ComplexityRoot.Mutation.CreateReview(childComplexity, args["episode"].(models.Episode), args["review"].(models.Review)), true
 
 	case "PageInfo.endCursor":
-		if e.complexity.PageInfo.EndCursor == nil {
+		if e.ComplexityRoot.PageInfo.EndCursor == nil {
 			break
 		}
 
-		return e.complexity.PageInfo.EndCursor(childComplexity), true
+		return e.ComplexityRoot.PageInfo.EndCursor(childComplexity), true
 	case "PageInfo.hasNextPage":
-		if e.complexity.PageInfo.HasNextPage == nil {
+		if e.ComplexityRoot.PageInfo.HasNextPage == nil {
 			break
 		}
 
-		return e.complexity.PageInfo.HasNextPage(childComplexity), true
+		return e.ComplexityRoot.PageInfo.HasNextPage(childComplexity), true
 	case "PageInfo.startCursor":
-		if e.complexity.PageInfo.StartCursor == nil {
+		if e.ComplexityRoot.PageInfo.StartCursor == nil {
 			break
 		}
 
-		return e.complexity.PageInfo.StartCursor(childComplexity), true
+		return e.ComplexityRoot.PageInfo.StartCursor(childComplexity), true
 
 	case "Query.character":
-		if e.complexity.Query.Character == nil {
+		if e.ComplexityRoot.Query.Character == nil {
 			break
 		}
 
@@ -355,9 +345,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Character(childComplexity, args["id"].(string)), true
+		return e.ComplexityRoot.Query.Character(childComplexity, args["id"].(string)), true
 	case "Query.droid":
-		if e.complexity.Query.Droid == nil {
+		if e.ComplexityRoot.Query.Droid == nil {
 			break
 		}
 
@@ -366,9 +356,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Droid(childComplexity, args["id"].(string)), true
+		return e.ComplexityRoot.Query.Droid(childComplexity, args["id"].(string)), true
 	case "Query.hero":
-		if e.complexity.Query.Hero == nil {
+		if e.ComplexityRoot.Query.Hero == nil {
 			break
 		}
 
@@ -377,9 +367,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Hero(childComplexity, args["episode"].(*models.Episode)), true
+		return e.ComplexityRoot.Query.Hero(childComplexity, args["episode"].(*models.Episode)), true
 	case "Query.human":
-		if e.complexity.Query.Human == nil {
+		if e.ComplexityRoot.Query.Human == nil {
 			break
 		}
 
@@ -388,9 +378,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Human(childComplexity, args["id"].(string)), true
+		return e.ComplexityRoot.Query.Human(childComplexity, args["id"].(string)), true
 	case "Query.reviews":
-		if e.complexity.Query.Reviews == nil {
+		if e.ComplexityRoot.Query.Reviews == nil {
 			break
 		}
 
@@ -399,9 +389,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Reviews(childComplexity, args["episode"].(models.Episode), args["since"].(*time.Time)), true
+		return e.ComplexityRoot.Query.Reviews(childComplexity, args["episode"].(models.Episode), args["since"].(*time.Time)), true
 	case "Query.search":
-		if e.complexity.Query.Search == nil {
+		if e.ComplexityRoot.Query.Search == nil {
 			break
 		}
 
@@ -410,9 +400,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Search(childComplexity, args["text"].(string)), true
+		return e.ComplexityRoot.Query.Search(childComplexity, args["text"].(string)), true
 	case "Query.starship":
-		if e.complexity.Query.Starship == nil {
+		if e.ComplexityRoot.Query.Starship == nil {
 			break
 		}
 
@@ -421,41 +411,41 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Starship(childComplexity, args["id"].(string)), true
+		return e.ComplexityRoot.Query.Starship(childComplexity, args["id"].(string)), true
 
 	case "Review.commentary":
-		if e.complexity.Review.Commentary == nil {
+		if e.ComplexityRoot.Review.Commentary == nil {
 			break
 		}
 
-		return e.complexity.Review.Commentary(childComplexity), true
+		return e.ComplexityRoot.Review.Commentary(childComplexity), true
 	case "Review.stars":
-		if e.complexity.Review.Stars == nil {
+		if e.ComplexityRoot.Review.Stars == nil {
 			break
 		}
 
-		return e.complexity.Review.Stars(childComplexity), true
+		return e.ComplexityRoot.Review.Stars(childComplexity), true
 	case "Review.time":
-		if e.complexity.Review.Time == nil {
+		if e.ComplexityRoot.Review.Time == nil {
 			break
 		}
 
-		return e.complexity.Review.Time(childComplexity), true
+		return e.ComplexityRoot.Review.Time(childComplexity), true
 
 	case "Starship.history":
-		if e.complexity.Starship.History == nil {
+		if e.ComplexityRoot.Starship.History == nil {
 			break
 		}
 
-		return e.complexity.Starship.History(childComplexity), true
+		return e.ComplexityRoot.Starship.History(childComplexity), true
 	case "Starship.id":
-		if e.complexity.Starship.ID == nil {
+		if e.ComplexityRoot.Starship.ID == nil {
 			break
 		}
 
-		return e.complexity.Starship.ID(childComplexity), true
+		return e.ComplexityRoot.Starship.ID(childComplexity), true
 	case "Starship.length":
-		if e.complexity.Starship.Length == nil {
+		if e.ComplexityRoot.Starship.Length == nil {
 			break
 		}
 
@@ -464,13 +454,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Starship.Length(childComplexity, args["unit"].(*models.LengthUnit)), true
+		return e.ComplexityRoot.Starship.Length(childComplexity, args["unit"].(*models.LengthUnit)), true
 	case "Starship.name":
-		if e.complexity.Starship.Name == nil {
+		if e.ComplexityRoot.Starship.Name == nil {
 			break
 		}
 
-		return e.complexity.Starship.Name(childComplexity), true
+		return e.ComplexityRoot.Starship.Name(childComplexity), true
 
 	}
 	return 0, false
@@ -1001,7 +991,7 @@ func (ec *executionContext) _Droid_friends(ctx context.Context, field graphql.Co
 		field,
 		ec.fieldContext_Droid_friends,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Droid().Friends(ctx, obj)
+			return ec.Resolvers.Droid().Friends(ctx, obj)
 		},
 		nil,
 		ec.marshalOCharacter2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐCharacterᚄ,
@@ -1031,7 +1021,7 @@ func (ec *executionContext) _Droid_friendsConnection(ctx context.Context, field 
 		ec.fieldContext_Droid_friendsConnection,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Droid().FriendsConnection(ctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*string))
+			return ec.Resolvers.Droid().FriendsConnection(ctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*string))
 		},
 		nil,
 		ec.marshalNFriendsConnection2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐFriendsConnection,
@@ -1168,7 +1158,7 @@ func (ec *executionContext) _FriendsConnection_edges(ctx context.Context, field 
 		field,
 		ec.fieldContext_FriendsConnection_edges,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.FriendsConnection().Edges(ctx, obj)
+			return ec.Resolvers.FriendsConnection().Edges(ctx, obj)
 		},
 		nil,
 		ec.marshalOFriendsEdge2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐFriendsEdgeᚄ,
@@ -1203,7 +1193,7 @@ func (ec *executionContext) _FriendsConnection_friends(ctx context.Context, fiel
 		field,
 		ec.fieldContext_FriendsConnection_friends,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.FriendsConnection().Friends(ctx, obj)
+			return ec.Resolvers.FriendsConnection().Friends(ctx, obj)
 		},
 		nil,
 		ec.marshalOCharacter2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐCharacterᚄ,
@@ -1455,7 +1445,7 @@ func (ec *executionContext) _Human_friends(ctx context.Context, field graphql.Co
 		field,
 		ec.fieldContext_Human_friends,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Human().Friends(ctx, obj)
+			return ec.Resolvers.Human().Friends(ctx, obj)
 		},
 		nil,
 		ec.marshalOCharacter2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐCharacterᚄ,
@@ -1485,7 +1475,7 @@ func (ec *executionContext) _Human_friendsConnection(ctx context.Context, field 
 		ec.fieldContext_Human_friendsConnection,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Human().FriendsConnection(ctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*string))
+			return ec.Resolvers.Human().FriendsConnection(ctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*string))
 		},
 		nil,
 		ec.marshalNFriendsConnection2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐFriendsConnection,
@@ -1564,7 +1554,7 @@ func (ec *executionContext) _Human_starships(ctx context.Context, field graphql.
 		field,
 		ec.fieldContext_Human_starships,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Human().Starships(ctx, obj)
+			return ec.Resolvers.Human().Starships(ctx, obj)
 		},
 		nil,
 		ec.marshalOStarship2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐStarshipᚄ,
@@ -1688,7 +1678,7 @@ func (ec *executionContext) _Mutation_createReview(ctx context.Context, field gr
 		ec.fieldContext_Mutation_createReview,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().CreateReview(ctx, fc.Args["episode"].(models.Episode), fc.Args["review"].(models.Review))
+			return ec.Resolvers.Mutation().CreateReview(ctx, fc.Args["episode"].(models.Episode), fc.Args["review"].(models.Review))
 		},
 		nil,
 		ec.marshalOReview2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐReview,
@@ -1824,7 +1814,7 @@ func (ec *executionContext) _Query_hero(ctx context.Context, field graphql.Colle
 		ec.fieldContext_Query_hero,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Hero(ctx, fc.Args["episode"].(*models.Episode))
+			return ec.Resolvers.Query().Hero(ctx, fc.Args["episode"].(*models.Episode))
 		},
 		nil,
 		ec.marshalOCharacter2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐCharacter,
@@ -1865,7 +1855,7 @@ func (ec *executionContext) _Query_reviews(ctx context.Context, field graphql.Co
 		ec.fieldContext_Query_reviews,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Reviews(ctx, fc.Args["episode"].(models.Episode), fc.Args["since"].(*time.Time))
+			return ec.Resolvers.Query().Reviews(ctx, fc.Args["episode"].(models.Episode), fc.Args["since"].(*time.Time))
 		},
 		nil,
 		ec.marshalNReview2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐReviewᚄ,
@@ -1914,7 +1904,7 @@ func (ec *executionContext) _Query_search(ctx context.Context, field graphql.Col
 		ec.fieldContext_Query_search,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Search(ctx, fc.Args["text"].(string))
+			return ec.Resolvers.Query().Search(ctx, fc.Args["text"].(string))
 		},
 		nil,
 		ec.marshalNSearchResult2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐSearchResultᚄ,
@@ -1955,7 +1945,7 @@ func (ec *executionContext) _Query_character(ctx context.Context, field graphql.
 		ec.fieldContext_Query_character,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Character(ctx, fc.Args["id"].(string))
+			return ec.Resolvers.Query().Character(ctx, fc.Args["id"].(string))
 		},
 		nil,
 		ec.marshalOCharacter2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐCharacter,
@@ -1996,7 +1986,7 @@ func (ec *executionContext) _Query_droid(ctx context.Context, field graphql.Coll
 		ec.fieldContext_Query_droid,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Droid(ctx, fc.Args["id"].(string))
+			return ec.Resolvers.Query().Droid(ctx, fc.Args["id"].(string))
 		},
 		nil,
 		ec.marshalODroid2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐDroid,
@@ -2051,7 +2041,7 @@ func (ec *executionContext) _Query_human(ctx context.Context, field graphql.Coll
 		ec.fieldContext_Query_human,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Human(ctx, fc.Args["id"].(string))
+			return ec.Resolvers.Query().Human(ctx, fc.Args["id"].(string))
 		},
 		nil,
 		ec.marshalOHuman2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐHuman,
@@ -2114,7 +2104,7 @@ func (ec *executionContext) _Query_starship(ctx context.Context, field graphql.C
 		ec.fieldContext_Query_starship,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Starship(ctx, fc.Args["id"].(string))
+			return ec.Resolvers.Query().Starship(ctx, fc.Args["id"].(string))
 		},
 		nil,
 		ec.marshalOStarship2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋstarwarsᚋmodelsᚐStarship,
@@ -2418,7 +2408,7 @@ func (ec *executionContext) _Starship_length(ctx context.Context, field graphql.
 		ec.fieldContext_Starship_length,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Starship().Length(ctx, obj, fc.Args["unit"].(*models.LengthUnit))
+			return ec.Resolvers.Starship().Length(ctx, obj, fc.Args["unit"].(*models.LengthUnit))
 		},
 		nil,
 		ec.marshalNFloat2float64,

--- a/_examples/type-system-extension/generated.go
+++ b/_examples/type-system-extension/generated.go
@@ -22,12 +22,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -73,16 +68,11 @@ type MyQueryResolver interface {
 	Todo(ctx context.Context, id string) (*Todo, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -93,7 +83,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "MyMutation.createTodo":
-		if e.complexity.MyMutation.CreateTodo == nil {
+		if e.ComplexityRoot.MyMutation.CreateTodo == nil {
 			break
 		}
 
@@ -102,10 +92,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.MyMutation.CreateTodo(childComplexity, args["todo"].(TodoInput)), true
+		return e.ComplexityRoot.MyMutation.CreateTodo(childComplexity, args["todo"].(TodoInput)), true
 
 	case "MyQuery.todo":
-		if e.complexity.MyQuery.Todo == nil {
+		if e.ComplexityRoot.MyQuery.Todo == nil {
 			break
 		}
 
@@ -114,38 +104,38 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.MyQuery.Todo(childComplexity, args["id"].(string)), true
+		return e.ComplexityRoot.MyQuery.Todo(childComplexity, args["id"].(string)), true
 	case "MyQuery.todos":
-		if e.complexity.MyQuery.Todos == nil {
+		if e.ComplexityRoot.MyQuery.Todos == nil {
 			break
 		}
 
-		return e.complexity.MyQuery.Todos(childComplexity), true
+		return e.ComplexityRoot.MyQuery.Todos(childComplexity), true
 
 	case "Todo.id":
-		if e.complexity.Todo.ID == nil {
+		if e.ComplexityRoot.Todo.ID == nil {
 			break
 		}
 
-		return e.complexity.Todo.ID(childComplexity), true
+		return e.ComplexityRoot.Todo.ID(childComplexity), true
 	case "Todo.state":
-		if e.complexity.Todo.State == nil {
+		if e.ComplexityRoot.Todo.State == nil {
 			break
 		}
 
-		return e.complexity.Todo.State(childComplexity), true
+		return e.ComplexityRoot.Todo.State(childComplexity), true
 	case "Todo.text":
-		if e.complexity.Todo.Text == nil {
+		if e.ComplexityRoot.Todo.Text == nil {
 			break
 		}
 
-		return e.complexity.Todo.Text(childComplexity), true
+		return e.ComplexityRoot.Todo.Text(childComplexity), true
 	case "Todo.verified":
-		if e.complexity.Todo.Verified == nil {
+		if e.ComplexityRoot.Todo.Verified == nil {
 			break
 		}
 
-		return e.complexity.Todo.Verified(childComplexity), true
+		return e.ComplexityRoot.Todo.Verified(childComplexity), true
 
 	}
 	return 0, false
@@ -373,17 +363,17 @@ func (ec *executionContext) _MyMutation_createTodo(ctx context.Context, field gr
 		ec.fieldContext_MyMutation_createTodo,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.MyMutation().CreateTodo(ctx, fc.Args["todo"].(TodoInput))
+			return ec.Resolvers.MyMutation().CreateTodo(ctx, fc.Args["todo"].(TodoInput))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.ObjectLogging == nil {
+				if ec.Directives.ObjectLogging == nil {
 					var zeroVal *Todo
 					return zeroVal, errors.New("directive objectLogging is not implemented")
 				}
-				return ec.directives.ObjectLogging(ctx, nil, directive0)
+				return ec.Directives.ObjectLogging(ctx, nil, directive0)
 			}
 
 			next = directive1
@@ -436,17 +426,17 @@ func (ec *executionContext) _MyQuery_todos(ctx context.Context, field graphql.Co
 		field,
 		ec.fieldContext_MyQuery_todos,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.MyQuery().Todos(ctx)
+			return ec.Resolvers.MyQuery().Todos(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.ObjectLogging == nil {
+				if ec.Directives.ObjectLogging == nil {
 					var zeroVal []*Todo
 					return zeroVal, errors.New("directive objectLogging is not implemented")
 				}
-				return ec.directives.ObjectLogging(ctx, nil, directive0)
+				return ec.Directives.ObjectLogging(ctx, nil, directive0)
 			}
 
 			next = directive1
@@ -489,17 +479,17 @@ func (ec *executionContext) _MyQuery_todo(ctx context.Context, field graphql.Col
 		ec.fieldContext_MyQuery_todo,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.MyQuery().Todo(ctx, fc.Args["id"].(string))
+			return ec.Resolvers.MyQuery().Todo(ctx, fc.Args["id"].(string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.ObjectLogging == nil {
+				if ec.Directives.ObjectLogging == nil {
 					var zeroVal *Todo
 					return zeroVal, errors.New("directive objectLogging is not implemented")
 				}
-				return ec.directives.ObjectLogging(ctx, nil, directive0)
+				return ec.Directives.ObjectLogging(ctx, nil, directive0)
 			}
 
 			next = directive1
@@ -753,11 +743,11 @@ func (ec *executionContext) _Todo_verified(ctx context.Context, field graphql.Co
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.FieldLogging == nil {
+				if ec.Directives.FieldLogging == nil {
 					var zeroVal bool
 					return zeroVal, errors.New("directive fieldLogging is not implemented")
 				}
-				return ec.directives.FieldLogging(ctx, obj, directive0)
+				return ec.Directives.FieldLogging(ctx, obj, directive0)
 			}
 
 			next = directive1
@@ -2247,11 +2237,11 @@ func (ec *executionContext) unmarshalInputTodoInput(ctx context.Context, obj any
 			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalNString2string(ctx, v) }
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.InputLogging == nil {
+				if ec.Directives.InputLogging == nil {
 					var zeroVal string
 					return zeroVal, errors.New("directive inputLogging is not implemented")
 				}
-				return ec.directives.InputLogging(ctx, obj, directive0)
+				return ec.Directives.InputLogging(ctx, obj, directive0)
 			}
 
 			tmp, err := directive1(ctx)

--- a/_examples/union-extension/generated.go
+++ b/_examples/union-extension/generated.go
@@ -22,12 +22,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -59,16 +54,11 @@ type QueryResolver interface {
 	CachedEvents(ctx context.Context) ([]Event, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -79,31 +69,31 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "Like.from":
-		if e.complexity.Like.From == nil {
+		if e.ComplexityRoot.Like.From == nil {
 			break
 		}
 
-		return e.complexity.Like.From(childComplexity), true
+		return e.ComplexityRoot.Like.From(childComplexity), true
 
 	case "Post.message":
-		if e.complexity.Post.Message == nil {
+		if e.ComplexityRoot.Post.Message == nil {
 			break
 		}
 
-		return e.complexity.Post.Message(childComplexity), true
+		return e.ComplexityRoot.Post.Message(childComplexity), true
 
 	case "Query.cachedEvents":
-		if e.complexity.Query.CachedEvents == nil {
+		if e.ComplexityRoot.Query.CachedEvents == nil {
 			break
 		}
 
-		return e.complexity.Query.CachedEvents(childComplexity), true
+		return e.ComplexityRoot.Query.CachedEvents(childComplexity), true
 	case "Query.events":
-		if e.complexity.Query.Events == nil {
+		if e.ComplexityRoot.Query.Events == nil {
 			break
 		}
 
-		return e.complexity.Query.Events(childComplexity), true
+		return e.ComplexityRoot.Query.Events(childComplexity), true
 
 	}
 	return 0, false
@@ -341,7 +331,7 @@ func (ec *executionContext) _Query_events(ctx context.Context, field graphql.Col
 		field,
 		ec.fieldContext_Query_events,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Events(ctx)
+			return ec.Resolvers.Query().Events(ctx)
 		},
 		nil,
 		ec.marshalNEvent2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋunionᚑextensionᚐEventᚄ,
@@ -370,7 +360,7 @@ func (ec *executionContext) _Query_cachedEvents(ctx context.Context, field graph
 		field,
 		ec.fieldContext_Query_cachedEvents,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().CachedEvents(ctx)
+			return ec.Resolvers.Query().CachedEvents(ctx)
 		},
 		nil,
 		ec.marshalNEvent2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋunionᚑextensionᚐEventᚄ,

--- a/codegen/directive.go
+++ b/codegen/directive.go
@@ -209,7 +209,7 @@ func (d *Directive) CallPath() string {
 		return "builtInDirective" + d.CallName()
 	}
 
-	return "ec.directives." + d.CallName()
+	return "ec.Directives." + d.CallName()
 }
 
 func (d *Directive) FunctionImpl() string {

--- a/codegen/field.gotpl
+++ b/codegen/field.gotpl
@@ -140,7 +140,7 @@ func (ec *executionContext) {{ $field.FieldContextFunc }}({{ if not $field.Args 
 
 {{- if and $field.IsBatch (not $object.Root) }}
 func (ec *executionContext) resolveBatch_{{$object.Name}}_{{$field.Name}}(ctx context.Context, field graphql.CollectedField, obj {{$object.Reference | ref}}) (any, error) {
-	resolver := ec.resolvers.{{ ucFirst $object.Name }}()
+	resolver := ec.Resolvers.{{ ucFirst $object.Name }}()
 	{{- if $field.Args }}
 	fc := graphql.GetFieldContext(ctx)
 	{{- end }}
@@ -197,7 +197,7 @@ func (ec *executionContext) resolveBatch_{{$object.Name}}_{{$field.Name}}(ctx co
 	{{- end }}
 	{{ end }}
 	{{- if .IsResolver -}}
-		return ec.resolvers.{{ .ShortInvocation }}
+		return ec.Resolvers.{{ .ShortInvocation }}
 	{{- else if .IsMap -}}
 		switch v := {{.GoReceiverName}}[{{.Name|quote}}].(type) {
 		case {{if .Stream}}<-chan {{end}}{{.TypeReference.GO | ref}}:

--- a/codegen/generated!.gotpl
+++ b/codegen/generated!.gotpl
@@ -21,12 +21,7 @@
 {{ if eq .Config.Exec.Layout "single-file" }}
 	// NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 	func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-		return &executableSchema{
-		 	schema: cfg.Schema,
-			resolvers: cfg.Resolvers,
-			directives: cfg.Directives,
-			complexity: cfg.Complexity,
-		}
+		return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 	}
 
 	type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -101,16 +96,11 @@
 {{ end }}
 
 {{ if eq .Config.Exec.Layout "single-file" }}
-	type executableSchema struct {
-		schema    *ast.Schema
-		resolvers  ResolverRoot
-		directives DirectiveRoot
-		complexity ComplexityRoot
-	}
+	type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 	func (e *executableSchema) Schema() *ast.Schema {
-		if e.schema != nil {
-        		return e.schema
+		if e.SchemaData != nil {
+        		return e.SchemaData
 		}
 		return parsedSchema
 	}
@@ -128,7 +118,7 @@
 						{{- $last := eq (add $i 1) $len }}
 						{{- if not $field.IsReserved }}
 							{{- if eq $i 0 }}case {{ end }}"{{$object.Name}}.{{$field.Name}}"{{ if not $last }},{{ else }}:
-								if e.complexity.{{ucFirst $object.Name}}.{{$field.GoFieldName}} == nil {
+								if e.ComplexityRoot.{{ucFirst $object.Name}}.{{$field.GoFieldName}} == nil {
 									break
 								}
 								{{ if $field.Args }}
@@ -141,7 +131,7 @@
 										return 0, false
 									}
 								{{ end }}
-								return e.complexity.{{ucFirst $object.Name}}.{{$field.GoFieldName}}(childComplexity{{if $field.Args}}, {{$field.ComplexityArgs}} {{ end }}), true
+								return e.ComplexityRoot.{{ucFirst $object.Name}}.{{$field.GoFieldName}}(childComplexity{{if $field.Args}}, {{$field.ComplexityArgs}} {{ end }}), true
 							{{- end }}
 						{{- end }}
 					{{- end }}

--- a/codegen/input.gotpl
+++ b/codegen/input.gotpl
@@ -55,7 +55,7 @@
 					}
 					if data, ok := tmp.({{ $field.TypeReference.GO | ref }}) ; ok {
 						{{- if $field.IsResolver }}
-							if err = ec.resolvers.{{ $field.ShortInvocation }}; err != nil {
+							if err = ec.Resolvers.{{ $field.ShortInvocation }}; err != nil {
 								return {{$it}}, err
 							}
 						{{- else }}
@@ -89,7 +89,7 @@
 						if err != nil {
 							return {{$it}}, err
 						}
-						if err = ec.resolvers.{{ $field.ShortInvocation }}; err != nil {
+						if err = ec.Resolvers.{{ $field.ShortInvocation }}; err != nil {
 							return {{$it}}, err
 						}
 					{{- else }}

--- a/codegen/root_.gotpl
+++ b/codegen/root_.gotpl
@@ -19,12 +19,7 @@
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema: cfg.Schema,
-		resolvers: cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -71,16 +66,11 @@ type ComplexityRoot struct {
 	)
 {{ end }}
 
-type executableSchema struct {
-	schema    *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-			return e.schema
+	if e.SchemaData != nil {
+			return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -98,7 +88,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 					{{- $last := eq (add $i 1) $len }}
 					{{- if not $field.IsReserved }}
 						{{- if eq $i 0 }}case {{ end }}"{{$object.Name}}.{{$field.Name}}"{{ if not $last }},{{ else }}:
-						if e.complexity.{{ucFirst $object.Name }}.{{$field.GoFieldName}} == nil {
+						if e.ComplexityRoot.{{ucFirst $object.Name }}.{{$field.GoFieldName}} == nil {
 						break
 						}
 						{{ if $field.Args }}
@@ -111,7 +101,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 							return 0, false
 							}
 						{{ end }}
-						return e.complexity.{{ucFirst $object.Name}}.{{$field.GoFieldName}}(childComplexity{{if $field.Args}}, {{$field.ComplexityArgs}} {{ end }}), true
+						return e.ComplexityRoot.{{ucFirst $object.Name}}.{{$field.GoFieldName}}(childComplexity{{if $field.Args}}, {{$field.ComplexityArgs}} {{ end }}), true
 						{{ end }}
 					{{- end }}
 				{{- end }}

--- a/codegen/testserver/benchmark/generated/root_.generated.go
+++ b/codegen/testserver/benchmark/generated/root_.generated.go
@@ -17,12 +17,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -64,16 +59,11 @@ type ComplexityRoot struct {
 	}
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -84,35 +74,35 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "PageInfo.endCursor":
-		if e.complexity.PageInfo.EndCursor == nil {
+		if e.ComplexityRoot.PageInfo.EndCursor == nil {
 			break
 		}
 
-		return e.complexity.PageInfo.EndCursor(childComplexity), true
+		return e.ComplexityRoot.PageInfo.EndCursor(childComplexity), true
 
 	case "PageInfo.hasNextPage":
-		if e.complexity.PageInfo.HasNextPage == nil {
+		if e.ComplexityRoot.PageInfo.HasNextPage == nil {
 			break
 		}
 
-		return e.complexity.PageInfo.HasNextPage(childComplexity), true
+		return e.ComplexityRoot.PageInfo.HasNextPage(childComplexity), true
 
 	case "PageInfo.hasPreviousPage":
-		if e.complexity.PageInfo.HasPreviousPage == nil {
+		if e.ComplexityRoot.PageInfo.HasPreviousPage == nil {
 			break
 		}
 
-		return e.complexity.PageInfo.HasPreviousPage(childComplexity), true
+		return e.ComplexityRoot.PageInfo.HasPreviousPage(childComplexity), true
 
 	case "PageInfo.startCursor":
-		if e.complexity.PageInfo.StartCursor == nil {
+		if e.ComplexityRoot.PageInfo.StartCursor == nil {
 			break
 		}
 
-		return e.complexity.PageInfo.StartCursor(childComplexity), true
+		return e.ComplexityRoot.PageInfo.StartCursor(childComplexity), true
 
 	case "Query.users":
-		if e.complexity.Query.Users == nil {
+		if e.ComplexityRoot.Query.Users == nil {
 			break
 		}
 
@@ -121,63 +111,63 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Users(childComplexity, args["query"].(*string), args["first"].(*int), args["last"].(*int), args["before"].(*string), args["after"].(*string), args["orderBy"].(models.UserOrderBy)), true
+		return e.ComplexityRoot.Query.Users(childComplexity, args["query"].(*string), args["first"].(*int), args["last"].(*int), args["before"].(*string), args["after"].(*string), args["orderBy"].(models.UserOrderBy)), true
 
 	case "User.email":
-		if e.complexity.User.Email == nil {
+		if e.ComplexityRoot.User.Email == nil {
 			break
 		}
 
-		return e.complexity.User.Email(childComplexity), true
+		return e.ComplexityRoot.User.Email(childComplexity), true
 
 	case "User.firstName":
-		if e.complexity.User.FirstName == nil {
+		if e.ComplexityRoot.User.FirstName == nil {
 			break
 		}
 
-		return e.complexity.User.FirstName(childComplexity), true
+		return e.ComplexityRoot.User.FirstName(childComplexity), true
 
 	case "User.lastName":
-		if e.complexity.User.LastName == nil {
+		if e.ComplexityRoot.User.LastName == nil {
 			break
 		}
 
-		return e.complexity.User.LastName(childComplexity), true
+		return e.ComplexityRoot.User.LastName(childComplexity), true
 
 	case "UserConnection.edges":
-		if e.complexity.UserConnection.Edges == nil {
+		if e.ComplexityRoot.UserConnection.Edges == nil {
 			break
 		}
 
-		return e.complexity.UserConnection.Edges(childComplexity), true
+		return e.ComplexityRoot.UserConnection.Edges(childComplexity), true
 
 	case "UserConnection.pageInfo":
-		if e.complexity.UserConnection.PageInfo == nil {
+		if e.ComplexityRoot.UserConnection.PageInfo == nil {
 			break
 		}
 
-		return e.complexity.UserConnection.PageInfo(childComplexity), true
+		return e.ComplexityRoot.UserConnection.PageInfo(childComplexity), true
 
 	case "UserConnection.totalCount":
-		if e.complexity.UserConnection.TotalCount == nil {
+		if e.ComplexityRoot.UserConnection.TotalCount == nil {
 			break
 		}
 
-		return e.complexity.UserConnection.TotalCount(childComplexity), true
+		return e.ComplexityRoot.UserConnection.TotalCount(childComplexity), true
 
 	case "UserEdge.cursor":
-		if e.complexity.UserEdge.Cursor == nil {
+		if e.ComplexityRoot.UserEdge.Cursor == nil {
 			break
 		}
 
-		return e.complexity.UserEdge.Cursor(childComplexity), true
+		return e.ComplexityRoot.UserEdge.Cursor(childComplexity), true
 
 	case "UserEdge.node":
-		if e.complexity.UserEdge.Node == nil {
+		if e.ComplexityRoot.UserEdge.Node == nil {
 			break
 		}
 
-		return e.complexity.UserEdge.Node(childComplexity), true
+		return e.ComplexityRoot.UserEdge.Node(childComplexity), true
 
 	}
 	return 0, false

--- a/codegen/testserver/benchmark/generated/schema.generated.go
+++ b/codegen/testserver/benchmark/generated/schema.generated.go
@@ -204,7 +204,7 @@ func (ec *executionContext) _Query_users(ctx context.Context, field graphql.Coll
 		ec.fieldContext_Query_users,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Users(ctx, fc.Args["query"].(*string), fc.Args["first"].(*int), fc.Args["last"].(*int), fc.Args["before"].(*string), fc.Args["after"].(*string), fc.Args["orderBy"].(models.UserOrderBy))
+			return ec.Resolvers.Query().Users(ctx, fc.Args["query"].(*string), fc.Args["first"].(*int), fc.Args["last"].(*int), fc.Args["before"].(*string), fc.Args["after"].(*string), fc.Args["orderBy"].(models.UserOrderBy))
 		},
 		nil,
 		ec.marshalOUserConnection2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋbenchmarkᚋgeneratedᚋmodelsᚐUserConnection,

--- a/codegen/testserver/compliant-int/generated-compliant-strict/schema.go
+++ b/codegen/testserver/compliant-int/generated-compliant-strict/schema.go
@@ -21,12 +21,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -62,16 +57,11 @@ type QueryResolver interface {
 	EchoInt64InputToInt64Object(ctx context.Context, input Input64) (*Result64, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -82,7 +72,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "Query.echoInt64InputToInt64Object":
-		if e.complexity.Query.EchoInt64InputToInt64Object == nil {
+		if e.ComplexityRoot.Query.EchoInt64InputToInt64Object == nil {
 			break
 		}
 
@@ -91,9 +81,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.EchoInt64InputToInt64Object(childComplexity, args["input"].(Input64)), true
+		return e.ComplexityRoot.Query.EchoInt64InputToInt64Object(childComplexity, args["input"].(Input64)), true
 	case "Query.echoInt64ToInt64":
-		if e.complexity.Query.EchoInt64ToInt64 == nil {
+		if e.ComplexityRoot.Query.EchoInt64ToInt64 == nil {
 			break
 		}
 
@@ -102,9 +92,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.EchoInt64ToInt64(childComplexity, args["n"].(*int)), true
+		return e.ComplexityRoot.Query.EchoInt64ToInt64(childComplexity, args["n"].(*int)), true
 	case "Query.echoIntInputToIntObject":
-		if e.complexity.Query.EchoIntInputToIntObject == nil {
+		if e.ComplexityRoot.Query.EchoIntInputToIntObject == nil {
 			break
 		}
 
@@ -113,9 +103,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.EchoIntInputToIntObject(childComplexity, args["input"].(Input)), true
+		return e.ComplexityRoot.Query.EchoIntInputToIntObject(childComplexity, args["input"].(Input)), true
 	case "Query.echoIntToInt":
-		if e.complexity.Query.EchoIntToInt == nil {
+		if e.ComplexityRoot.Query.EchoIntToInt == nil {
 			break
 		}
 
@@ -124,21 +114,21 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.EchoIntToInt(childComplexity, args["n"].(*int32)), true
+		return e.ComplexityRoot.Query.EchoIntToInt(childComplexity, args["n"].(*int32)), true
 
 	case "Result.n":
-		if e.complexity.Result.N == nil {
+		if e.ComplexityRoot.Result.N == nil {
 			break
 		}
 
-		return e.complexity.Result.N(childComplexity), true
+		return e.ComplexityRoot.Result.N(childComplexity), true
 
 	case "Result64.n":
-		if e.complexity.Result64.N == nil {
+		if e.ComplexityRoot.Result64.N == nil {
 			break
 		}
 
-		return e.complexity.Result64.N(childComplexity), true
+		return e.ComplexityRoot.Result64.N(childComplexity), true
 
 	}
 	return 0, false
@@ -379,7 +369,7 @@ func (ec *executionContext) _Query_echoIntToInt(ctx context.Context, field graph
 		ec.fieldContext_Query_echoIntToInt,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().EchoIntToInt(ctx, fc.Args["n"].(*int32))
+			return ec.Resolvers.Query().EchoIntToInt(ctx, fc.Args["n"].(*int32))
 		},
 		nil,
 		ec.marshalNInt2int32,
@@ -420,7 +410,7 @@ func (ec *executionContext) _Query_echoInt64ToInt64(ctx context.Context, field g
 		ec.fieldContext_Query_echoInt64ToInt64,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().EchoInt64ToInt64(ctx, fc.Args["n"].(*int))
+			return ec.Resolvers.Query().EchoInt64ToInt64(ctx, fc.Args["n"].(*int))
 		},
 		nil,
 		ec.marshalNInt642int,
@@ -461,7 +451,7 @@ func (ec *executionContext) _Query_echoIntInputToIntObject(ctx context.Context, 
 		ec.fieldContext_Query_echoIntInputToIntObject,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().EchoIntInputToIntObject(ctx, fc.Args["input"].(Input))
+			return ec.Resolvers.Query().EchoIntInputToIntObject(ctx, fc.Args["input"].(Input))
 		},
 		nil,
 		ec.marshalOResult2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋcompliantᚑintᚋgeneratedᚑcompliantᚑstrictᚐResult,
@@ -506,7 +496,7 @@ func (ec *executionContext) _Query_echoInt64InputToInt64Object(ctx context.Conte
 		ec.fieldContext_Query_echoInt64InputToInt64Object,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().EchoInt64InputToInt64Object(ctx, fc.Args["input"].(Input64))
+			return ec.Resolvers.Query().EchoInt64InputToInt64Object(ctx, fc.Args["input"].(Input64))
 		},
 		nil,
 		ec.marshalOResult642ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋcompliantᚑintᚋgeneratedᚑcompliantᚑstrictᚐResult64,

--- a/codegen/testserver/compliant-int/generated-default/schema.go
+++ b/codegen/testserver/compliant-int/generated-default/schema.go
@@ -21,12 +21,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -62,16 +57,11 @@ type QueryResolver interface {
 	EchoInt64InputToInt64Object(ctx context.Context, input Input64) (*Result64, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -82,7 +72,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "Query.echoInt64InputToInt64Object":
-		if e.complexity.Query.EchoInt64InputToInt64Object == nil {
+		if e.ComplexityRoot.Query.EchoInt64InputToInt64Object == nil {
 			break
 		}
 
@@ -91,9 +81,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.EchoInt64InputToInt64Object(childComplexity, args["input"].(Input64)), true
+		return e.ComplexityRoot.Query.EchoInt64InputToInt64Object(childComplexity, args["input"].(Input64)), true
 	case "Query.echoInt64ToInt64":
-		if e.complexity.Query.EchoInt64ToInt64 == nil {
+		if e.ComplexityRoot.Query.EchoInt64ToInt64 == nil {
 			break
 		}
 
@@ -102,9 +92,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.EchoInt64ToInt64(childComplexity, args["n"].(*int)), true
+		return e.ComplexityRoot.Query.EchoInt64ToInt64(childComplexity, args["n"].(*int)), true
 	case "Query.echoIntInputToIntObject":
-		if e.complexity.Query.EchoIntInputToIntObject == nil {
+		if e.ComplexityRoot.Query.EchoIntInputToIntObject == nil {
 			break
 		}
 
@@ -113,9 +103,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.EchoIntInputToIntObject(childComplexity, args["input"].(Input)), true
+		return e.ComplexityRoot.Query.EchoIntInputToIntObject(childComplexity, args["input"].(Input)), true
 	case "Query.echoIntToInt":
-		if e.complexity.Query.EchoIntToInt == nil {
+		if e.ComplexityRoot.Query.EchoIntToInt == nil {
 			break
 		}
 
@@ -124,21 +114,21 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.EchoIntToInt(childComplexity, args["n"].(*int)), true
+		return e.ComplexityRoot.Query.EchoIntToInt(childComplexity, args["n"].(*int)), true
 
 	case "Result.n":
-		if e.complexity.Result.N == nil {
+		if e.ComplexityRoot.Result.N == nil {
 			break
 		}
 
-		return e.complexity.Result.N(childComplexity), true
+		return e.ComplexityRoot.Result.N(childComplexity), true
 
 	case "Result64.n":
-		if e.complexity.Result64.N == nil {
+		if e.ComplexityRoot.Result64.N == nil {
 			break
 		}
 
-		return e.complexity.Result64.N(childComplexity), true
+		return e.ComplexityRoot.Result64.N(childComplexity), true
 
 	}
 	return 0, false
@@ -379,7 +369,7 @@ func (ec *executionContext) _Query_echoIntToInt(ctx context.Context, field graph
 		ec.fieldContext_Query_echoIntToInt,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().EchoIntToInt(ctx, fc.Args["n"].(*int))
+			return ec.Resolvers.Query().EchoIntToInt(ctx, fc.Args["n"].(*int))
 		},
 		nil,
 		ec.marshalNInt2int,
@@ -420,7 +410,7 @@ func (ec *executionContext) _Query_echoInt64ToInt64(ctx context.Context, field g
 		ec.fieldContext_Query_echoInt64ToInt64,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().EchoInt64ToInt64(ctx, fc.Args["n"].(*int))
+			return ec.Resolvers.Query().EchoInt64ToInt64(ctx, fc.Args["n"].(*int))
 		},
 		nil,
 		ec.marshalNInt642int,
@@ -461,7 +451,7 @@ func (ec *executionContext) _Query_echoIntInputToIntObject(ctx context.Context, 
 		ec.fieldContext_Query_echoIntInputToIntObject,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().EchoIntInputToIntObject(ctx, fc.Args["input"].(Input))
+			return ec.Resolvers.Query().EchoIntInputToIntObject(ctx, fc.Args["input"].(Input))
 		},
 		nil,
 		ec.marshalOResult2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋcompliantᚑintᚋgeneratedᚑdefaultᚐResult,
@@ -506,7 +496,7 @@ func (ec *executionContext) _Query_echoInt64InputToInt64Object(ctx context.Conte
 		ec.fieldContext_Query_echoInt64InputToInt64Object,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().EchoInt64InputToInt64Object(ctx, fc.Args["input"].(Input64))
+			return ec.Resolvers.Query().EchoInt64InputToInt64Object(ctx, fc.Args["input"].(Input64))
 		},
 		nil,
 		ec.marshalOResult642ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋcompliantᚑintᚋgeneratedᚑdefaultᚐResult64,

--- a/codegen/testserver/followschema/complexity.generated.go
+++ b/codegen/testserver/followschema/complexity.generated.go
@@ -99,7 +99,7 @@ func (ec *executionContext) _OverlappingFields_oldFoo(ctx context.Context, field
 		field,
 		ec.fieldContext_OverlappingFields_oldFoo,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.OverlappingFields().OldFoo(ctx, obj)
+			return ec.Resolvers.OverlappingFields().OldFoo(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)

--- a/codegen/testserver/followschema/defaults.generated.go
+++ b/codegen/testserver/followschema/defaults.generated.go
@@ -170,7 +170,7 @@ func (ec *executionContext) _Mutation_defaultInput(ctx context.Context, field gr
 		ec.fieldContext_Mutation_defaultInput,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().DefaultInput(ctx, fc.Args["input"].(DefaultInput))
+			return ec.Resolvers.Mutation().DefaultInput(ctx, fc.Args["input"].(DefaultInput))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -219,7 +219,7 @@ func (ec *executionContext) _Mutation_overrideValueViaInput(ctx context.Context,
 		ec.fieldContext_Mutation_overrideValueViaInput,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().OverrideValueViaInput(ctx, fc.Args["input"].(FieldsOrderInput))
+			return ec.Resolvers.Mutation().OverrideValueViaInput(ctx, fc.Args["input"].(FieldsOrderInput))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -266,7 +266,7 @@ func (ec *executionContext) _Mutation_updateProduct(ctx context.Context, field g
 		ec.fieldContext_Mutation_updateProduct,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().UpdateProduct(ctx, map[string]interface{}{
+			return ec.Resolvers.Mutation().UpdateProduct(ctx, map[string]interface{}{
 				"id":    fc.Args["id"].(string),
 				"name":  fc.Args["name"].(*string),
 				"price": fc.Args["price"].(*float64),
@@ -313,7 +313,7 @@ func (ec *executionContext) _Mutation_updateSomething(ctx context.Context, field
 		ec.fieldContext_Mutation_updateSomething,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().UpdateSomething(ctx, fc.Args["input"].(SpecialInput))
+			return ec.Resolvers.Mutation().UpdateSomething(ctx, fc.Args["input"].(SpecialInput))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -356,7 +356,7 @@ func (ec *executionContext) _Mutation_updatePtrToPtr(ctx context.Context, field 
 		ec.fieldContext_Mutation_updatePtrToPtr,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().UpdatePtrToPtr(ctx, fc.Args["input"].(UpdatePtrToPtrOuter))
+			return ec.Resolvers.Mutation().UpdatePtrToPtr(ctx, fc.Args["input"].(UpdatePtrToPtrOuter))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)

--- a/codegen/testserver/followschema/defer.generated.go
+++ b/codegen/testserver/followschema/defer.generated.go
@@ -100,7 +100,7 @@ func (ec *executionContext) _DeferModel_values(ctx context.Context, field graphq
 		field,
 		ec.fieldContext_DeferModel_values,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.DeferModel().Values(ctx, obj)
+			return ec.Resolvers.DeferModel().Values(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)

--- a/codegen/testserver/followschema/directive.generated.go
+++ b/codegen/testserver/followschema/directive.generated.go
@@ -117,10 +117,10 @@ func (ec *executionContext) _fieldMiddleware(ctx context.Context, obj any, next 
 			}
 			n := next
 			next = func(ctx context.Context) (any, error) {
-				if ec.directives.Logged == nil {
+				if ec.Directives.Logged == nil {
 					return nil, errors.New("directive logged is not implemented")
 				}
-				return ec.directives.Logged(ctx, obj, n, args["id"].(string))
+				return ec.Directives.Logged(ctx, obj, n, args["id"].(string))
 			}
 		}
 	}
@@ -159,11 +159,11 @@ func (ec *executionContext) _ObjectDirectives_text(ctx context.Context, field gr
 					var zeroVal string
 					return zeroVal, err
 				}
-				if ec.directives.Length == nil {
+				if ec.Directives.Length == nil {
 					var zeroVal string
 					return zeroVal, errors.New("directive length is not implemented")
 				}
-				return ec.directives.Length(ctx, obj, directive0, min, max, message)
+				return ec.Directives.Length(ctx, obj, directive0, min, max, message)
 			}
 
 			next = directive1
@@ -201,11 +201,11 @@ func (ec *executionContext) _ObjectDirectives_nullableText(ctx context.Context, 
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.ToNull == nil {
+				if ec.Directives.ToNull == nil {
 					var zeroVal *string
 					return zeroVal, errors.New("directive toNull is not implemented")
 				}
-				return ec.directives.ToNull(ctx, obj, directive0)
+				return ec.Directives.ToNull(ctx, obj, directive0)
 			}
 
 			next = directive1
@@ -274,11 +274,11 @@ func (ec *executionContext) _ObjectDirectivesWithCustomGoModel_nullableText(ctx 
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.ToNull == nil {
+				if ec.Directives.ToNull == nil {
 					var zeroVal string
 					return zeroVal, errors.New("directive toNull is not implemented")
 				}
-				return ec.directives.ToNull(ctx, obj, directive0)
+				return ec.Directives.ToNull(ctx, obj, directive0)
 			}
 
 			next = directive1
@@ -336,11 +336,11 @@ func (ec *executionContext) unmarshalInputInnerDirectives(ctx context.Context, o
 					var zeroVal string
 					return zeroVal, err
 				}
-				if ec.directives.Length == nil {
+				if ec.Directives.Length == nil {
 					var zeroVal string
 					return zeroVal, errors.New("directive length is not implemented")
 				}
-				return ec.directives.Length(ctx, obj, directive0, min, nil, message)
+				return ec.Directives.Length(ctx, obj, directive0, min, nil, message)
 			}
 
 			tmp, err := directive1(ctx)
@@ -378,11 +378,11 @@ func (ec *executionContext) unmarshalInputInputDirectives(ctx context.Context, o
 			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalNString2string(ctx, v) }
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.Directive3 == nil {
+				if ec.Directives.Directive3 == nil {
 					var zeroVal string
 					return zeroVal, errors.New("directive directive3 is not implemented")
 				}
-				return ec.directives.Directive3(ctx, obj, directive0)
+				return ec.Directives.Directive3(ctx, obj, directive0)
 			}
 			directive2 := func(ctx context.Context) (any, error) {
 				min, err := ec.unmarshalNInt2int(ctx, 0)
@@ -400,11 +400,11 @@ func (ec *executionContext) unmarshalInputInputDirectives(ctx context.Context, o
 					var zeroVal string
 					return zeroVal, err
 				}
-				if ec.directives.Length == nil {
+				if ec.Directives.Length == nil {
 					var zeroVal string
 					return zeroVal, errors.New("directive length is not implemented")
 				}
-				return ec.directives.Length(ctx, obj, directive1, min, max, message)
+				return ec.Directives.Length(ctx, obj, directive1, min, max, message)
 			}
 
 			tmp, err := directive2(ctx)
@@ -422,18 +422,18 @@ func (ec *executionContext) unmarshalInputInputDirectives(ctx context.Context, o
 			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.Directive3 == nil {
+				if ec.Directives.Directive3 == nil {
 					var zeroVal *string
 					return zeroVal, errors.New("directive directive3 is not implemented")
 				}
-				return ec.directives.Directive3(ctx, obj, directive0)
+				return ec.Directives.Directive3(ctx, obj, directive0)
 			}
 			directive2 := func(ctx context.Context) (any, error) {
-				if ec.directives.ToNull == nil {
+				if ec.Directives.ToNull == nil {
 					var zeroVal *string
 					return zeroVal, errors.New("directive toNull is not implemented")
 				}
-				return ec.directives.ToNull(ctx, obj, directive1)
+				return ec.Directives.ToNull(ctx, obj, directive1)
 			}
 
 			tmp, err := directive2(ctx)
@@ -455,11 +455,11 @@ func (ec *executionContext) unmarshalInputInputDirectives(ctx context.Context, o
 			}
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.Directive3 == nil {
+				if ec.Directives.Directive3 == nil {
 					var zeroVal *InnerDirectives
 					return zeroVal, errors.New("directive directive3 is not implemented")
 				}
-				return ec.directives.Directive3(ctx, obj, directive0)
+				return ec.Directives.Directive3(ctx, obj, directive0)
 			}
 
 			tmp, err := directive1(ctx)
@@ -481,11 +481,11 @@ func (ec *executionContext) unmarshalInputInputDirectives(ctx context.Context, o
 			}
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.Directive3 == nil {
+				if ec.Directives.Directive3 == nil {
 					var zeroVal *InnerDirectives
 					return zeroVal, errors.New("directive directive3 is not implemented")
 				}
-				return ec.directives.Directive3(ctx, obj, directive0)
+				return ec.Directives.Directive3(ctx, obj, directive0)
 			}
 
 			tmp, err := directive1(ctx)
@@ -507,11 +507,11 @@ func (ec *executionContext) unmarshalInputInputDirectives(ctx context.Context, o
 			}
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.Directive3 == nil {
+				if ec.Directives.Directive3 == nil {
 					var zeroVal *ThirdParty
 					return zeroVal, errors.New("directive directive3 is not implemented")
 				}
-				return ec.directives.Directive3(ctx, obj, directive0)
+				return ec.Directives.Directive3(ctx, obj, directive0)
 			}
 			directive2 := func(ctx context.Context) (any, error) {
 				min, err := ec.unmarshalNInt2int(ctx, 0)
@@ -524,11 +524,11 @@ func (ec *executionContext) unmarshalInputInputDirectives(ctx context.Context, o
 					var zeroVal *ThirdParty
 					return zeroVal, err
 				}
-				if ec.directives.Length == nil {
+				if ec.Directives.Length == nil {
 					var zeroVal *ThirdParty
 					return zeroVal, errors.New("directive length is not implemented")
 				}
-				return ec.directives.Length(ctx, obj, directive1, min, max, nil)
+				return ec.Directives.Length(ctx, obj, directive1, min, max, nil)
 			}
 
 			tmp, err := directive2(ctx)

--- a/codegen/testserver/followschema/fields_order.generated.go
+++ b/codegen/testserver/followschema/fields_order.generated.go
@@ -92,7 +92,7 @@ func (ec *executionContext) unmarshalInputFieldsOrderInput(ctx context.Context, 
 			if err != nil {
 				return it, err
 			}
-			if err = ec.resolvers.FieldsOrderInput().OverrideFirstField(ctx, &it, data); err != nil {
+			if err = ec.Resolvers.FieldsOrderInput().OverrideFirstField(ctx, &it, data); err != nil {
 				return it, err
 			}
 		}

--- a/codegen/testserver/followschema/interfaces.generated.go
+++ b/codegen/testserver/followschema/interfaces.generated.go
@@ -39,7 +39,7 @@ func (ec *executionContext) _BackedByInterface_id(ctx context.Context, field gra
 		field,
 		ec.fieldContext_BackedByInterface_id,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.BackedByInterface().ID(ctx, obj)
+			return ec.Resolvers.BackedByInterface().ID(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)

--- a/codegen/testserver/followschema/nulls.generated.go
+++ b/codegen/testserver/followschema/nulls.generated.go
@@ -167,7 +167,7 @@ func (ec *executionContext) _Errors_a(ctx context.Context, field graphql.Collect
 		field,
 		ec.fieldContext_Errors_a,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Errors().A(ctx, obj)
+			return ec.Resolvers.Errors().A(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -208,7 +208,7 @@ func (ec *executionContext) _Errors_b(ctx context.Context, field graphql.Collect
 		field,
 		ec.fieldContext_Errors_b,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Errors().B(ctx, obj)
+			return ec.Resolvers.Errors().B(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -249,7 +249,7 @@ func (ec *executionContext) _Errors_c(ctx context.Context, field graphql.Collect
 		field,
 		ec.fieldContext_Errors_c,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Errors().C(ctx, obj)
+			return ec.Resolvers.Errors().C(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -290,7 +290,7 @@ func (ec *executionContext) _Errors_d(ctx context.Context, field graphql.Collect
 		field,
 		ec.fieldContext_Errors_d,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Errors().D(ctx, obj)
+			return ec.Resolvers.Errors().D(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -331,7 +331,7 @@ func (ec *executionContext) _Errors_e(ctx context.Context, field graphql.Collect
 		field,
 		ec.fieldContext_Errors_e,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Errors().E(ctx, obj)
+			return ec.Resolvers.Errors().E(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)

--- a/codegen/testserver/followschema/panics.generated.go
+++ b/codegen/testserver/followschema/panics.generated.go
@@ -61,7 +61,7 @@ func (ec *executionContext) _Panics_fieldScalarMarshal(ctx context.Context, fiel
 		field,
 		ec.fieldContext_Panics_fieldScalarMarshal,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Panics().FieldScalarMarshal(ctx, obj)
+			return ec.Resolvers.Panics().FieldScalarMarshal(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -136,7 +136,7 @@ func (ec *executionContext) _Panics_argUnmarshal(ctx context.Context, field grap
 		ec.fieldContext_Panics_argUnmarshal,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Panics().ArgUnmarshal(ctx, obj, fc.Args["u"].([]MarshalPanic))
+			return ec.Resolvers.Panics().ArgUnmarshal(ctx, obj, fc.Args["u"].([]MarshalPanic))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)

--- a/codegen/testserver/followschema/primitive_objects.generated.go
+++ b/codegen/testserver/followschema/primitive_objects.generated.go
@@ -43,7 +43,7 @@ func (ec *executionContext) _Primitive_value(ctx context.Context, field graphql.
 		field,
 		ec.fieldContext_Primitive_value,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Primitive().Value(ctx, obj)
+			return ec.Resolvers.Primitive().Value(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -105,7 +105,7 @@ func (ec *executionContext) _PrimitiveString_value(ctx context.Context, field gr
 		field,
 		ec.fieldContext_PrimitiveString_value,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.PrimitiveString().Value(ctx, obj)
+			return ec.Resolvers.PrimitiveString().Value(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -167,7 +167,7 @@ func (ec *executionContext) _PrimitiveString_len(ctx context.Context, field grap
 		field,
 		ec.fieldContext_PrimitiveString_len,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.PrimitiveString().Len(ctx, obj)
+			return ec.Resolvers.PrimitiveString().Len(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)

--- a/codegen/testserver/followschema/root_.generated.go
+++ b/codegen/testserver/followschema/root_.generated.go
@@ -16,12 +16,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -492,16 +487,11 @@ type ComplexityRoot struct {
 	}
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -512,497 +502,497 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "A.id":
-		if e.complexity.A.ID == nil {
+		if e.ComplexityRoot.A.ID == nil {
 			break
 		}
 
-		return e.complexity.A.ID(childComplexity), true
+		return e.ComplexityRoot.A.ID(childComplexity), true
 
 	case "AIt.id":
-		if e.complexity.AIt.ID == nil {
+		if e.ComplexityRoot.AIt.ID == nil {
 			break
 		}
 
-		return e.complexity.AIt.ID(childComplexity), true
+		return e.ComplexityRoot.AIt.ID(childComplexity), true
 
 	case "AbIt.id":
-		if e.complexity.AbIt.ID == nil {
+		if e.ComplexityRoot.AbIt.ID == nil {
 			break
 		}
 
-		return e.complexity.AbIt.ID(childComplexity), true
+		return e.ComplexityRoot.AbIt.ID(childComplexity), true
 
 	case "Autobind.idInt":
-		if e.complexity.Autobind.IdInt == nil {
+		if e.ComplexityRoot.Autobind.IdInt == nil {
 			break
 		}
 
-		return e.complexity.Autobind.IdInt(childComplexity), true
+		return e.ComplexityRoot.Autobind.IdInt(childComplexity), true
 
 	case "Autobind.idStr":
-		if e.complexity.Autobind.IdStr == nil {
+		if e.ComplexityRoot.Autobind.IdStr == nil {
 			break
 		}
 
-		return e.complexity.Autobind.IdStr(childComplexity), true
+		return e.ComplexityRoot.Autobind.IdStr(childComplexity), true
 
 	case "Autobind.int":
-		if e.complexity.Autobind.Int == nil {
+		if e.ComplexityRoot.Autobind.Int == nil {
 			break
 		}
 
-		return e.complexity.Autobind.Int(childComplexity), true
+		return e.ComplexityRoot.Autobind.Int(childComplexity), true
 
 	case "Autobind.int32":
-		if e.complexity.Autobind.Int32 == nil {
+		if e.ComplexityRoot.Autobind.Int32 == nil {
 			break
 		}
 
-		return e.complexity.Autobind.Int32(childComplexity), true
+		return e.ComplexityRoot.Autobind.Int32(childComplexity), true
 
 	case "Autobind.int64":
-		if e.complexity.Autobind.Int64 == nil {
+		if e.ComplexityRoot.Autobind.Int64 == nil {
 			break
 		}
 
-		return e.complexity.Autobind.Int64(childComplexity), true
+		return e.ComplexityRoot.Autobind.Int64(childComplexity), true
 
 	case "B.id":
-		if e.complexity.B.ID == nil {
+		if e.ComplexityRoot.B.ID == nil {
 			break
 		}
 
-		return e.complexity.B.ID(childComplexity), true
+		return e.ComplexityRoot.B.ID(childComplexity), true
 
 	case "BackedByInterface.id":
-		if e.complexity.BackedByInterface.ID == nil {
+		if e.ComplexityRoot.BackedByInterface.ID == nil {
 			break
 		}
 
-		return e.complexity.BackedByInterface.ID(childComplexity), true
+		return e.ComplexityRoot.BackedByInterface.ID(childComplexity), true
 
 	case "BackedByInterface.thisShouldBind":
-		if e.complexity.BackedByInterface.ThisShouldBind == nil {
+		if e.ComplexityRoot.BackedByInterface.ThisShouldBind == nil {
 			break
 		}
 
-		return e.complexity.BackedByInterface.ThisShouldBind(childComplexity), true
+		return e.ComplexityRoot.BackedByInterface.ThisShouldBind(childComplexity), true
 
 	case "BackedByInterface.thisShouldBindWithError":
-		if e.complexity.BackedByInterface.ThisShouldBindWithError == nil {
+		if e.ComplexityRoot.BackedByInterface.ThisShouldBindWithError == nil {
 			break
 		}
 
-		return e.complexity.BackedByInterface.ThisShouldBindWithError(childComplexity), true
+		return e.ComplexityRoot.BackedByInterface.ThisShouldBindWithError(childComplexity), true
 
 	case "Cat.catBreed":
-		if e.complexity.Cat.CatBreed == nil {
+		if e.ComplexityRoot.Cat.CatBreed == nil {
 			break
 		}
 
-		return e.complexity.Cat.CatBreed(childComplexity), true
+		return e.ComplexityRoot.Cat.CatBreed(childComplexity), true
 
 	case "Cat.size":
-		if e.complexity.Cat.Size == nil {
+		if e.ComplexityRoot.Cat.Size == nil {
 			break
 		}
 
-		return e.complexity.Cat.Size(childComplexity), true
+		return e.ComplexityRoot.Cat.Size(childComplexity), true
 
 	case "Cat.species":
-		if e.complexity.Cat.Species == nil {
+		if e.ComplexityRoot.Cat.Species == nil {
 			break
 		}
 
-		return e.complexity.Cat.Species(childComplexity), true
+		return e.ComplexityRoot.Cat.Species(childComplexity), true
 
 	case "CheckIssue896.id":
-		if e.complexity.CheckIssue896.ID == nil {
+		if e.ComplexityRoot.CheckIssue896.ID == nil {
 			break
 		}
 
-		return e.complexity.CheckIssue896.ID(childComplexity), true
+		return e.ComplexityRoot.CheckIssue896.ID(childComplexity), true
 
 	case "Circle.area":
-		if e.complexity.Circle.Area == nil {
+		if e.ComplexityRoot.Circle.Area == nil {
 			break
 		}
 
-		return e.complexity.Circle.Area(childComplexity), true
+		return e.ComplexityRoot.Circle.Area(childComplexity), true
 
 	case "Circle.coordinates":
-		if e.complexity.Circle.Coordinates == nil {
+		if e.ComplexityRoot.Circle.Coordinates == nil {
 			break
 		}
 
-		return e.complexity.Circle.Coordinates(childComplexity), true
+		return e.ComplexityRoot.Circle.Coordinates(childComplexity), true
 
 	case "Circle.radius":
-		if e.complexity.Circle.Radius == nil {
+		if e.ComplexityRoot.Circle.Radius == nil {
 			break
 		}
 
-		return e.complexity.Circle.Radius(childComplexity), true
+		return e.ComplexityRoot.Circle.Radius(childComplexity), true
 
 	case "ConcreteNodeA.child":
-		if e.complexity.ConcreteNodeA.Child == nil {
+		if e.ComplexityRoot.ConcreteNodeA.Child == nil {
 			break
 		}
 
-		return e.complexity.ConcreteNodeA.Child(childComplexity), true
+		return e.ComplexityRoot.ConcreteNodeA.Child(childComplexity), true
 
 	case "ConcreteNodeA.id":
-		if e.complexity.ConcreteNodeA.ID == nil {
+		if e.ComplexityRoot.ConcreteNodeA.ID == nil {
 			break
 		}
 
-		return e.complexity.ConcreteNodeA.ID(childComplexity), true
+		return e.ComplexityRoot.ConcreteNodeA.ID(childComplexity), true
 
 	case "ConcreteNodeA.name":
-		if e.complexity.ConcreteNodeA.Name == nil {
+		if e.ComplexityRoot.ConcreteNodeA.Name == nil {
 			break
 		}
 
-		return e.complexity.ConcreteNodeA.Name(childComplexity), true
+		return e.ComplexityRoot.ConcreteNodeA.Name(childComplexity), true
 
 	case "ConcreteNodeInterface.child":
-		if e.complexity.ConcreteNodeInterface.Child == nil {
+		if e.ComplexityRoot.ConcreteNodeInterface.Child == nil {
 			break
 		}
 
-		return e.complexity.ConcreteNodeInterface.Child(childComplexity), true
+		return e.ComplexityRoot.ConcreteNodeInterface.Child(childComplexity), true
 
 	case "ConcreteNodeInterface.id":
-		if e.complexity.ConcreteNodeInterface.ID == nil {
+		if e.ComplexityRoot.ConcreteNodeInterface.ID == nil {
 			break
 		}
 
-		return e.complexity.ConcreteNodeInterface.ID(childComplexity), true
+		return e.ComplexityRoot.ConcreteNodeInterface.ID(childComplexity), true
 
 	case "Content_Post.foo":
-		if e.complexity.Content_Post.Foo == nil {
+		if e.ComplexityRoot.Content_Post.Foo == nil {
 			break
 		}
 
-		return e.complexity.Content_Post.Foo(childComplexity), true
+		return e.ComplexityRoot.Content_Post.Foo(childComplexity), true
 
 	case "Content_User.foo":
-		if e.complexity.Content_User.Foo == nil {
+		if e.ComplexityRoot.Content_User.Foo == nil {
 			break
 		}
 
-		return e.complexity.Content_User.Foo(childComplexity), true
+		return e.ComplexityRoot.Content_User.Foo(childComplexity), true
 
 	case "Coordinates.x":
-		if e.complexity.Coordinates.X == nil {
+		if e.ComplexityRoot.Coordinates.X == nil {
 			break
 		}
 
-		return e.complexity.Coordinates.X(childComplexity), true
+		return e.ComplexityRoot.Coordinates.X(childComplexity), true
 
 	case "Coordinates.y":
-		if e.complexity.Coordinates.Y == nil {
+		if e.ComplexityRoot.Coordinates.Y == nil {
 			break
 		}
 
-		return e.complexity.Coordinates.Y(childComplexity), true
+		return e.ComplexityRoot.Coordinates.Y(childComplexity), true
 
 	case "DefaultParametersMirror.falsyBoolean":
-		if e.complexity.DefaultParametersMirror.FalsyBoolean == nil {
+		if e.ComplexityRoot.DefaultParametersMirror.FalsyBoolean == nil {
 			break
 		}
 
-		return e.complexity.DefaultParametersMirror.FalsyBoolean(childComplexity), true
+		return e.ComplexityRoot.DefaultParametersMirror.FalsyBoolean(childComplexity), true
 
 	case "DefaultParametersMirror.truthyBoolean":
-		if e.complexity.DefaultParametersMirror.TruthyBoolean == nil {
+		if e.ComplexityRoot.DefaultParametersMirror.TruthyBoolean == nil {
 			break
 		}
 
-		return e.complexity.DefaultParametersMirror.TruthyBoolean(childComplexity), true
+		return e.ComplexityRoot.DefaultParametersMirror.TruthyBoolean(childComplexity), true
 
 	case "DeferModel.id":
-		if e.complexity.DeferModel.ID == nil {
+		if e.ComplexityRoot.DeferModel.ID == nil {
 			break
 		}
 
-		return e.complexity.DeferModel.ID(childComplexity), true
+		return e.ComplexityRoot.DeferModel.ID(childComplexity), true
 
 	case "DeferModel.name":
-		if e.complexity.DeferModel.Name == nil {
+		if e.ComplexityRoot.DeferModel.Name == nil {
 			break
 		}
 
-		return e.complexity.DeferModel.Name(childComplexity), true
+		return e.ComplexityRoot.DeferModel.Name(childComplexity), true
 
 	case "DeferModel.values":
-		if e.complexity.DeferModel.Values == nil {
+		if e.ComplexityRoot.DeferModel.Values == nil {
 			break
 		}
 
-		return e.complexity.DeferModel.Values(childComplexity), true
+		return e.ComplexityRoot.DeferModel.Values(childComplexity), true
 
 	case "Dog.dogBreed":
-		if e.complexity.Dog.DogBreed == nil {
+		if e.ComplexityRoot.Dog.DogBreed == nil {
 			break
 		}
 
-		return e.complexity.Dog.DogBreed(childComplexity), true
+		return e.ComplexityRoot.Dog.DogBreed(childComplexity), true
 
 	case "Dog.size":
-		if e.complexity.Dog.Size == nil {
+		if e.ComplexityRoot.Dog.Size == nil {
 			break
 		}
 
-		return e.complexity.Dog.Size(childComplexity), true
+		return e.ComplexityRoot.Dog.Size(childComplexity), true
 
 	case "Dog.species":
-		if e.complexity.Dog.Species == nil {
+		if e.ComplexityRoot.Dog.Species == nil {
 			break
 		}
 
-		return e.complexity.Dog.Species(childComplexity), true
+		return e.ComplexityRoot.Dog.Species(childComplexity), true
 
 	case "EmbeddedCase1.exportedEmbeddedPointerExportedMethod":
-		if e.complexity.EmbeddedCase1.ExportedEmbeddedPointerExportedMethod == nil {
+		if e.ComplexityRoot.EmbeddedCase1.ExportedEmbeddedPointerExportedMethod == nil {
 			break
 		}
 
-		return e.complexity.EmbeddedCase1.ExportedEmbeddedPointerExportedMethod(childComplexity), true
+		return e.ComplexityRoot.EmbeddedCase1.ExportedEmbeddedPointerExportedMethod(childComplexity), true
 
 	case "EmbeddedCase2.unexportedEmbeddedPointerExportedMethod":
-		if e.complexity.EmbeddedCase2.UnexportedEmbeddedPointerExportedMethod == nil {
+		if e.ComplexityRoot.EmbeddedCase2.UnexportedEmbeddedPointerExportedMethod == nil {
 			break
 		}
 
-		return e.complexity.EmbeddedCase2.UnexportedEmbeddedPointerExportedMethod(childComplexity), true
+		return e.ComplexityRoot.EmbeddedCase2.UnexportedEmbeddedPointerExportedMethod(childComplexity), true
 
 	case "EmbeddedCase3.unexportedEmbeddedInterfaceExportedMethod":
-		if e.complexity.EmbeddedCase3.UnexportedEmbeddedInterfaceExportedMethod == nil {
+		if e.ComplexityRoot.EmbeddedCase3.UnexportedEmbeddedInterfaceExportedMethod == nil {
 			break
 		}
 
-		return e.complexity.EmbeddedCase3.UnexportedEmbeddedInterfaceExportedMethod(childComplexity), true
+		return e.ComplexityRoot.EmbeddedCase3.UnexportedEmbeddedInterfaceExportedMethod(childComplexity), true
 
 	case "EmbeddedDefaultScalar.value":
-		if e.complexity.EmbeddedDefaultScalar.Value == nil {
+		if e.ComplexityRoot.EmbeddedDefaultScalar.Value == nil {
 			break
 		}
 
-		return e.complexity.EmbeddedDefaultScalar.Value(childComplexity), true
+		return e.ComplexityRoot.EmbeddedDefaultScalar.Value(childComplexity), true
 
 	case "EmbeddedPointer.ID":
-		if e.complexity.EmbeddedPointer.ID == nil {
+		if e.ComplexityRoot.EmbeddedPointer.ID == nil {
 			break
 		}
 
-		return e.complexity.EmbeddedPointer.ID(childComplexity), true
+		return e.ComplexityRoot.EmbeddedPointer.ID(childComplexity), true
 
 	case "EmbeddedPointer.Title":
-		if e.complexity.EmbeddedPointer.Title == nil {
+		if e.ComplexityRoot.EmbeddedPointer.Title == nil {
 			break
 		}
 
-		return e.complexity.EmbeddedPointer.Title(childComplexity), true
+		return e.ComplexityRoot.EmbeddedPointer.Title(childComplexity), true
 
 	case "Error.errorOnNonRequiredField":
-		if e.complexity.Error.ErrorOnNonRequiredField == nil {
+		if e.ComplexityRoot.Error.ErrorOnNonRequiredField == nil {
 			break
 		}
 
-		return e.complexity.Error.ErrorOnNonRequiredField(childComplexity), true
+		return e.ComplexityRoot.Error.ErrorOnNonRequiredField(childComplexity), true
 
 	case "Error.errorOnRequiredField":
-		if e.complexity.Error.ErrorOnRequiredField == nil {
+		if e.ComplexityRoot.Error.ErrorOnRequiredField == nil {
 			break
 		}
 
-		return e.complexity.Error.ErrorOnRequiredField(childComplexity), true
+		return e.ComplexityRoot.Error.ErrorOnRequiredField(childComplexity), true
 
 	case "Error.id":
-		if e.complexity.Error.ID == nil {
+		if e.ComplexityRoot.Error.ID == nil {
 			break
 		}
 
-		return e.complexity.Error.ID(childComplexity), true
+		return e.ComplexityRoot.Error.ID(childComplexity), true
 
 	case "Error.nilOnRequiredField":
-		if e.complexity.Error.NilOnRequiredField == nil {
+		if e.ComplexityRoot.Error.NilOnRequiredField == nil {
 			break
 		}
 
-		return e.complexity.Error.NilOnRequiredField(childComplexity), true
+		return e.ComplexityRoot.Error.NilOnRequiredField(childComplexity), true
 
 	case "Errors.a":
-		if e.complexity.Errors.A == nil {
+		if e.ComplexityRoot.Errors.A == nil {
 			break
 		}
 
-		return e.complexity.Errors.A(childComplexity), true
+		return e.ComplexityRoot.Errors.A(childComplexity), true
 
 	case "Errors.b":
-		if e.complexity.Errors.B == nil {
+		if e.ComplexityRoot.Errors.B == nil {
 			break
 		}
 
-		return e.complexity.Errors.B(childComplexity), true
+		return e.ComplexityRoot.Errors.B(childComplexity), true
 
 	case "Errors.c":
-		if e.complexity.Errors.C == nil {
+		if e.ComplexityRoot.Errors.C == nil {
 			break
 		}
 
-		return e.complexity.Errors.C(childComplexity), true
+		return e.ComplexityRoot.Errors.C(childComplexity), true
 
 	case "Errors.d":
-		if e.complexity.Errors.D == nil {
+		if e.ComplexityRoot.Errors.D == nil {
 			break
 		}
 
-		return e.complexity.Errors.D(childComplexity), true
+		return e.ComplexityRoot.Errors.D(childComplexity), true
 
 	case "Errors.e":
-		if e.complexity.Errors.E == nil {
+		if e.ComplexityRoot.Errors.E == nil {
 			break
 		}
 
-		return e.complexity.Errors.E(childComplexity), true
+		return e.ComplexityRoot.Errors.E(childComplexity), true
 
 	case "FieldsOrderPayload.firstFieldValue":
-		if e.complexity.FieldsOrderPayload.FirstFieldValue == nil {
+		if e.ComplexityRoot.FieldsOrderPayload.FirstFieldValue == nil {
 			break
 		}
 
-		return e.complexity.FieldsOrderPayload.FirstFieldValue(childComplexity), true
+		return e.ComplexityRoot.FieldsOrderPayload.FirstFieldValue(childComplexity), true
 
 	case "ForcedResolver.field":
-		if e.complexity.ForcedResolver.Field == nil {
+		if e.ComplexityRoot.ForcedResolver.Field == nil {
 			break
 		}
 
-		return e.complexity.ForcedResolver.Field(childComplexity), true
+		return e.ComplexityRoot.ForcedResolver.Field(childComplexity), true
 
 	case "Horse.horseBreed":
-		if e.complexity.Horse.HorseBreed == nil {
+		if e.ComplexityRoot.Horse.HorseBreed == nil {
 			break
 		}
 
-		return e.complexity.Horse.HorseBreed(childComplexity), true
+		return e.ComplexityRoot.Horse.HorseBreed(childComplexity), true
 
 	case "Horse.size":
-		if e.complexity.Horse.Size == nil {
+		if e.ComplexityRoot.Horse.Size == nil {
 			break
 		}
 
-		return e.complexity.Horse.Size(childComplexity), true
+		return e.ComplexityRoot.Horse.Size(childComplexity), true
 
 	case "Horse.species":
-		if e.complexity.Horse.Species == nil {
+		if e.ComplexityRoot.Horse.Species == nil {
 			break
 		}
 
-		return e.complexity.Horse.Species(childComplexity), true
+		return e.ComplexityRoot.Horse.Species(childComplexity), true
 
 	case "InnerObject.id":
-		if e.complexity.InnerObject.ID == nil {
+		if e.ComplexityRoot.InnerObject.ID == nil {
 			break
 		}
 
-		return e.complexity.InnerObject.ID(childComplexity), true
+		return e.ComplexityRoot.InnerObject.ID(childComplexity), true
 
 	case "InvalidIdentifier.id":
-		if e.complexity.InvalidIdentifier.ID == nil {
+		if e.ComplexityRoot.InvalidIdentifier.ID == nil {
 			break
 		}
 
-		return e.complexity.InvalidIdentifier.ID(childComplexity), true
+		return e.ComplexityRoot.InvalidIdentifier.ID(childComplexity), true
 
 	case "It.id":
-		if e.complexity.It.ID == nil {
+		if e.ComplexityRoot.It.ID == nil {
 			break
 		}
 
-		return e.complexity.It.ID(childComplexity), true
+		return e.ComplexityRoot.It.ID(childComplexity), true
 
 	case "LoopA.b":
-		if e.complexity.LoopA.B == nil {
+		if e.ComplexityRoot.LoopA.B == nil {
 			break
 		}
 
-		return e.complexity.LoopA.B(childComplexity), true
+		return e.ComplexityRoot.LoopA.B(childComplexity), true
 
 	case "LoopB.a":
-		if e.complexity.LoopB.A == nil {
+		if e.ComplexityRoot.LoopB.A == nil {
 			break
 		}
 
-		return e.complexity.LoopB.A(childComplexity), true
+		return e.ComplexityRoot.LoopB.A(childComplexity), true
 
 	case "Map.id":
-		if e.complexity.Map.ID == nil {
+		if e.ComplexityRoot.Map.ID == nil {
 			break
 		}
 
-		return e.complexity.Map.ID(childComplexity), true
+		return e.ComplexityRoot.Map.ID(childComplexity), true
 
 	case "MapNested.value":
-		if e.complexity.MapNested.Value == nil {
+		if e.ComplexityRoot.MapNested.Value == nil {
 			break
 		}
 
-		return e.complexity.MapNested.Value(childComplexity), true
+		return e.ComplexityRoot.MapNested.Value(childComplexity), true
 
 	case "MapStringInterfaceType.a":
-		if e.complexity.MapStringInterfaceType.A == nil {
+		if e.ComplexityRoot.MapStringInterfaceType.A == nil {
 			break
 		}
 
-		return e.complexity.MapStringInterfaceType.A(childComplexity), true
+		return e.ComplexityRoot.MapStringInterfaceType.A(childComplexity), true
 
 	case "MapStringInterfaceType.b":
-		if e.complexity.MapStringInterfaceType.B == nil {
+		if e.ComplexityRoot.MapStringInterfaceType.B == nil {
 			break
 		}
 
-		return e.complexity.MapStringInterfaceType.B(childComplexity), true
+		return e.ComplexityRoot.MapStringInterfaceType.B(childComplexity), true
 
 	case "MapStringInterfaceType.c":
-		if e.complexity.MapStringInterfaceType.C == nil {
+		if e.ComplexityRoot.MapStringInterfaceType.C == nil {
 			break
 		}
 
-		return e.complexity.MapStringInterfaceType.C(childComplexity), true
+		return e.ComplexityRoot.MapStringInterfaceType.C(childComplexity), true
 
 	case "MapStringInterfaceType.nested":
-		if e.complexity.MapStringInterfaceType.Nested == nil {
+		if e.ComplexityRoot.MapStringInterfaceType.Nested == nil {
 			break
 		}
 
-		return e.complexity.MapStringInterfaceType.Nested(childComplexity), true
+		return e.ComplexityRoot.MapStringInterfaceType.Nested(childComplexity), true
 
 	case "ModelMethods.noContext":
-		if e.complexity.ModelMethods.NoContext == nil {
+		if e.ComplexityRoot.ModelMethods.NoContext == nil {
 			break
 		}
 
-		return e.complexity.ModelMethods.NoContext(childComplexity), true
+		return e.ComplexityRoot.ModelMethods.NoContext(childComplexity), true
 
 	case "ModelMethods.resolverField":
-		if e.complexity.ModelMethods.ResolverField == nil {
+		if e.ComplexityRoot.ModelMethods.ResolverField == nil {
 			break
 		}
 
-		return e.complexity.ModelMethods.ResolverField(childComplexity), true
+		return e.ComplexityRoot.ModelMethods.ResolverField(childComplexity), true
 
 	case "ModelMethods.withContext":
-		if e.complexity.ModelMethods.WithContext == nil {
+		if e.ComplexityRoot.ModelMethods.WithContext == nil {
 			break
 		}
 
-		return e.complexity.ModelMethods.WithContext(childComplexity), true
+		return e.ComplexityRoot.ModelMethods.WithContext(childComplexity), true
 
 	case "Mutation.defaultInput":
-		if e.complexity.Mutation.DefaultInput == nil {
+		if e.ComplexityRoot.Mutation.DefaultInput == nil {
 			break
 		}
 
@@ -1011,10 +1001,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.DefaultInput(childComplexity, args["input"].(DefaultInput)), true
+		return e.ComplexityRoot.Mutation.DefaultInput(childComplexity, args["input"].(DefaultInput)), true
 
 	case "Mutation.overrideValueViaInput":
-		if e.complexity.Mutation.OverrideValueViaInput == nil {
+		if e.ComplexityRoot.Mutation.OverrideValueViaInput == nil {
 			break
 		}
 
@@ -1023,10 +1013,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.OverrideValueViaInput(childComplexity, args["input"].(FieldsOrderInput)), true
+		return e.ComplexityRoot.Mutation.OverrideValueViaInput(childComplexity, args["input"].(FieldsOrderInput)), true
 
 	case "Mutation.updateProduct":
-		if e.complexity.Mutation.UpdateProduct == nil {
+		if e.ComplexityRoot.Mutation.UpdateProduct == nil {
 			break
 		}
 
@@ -1035,10 +1025,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.UpdateProduct(childComplexity, args["id"].(string), args["name"].(*string), args["price"].(*float64)), true
+		return e.ComplexityRoot.Mutation.UpdateProduct(childComplexity, args["id"].(string), args["name"].(*string), args["price"].(*float64)), true
 
 	case "Mutation.updatePtrToPtr":
-		if e.complexity.Mutation.UpdatePtrToPtr == nil {
+		if e.ComplexityRoot.Mutation.UpdatePtrToPtr == nil {
 			break
 		}
 
@@ -1047,10 +1037,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.UpdatePtrToPtr(childComplexity, args["input"].(UpdatePtrToPtrOuter)), true
+		return e.ComplexityRoot.Mutation.UpdatePtrToPtr(childComplexity, args["input"].(UpdatePtrToPtrOuter)), true
 
 	case "Mutation.updateSomething":
-		if e.complexity.Mutation.UpdateSomething == nil {
+		if e.ComplexityRoot.Mutation.UpdateSomething == nil {
 			break
 		}
 
@@ -1059,66 +1049,66 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.UpdateSomething(childComplexity, args["input"].(SpecialInput)), true
+		return e.ComplexityRoot.Mutation.UpdateSomething(childComplexity, args["input"].(SpecialInput)), true
 
 	case "ObjectDirectives.nullableText":
-		if e.complexity.ObjectDirectives.NullableText == nil {
+		if e.ComplexityRoot.ObjectDirectives.NullableText == nil {
 			break
 		}
 
-		return e.complexity.ObjectDirectives.NullableText(childComplexity), true
+		return e.ComplexityRoot.ObjectDirectives.NullableText(childComplexity), true
 
 	case "ObjectDirectives.order":
-		if e.complexity.ObjectDirectives.Order == nil {
+		if e.ComplexityRoot.ObjectDirectives.Order == nil {
 			break
 		}
 
-		return e.complexity.ObjectDirectives.Order(childComplexity), true
+		return e.ComplexityRoot.ObjectDirectives.Order(childComplexity), true
 
 	case "ObjectDirectives.text":
-		if e.complexity.ObjectDirectives.Text == nil {
+		if e.ComplexityRoot.ObjectDirectives.Text == nil {
 			break
 		}
 
-		return e.complexity.ObjectDirectives.Text(childComplexity), true
+		return e.ComplexityRoot.ObjectDirectives.Text(childComplexity), true
 
 	case "ObjectDirectivesWithCustomGoModel.nullableText":
-		if e.complexity.ObjectDirectivesWithCustomGoModel.NullableText == nil {
+		if e.ComplexityRoot.ObjectDirectivesWithCustomGoModel.NullableText == nil {
 			break
 		}
 
-		return e.complexity.ObjectDirectivesWithCustomGoModel.NullableText(childComplexity), true
+		return e.ComplexityRoot.ObjectDirectivesWithCustomGoModel.NullableText(childComplexity), true
 
 	case "OuterObject.inner":
-		if e.complexity.OuterObject.Inner == nil {
+		if e.ComplexityRoot.OuterObject.Inner == nil {
 			break
 		}
 
-		return e.complexity.OuterObject.Inner(childComplexity), true
+		return e.ComplexityRoot.OuterObject.Inner(childComplexity), true
 
 	case "OverlappingFields.oneFoo", "OverlappingFields.twoFoo":
-		if e.complexity.OverlappingFields.Foo == nil {
+		if e.ComplexityRoot.OverlappingFields.Foo == nil {
 			break
 		}
 
-		return e.complexity.OverlappingFields.Foo(childComplexity), true
+		return e.ComplexityRoot.OverlappingFields.Foo(childComplexity), true
 
 	case "OverlappingFields.newFoo", "OverlappingFields.new_foo":
-		if e.complexity.OverlappingFields.NewFoo == nil {
+		if e.ComplexityRoot.OverlappingFields.NewFoo == nil {
 			break
 		}
 
-		return e.complexity.OverlappingFields.NewFoo(childComplexity), true
+		return e.ComplexityRoot.OverlappingFields.NewFoo(childComplexity), true
 
 	case "OverlappingFields.oldFoo":
-		if e.complexity.OverlappingFields.OldFoo == nil {
+		if e.ComplexityRoot.OverlappingFields.OldFoo == nil {
 			break
 		}
 
-		return e.complexity.OverlappingFields.OldFoo(childComplexity), true
+		return e.ComplexityRoot.OverlappingFields.OldFoo(childComplexity), true
 
 	case "Panics.argUnmarshal":
-		if e.complexity.Panics.ArgUnmarshal == nil {
+		if e.ComplexityRoot.Panics.ArgUnmarshal == nil {
 			break
 		}
 
@@ -1127,10 +1117,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Panics.ArgUnmarshal(childComplexity, args["u"].([]MarshalPanic)), true
+		return e.ComplexityRoot.Panics.ArgUnmarshal(childComplexity, args["u"].([]MarshalPanic)), true
 
 	case "Panics.fieldFuncMarshal":
-		if e.complexity.Panics.FieldFuncMarshal == nil {
+		if e.ComplexityRoot.Panics.FieldFuncMarshal == nil {
 			break
 		}
 
@@ -1139,17 +1129,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Panics.FieldFuncMarshal(childComplexity, args["u"].([]MarshalPanic)), true
+		return e.ComplexityRoot.Panics.FieldFuncMarshal(childComplexity, args["u"].([]MarshalPanic)), true
 
 	case "Panics.fieldScalarMarshal":
-		if e.complexity.Panics.FieldScalarMarshal == nil {
+		if e.ComplexityRoot.Panics.FieldScalarMarshal == nil {
 			break
 		}
 
-		return e.complexity.Panics.FieldScalarMarshal(childComplexity), true
+		return e.ComplexityRoot.Panics.FieldScalarMarshal(childComplexity), true
 
 	case "Pet.friends":
-		if e.complexity.Pet.Friends == nil {
+		if e.ComplexityRoot.Pet.Friends == nil {
 			break
 		}
 
@@ -1158,129 +1148,129 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Pet.Friends(childComplexity, args["limit"].(*int)), true
+		return e.ComplexityRoot.Pet.Friends(childComplexity, args["limit"].(*int)), true
 
 	case "Pet.id":
-		if e.complexity.Pet.ID == nil {
+		if e.ComplexityRoot.Pet.ID == nil {
 			break
 		}
 
-		return e.complexity.Pet.ID(childComplexity), true
+		return e.ComplexityRoot.Pet.ID(childComplexity), true
 
 	case "Primitive.squared":
-		if e.complexity.Primitive.Squared == nil {
+		if e.ComplexityRoot.Primitive.Squared == nil {
 			break
 		}
 
-		return e.complexity.Primitive.Squared(childComplexity), true
+		return e.ComplexityRoot.Primitive.Squared(childComplexity), true
 
 	case "Primitive.value":
-		if e.complexity.Primitive.Value == nil {
+		if e.ComplexityRoot.Primitive.Value == nil {
 			break
 		}
 
-		return e.complexity.Primitive.Value(childComplexity), true
+		return e.ComplexityRoot.Primitive.Value(childComplexity), true
 
 	case "PrimitiveString.doubled":
-		if e.complexity.PrimitiveString.Doubled == nil {
+		if e.ComplexityRoot.PrimitiveString.Doubled == nil {
 			break
 		}
 
-		return e.complexity.PrimitiveString.Doubled(childComplexity), true
+		return e.ComplexityRoot.PrimitiveString.Doubled(childComplexity), true
 
 	case "PrimitiveString.len":
-		if e.complexity.PrimitiveString.Len == nil {
+		if e.ComplexityRoot.PrimitiveString.Len == nil {
 			break
 		}
 
-		return e.complexity.PrimitiveString.Len(childComplexity), true
+		return e.ComplexityRoot.PrimitiveString.Len(childComplexity), true
 
 	case "PrimitiveString.value":
-		if e.complexity.PrimitiveString.Value == nil {
+		if e.ComplexityRoot.PrimitiveString.Value == nil {
 			break
 		}
 
-		return e.complexity.PrimitiveString.Value(childComplexity), true
+		return e.ComplexityRoot.PrimitiveString.Value(childComplexity), true
 
 	case "PtrToAnyContainer.binding":
-		if e.complexity.PtrToAnyContainer.Binding == nil {
+		if e.ComplexityRoot.PtrToAnyContainer.Binding == nil {
 			break
 		}
 
-		return e.complexity.PtrToAnyContainer.Binding(childComplexity), true
+		return e.ComplexityRoot.PtrToAnyContainer.Binding(childComplexity), true
 
 	case "PtrToAnyContainer.ptrToAny":
-		if e.complexity.PtrToAnyContainer.PtrToAny == nil {
+		if e.ComplexityRoot.PtrToAnyContainer.PtrToAny == nil {
 			break
 		}
 
-		return e.complexity.PtrToAnyContainer.PtrToAny(childComplexity), true
+		return e.ComplexityRoot.PtrToAnyContainer.PtrToAny(childComplexity), true
 
 	case "PtrToPtrInner.key":
-		if e.complexity.PtrToPtrInner.Key == nil {
+		if e.ComplexityRoot.PtrToPtrInner.Key == nil {
 			break
 		}
 
-		return e.complexity.PtrToPtrInner.Key(childComplexity), true
+		return e.ComplexityRoot.PtrToPtrInner.Key(childComplexity), true
 
 	case "PtrToPtrInner.value":
-		if e.complexity.PtrToPtrInner.Value == nil {
+		if e.ComplexityRoot.PtrToPtrInner.Value == nil {
 			break
 		}
 
-		return e.complexity.PtrToPtrInner.Value(childComplexity), true
+		return e.ComplexityRoot.PtrToPtrInner.Value(childComplexity), true
 
 	case "PtrToPtrOuter.inner":
-		if e.complexity.PtrToPtrOuter.Inner == nil {
+		if e.ComplexityRoot.PtrToPtrOuter.Inner == nil {
 			break
 		}
 
-		return e.complexity.PtrToPtrOuter.Inner(childComplexity), true
+		return e.ComplexityRoot.PtrToPtrOuter.Inner(childComplexity), true
 
 	case "PtrToPtrOuter.name":
-		if e.complexity.PtrToPtrOuter.Name == nil {
+		if e.ComplexityRoot.PtrToPtrOuter.Name == nil {
 			break
 		}
 
-		return e.complexity.PtrToPtrOuter.Name(childComplexity), true
+		return e.ComplexityRoot.PtrToPtrOuter.Name(childComplexity), true
 
 	case "PtrToPtrOuter.stupidInner":
-		if e.complexity.PtrToPtrOuter.StupidInner == nil {
+		if e.ComplexityRoot.PtrToPtrOuter.StupidInner == nil {
 			break
 		}
 
-		return e.complexity.PtrToPtrOuter.StupidInner(childComplexity), true
+		return e.ComplexityRoot.PtrToPtrOuter.StupidInner(childComplexity), true
 
 	case "PtrToSliceContainer.ptrToSlice":
-		if e.complexity.PtrToSliceContainer.PtrToSlice == nil {
+		if e.ComplexityRoot.PtrToSliceContainer.PtrToSlice == nil {
 			break
 		}
 
-		return e.complexity.PtrToSliceContainer.PtrToSlice(childComplexity), true
+		return e.ComplexityRoot.PtrToSliceContainer.PtrToSlice(childComplexity), true
 
 	case "Query.animal":
-		if e.complexity.Query.Animal == nil {
+		if e.ComplexityRoot.Query.Animal == nil {
 			break
 		}
 
-		return e.complexity.Query.Animal(childComplexity), true
+		return e.ComplexityRoot.Query.Animal(childComplexity), true
 
 	case "Query.autobind":
-		if e.complexity.Query.Autobind == nil {
+		if e.ComplexityRoot.Query.Autobind == nil {
 			break
 		}
 
-		return e.complexity.Query.Autobind(childComplexity), true
+		return e.ComplexityRoot.Query.Autobind(childComplexity), true
 
 	case "Query.collision":
-		if e.complexity.Query.Collision == nil {
+		if e.ComplexityRoot.Query.Collision == nil {
 			break
 		}
 
-		return e.complexity.Query.Collision(childComplexity), true
+		return e.ComplexityRoot.Query.Collision(childComplexity), true
 
 	case "Query.defaultParameters":
-		if e.complexity.Query.DefaultParameters == nil {
+		if e.ComplexityRoot.Query.DefaultParameters == nil {
 			break
 		}
 
@@ -1289,10 +1279,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.DefaultParameters(childComplexity, args["falsyBoolean"].(*bool), args["truthyBoolean"].(*bool)), true
+		return e.ComplexityRoot.Query.DefaultParameters(childComplexity, args["falsyBoolean"].(*bool), args["truthyBoolean"].(*bool)), true
 
 	case "Query.defaultScalar":
-		if e.complexity.Query.DefaultScalar == nil {
+		if e.ComplexityRoot.Query.DefaultScalar == nil {
 			break
 		}
 
@@ -1301,31 +1291,31 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.DefaultScalar(childComplexity, args["arg"].(string)), true
+		return e.ComplexityRoot.Query.DefaultScalar(childComplexity, args["arg"].(string)), true
 
 	case "Query.deferMultiple":
-		if e.complexity.Query.DeferMultiple == nil {
+		if e.ComplexityRoot.Query.DeferMultiple == nil {
 			break
 		}
 
-		return e.complexity.Query.DeferMultiple(childComplexity), true
+		return e.ComplexityRoot.Query.DeferMultiple(childComplexity), true
 
 	case "Query.deferSingle":
-		if e.complexity.Query.DeferSingle == nil {
+		if e.ComplexityRoot.Query.DeferSingle == nil {
 			break
 		}
 
-		return e.complexity.Query.DeferSingle(childComplexity), true
+		return e.ComplexityRoot.Query.DeferSingle(childComplexity), true
 
 	case "Query.deprecatedField":
-		if e.complexity.Query.DeprecatedField == nil {
+		if e.ComplexityRoot.Query.DeprecatedField == nil {
 			break
 		}
 
-		return e.complexity.Query.DeprecatedField(childComplexity), true
+		return e.ComplexityRoot.Query.DeprecatedField(childComplexity), true
 
 	case "Query.directiveArg":
-		if e.complexity.Query.DirectiveArg == nil {
+		if e.ComplexityRoot.Query.DirectiveArg == nil {
 			break
 		}
 
@@ -1334,24 +1324,24 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.DirectiveArg(childComplexity, args["arg"].(string)), true
+		return e.ComplexityRoot.Query.DirectiveArg(childComplexity, args["arg"].(string)), true
 
 	case "Query.directiveDouble":
-		if e.complexity.Query.DirectiveDouble == nil {
+		if e.ComplexityRoot.Query.DirectiveDouble == nil {
 			break
 		}
 
-		return e.complexity.Query.DirectiveDouble(childComplexity), true
+		return e.ComplexityRoot.Query.DirectiveDouble(childComplexity), true
 
 	case "Query.directiveField":
-		if e.complexity.Query.DirectiveField == nil {
+		if e.ComplexityRoot.Query.DirectiveField == nil {
 			break
 		}
 
-		return e.complexity.Query.DirectiveField(childComplexity), true
+		return e.ComplexityRoot.Query.DirectiveField(childComplexity), true
 
 	case "Query.directiveFieldDef":
-		if e.complexity.Query.DirectiveFieldDef == nil {
+		if e.ComplexityRoot.Query.DirectiveFieldDef == nil {
 			break
 		}
 
@@ -1360,10 +1350,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.DirectiveFieldDef(childComplexity, args["ret"].(string)), true
+		return e.ComplexityRoot.Query.DirectiveFieldDef(childComplexity, args["ret"].(string)), true
 
 	case "Query.directiveInput":
-		if e.complexity.Query.DirectiveInput == nil {
+		if e.ComplexityRoot.Query.DirectiveInput == nil {
 			break
 		}
 
@@ -1372,10 +1362,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.DirectiveInput(childComplexity, args["arg"].(InputDirectives)), true
+		return e.ComplexityRoot.Query.DirectiveInput(childComplexity, args["arg"].(InputDirectives)), true
 
 	case "Query.directiveInputNullable":
-		if e.complexity.Query.DirectiveInputNullable == nil {
+		if e.ComplexityRoot.Query.DirectiveInputNullable == nil {
 			break
 		}
 
@@ -1384,10 +1374,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.DirectiveInputNullable(childComplexity, args["arg"].(*InputDirectives)), true
+		return e.ComplexityRoot.Query.DirectiveInputNullable(childComplexity, args["arg"].(*InputDirectives)), true
 
 	case "Query.directiveInputType":
-		if e.complexity.Query.DirectiveInputType == nil {
+		if e.ComplexityRoot.Query.DirectiveInputType == nil {
 			break
 		}
 
@@ -1396,10 +1386,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.DirectiveInputType(childComplexity, args["arg"].(InnerInput)), true
+		return e.ComplexityRoot.Query.DirectiveInputType(childComplexity, args["arg"].(InnerInput)), true
 
 	case "Query.directiveNullableArg":
-		if e.complexity.Query.DirectiveNullableArg == nil {
+		if e.ComplexityRoot.Query.DirectiveNullableArg == nil {
 			break
 		}
 
@@ -1408,24 +1398,24 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.DirectiveNullableArg(childComplexity, args["arg"].(*int), args["arg2"].(*int), args["arg3"].(*string)), true
+		return e.ComplexityRoot.Query.DirectiveNullableArg(childComplexity, args["arg"].(*int), args["arg2"].(*int), args["arg3"].(*string)), true
 
 	case "Query.directiveObject":
-		if e.complexity.Query.DirectiveObject == nil {
+		if e.ComplexityRoot.Query.DirectiveObject == nil {
 			break
 		}
 
-		return e.complexity.Query.DirectiveObject(childComplexity), true
+		return e.ComplexityRoot.Query.DirectiveObject(childComplexity), true
 
 	case "Query.directiveObjectWithCustomGoModel":
-		if e.complexity.Query.DirectiveObjectWithCustomGoModel == nil {
+		if e.ComplexityRoot.Query.DirectiveObjectWithCustomGoModel == nil {
 			break
 		}
 
-		return e.complexity.Query.DirectiveObjectWithCustomGoModel(childComplexity), true
+		return e.ComplexityRoot.Query.DirectiveObjectWithCustomGoModel(childComplexity), true
 
 	case "Query.directiveSingleNullableArg":
-		if e.complexity.Query.DirectiveSingleNullableArg == nil {
+		if e.ComplexityRoot.Query.DirectiveSingleNullableArg == nil {
 			break
 		}
 
@@ -1434,45 +1424,45 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.DirectiveSingleNullableArg(childComplexity, args["arg1"].(*string)), true
+		return e.ComplexityRoot.Query.DirectiveSingleNullableArg(childComplexity, args["arg1"].(*string)), true
 
 	case "Query.directiveUnimplemented":
-		if e.complexity.Query.DirectiveUnimplemented == nil {
+		if e.ComplexityRoot.Query.DirectiveUnimplemented == nil {
 			break
 		}
 
-		return e.complexity.Query.DirectiveUnimplemented(childComplexity), true
+		return e.ComplexityRoot.Query.DirectiveUnimplemented(childComplexity), true
 
 	case "Query.dog":
-		if e.complexity.Query.Dog == nil {
+		if e.ComplexityRoot.Query.Dog == nil {
 			break
 		}
 
-		return e.complexity.Query.Dog(childComplexity), true
+		return e.ComplexityRoot.Query.Dog(childComplexity), true
 
 	case "Query.embeddedCase1":
-		if e.complexity.Query.EmbeddedCase1 == nil {
+		if e.ComplexityRoot.Query.EmbeddedCase1 == nil {
 			break
 		}
 
-		return e.complexity.Query.EmbeddedCase1(childComplexity), true
+		return e.ComplexityRoot.Query.EmbeddedCase1(childComplexity), true
 
 	case "Query.embeddedCase2":
-		if e.complexity.Query.EmbeddedCase2 == nil {
+		if e.ComplexityRoot.Query.EmbeddedCase2 == nil {
 			break
 		}
 
-		return e.complexity.Query.EmbeddedCase2(childComplexity), true
+		return e.ComplexityRoot.Query.EmbeddedCase2(childComplexity), true
 
 	case "Query.embeddedCase3":
-		if e.complexity.Query.EmbeddedCase3 == nil {
+		if e.ComplexityRoot.Query.EmbeddedCase3 == nil {
 			break
 		}
 
-		return e.complexity.Query.EmbeddedCase3(childComplexity), true
+		return e.ComplexityRoot.Query.EmbeddedCase3(childComplexity), true
 
 	case "Query.enumInInput":
-		if e.complexity.Query.EnumInInput == nil {
+		if e.ComplexityRoot.Query.EnumInInput == nil {
 			break
 		}
 
@@ -1481,38 +1471,38 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.EnumInInput(childComplexity, args["input"].(*InputWithEnumValue)), true
+		return e.ComplexityRoot.Query.EnumInInput(childComplexity, args["input"].(*InputWithEnumValue)), true
 
 	case "Query.errorBubble":
-		if e.complexity.Query.ErrorBubble == nil {
+		if e.ComplexityRoot.Query.ErrorBubble == nil {
 			break
 		}
 
-		return e.complexity.Query.ErrorBubble(childComplexity), true
+		return e.ComplexityRoot.Query.ErrorBubble(childComplexity), true
 
 	case "Query.errorBubbleList":
-		if e.complexity.Query.ErrorBubbleList == nil {
+		if e.ComplexityRoot.Query.ErrorBubbleList == nil {
 			break
 		}
 
-		return e.complexity.Query.ErrorBubbleList(childComplexity), true
+		return e.ComplexityRoot.Query.ErrorBubbleList(childComplexity), true
 
 	case "Query.errorList":
-		if e.complexity.Query.ErrorList == nil {
+		if e.ComplexityRoot.Query.ErrorList == nil {
 			break
 		}
 
-		return e.complexity.Query.ErrorList(childComplexity), true
+		return e.ComplexityRoot.Query.ErrorList(childComplexity), true
 
 	case "Query.errors":
-		if e.complexity.Query.Errors == nil {
+		if e.ComplexityRoot.Query.Errors == nil {
 			break
 		}
 
-		return e.complexity.Query.Errors(childComplexity), true
+		return e.ComplexityRoot.Query.Errors(childComplexity), true
 
 	case "Query.fallback":
-		if e.complexity.Query.Fallback == nil {
+		if e.ComplexityRoot.Query.Fallback == nil {
 			break
 		}
 
@@ -1521,10 +1511,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Fallback(childComplexity, args["arg"].(FallbackToStringEncoding)), true
+		return e.ComplexityRoot.Query.Fallback(childComplexity, args["arg"].(FallbackToStringEncoding)), true
 
 	case "Query.fieldWithDeprecatedArg":
-		if e.complexity.Query.FieldWithDeprecatedArg == nil {
+		if e.ComplexityRoot.Query.FieldWithDeprecatedArg == nil {
 			break
 		}
 
@@ -1533,10 +1523,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.FieldWithDeprecatedArg(childComplexity, args["oldArg"].(*int), args["newArg"].(*int)), true
+		return e.ComplexityRoot.Query.FieldWithDeprecatedArg(childComplexity, args["oldArg"].(*int), args["newArg"].(*int)), true
 
 	case "Query.filterProducts":
-		if e.complexity.Query.FilterProducts == nil {
+		if e.ComplexityRoot.Query.FilterProducts == nil {
 			break
 		}
 
@@ -1545,10 +1535,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.FilterProducts(childComplexity, args["query"].(*string), args["category"].(*string), args["minPrice"].(*int)), true
+		return e.ComplexityRoot.Query.FilterProducts(childComplexity, args["query"].(*string), args["category"].(*string), args["minPrice"].(*int)), true
 
 	case "Query.findProducts":
-		if e.complexity.Query.FindProducts == nil {
+		if e.ComplexityRoot.Query.FindProducts == nil {
 			break
 		}
 
@@ -1557,17 +1547,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.FindProducts(childComplexity, args["query"].(*string), args["category"].(*string), args["minPrice"].(*int)), true
+		return e.ComplexityRoot.Query.FindProducts(childComplexity, args["query"].(*string), args["category"].(*string), args["minPrice"].(*int)), true
 
 	case "Query.infinity":
-		if e.complexity.Query.Infinity == nil {
+		if e.ComplexityRoot.Query.Infinity == nil {
 			break
 		}
 
-		return e.complexity.Query.Infinity(childComplexity), true
+		return e.ComplexityRoot.Query.Infinity(childComplexity), true
 
 	case "Query.inputNullableSlice":
-		if e.complexity.Query.InputNullableSlice == nil {
+		if e.ComplexityRoot.Query.InputNullableSlice == nil {
 			break
 		}
 
@@ -1576,10 +1566,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.InputNullableSlice(childComplexity, args["arg"].([]string)), true
+		return e.ComplexityRoot.Query.InputNullableSlice(childComplexity, args["arg"].([]string)), true
 
 	case "Query.inputOmittable":
-		if e.complexity.Query.InputOmittable == nil {
+		if e.ComplexityRoot.Query.InputOmittable == nil {
 			break
 		}
 
@@ -1588,10 +1578,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.InputOmittable(childComplexity, args["arg"].(OmittableInput)), true
+		return e.ComplexityRoot.Query.InputOmittable(childComplexity, args["arg"].(OmittableInput)), true
 
 	case "Query.inputSlice":
-		if e.complexity.Query.InputSlice == nil {
+		if e.ComplexityRoot.Query.InputSlice == nil {
 			break
 		}
 
@@ -1600,31 +1590,31 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.InputSlice(childComplexity, args["arg"].([]string)), true
+		return e.ComplexityRoot.Query.InputSlice(childComplexity, args["arg"].([]string)), true
 
 	case "Query.invalid":
-		if e.complexity.Query.Invalid == nil {
+		if e.ComplexityRoot.Query.Invalid == nil {
 			break
 		}
 
-		return e.complexity.Query.Invalid(childComplexity), true
+		return e.ComplexityRoot.Query.Invalid(childComplexity), true
 
 	case "Query.invalidIdentifier":
-		if e.complexity.Query.InvalidIdentifier == nil {
+		if e.ComplexityRoot.Query.InvalidIdentifier == nil {
 			break
 		}
 
-		return e.complexity.Query.InvalidIdentifier(childComplexity), true
+		return e.ComplexityRoot.Query.InvalidIdentifier(childComplexity), true
 
 	case "Query.issue896a":
-		if e.complexity.Query.Issue896a == nil {
+		if e.ComplexityRoot.Query.Issue896a == nil {
 			break
 		}
 
-		return e.complexity.Query.Issue896a(childComplexity), true
+		return e.ComplexityRoot.Query.Issue896a(childComplexity), true
 
 	case "Query.mapInput":
-		if e.complexity.Query.MapInput == nil {
+		if e.ComplexityRoot.Query.MapInput == nil {
 			break
 		}
 
@@ -1633,10 +1623,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.MapInput(childComplexity, args["input"].(map[string]any)), true
+		return e.ComplexityRoot.Query.MapInput(childComplexity, args["input"].(map[string]any)), true
 
 	case "Query.mapNestedMapSlice":
-		if e.complexity.Query.MapNestedMapSlice == nil {
+		if e.ComplexityRoot.Query.MapNestedMapSlice == nil {
 			break
 		}
 
@@ -1645,10 +1635,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.MapNestedMapSlice(childComplexity, args["input"].(map[string]any)), true
+		return e.ComplexityRoot.Query.MapNestedMapSlice(childComplexity, args["input"].(map[string]any)), true
 
 	case "Query.mapNestedStringInterface":
-		if e.complexity.Query.MapNestedStringInterface == nil {
+		if e.ComplexityRoot.Query.MapNestedStringInterface == nil {
 			break
 		}
 
@@ -1657,10 +1647,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.MapNestedStringInterface(childComplexity, args["in"].(*NestedMapInput)), true
+		return e.ComplexityRoot.Query.MapNestedStringInterface(childComplexity, args["in"].(*NestedMapInput)), true
 
 	case "Query.mapStringInterface":
-		if e.complexity.Query.MapStringInterface == nil {
+		if e.ComplexityRoot.Query.MapStringInterface == nil {
 			break
 		}
 
@@ -1669,17 +1659,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.MapStringInterface(childComplexity, args["in"].(map[string]any)), true
+		return e.ComplexityRoot.Query.MapStringInterface(childComplexity, args["in"].(map[string]any)), true
 
 	case "Query.modelMethods":
-		if e.complexity.Query.ModelMethods == nil {
+		if e.ComplexityRoot.Query.ModelMethods == nil {
 			break
 		}
 
-		return e.complexity.Query.ModelMethods(childComplexity), true
+		return e.ComplexityRoot.Query.ModelMethods(childComplexity), true
 
 	case "Query.nestedInputs":
-		if e.complexity.Query.NestedInputs == nil {
+		if e.ComplexityRoot.Query.NestedInputs == nil {
 			break
 		}
 
@@ -1688,45 +1678,45 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.NestedInputs(childComplexity, args["input"].([][]*OuterInput)), true
+		return e.ComplexityRoot.Query.NestedInputs(childComplexity, args["input"].([][]*OuterInput)), true
 
 	case "Query.nestedOutputs":
-		if e.complexity.Query.NestedOutputs == nil {
+		if e.ComplexityRoot.Query.NestedOutputs == nil {
 			break
 		}
 
-		return e.complexity.Query.NestedOutputs(childComplexity), true
+		return e.ComplexityRoot.Query.NestedOutputs(childComplexity), true
 
 	case "Query.noShape":
-		if e.complexity.Query.NoShape == nil {
+		if e.ComplexityRoot.Query.NoShape == nil {
 			break
 		}
 
-		return e.complexity.Query.NoShape(childComplexity), true
+		return e.ComplexityRoot.Query.NoShape(childComplexity), true
 
 	case "Query.noShapeTypedNil":
-		if e.complexity.Query.NoShapeTypedNil == nil {
+		if e.ComplexityRoot.Query.NoShapeTypedNil == nil {
 			break
 		}
 
-		return e.complexity.Query.NoShapeTypedNil(childComplexity), true
+		return e.ComplexityRoot.Query.NoShapeTypedNil(childComplexity), true
 
 	case "Query.node":
-		if e.complexity.Query.Node == nil {
+		if e.ComplexityRoot.Query.Node == nil {
 			break
 		}
 
-		return e.complexity.Query.Node(childComplexity), true
+		return e.ComplexityRoot.Query.Node(childComplexity), true
 
 	case "Query.notAnInterface":
-		if e.complexity.Query.NotAnInterface == nil {
+		if e.ComplexityRoot.Query.NotAnInterface == nil {
 			break
 		}
 
-		return e.complexity.Query.NotAnInterface(childComplexity), true
+		return e.ComplexityRoot.Query.NotAnInterface(childComplexity), true
 
 	case "Query.nullableArg":
-		if e.complexity.Query.NullableArg == nil {
+		if e.ComplexityRoot.Query.NullableArg == nil {
 			break
 		}
 
@@ -1735,59 +1725,59 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.NullableArg(childComplexity, args["arg"].(*int)), true
+		return e.ComplexityRoot.Query.NullableArg(childComplexity, args["arg"].(*int)), true
 
 	case "Query.optionalUnion":
-		if e.complexity.Query.OptionalUnion == nil {
+		if e.ComplexityRoot.Query.OptionalUnion == nil {
 			break
 		}
 
-		return e.complexity.Query.OptionalUnion(childComplexity), true
+		return e.ComplexityRoot.Query.OptionalUnion(childComplexity), true
 
 	case "Query.overlapping":
-		if e.complexity.Query.Overlapping == nil {
+		if e.ComplexityRoot.Query.Overlapping == nil {
 			break
 		}
 
-		return e.complexity.Query.Overlapping(childComplexity), true
+		return e.ComplexityRoot.Query.Overlapping(childComplexity), true
 
 	case "Query.panics":
-		if e.complexity.Query.Panics == nil {
+		if e.ComplexityRoot.Query.Panics == nil {
 			break
 		}
 
-		return e.complexity.Query.Panics(childComplexity), true
+		return e.ComplexityRoot.Query.Panics(childComplexity), true
 
 	case "Query.primitiveObject":
-		if e.complexity.Query.PrimitiveObject == nil {
+		if e.ComplexityRoot.Query.PrimitiveObject == nil {
 			break
 		}
 
-		return e.complexity.Query.PrimitiveObject(childComplexity), true
+		return e.ComplexityRoot.Query.PrimitiveObject(childComplexity), true
 
 	case "Query.primitiveStringObject":
-		if e.complexity.Query.PrimitiveStringObject == nil {
+		if e.ComplexityRoot.Query.PrimitiveStringObject == nil {
 			break
 		}
 
-		return e.complexity.Query.PrimitiveStringObject(childComplexity), true
+		return e.ComplexityRoot.Query.PrimitiveStringObject(childComplexity), true
 
 	case "Query.ptrToAnyContainer":
-		if e.complexity.Query.PtrToAnyContainer == nil {
+		if e.ComplexityRoot.Query.PtrToAnyContainer == nil {
 			break
 		}
 
-		return e.complexity.Query.PtrToAnyContainer(childComplexity), true
+		return e.ComplexityRoot.Query.PtrToAnyContainer(childComplexity), true
 
 	case "Query.ptrToSliceContainer":
-		if e.complexity.Query.PtrToSliceContainer == nil {
+		if e.ComplexityRoot.Query.PtrToSliceContainer == nil {
 			break
 		}
 
-		return e.complexity.Query.PtrToSliceContainer(childComplexity), true
+		return e.ComplexityRoot.Query.PtrToSliceContainer(childComplexity), true
 
 	case "Query.recursive":
-		if e.complexity.Query.Recursive == nil {
+		if e.ComplexityRoot.Query.Recursive == nil {
 			break
 		}
 
@@ -1796,17 +1786,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Recursive(childComplexity, args["input"].(*RecursiveInputSlice)), true
+		return e.ComplexityRoot.Query.Recursive(childComplexity, args["input"].(*RecursiveInputSlice)), true
 
 	case "Query.scalarSlice":
-		if e.complexity.Query.ScalarSlice == nil {
+		if e.ComplexityRoot.Query.ScalarSlice == nil {
 			break
 		}
 
-		return e.complexity.Query.ScalarSlice(childComplexity), true
+		return e.ComplexityRoot.Query.ScalarSlice(childComplexity), true
 
 	case "Query.searchMixed":
-		if e.complexity.Query.SearchMixed == nil {
+		if e.ComplexityRoot.Query.SearchMixed == nil {
 			break
 		}
 
@@ -1815,10 +1805,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.SearchMixed(childComplexity, args["query"].(*string), args["category"].(*string), args["minPrice"].(*int), args["limit"].(*int), args["offset"].(*int), args["sortBy"].(*string)), true
+		return e.ComplexityRoot.Query.SearchMixed(childComplexity, args["query"].(*string), args["category"].(*string), args["minPrice"].(*int), args["limit"].(*int), args["offset"].(*int), args["sortBy"].(*string)), true
 
 	case "Query.searchProducts":
-		if e.complexity.Query.SearchProducts == nil {
+		if e.ComplexityRoot.Query.SearchProducts == nil {
 			break
 		}
 
@@ -1827,10 +1817,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.SearchProducts(childComplexity, args["query"].(*string), args["category"].(*string), args["minPrice"].(*int)), true
+		return e.ComplexityRoot.Query.SearchProducts(childComplexity, args["query"].(*string), args["category"].(*string), args["minPrice"].(*int)), true
 
 	case "Query.searchProductsNormal":
-		if e.complexity.Query.SearchProductsNormal == nil {
+		if e.ComplexityRoot.Query.SearchProductsNormal == nil {
 			break
 		}
 
@@ -1839,10 +1829,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.SearchProductsNormal(childComplexity, args["filters"].(map[string]any)), true
+		return e.ComplexityRoot.Query.SearchProductsNormal(childComplexity, args["filters"].(map[string]any)), true
 
 	case "Query.searchRequired":
-		if e.complexity.Query.SearchRequired == nil {
+		if e.ComplexityRoot.Query.SearchRequired == nil {
 			break
 		}
 
@@ -1851,10 +1841,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.SearchRequired(childComplexity, args["name"].(string), args["age"].(int)), true
+		return e.ComplexityRoot.Query.SearchRequired(childComplexity, args["name"].(string), args["age"].(int)), true
 
 	case "Query.searchWithDefaults":
-		if e.complexity.Query.SearchWithDefaults == nil {
+		if e.ComplexityRoot.Query.SearchWithDefaults == nil {
 			break
 		}
 
@@ -1863,10 +1853,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.SearchWithDefaults(childComplexity, args["query"].(*string), args["limit"].(*int), args["includeArchived"].(*bool)), true
+		return e.ComplexityRoot.Query.SearchWithDefaults(childComplexity, args["query"].(*string), args["limit"].(*int), args["includeArchived"].(*bool)), true
 
 	case "Query.searchWithDirectives":
-		if e.complexity.Query.SearchWithDirectives == nil {
+		if e.ComplexityRoot.Query.SearchWithDirectives == nil {
 			break
 		}
 
@@ -1875,52 +1865,52 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.SearchWithDirectives(childComplexity, args["oldField"].(*string), args["newField"].(*string)), true
+		return e.ComplexityRoot.Query.SearchWithDirectives(childComplexity, args["oldField"].(*string), args["newField"].(*string)), true
 
 	case "Query.shapeUnion":
-		if e.complexity.Query.ShapeUnion == nil {
+		if e.ComplexityRoot.Query.ShapeUnion == nil {
 			break
 		}
 
-		return e.complexity.Query.ShapeUnion(childComplexity), true
+		return e.ComplexityRoot.Query.ShapeUnion(childComplexity), true
 
 	case "Query.shapes":
-		if e.complexity.Query.Shapes == nil {
+		if e.ComplexityRoot.Query.Shapes == nil {
 			break
 		}
 
-		return e.complexity.Query.Shapes(childComplexity), true
+		return e.ComplexityRoot.Query.Shapes(childComplexity), true
 
 	case "Query.skipInclude":
-		if e.complexity.Query.SkipInclude == nil {
+		if e.ComplexityRoot.Query.SkipInclude == nil {
 			break
 		}
 
-		return e.complexity.Query.SkipInclude(childComplexity), true
+		return e.ComplexityRoot.Query.SkipInclude(childComplexity), true
 
 	case "Query.slices":
-		if e.complexity.Query.Slices == nil {
+		if e.ComplexityRoot.Query.Slices == nil {
 			break
 		}
 
-		return e.complexity.Query.Slices(childComplexity), true
+		return e.ComplexityRoot.Query.Slices(childComplexity), true
 
 	case "Query.stringFromContextFunction":
-		if e.complexity.Query.StringFromContextFunction == nil {
+		if e.ComplexityRoot.Query.StringFromContextFunction == nil {
 			break
 		}
 
-		return e.complexity.Query.StringFromContextFunction(childComplexity), true
+		return e.ComplexityRoot.Query.StringFromContextFunction(childComplexity), true
 
 	case "Query.stringFromContextInterface":
-		if e.complexity.Query.StringFromContextInterface == nil {
+		if e.ComplexityRoot.Query.StringFromContextInterface == nil {
 			break
 		}
 
-		return e.complexity.Query.StringFromContextInterface(childComplexity), true
+		return e.ComplexityRoot.Query.StringFromContextInterface(childComplexity), true
 
 	case "Query.user":
-		if e.complexity.Query.User == nil {
+		if e.ComplexityRoot.Query.User == nil {
 			break
 		}
 
@@ -1929,157 +1919,157 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.User(childComplexity, args["id"].(int)), true
+		return e.ComplexityRoot.Query.User(childComplexity, args["id"].(int)), true
 
 	case "Query.vOkCaseNil":
-		if e.complexity.Query.VOkCaseNil == nil {
+		if e.ComplexityRoot.Query.VOkCaseNil == nil {
 			break
 		}
 
-		return e.complexity.Query.VOkCaseNil(childComplexity), true
+		return e.ComplexityRoot.Query.VOkCaseNil(childComplexity), true
 
 	case "Query.vOkCaseValue":
-		if e.complexity.Query.VOkCaseValue == nil {
+		if e.ComplexityRoot.Query.VOkCaseValue == nil {
 			break
 		}
 
-		return e.complexity.Query.VOkCaseValue(childComplexity), true
+		return e.ComplexityRoot.Query.VOkCaseValue(childComplexity), true
 
 	case "Query.valid":
-		if e.complexity.Query.Valid == nil {
+		if e.ComplexityRoot.Query.Valid == nil {
 			break
 		}
 
-		return e.complexity.Query.Valid(childComplexity), true
+		return e.ComplexityRoot.Query.Valid(childComplexity), true
 
 	case "Query.validType":
-		if e.complexity.Query.ValidType == nil {
+		if e.ComplexityRoot.Query.ValidType == nil {
 			break
 		}
 
-		return e.complexity.Query.ValidType(childComplexity), true
+		return e.ComplexityRoot.Query.ValidType(childComplexity), true
 
 	case "Query.variadicModel":
-		if e.complexity.Query.VariadicModel == nil {
+		if e.ComplexityRoot.Query.VariadicModel == nil {
 			break
 		}
 
-		return e.complexity.Query.VariadicModel(childComplexity), true
+		return e.ComplexityRoot.Query.VariadicModel(childComplexity), true
 
 	case "Query.wrappedMap":
-		if e.complexity.Query.WrappedMap == nil {
+		if e.ComplexityRoot.Query.WrappedMap == nil {
 			break
 		}
 
-		return e.complexity.Query.WrappedMap(childComplexity), true
+		return e.ComplexityRoot.Query.WrappedMap(childComplexity), true
 
 	case "Query.wrappedScalar":
-		if e.complexity.Query.WrappedScalar == nil {
+		if e.ComplexityRoot.Query.WrappedScalar == nil {
 			break
 		}
 
-		return e.complexity.Query.WrappedScalar(childComplexity), true
+		return e.ComplexityRoot.Query.WrappedScalar(childComplexity), true
 
 	case "Query.wrappedSlice":
-		if e.complexity.Query.WrappedSlice == nil {
+		if e.ComplexityRoot.Query.WrappedSlice == nil {
 			break
 		}
 
-		return e.complexity.Query.WrappedSlice(childComplexity), true
+		return e.ComplexityRoot.Query.WrappedSlice(childComplexity), true
 
 	case "Query.wrappedStruct":
-		if e.complexity.Query.WrappedStruct == nil {
+		if e.ComplexityRoot.Query.WrappedStruct == nil {
 			break
 		}
 
-		return e.complexity.Query.WrappedStruct(childComplexity), true
+		return e.ComplexityRoot.Query.WrappedStruct(childComplexity), true
 
 	case "Rectangle.area":
-		if e.complexity.Rectangle.Area == nil {
+		if e.ComplexityRoot.Rectangle.Area == nil {
 			break
 		}
 
-		return e.complexity.Rectangle.Area(childComplexity), true
+		return e.ComplexityRoot.Rectangle.Area(childComplexity), true
 
 	case "Rectangle.coordinates":
-		if e.complexity.Rectangle.Coordinates == nil {
+		if e.ComplexityRoot.Rectangle.Coordinates == nil {
 			break
 		}
 
-		return e.complexity.Rectangle.Coordinates(childComplexity), true
+		return e.ComplexityRoot.Rectangle.Coordinates(childComplexity), true
 
 	case "Rectangle.length":
-		if e.complexity.Rectangle.Length == nil {
+		if e.ComplexityRoot.Rectangle.Length == nil {
 			break
 		}
 
-		return e.complexity.Rectangle.Length(childComplexity), true
+		return e.ComplexityRoot.Rectangle.Length(childComplexity), true
 
 	case "Rectangle.width":
-		if e.complexity.Rectangle.Width == nil {
+		if e.ComplexityRoot.Rectangle.Width == nil {
 			break
 		}
 
-		return e.complexity.Rectangle.Width(childComplexity), true
+		return e.ComplexityRoot.Rectangle.Width(childComplexity), true
 
 	case "Size.height":
-		if e.complexity.Size.Height == nil {
+		if e.ComplexityRoot.Size.Height == nil {
 			break
 		}
 
-		return e.complexity.Size.Height(childComplexity), true
+		return e.ComplexityRoot.Size.Height(childComplexity), true
 
 	case "Size.weight":
-		if e.complexity.Size.Weight == nil {
+		if e.ComplexityRoot.Size.Weight == nil {
 			break
 		}
 
-		return e.complexity.Size.Weight(childComplexity), true
+		return e.ComplexityRoot.Size.Weight(childComplexity), true
 
 	case "SkipIncludeTestType.a":
-		if e.complexity.SkipIncludeTestType.A == nil {
+		if e.ComplexityRoot.SkipIncludeTestType.A == nil {
 			break
 		}
 
-		return e.complexity.SkipIncludeTestType.A(childComplexity), true
+		return e.ComplexityRoot.SkipIncludeTestType.A(childComplexity), true
 
 	case "SkipIncludeTestType.b":
-		if e.complexity.SkipIncludeTestType.B == nil {
+		if e.ComplexityRoot.SkipIncludeTestType.B == nil {
 			break
 		}
 
-		return e.complexity.SkipIncludeTestType.B(childComplexity), true
+		return e.ComplexityRoot.SkipIncludeTestType.B(childComplexity), true
 
 	case "Slices.test1":
-		if e.complexity.Slices.Test1 == nil {
+		if e.ComplexityRoot.Slices.Test1 == nil {
 			break
 		}
 
-		return e.complexity.Slices.Test1(childComplexity), true
+		return e.ComplexityRoot.Slices.Test1(childComplexity), true
 
 	case "Slices.test2":
-		if e.complexity.Slices.Test2 == nil {
+		if e.ComplexityRoot.Slices.Test2 == nil {
 			break
 		}
 
-		return e.complexity.Slices.Test2(childComplexity), true
+		return e.ComplexityRoot.Slices.Test2(childComplexity), true
 
 	case "Slices.test3":
-		if e.complexity.Slices.Test3 == nil {
+		if e.ComplexityRoot.Slices.Test3 == nil {
 			break
 		}
 
-		return e.complexity.Slices.Test3(childComplexity), true
+		return e.ComplexityRoot.Slices.Test3(childComplexity), true
 
 	case "Slices.test4":
-		if e.complexity.Slices.Test4 == nil {
+		if e.ComplexityRoot.Slices.Test4 == nil {
 			break
 		}
 
-		return e.complexity.Slices.Test4(childComplexity), true
+		return e.ComplexityRoot.Slices.Test4(childComplexity), true
 
 	case "Subscription.directiveArg":
-		if e.complexity.Subscription.DirectiveArg == nil {
+		if e.ComplexityRoot.Subscription.DirectiveArg == nil {
 			break
 		}
 
@@ -2088,17 +2078,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Subscription.DirectiveArg(childComplexity, args["arg"].(string)), true
+		return e.ComplexityRoot.Subscription.DirectiveArg(childComplexity, args["arg"].(string)), true
 
 	case "Subscription.directiveDouble":
-		if e.complexity.Subscription.DirectiveDouble == nil {
+		if e.ComplexityRoot.Subscription.DirectiveDouble == nil {
 			break
 		}
 
-		return e.complexity.Subscription.DirectiveDouble(childComplexity), true
+		return e.ComplexityRoot.Subscription.DirectiveDouble(childComplexity), true
 
 	case "Subscription.directiveNullableArg":
-		if e.complexity.Subscription.DirectiveNullableArg == nil {
+		if e.ComplexityRoot.Subscription.DirectiveNullableArg == nil {
 			break
 		}
 
@@ -2107,66 +2097,66 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Subscription.DirectiveNullableArg(childComplexity, args["arg"].(*int), args["arg2"].(*int), args["arg3"].(*string)), true
+		return e.ComplexityRoot.Subscription.DirectiveNullableArg(childComplexity, args["arg"].(*int), args["arg2"].(*int), args["arg3"].(*string)), true
 
 	case "Subscription.directiveUnimplemented":
-		if e.complexity.Subscription.DirectiveUnimplemented == nil {
+		if e.ComplexityRoot.Subscription.DirectiveUnimplemented == nil {
 			break
 		}
 
-		return e.complexity.Subscription.DirectiveUnimplemented(childComplexity), true
+		return e.ComplexityRoot.Subscription.DirectiveUnimplemented(childComplexity), true
 
 	case "Subscription.errorRequired":
-		if e.complexity.Subscription.ErrorRequired == nil {
+		if e.ComplexityRoot.Subscription.ErrorRequired == nil {
 			break
 		}
 
-		return e.complexity.Subscription.ErrorRequired(childComplexity), true
+		return e.ComplexityRoot.Subscription.ErrorRequired(childComplexity), true
 
 	case "Subscription.initPayload":
-		if e.complexity.Subscription.InitPayload == nil {
+		if e.ComplexityRoot.Subscription.InitPayload == nil {
 			break
 		}
 
-		return e.complexity.Subscription.InitPayload(childComplexity), true
+		return e.ComplexityRoot.Subscription.InitPayload(childComplexity), true
 
 	case "Subscription.issue896b":
-		if e.complexity.Subscription.Issue896b == nil {
+		if e.ComplexityRoot.Subscription.Issue896b == nil {
 			break
 		}
 
-		return e.complexity.Subscription.Issue896b(childComplexity), true
+		return e.ComplexityRoot.Subscription.Issue896b(childComplexity), true
 
 	case "Subscription.updated":
-		if e.complexity.Subscription.Updated == nil {
+		if e.ComplexityRoot.Subscription.Updated == nil {
 			break
 		}
 
-		return e.complexity.Subscription.Updated(childComplexity), true
+		return e.ComplexityRoot.Subscription.Updated(childComplexity), true
 
 	case "User.created":
-		if e.complexity.User.Created == nil {
+		if e.ComplexityRoot.User.Created == nil {
 			break
 		}
 
-		return e.complexity.User.Created(childComplexity), true
+		return e.ComplexityRoot.User.Created(childComplexity), true
 
 	case "User.friends":
-		if e.complexity.User.Friends == nil {
+		if e.ComplexityRoot.User.Friends == nil {
 			break
 		}
 
-		return e.complexity.User.Friends(childComplexity), true
+		return e.ComplexityRoot.User.Friends(childComplexity), true
 
 	case "User.id":
-		if e.complexity.User.ID == nil {
+		if e.ComplexityRoot.User.ID == nil {
 			break
 		}
 
-		return e.complexity.User.ID(childComplexity), true
+		return e.ComplexityRoot.User.ID(childComplexity), true
 
 	case "User.pets":
-		if e.complexity.User.Pets == nil {
+		if e.ComplexityRoot.User.Pets == nil {
 			break
 		}
 
@@ -2175,45 +2165,45 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.User.Pets(childComplexity, args["limit"].(*int)), true
+		return e.ComplexityRoot.User.Pets(childComplexity, args["limit"].(*int)), true
 
 	case "User.updated":
-		if e.complexity.User.Updated == nil {
+		if e.ComplexityRoot.User.Updated == nil {
 			break
 		}
 
-		return e.complexity.User.Updated(childComplexity), true
+		return e.ComplexityRoot.User.Updated(childComplexity), true
 
 	case "VOkCaseNil.value":
-		if e.complexity.VOkCaseNil.Value == nil {
+		if e.ComplexityRoot.VOkCaseNil.Value == nil {
 			break
 		}
 
-		return e.complexity.VOkCaseNil.Value(childComplexity), true
+		return e.ComplexityRoot.VOkCaseNil.Value(childComplexity), true
 
 	case "VOkCaseValue.value":
-		if e.complexity.VOkCaseValue.Value == nil {
+		if e.ComplexityRoot.VOkCaseValue.Value == nil {
 			break
 		}
 
-		return e.complexity.VOkCaseValue.Value(childComplexity), true
+		return e.ComplexityRoot.VOkCaseValue.Value(childComplexity), true
 
 	case "ValidType.differentCase":
-		if e.complexity.ValidType.DifferentCase == nil {
+		if e.ComplexityRoot.ValidType.DifferentCase == nil {
 			break
 		}
 
-		return e.complexity.ValidType.DifferentCase(childComplexity), true
+		return e.ComplexityRoot.ValidType.DifferentCase(childComplexity), true
 
 	case "ValidType.different_case":
-		if e.complexity.ValidType.DifferentCaseOld == nil {
+		if e.ComplexityRoot.ValidType.DifferentCaseOld == nil {
 			break
 		}
 
-		return e.complexity.ValidType.DifferentCaseOld(childComplexity), true
+		return e.ComplexityRoot.ValidType.DifferentCaseOld(childComplexity), true
 
 	case "ValidType.validArgs":
-		if e.complexity.ValidType.ValidArgs == nil {
+		if e.ComplexityRoot.ValidType.ValidArgs == nil {
 			break
 		}
 
@@ -2222,10 +2212,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.ValidType.ValidArgs(childComplexity, args["break"].(string), args["default"].(string), args["func"].(string), args["interface"].(string), args["select"].(string), args["case"].(string), args["defer"].(string), args["go"].(string), args["map"].(string), args["struct"].(string), args["chan"].(string), args["else"].(string), args["goto"].(string), args["package"].(string), args["switch"].(string), args["const"].(string), args["fallthrough"].(string), args["if"].(string), args["range"].(string), args["type"].(string), args["continue"].(string), args["for"].(string), args["import"].(string), args["return"].(string), args["var"].(string), args["_"].(string)), true
+		return e.ComplexityRoot.ValidType.ValidArgs(childComplexity, args["break"].(string), args["default"].(string), args["func"].(string), args["interface"].(string), args["select"].(string), args["case"].(string), args["defer"].(string), args["go"].(string), args["map"].(string), args["struct"].(string), args["chan"].(string), args["else"].(string), args["goto"].(string), args["package"].(string), args["switch"].(string), args["const"].(string), args["fallthrough"].(string), args["if"].(string), args["range"].(string), args["type"].(string), args["continue"].(string), args["for"].(string), args["import"].(string), args["return"].(string), args["var"].(string), args["_"].(string)), true
 
 	case "ValidType.validInputKeywords":
-		if e.complexity.ValidType.ValidInputKeywords == nil {
+		if e.ComplexityRoot.ValidType.ValidInputKeywords == nil {
 			break
 		}
 
@@ -2234,10 +2224,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.ValidType.ValidInputKeywords(childComplexity, args["input"].(*ValidInput)), true
+		return e.ComplexityRoot.ValidType.ValidInputKeywords(childComplexity, args["input"].(*ValidInput)), true
 
 	case "VariadicModel.value":
-		if e.complexity.VariadicModel.Value == nil {
+		if e.ComplexityRoot.VariadicModel.Value == nil {
 			break
 		}
 
@@ -2246,10 +2236,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.VariadicModel.Value(childComplexity, args["rank"].(int)), true
+		return e.ComplexityRoot.VariadicModel.Value(childComplexity, args["rank"].(int)), true
 
 	case "WrappedMap.get":
-		if e.complexity.WrappedMap.Get == nil {
+		if e.ComplexityRoot.WrappedMap.Get == nil {
 			break
 		}
 
@@ -2258,10 +2248,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.WrappedMap.Get(childComplexity, args["key"].(string)), true
+		return e.ComplexityRoot.WrappedMap.Get(childComplexity, args["key"].(string)), true
 
 	case "WrappedSlice.get":
-		if e.complexity.WrappedSlice.Get == nil {
+		if e.ComplexityRoot.WrappedSlice.Get == nil {
 			break
 		}
 
@@ -2270,49 +2260,49 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.WrappedSlice.Get(childComplexity, args["idx"].(int)), true
+		return e.ComplexityRoot.WrappedSlice.Get(childComplexity, args["idx"].(int)), true
 
 	case "WrappedStruct.desc":
-		if e.complexity.WrappedStruct.Desc == nil {
+		if e.ComplexityRoot.WrappedStruct.Desc == nil {
 			break
 		}
 
-		return e.complexity.WrappedStruct.Desc(childComplexity), true
+		return e.ComplexityRoot.WrappedStruct.Desc(childComplexity), true
 
 	case "WrappedStruct.name":
-		if e.complexity.WrappedStruct.Name == nil {
+		if e.ComplexityRoot.WrappedStruct.Name == nil {
 			break
 		}
 
-		return e.complexity.WrappedStruct.Name(childComplexity), true
+		return e.ComplexityRoot.WrappedStruct.Name(childComplexity), true
 
 	case "XXIt.id":
-		if e.complexity.XXIt.ID == nil {
+		if e.ComplexityRoot.XXIt.ID == nil {
 			break
 		}
 
-		return e.complexity.XXIt.ID(childComplexity), true
+		return e.ComplexityRoot.XXIt.ID(childComplexity), true
 
 	case "XxIt.id":
-		if e.complexity.XxIt.ID == nil {
+		if e.ComplexityRoot.XxIt.ID == nil {
 			break
 		}
 
-		return e.complexity.XxIt.ID(childComplexity), true
+		return e.ComplexityRoot.XxIt.ID(childComplexity), true
 
 	case "asdfIt.id":
-		if e.complexity.AsdfIt.ID == nil {
+		if e.ComplexityRoot.AsdfIt.ID == nil {
 			break
 		}
 
-		return e.complexity.AsdfIt.ID(childComplexity), true
+		return e.ComplexityRoot.AsdfIt.ID(childComplexity), true
 
 	case "iIt.id":
-		if e.complexity.IIt.ID == nil {
+		if e.ComplexityRoot.IIt.ID == nil {
 			break
 		}
 
-		return e.complexity.IIt.ID(childComplexity), true
+		return e.ComplexityRoot.IIt.ID(childComplexity), true
 
 	}
 	return 0, false

--- a/codegen/testserver/followschema/schema.generated.go
+++ b/codegen/testserver/followschema/schema.generated.go
@@ -246,11 +246,11 @@ func (ec *executionContext) field_Query_directiveArg_argsArg(
 			var zeroVal string
 			return zeroVal, err
 		}
-		if ec.directives.Length == nil {
+		if ec.Directives.Length == nil {
 			var zeroVal string
 			return zeroVal, errors.New("directive length is not implemented")
 		}
-		return ec.directives.Length(ctx, rawArgs, directive0, min, max, message)
+		return ec.Directives.Length(ctx, rawArgs, directive0, min, max, message)
 	}
 
 	tmp, err := directive1(ctx)
@@ -320,11 +320,11 @@ func (ec *executionContext) field_Query_directiveInputType_argsArg(
 	}
 
 	directive1 := func(ctx context.Context) (any, error) {
-		if ec.directives.Custom == nil {
+		if ec.Directives.Custom == nil {
 			var zeroVal InnerInput
 			return zeroVal, errors.New("directive custom is not implemented")
 		}
-		return ec.directives.Custom(ctx, rawArgs, directive0)
+		return ec.Directives.Custom(ctx, rawArgs, directive0)
 	}
 
 	tmp, err := directive1(ctx)
@@ -400,11 +400,11 @@ func (ec *executionContext) field_Query_directiveNullableArg_argsArg(
 			var zeroVal *int
 			return zeroVal, err
 		}
-		if ec.directives.Range == nil {
+		if ec.Directives.Range == nil {
 			var zeroVal *int
 			return zeroVal, errors.New("directive range is not implemented")
 		}
-		return ec.directives.Range(ctx, rawArgs, directive0, min, nil)
+		return ec.Directives.Range(ctx, rawArgs, directive0, min, nil)
 	}
 
 	tmp, err := directive1(ctx)
@@ -448,11 +448,11 @@ func (ec *executionContext) field_Query_directiveNullableArg_argsArg2(
 			var zeroVal *int
 			return zeroVal, err
 		}
-		if ec.directives.Range == nil {
+		if ec.Directives.Range == nil {
 			var zeroVal *int
 			return zeroVal, errors.New("directive range is not implemented")
 		}
-		return ec.directives.Range(ctx, rawArgs, directive0, min, nil)
+		return ec.Directives.Range(ctx, rawArgs, directive0, min, nil)
 	}
 
 	tmp, err := directive1(ctx)
@@ -491,11 +491,11 @@ func (ec *executionContext) field_Query_directiveNullableArg_argsArg3(
 	}
 
 	directive1 := func(ctx context.Context) (any, error) {
-		if ec.directives.ToNull == nil {
+		if ec.Directives.ToNull == nil {
 			var zeroVal *string
 			return zeroVal, errors.New("directive toNull is not implemented")
 		}
-		return ec.directives.ToNull(ctx, rawArgs, directive0)
+		return ec.Directives.ToNull(ctx, rawArgs, directive0)
 	}
 
 	tmp, err := directive1(ctx)
@@ -551,18 +551,18 @@ func (ec *executionContext) field_Query_directiveSingleNullableArg_argsArg1(
 			var zeroVal *string
 			return zeroVal, err
 		}
-		if ec.directives.Populate == nil {
+		if ec.Directives.Populate == nil {
 			var zeroVal *string
 			return zeroVal, errors.New("directive populate is not implemented")
 		}
-		return ec.directives.Populate(ctx, rawArgs, directive0, value)
+		return ec.Directives.Populate(ctx, rawArgs, directive0, value)
 	}
 	directive2 := func(ctx context.Context) (any, error) {
-		if ec.directives.Noop == nil {
+		if ec.Directives.Noop == nil {
 			var zeroVal *string
 			return zeroVal, errors.New("directive noop is not implemented")
 		}
-		return ec.directives.Noop(ctx, rawArgs, directive1)
+		return ec.Directives.Noop(ctx, rawArgs, directive1)
 	}
 
 	tmp, err := directive2(ctx)
@@ -950,11 +950,11 @@ func (ec *executionContext) field_Subscription_directiveArg_argsArg(
 			var zeroVal string
 			return zeroVal, err
 		}
-		if ec.directives.Length == nil {
+		if ec.Directives.Length == nil {
 			var zeroVal string
 			return zeroVal, errors.New("directive length is not implemented")
 		}
-		return ec.directives.Length(ctx, rawArgs, directive0, min, max, message)
+		return ec.Directives.Length(ctx, rawArgs, directive0, min, max, message)
 	}
 
 	tmp, err := directive1(ctx)
@@ -1019,11 +1019,11 @@ func (ec *executionContext) field_Subscription_directiveNullableArg_argsArg(
 			var zeroVal *int
 			return zeroVal, err
 		}
-		if ec.directives.Range == nil {
+		if ec.Directives.Range == nil {
 			var zeroVal *int
 			return zeroVal, errors.New("directive range is not implemented")
 		}
-		return ec.directives.Range(ctx, rawArgs, directive0, min, nil)
+		return ec.Directives.Range(ctx, rawArgs, directive0, min, nil)
 	}
 
 	tmp, err := directive1(ctx)
@@ -1067,11 +1067,11 @@ func (ec *executionContext) field_Subscription_directiveNullableArg_argsArg2(
 			var zeroVal *int
 			return zeroVal, err
 		}
-		if ec.directives.Range == nil {
+		if ec.Directives.Range == nil {
 			var zeroVal *int
 			return zeroVal, errors.New("directive range is not implemented")
 		}
-		return ec.directives.Range(ctx, rawArgs, directive0, min, nil)
+		return ec.Directives.Range(ctx, rawArgs, directive0, min, nil)
 	}
 
 	tmp, err := directive1(ctx)
@@ -1110,11 +1110,11 @@ func (ec *executionContext) field_Subscription_directiveNullableArg_argsArg3(
 	}
 
 	directive1 := func(ctx context.Context) (any, error) {
-		if ec.directives.ToNull == nil {
+		if ec.Directives.ToNull == nil {
 			var zeroVal *string
 			return zeroVal, errors.New("directive toNull is not implemented")
 		}
-		return ec.directives.ToNull(ctx, rawArgs, directive0)
+		return ec.Directives.ToNull(ctx, rawArgs, directive0)
 	}
 
 	tmp, err := directive1(ctx)
@@ -1376,7 +1376,7 @@ func (ec *executionContext) _ForcedResolver_field(ctx context.Context, field gra
 		field,
 		ec.fieldContext_ForcedResolver_field,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.ForcedResolver().Field(ctx, obj)
+			return ec.Resolvers.ForcedResolver().Field(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -1508,7 +1508,7 @@ func (ec *executionContext) _ModelMethods_resolverField(ctx context.Context, fie
 		field,
 		ec.fieldContext_ModelMethods_resolverField,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.ModelMethods().ResolverField(ctx, obj)
+			return ec.Resolvers.ModelMethods().ResolverField(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -1668,7 +1668,7 @@ func (ec *executionContext) _Pet_friends(ctx context.Context, field graphql.Coll
 		ec.fieldContext_Pet_friends,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Pet().Friends(ctx, obj, fc.Args["limit"].(*int))
+			return ec.Resolvers.Pet().Friends(ctx, obj, fc.Args["limit"].(*int))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -1716,7 +1716,7 @@ func (ec *executionContext) _Query_invalidIdentifier(ctx context.Context, field 
 		field,
 		ec.fieldContext_Query_invalidIdentifier,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().InvalidIdentifier(ctx)
+			return ec.Resolvers.Query().InvalidIdentifier(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -1751,7 +1751,7 @@ func (ec *executionContext) _Query_collision(ctx context.Context, field graphql.
 		field,
 		ec.fieldContext_Query_collision,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Collision(ctx)
+			return ec.Resolvers.Query().Collision(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -1787,7 +1787,7 @@ func (ec *executionContext) _Query_mapInput(ctx context.Context, field graphql.C
 		ec.fieldContext_Query_mapInput,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().MapInput(ctx, fc.Args["input"].(map[string]any))
+			return ec.Resolvers.Query().MapInput(ctx, fc.Args["input"].(map[string]any))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -1830,7 +1830,7 @@ func (ec *executionContext) _Query_recursive(ctx context.Context, field graphql.
 		ec.fieldContext_Query_recursive,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Recursive(ctx, fc.Args["input"].(*RecursiveInputSlice))
+			return ec.Resolvers.Query().Recursive(ctx, fc.Args["input"].(*RecursiveInputSlice))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -1873,7 +1873,7 @@ func (ec *executionContext) _Query_nestedInputs(ctx context.Context, field graph
 		ec.fieldContext_Query_nestedInputs,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().NestedInputs(ctx, fc.Args["input"].([][]*OuterInput))
+			return ec.Resolvers.Query().NestedInputs(ctx, fc.Args["input"].([][]*OuterInput))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -1915,7 +1915,7 @@ func (ec *executionContext) _Query_nestedOutputs(ctx context.Context, field grap
 		field,
 		ec.fieldContext_Query_nestedOutputs,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().NestedOutputs(ctx)
+			return ec.Resolvers.Query().NestedOutputs(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -1950,7 +1950,7 @@ func (ec *executionContext) _Query_modelMethods(ctx context.Context, field graph
 		field,
 		ec.fieldContext_Query_modelMethods,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().ModelMethods(ctx)
+			return ec.Resolvers.Query().ModelMethods(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -1990,7 +1990,7 @@ func (ec *executionContext) _Query_user(ctx context.Context, field graphql.Colle
 		ec.fieldContext_Query_user,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().User(ctx, fc.Args["id"].(int))
+			return ec.Resolvers.Query().User(ctx, fc.Args["id"].(int))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2045,7 +2045,7 @@ func (ec *executionContext) _Query_nullableArg(ctx context.Context, field graphq
 		ec.fieldContext_Query_nullableArg,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().NullableArg(ctx, fc.Args["arg"].(*int))
+			return ec.Resolvers.Query().NullableArg(ctx, fc.Args["arg"].(*int))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2088,7 +2088,7 @@ func (ec *executionContext) _Query_inputSlice(ctx context.Context, field graphql
 		ec.fieldContext_Query_inputSlice,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().InputSlice(ctx, fc.Args["arg"].([]string))
+			return ec.Resolvers.Query().InputSlice(ctx, fc.Args["arg"].([]string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2131,7 +2131,7 @@ func (ec *executionContext) _Query_inputNullableSlice(ctx context.Context, field
 		ec.fieldContext_Query_inputNullableSlice,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().InputNullableSlice(ctx, fc.Args["arg"].([]string))
+			return ec.Resolvers.Query().InputNullableSlice(ctx, fc.Args["arg"].([]string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2174,7 +2174,7 @@ func (ec *executionContext) _Query_inputOmittable(ctx context.Context, field gra
 		ec.fieldContext_Query_inputOmittable,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().InputOmittable(ctx, fc.Args["arg"].(OmittableInput))
+			return ec.Resolvers.Query().InputOmittable(ctx, fc.Args["arg"].(OmittableInput))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2216,7 +2216,7 @@ func (ec *executionContext) _Query_shapeUnion(ctx context.Context, field graphql
 		field,
 		ec.fieldContext_Query_shapeUnion,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().ShapeUnion(ctx)
+			return ec.Resolvers.Query().ShapeUnion(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2247,7 +2247,7 @@ func (ec *executionContext) _Query_autobind(ctx context.Context, field graphql.C
 		field,
 		ec.fieldContext_Query_autobind,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Autobind(ctx)
+			return ec.Resolvers.Query().Autobind(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2290,7 +2290,7 @@ func (ec *executionContext) _Query_deprecatedField(ctx context.Context, field gr
 		field,
 		ec.fieldContext_Query_deprecatedField,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().DeprecatedField(ctx)
+			return ec.Resolvers.Query().DeprecatedField(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2322,7 +2322,7 @@ func (ec *executionContext) _Query_fieldWithDeprecatedArg(ctx context.Context, f
 		ec.fieldContext_Query_fieldWithDeprecatedArg,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().FieldWithDeprecatedArg(ctx, fc.Args["oldArg"].(*int), fc.Args["newArg"].(*int))
+			return ec.Resolvers.Query().FieldWithDeprecatedArg(ctx, fc.Args["oldArg"].(*int), fc.Args["newArg"].(*int))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2364,7 +2364,7 @@ func (ec *executionContext) _Query_overlapping(ctx context.Context, field graphq
 		field,
 		ec.fieldContext_Query_overlapping,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Overlapping(ctx)
+			return ec.Resolvers.Query().Overlapping(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2408,7 +2408,7 @@ func (ec *executionContext) _Query_defaultParameters(ctx context.Context, field 
 		ec.fieldContext_Query_defaultParameters,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().DefaultParameters(ctx, fc.Args["falsyBoolean"].(*bool), fc.Args["truthyBoolean"].(*bool))
+			return ec.Resolvers.Query().DefaultParameters(ctx, fc.Args["falsyBoolean"].(*bool), fc.Args["truthyBoolean"].(*bool))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2456,7 +2456,7 @@ func (ec *executionContext) _Query_deferSingle(ctx context.Context, field graphq
 		field,
 		ec.fieldContext_Query_deferSingle,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().DeferSingle(ctx)
+			return ec.Resolvers.Query().DeferSingle(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2495,7 +2495,7 @@ func (ec *executionContext) _Query_deferMultiple(ctx context.Context, field grap
 		field,
 		ec.fieldContext_Query_deferMultiple,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().DeferMultiple(ctx)
+			return ec.Resolvers.Query().DeferMultiple(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2535,7 +2535,7 @@ func (ec *executionContext) _Query_directiveArg(ctx context.Context, field graph
 		ec.fieldContext_Query_directiveArg,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().DirectiveArg(ctx, fc.Args["arg"].(string))
+			return ec.Resolvers.Query().DirectiveArg(ctx, fc.Args["arg"].(string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2578,7 +2578,7 @@ func (ec *executionContext) _Query_directiveNullableArg(ctx context.Context, fie
 		ec.fieldContext_Query_directiveNullableArg,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().DirectiveNullableArg(ctx, fc.Args["arg"].(*int), fc.Args["arg2"].(*int), fc.Args["arg3"].(*string))
+			return ec.Resolvers.Query().DirectiveNullableArg(ctx, fc.Args["arg"].(*int), fc.Args["arg2"].(*int), fc.Args["arg3"].(*string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2621,7 +2621,7 @@ func (ec *executionContext) _Query_directiveSingleNullableArg(ctx context.Contex
 		ec.fieldContext_Query_directiveSingleNullableArg,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().DirectiveSingleNullableArg(ctx, fc.Args["arg1"].(*string))
+			return ec.Resolvers.Query().DirectiveSingleNullableArg(ctx, fc.Args["arg1"].(*string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2664,7 +2664,7 @@ func (ec *executionContext) _Query_directiveInputNullable(ctx context.Context, f
 		ec.fieldContext_Query_directiveInputNullable,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().DirectiveInputNullable(ctx, fc.Args["arg"].(*InputDirectives))
+			return ec.Resolvers.Query().DirectiveInputNullable(ctx, fc.Args["arg"].(*InputDirectives))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2707,7 +2707,7 @@ func (ec *executionContext) _Query_directiveInput(ctx context.Context, field gra
 		ec.fieldContext_Query_directiveInput,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().DirectiveInput(ctx, fc.Args["arg"].(InputDirectives))
+			return ec.Resolvers.Query().DirectiveInput(ctx, fc.Args["arg"].(InputDirectives))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2750,7 +2750,7 @@ func (ec *executionContext) _Query_directiveInputType(ctx context.Context, field
 		ec.fieldContext_Query_directiveInputType,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().DirectiveInputType(ctx, fc.Args["arg"].(InnerInput))
+			return ec.Resolvers.Query().DirectiveInputType(ctx, fc.Args["arg"].(InnerInput))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2792,7 +2792,7 @@ func (ec *executionContext) _Query_directiveObject(ctx context.Context, field gr
 		field,
 		ec.fieldContext_Query_directiveObject,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().DirectiveObject(ctx)
+			return ec.Resolvers.Query().DirectiveObject(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
@@ -2803,11 +2803,11 @@ func (ec *executionContext) _Query_directiveObject(ctx context.Context, field gr
 					var zeroVal *ObjectDirectives
 					return zeroVal, err
 				}
-				if ec.directives.Order1 == nil {
+				if ec.Directives.Order1 == nil {
 					var zeroVal *ObjectDirectives
 					return zeroVal, errors.New("directive order1 is not implemented")
 				}
-				return ec.directives.Order1(ctx, nil, directive0, location)
+				return ec.Directives.Order1(ctx, nil, directive0, location)
 			}
 			directive2 := func(ctx context.Context) (any, error) {
 				location, err := ec.unmarshalNString2string(ctx, "order1_2")
@@ -2815,11 +2815,11 @@ func (ec *executionContext) _Query_directiveObject(ctx context.Context, field gr
 					var zeroVal *ObjectDirectives
 					return zeroVal, err
 				}
-				if ec.directives.Order1 == nil {
+				if ec.Directives.Order1 == nil {
 					var zeroVal *ObjectDirectives
 					return zeroVal, errors.New("directive order1 is not implemented")
 				}
-				return ec.directives.Order1(ctx, nil, directive1, location)
+				return ec.Directives.Order1(ctx, nil, directive1, location)
 			}
 			directive3 := func(ctx context.Context) (any, error) {
 				location, err := ec.unmarshalNString2string(ctx, "order2_1")
@@ -2827,11 +2827,11 @@ func (ec *executionContext) _Query_directiveObject(ctx context.Context, field gr
 					var zeroVal *ObjectDirectives
 					return zeroVal, err
 				}
-				if ec.directives.Order2 == nil {
+				if ec.Directives.Order2 == nil {
 					var zeroVal *ObjectDirectives
 					return zeroVal, errors.New("directive order2 is not implemented")
 				}
-				return ec.directives.Order2(ctx, nil, directive2, location)
+				return ec.Directives.Order2(ctx, nil, directive2, location)
 			}
 			directive4 := func(ctx context.Context) (any, error) {
 				location, err := ec.unmarshalNString2string(ctx, "Query_field")
@@ -2839,11 +2839,11 @@ func (ec *executionContext) _Query_directiveObject(ctx context.Context, field gr
 					var zeroVal *ObjectDirectives
 					return zeroVal, err
 				}
-				if ec.directives.Order1 == nil {
+				if ec.Directives.Order1 == nil {
 					var zeroVal *ObjectDirectives
 					return zeroVal, errors.New("directive order1 is not implemented")
 				}
-				return ec.directives.Order1(ctx, nil, directive3, location)
+				return ec.Directives.Order1(ctx, nil, directive3, location)
 			}
 
 			next = directive4
@@ -2883,7 +2883,7 @@ func (ec *executionContext) _Query_directiveObjectWithCustomGoModel(ctx context.
 		field,
 		ec.fieldContext_Query_directiveObjectWithCustomGoModel,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().DirectiveObjectWithCustomGoModel(ctx)
+			return ec.Resolvers.Query().DirectiveObjectWithCustomGoModel(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -2919,7 +2919,7 @@ func (ec *executionContext) _Query_directiveFieldDef(ctx context.Context, field 
 		ec.fieldContext_Query_directiveFieldDef,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().DirectiveFieldDef(ctx, fc.Args["ret"].(string))
+			return ec.Resolvers.Query().DirectiveFieldDef(ctx, fc.Args["ret"].(string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
@@ -2935,11 +2935,11 @@ func (ec *executionContext) _Query_directiveFieldDef(ctx context.Context, field 
 					var zeroVal string
 					return zeroVal, err
 				}
-				if ec.directives.Length == nil {
+				if ec.Directives.Length == nil {
 					var zeroVal string
 					return zeroVal, errors.New("directive length is not implemented")
 				}
-				return ec.directives.Length(ctx, nil, directive0, min, nil, message)
+				return ec.Directives.Length(ctx, nil, directive0, min, nil, message)
 			}
 
 			next = directive1
@@ -2982,7 +2982,7 @@ func (ec *executionContext) _Query_directiveField(ctx context.Context, field gra
 		field,
 		ec.fieldContext_Query_directiveField,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().DirectiveField(ctx)
+			return ec.Resolvers.Query().DirectiveField(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -3013,24 +3013,24 @@ func (ec *executionContext) _Query_directiveDouble(ctx context.Context, field gr
 		field,
 		ec.fieldContext_Query_directiveDouble,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().DirectiveDouble(ctx)
+			return ec.Resolvers.Query().DirectiveDouble(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.Directive1 == nil {
+				if ec.Directives.Directive1 == nil {
 					var zeroVal *string
 					return zeroVal, errors.New("directive directive1 is not implemented")
 				}
-				return ec.directives.Directive1(ctx, nil, directive0)
+				return ec.Directives.Directive1(ctx, nil, directive0)
 			}
 			directive2 := func(ctx context.Context) (any, error) {
-				if ec.directives.Directive2 == nil {
+				if ec.Directives.Directive2 == nil {
 					var zeroVal *string
 					return zeroVal, errors.New("directive directive2 is not implemented")
 				}
-				return ec.directives.Directive2(ctx, nil, directive1)
+				return ec.Directives.Directive2(ctx, nil, directive1)
 			}
 
 			next = directive2
@@ -3062,17 +3062,17 @@ func (ec *executionContext) _Query_directiveUnimplemented(ctx context.Context, f
 		field,
 		ec.fieldContext_Query_directiveUnimplemented,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().DirectiveUnimplemented(ctx)
+			return ec.Resolvers.Query().DirectiveUnimplemented(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.Unimplemented == nil {
+				if ec.Directives.Unimplemented == nil {
 					var zeroVal *string
 					return zeroVal, errors.New("directive unimplemented is not implemented")
 				}
-				return ec.directives.Unimplemented(ctx, nil, directive0)
+				return ec.Directives.Unimplemented(ctx, nil, directive0)
 			}
 
 			next = directive1
@@ -3104,7 +3104,7 @@ func (ec *executionContext) _Query_embeddedCase1(ctx context.Context, field grap
 		field,
 		ec.fieldContext_Query_embeddedCase1,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().EmbeddedCase1(ctx)
+			return ec.Resolvers.Query().EmbeddedCase1(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -3139,7 +3139,7 @@ func (ec *executionContext) _Query_embeddedCase2(ctx context.Context, field grap
 		field,
 		ec.fieldContext_Query_embeddedCase2,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().EmbeddedCase2(ctx)
+			return ec.Resolvers.Query().EmbeddedCase2(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -3174,7 +3174,7 @@ func (ec *executionContext) _Query_embeddedCase3(ctx context.Context, field grap
 		field,
 		ec.fieldContext_Query_embeddedCase3,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().EmbeddedCase3(ctx)
+			return ec.Resolvers.Query().EmbeddedCase3(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -3210,7 +3210,7 @@ func (ec *executionContext) _Query_enumInInput(ctx context.Context, field graphq
 		ec.fieldContext_Query_enumInInput,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().EnumInInput(ctx, fc.Args["input"].(*InputWithEnumValue))
+			return ec.Resolvers.Query().EnumInInput(ctx, fc.Args["input"].(*InputWithEnumValue))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -3253,7 +3253,7 @@ func (ec *executionContext) _Query_searchProducts(ctx context.Context, field gra
 		ec.fieldContext_Query_searchProducts,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().SearchProducts(ctx, map[string]interface{}{
+			return ec.Resolvers.Query().SearchProducts(ctx, map[string]interface{}{
 				"query":    fc.Args["query"].(*string),
 				"category": fc.Args["category"].(*string),
 				"minPrice": fc.Args["minPrice"].(*int),
@@ -3300,7 +3300,7 @@ func (ec *executionContext) _Query_searchRequired(ctx context.Context, field gra
 		ec.fieldContext_Query_searchRequired,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().SearchRequired(ctx, map[string]interface{}{
+			return ec.Resolvers.Query().SearchRequired(ctx, map[string]interface{}{
 				"name": fc.Args["name"].(string),
 				"age":  fc.Args["age"].(int),
 			})
@@ -3346,7 +3346,7 @@ func (ec *executionContext) _Query_searchProductsNormal(ctx context.Context, fie
 		ec.fieldContext_Query_searchProductsNormal,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().SearchProductsNormal(ctx, fc.Args["filters"].(map[string]any))
+			return ec.Resolvers.Query().SearchProductsNormal(ctx, fc.Args["filters"].(map[string]any))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -3389,7 +3389,7 @@ func (ec *executionContext) _Query_searchWithDefaults(ctx context.Context, field
 		ec.fieldContext_Query_searchWithDefaults,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().SearchWithDefaults(ctx, map[string]interface{}{
+			return ec.Resolvers.Query().SearchWithDefaults(ctx, map[string]interface{}{
 				"query":           fc.Args["query"].(*string),
 				"limit":           fc.Args["limit"].(*int),
 				"includeArchived": fc.Args["includeArchived"].(*bool),
@@ -3436,7 +3436,7 @@ func (ec *executionContext) _Query_searchMixed(ctx context.Context, field graphq
 		ec.fieldContext_Query_searchMixed,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().SearchMixed(ctx, map[string]interface{}{
+			return ec.Resolvers.Query().SearchMixed(ctx, map[string]interface{}{
 				"query":    fc.Args["query"].(*string),
 				"category": fc.Args["category"].(*string),
 				"minPrice": fc.Args["minPrice"].(*int),
@@ -3483,7 +3483,7 @@ func (ec *executionContext) _Query_filterProducts(ctx context.Context, field gra
 		ec.fieldContext_Query_filterProducts,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().FilterProducts(ctx, map[string]interface{}{
+			return ec.Resolvers.Query().FilterProducts(ctx, map[string]interface{}{
 				"query":    fc.Args["query"].(*string),
 				"category": fc.Args["category"].(*string),
 				"minPrice": fc.Args["minPrice"].(*int),
@@ -3530,7 +3530,7 @@ func (ec *executionContext) _Query_findProducts(ctx context.Context, field graph
 		ec.fieldContext_Query_findProducts,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().FindProducts(ctx, map[string]interface{}{
+			return ec.Resolvers.Query().FindProducts(ctx, map[string]interface{}{
 				"query":    fc.Args["query"].(*string),
 				"category": fc.Args["category"].(*string),
 				"minPrice": fc.Args["minPrice"].(*int),
@@ -3577,7 +3577,7 @@ func (ec *executionContext) _Query_searchWithDirectives(ctx context.Context, fie
 		ec.fieldContext_Query_searchWithDirectives,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().SearchWithDirectives(ctx, map[string]interface{}{
+			return ec.Resolvers.Query().SearchWithDirectives(ctx, map[string]interface{}{
 				"oldField": fc.Args["oldField"].(*string),
 				"newField": fc.Args["newField"].(*string),
 			})
@@ -3622,7 +3622,7 @@ func (ec *executionContext) _Query_shapes(ctx context.Context, field graphql.Col
 		field,
 		ec.fieldContext_Query_shapes,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Shapes(ctx)
+			return ec.Resolvers.Query().Shapes(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -3653,17 +3653,17 @@ func (ec *executionContext) _Query_noShape(ctx context.Context, field graphql.Co
 		field,
 		ec.fieldContext_Query_noShape,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().NoShape(ctx)
+			return ec.Resolvers.Query().NoShape(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.MakeNil == nil {
+				if ec.Directives.MakeNil == nil {
 					var zeroVal Shape
 					return zeroVal, errors.New("directive makeNil is not implemented")
 				}
-				return ec.directives.MakeNil(ctx, nil, directive0)
+				return ec.Directives.MakeNil(ctx, nil, directive0)
 			}
 
 			next = directive1
@@ -3695,7 +3695,7 @@ func (ec *executionContext) _Query_node(ctx context.Context, field graphql.Colle
 		field,
 		ec.fieldContext_Query_node,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Node(ctx)
+			return ec.Resolvers.Query().Node(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -3726,17 +3726,17 @@ func (ec *executionContext) _Query_noShapeTypedNil(ctx context.Context, field gr
 		field,
 		ec.fieldContext_Query_noShapeTypedNil,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().NoShapeTypedNil(ctx)
+			return ec.Resolvers.Query().NoShapeTypedNil(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.MakeTypedNil == nil {
+				if ec.Directives.MakeTypedNil == nil {
 					var zeroVal Shape
 					return zeroVal, errors.New("directive makeTypedNil is not implemented")
 				}
-				return ec.directives.MakeTypedNil(ctx, nil, directive0)
+				return ec.Directives.MakeTypedNil(ctx, nil, directive0)
 			}
 
 			next = directive1
@@ -3768,17 +3768,17 @@ func (ec *executionContext) _Query_animal(ctx context.Context, field graphql.Col
 		field,
 		ec.fieldContext_Query_animal,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Animal(ctx)
+			return ec.Resolvers.Query().Animal(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.MakeTypedNil == nil {
+				if ec.Directives.MakeTypedNil == nil {
 					var zeroVal Animal
 					return zeroVal, errors.New("directive makeTypedNil is not implemented")
 				}
-				return ec.directives.MakeTypedNil(ctx, nil, directive0)
+				return ec.Directives.MakeTypedNil(ctx, nil, directive0)
 			}
 
 			next = directive1
@@ -3810,7 +3810,7 @@ func (ec *executionContext) _Query_notAnInterface(ctx context.Context, field gra
 		field,
 		ec.fieldContext_Query_notAnInterface,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().NotAnInterface(ctx)
+			return ec.Resolvers.Query().NotAnInterface(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -3849,7 +3849,7 @@ func (ec *executionContext) _Query_dog(ctx context.Context, field graphql.Collec
 		field,
 		ec.fieldContext_Query_dog,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Dog(ctx)
+			return ec.Resolvers.Query().Dog(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -3888,7 +3888,7 @@ func (ec *executionContext) _Query_issue896a(ctx context.Context, field graphql.
 		field,
 		ec.fieldContext_Query_issue896a,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Issue896a(ctx)
+			return ec.Resolvers.Query().Issue896a(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -3924,7 +3924,7 @@ func (ec *executionContext) _Query_mapStringInterface(ctx context.Context, field
 		ec.fieldContext_Query_mapStringInterface,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().MapStringInterface(ctx, fc.Args["in"].(map[string]any))
+			return ec.Resolvers.Query().MapStringInterface(ctx, fc.Args["in"].(map[string]any))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -3977,7 +3977,7 @@ func (ec *executionContext) _Query_mapNestedStringInterface(ctx context.Context,
 		ec.fieldContext_Query_mapNestedStringInterface,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().MapNestedStringInterface(ctx, fc.Args["in"].(*NestedMapInput))
+			return ec.Resolvers.Query().MapNestedStringInterface(ctx, fc.Args["in"].(*NestedMapInput))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4030,7 +4030,7 @@ func (ec *executionContext) _Query_mapNestedMapSlice(ctx context.Context, field 
 		ec.fieldContext_Query_mapNestedMapSlice,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().MapNestedMapSlice(ctx, fc.Args["input"].(map[string]any))
+			return ec.Resolvers.Query().MapNestedMapSlice(ctx, fc.Args["input"].(map[string]any))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4072,7 +4072,7 @@ func (ec *executionContext) _Query_errorBubble(ctx context.Context, field graphq
 		field,
 		ec.fieldContext_Query_errorBubble,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().ErrorBubble(ctx)
+			return ec.Resolvers.Query().ErrorBubble(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4113,7 +4113,7 @@ func (ec *executionContext) _Query_errorBubbleList(ctx context.Context, field gr
 		field,
 		ec.fieldContext_Query_errorBubbleList,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().ErrorBubbleList(ctx)
+			return ec.Resolvers.Query().ErrorBubbleList(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4154,7 +4154,7 @@ func (ec *executionContext) _Query_errorList(ctx context.Context, field graphql.
 		field,
 		ec.fieldContext_Query_errorList,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().ErrorList(ctx)
+			return ec.Resolvers.Query().ErrorList(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4195,7 +4195,7 @@ func (ec *executionContext) _Query_errors(ctx context.Context, field graphql.Col
 		field,
 		ec.fieldContext_Query_errors,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Errors(ctx)
+			return ec.Resolvers.Query().Errors(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4238,7 +4238,7 @@ func (ec *executionContext) _Query_valid(ctx context.Context, field graphql.Coll
 		field,
 		ec.fieldContext_Query_valid,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Valid(ctx)
+			return ec.Resolvers.Query().Valid(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4269,7 +4269,7 @@ func (ec *executionContext) _Query_invalid(ctx context.Context, field graphql.Co
 		field,
 		ec.fieldContext_Query_invalid,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Invalid(ctx)
+			return ec.Resolvers.Query().Invalid(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4300,7 +4300,7 @@ func (ec *executionContext) _Query_panics(ctx context.Context, field graphql.Col
 		field,
 		ec.fieldContext_Query_panics,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Panics(ctx)
+			return ec.Resolvers.Query().Panics(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4339,7 +4339,7 @@ func (ec *executionContext) _Query_primitiveObject(ctx context.Context, field gr
 		field,
 		ec.fieldContext_Query_primitiveObject,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().PrimitiveObject(ctx)
+			return ec.Resolvers.Query().PrimitiveObject(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4376,7 +4376,7 @@ func (ec *executionContext) _Query_primitiveStringObject(ctx context.Context, fi
 		field,
 		ec.fieldContext_Query_primitiveStringObject,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().PrimitiveStringObject(ctx)
+			return ec.Resolvers.Query().PrimitiveStringObject(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4415,7 +4415,7 @@ func (ec *executionContext) _Query_ptrToAnyContainer(ctx context.Context, field 
 		field,
 		ec.fieldContext_Query_ptrToAnyContainer,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().PtrToAnyContainer(ctx)
+			return ec.Resolvers.Query().PtrToAnyContainer(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4452,7 +4452,7 @@ func (ec *executionContext) _Query_ptrToSliceContainer(ctx context.Context, fiel
 		field,
 		ec.fieldContext_Query_ptrToSliceContainer,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().PtrToSliceContainer(ctx)
+			return ec.Resolvers.Query().PtrToSliceContainer(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4487,7 +4487,7 @@ func (ec *executionContext) _Query_infinity(ctx context.Context, field graphql.C
 		field,
 		ec.fieldContext_Query_infinity,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Infinity(ctx)
+			return ec.Resolvers.Query().Infinity(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4518,7 +4518,7 @@ func (ec *executionContext) _Query_stringFromContextInterface(ctx context.Contex
 		field,
 		ec.fieldContext_Query_stringFromContextInterface,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().StringFromContextInterface(ctx)
+			return ec.Resolvers.Query().StringFromContextInterface(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4549,7 +4549,7 @@ func (ec *executionContext) _Query_stringFromContextFunction(ctx context.Context
 		field,
 		ec.fieldContext_Query_stringFromContextFunction,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().StringFromContextFunction(ctx)
+			return ec.Resolvers.Query().StringFromContextFunction(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4581,7 +4581,7 @@ func (ec *executionContext) _Query_defaultScalar(ctx context.Context, field grap
 		ec.fieldContext_Query_defaultScalar,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().DefaultScalar(ctx, fc.Args["arg"].(string))
+			return ec.Resolvers.Query().DefaultScalar(ctx, fc.Args["arg"].(string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4623,7 +4623,7 @@ func (ec *executionContext) _Query_skipInclude(ctx context.Context, field graphq
 		field,
 		ec.fieldContext_Query_skipInclude,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().SkipInclude(ctx)
+			return ec.Resolvers.Query().SkipInclude(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4660,7 +4660,7 @@ func (ec *executionContext) _Query_slices(ctx context.Context, field graphql.Col
 		field,
 		ec.fieldContext_Query_slices,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Slices(ctx)
+			return ec.Resolvers.Query().Slices(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4701,7 +4701,7 @@ func (ec *executionContext) _Query_scalarSlice(ctx context.Context, field graphq
 		field,
 		ec.fieldContext_Query_scalarSlice,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().ScalarSlice(ctx)
+			return ec.Resolvers.Query().ScalarSlice(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4733,7 +4733,7 @@ func (ec *executionContext) _Query_fallback(ctx context.Context, field graphql.C
 		ec.fieldContext_Query_fallback,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Fallback(ctx, fc.Args["arg"].(FallbackToStringEncoding))
+			return ec.Resolvers.Query().Fallback(ctx, fc.Args["arg"].(FallbackToStringEncoding))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4775,7 +4775,7 @@ func (ec *executionContext) _Query_optionalUnion(ctx context.Context, field grap
 		field,
 		ec.fieldContext_Query_optionalUnion,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().OptionalUnion(ctx)
+			return ec.Resolvers.Query().OptionalUnion(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4806,7 +4806,7 @@ func (ec *executionContext) _Query_vOkCaseValue(ctx context.Context, field graph
 		field,
 		ec.fieldContext_Query_vOkCaseValue,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().VOkCaseValue(ctx)
+			return ec.Resolvers.Query().VOkCaseValue(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4841,7 +4841,7 @@ func (ec *executionContext) _Query_vOkCaseNil(ctx context.Context, field graphql
 		field,
 		ec.fieldContext_Query_vOkCaseNil,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().VOkCaseNil(ctx)
+			return ec.Resolvers.Query().VOkCaseNil(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4876,7 +4876,7 @@ func (ec *executionContext) _Query_validType(ctx context.Context, field graphql.
 		field,
 		ec.fieldContext_Query_validType,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().ValidType(ctx)
+			return ec.Resolvers.Query().ValidType(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4917,7 +4917,7 @@ func (ec *executionContext) _Query_variadicModel(ctx context.Context, field grap
 		field,
 		ec.fieldContext_Query_variadicModel,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().VariadicModel(ctx)
+			return ec.Resolvers.Query().VariadicModel(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4952,7 +4952,7 @@ func (ec *executionContext) _Query_wrappedStruct(ctx context.Context, field grap
 		field,
 		ec.fieldContext_Query_wrappedStruct,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().WrappedStruct(ctx)
+			return ec.Resolvers.Query().WrappedStruct(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -4989,7 +4989,7 @@ func (ec *executionContext) _Query_wrappedScalar(ctx context.Context, field grap
 		field,
 		ec.fieldContext_Query_wrappedScalar,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().WrappedScalar(ctx)
+			return ec.Resolvers.Query().WrappedScalar(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -5020,7 +5020,7 @@ func (ec *executionContext) _Query_wrappedMap(ctx context.Context, field graphql
 		field,
 		ec.fieldContext_Query_wrappedMap,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().WrappedMap(ctx)
+			return ec.Resolvers.Query().WrappedMap(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -5055,7 +5055,7 @@ func (ec *executionContext) _Query_wrappedSlice(ctx context.Context, field graph
 		field,
 		ec.fieldContext_Query_wrappedSlice,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().WrappedSlice(ctx)
+			return ec.Resolvers.Query().WrappedSlice(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -5202,7 +5202,7 @@ func (ec *executionContext) _Subscription_updated(ctx context.Context, field gra
 		field,
 		ec.fieldContext_Subscription_updated,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Subscription().Updated(ctx)
+			return ec.Resolvers.Subscription().Updated(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -5233,7 +5233,7 @@ func (ec *executionContext) _Subscription_initPayload(ctx context.Context, field
 		field,
 		ec.fieldContext_Subscription_initPayload,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Subscription().InitPayload(ctx)
+			return ec.Resolvers.Subscription().InitPayload(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -5265,7 +5265,7 @@ func (ec *executionContext) _Subscription_directiveArg(ctx context.Context, fiel
 		ec.fieldContext_Subscription_directiveArg,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Subscription().DirectiveArg(ctx, fc.Args["arg"].(string))
+			return ec.Resolvers.Subscription().DirectiveArg(ctx, fc.Args["arg"].(string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -5308,7 +5308,7 @@ func (ec *executionContext) _Subscription_directiveNullableArg(ctx context.Conte
 		ec.fieldContext_Subscription_directiveNullableArg,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Subscription().DirectiveNullableArg(ctx, fc.Args["arg"].(*int), fc.Args["arg2"].(*int), fc.Args["arg3"].(*string))
+			return ec.Resolvers.Subscription().DirectiveNullableArg(ctx, fc.Args["arg"].(*int), fc.Args["arg2"].(*int), fc.Args["arg3"].(*string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -5350,24 +5350,24 @@ func (ec *executionContext) _Subscription_directiveDouble(ctx context.Context, f
 		field,
 		ec.fieldContext_Subscription_directiveDouble,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Subscription().DirectiveDouble(ctx)
+			return ec.Resolvers.Subscription().DirectiveDouble(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.Directive1 == nil {
+				if ec.Directives.Directive1 == nil {
 					var zeroVal *string
 					return zeroVal, errors.New("directive directive1 is not implemented")
 				}
-				return ec.directives.Directive1(ctx, nil, directive0)
+				return ec.Directives.Directive1(ctx, nil, directive0)
 			}
 			directive2 := func(ctx context.Context) (any, error) {
-				if ec.directives.Directive2 == nil {
+				if ec.Directives.Directive2 == nil {
 					var zeroVal *string
 					return zeroVal, errors.New("directive directive2 is not implemented")
 				}
-				return ec.directives.Directive2(ctx, nil, directive1)
+				return ec.Directives.Directive2(ctx, nil, directive1)
 			}
 
 			next = directive2
@@ -5399,17 +5399,17 @@ func (ec *executionContext) _Subscription_directiveUnimplemented(ctx context.Con
 		field,
 		ec.fieldContext_Subscription_directiveUnimplemented,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Subscription().DirectiveUnimplemented(ctx)
+			return ec.Resolvers.Subscription().DirectiveUnimplemented(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.Unimplemented == nil {
+				if ec.Directives.Unimplemented == nil {
 					var zeroVal *string
 					return zeroVal, errors.New("directive unimplemented is not implemented")
 				}
-				return ec.directives.Unimplemented(ctx, nil, directive0)
+				return ec.Directives.Unimplemented(ctx, nil, directive0)
 			}
 
 			next = directive1
@@ -5441,7 +5441,7 @@ func (ec *executionContext) _Subscription_issue896b(ctx context.Context, field g
 		field,
 		ec.fieldContext_Subscription_issue896b,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Subscription().Issue896b(ctx)
+			return ec.Resolvers.Subscription().Issue896b(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -5476,7 +5476,7 @@ func (ec *executionContext) _Subscription_errorRequired(ctx context.Context, fie
 		field,
 		ec.fieldContext_Subscription_errorRequired,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Subscription().ErrorRequired(ctx)
+			return ec.Resolvers.Subscription().ErrorRequired(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -5548,7 +5548,7 @@ func (ec *executionContext) _User_friends(ctx context.Context, field graphql.Col
 		field,
 		ec.fieldContext_User_friends,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.User().Friends(ctx, obj)
+			return ec.Resolvers.User().Friends(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -5654,7 +5654,7 @@ func (ec *executionContext) _User_pets(ctx context.Context, field graphql.Collec
 		ec.fieldContext_User_pets,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.User().Pets(ctx, obj, fc.Args["limit"].(*int))
+			return ec.Resolvers.User().Pets(ctx, obj, fc.Args["limit"].(*int))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)

--- a/codegen/testserver/followschema/wrapped_type.generated.go
+++ b/codegen/testserver/followschema/wrapped_type.generated.go
@@ -64,7 +64,7 @@ func (ec *executionContext) _WrappedMap_get(ctx context.Context, field graphql.C
 		ec.fieldContext_WrappedMap_get,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.WrappedMap().Get(ctx, obj, fc.Args["key"].(string))
+			return ec.Resolvers.WrappedMap().Get(ctx, obj, fc.Args["key"].(string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -107,7 +107,7 @@ func (ec *executionContext) _WrappedSlice_get(ctx context.Context, field graphql
 		ec.fieldContext_WrappedSlice_get,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.WrappedSlice().Get(ctx, obj, fc.Args["idx"].(int))
+			return ec.Resolvers.WrappedSlice().Get(ctx, obj, fc.Args["idx"].(int))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)

--- a/codegen/testserver/nullabledirectives/generated/directive.generated.go
+++ b/codegen/testserver/nullabledirectives/generated/directive.generated.go
@@ -77,18 +77,18 @@ func (ec *executionContext) field_Query_directiveSingleNullableArg_argsArg1(
 			var zeroVal *string
 			return zeroVal, err
 		}
-		if ec.directives.Populate == nil {
+		if ec.Directives.Populate == nil {
 			var zeroVal *string
 			return zeroVal, errors.New("directive populate is not implemented")
 		}
-		return ec.directives.Populate(ctx, rawArgs, directive0, value)
+		return ec.Directives.Populate(ctx, rawArgs, directive0, value)
 	}
 	directive2 := func(ctx context.Context) (any, error) {
-		if ec.directives.Noop == nil {
+		if ec.Directives.Noop == nil {
 			var zeroVal *string
 			return zeroVal, errors.New("directive noop is not implemented")
 		}
-		return ec.directives.Noop(ctx, rawArgs, directive1)
+		return ec.Directives.Noop(ctx, rawArgs, directive1)
 	}
 
 	tmp, err := directive2(ctx)
@@ -123,7 +123,7 @@ func (ec *executionContext) _Query_directiveSingleNullableArg(ctx context.Contex
 		ec.fieldContext_Query_directiveSingleNullableArg,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().DirectiveSingleNullableArg(ctx, fc.Args["arg1"].(*string))
+			return ec.Resolvers.Query().DirectiveSingleNullableArg(ctx, fc.Args["arg1"].(*string))
 		},
 		nil,
 		ec.marshalOString2ᚖstring,

--- a/codegen/testserver/nullabledirectives/generated/root_.generated.go
+++ b/codegen/testserver/nullabledirectives/generated/root_.generated.go
@@ -16,12 +16,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -41,16 +36,11 @@ type ComplexityRoot struct {
 	}
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -61,7 +51,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "Query.directiveSingleNullableArg":
-		if e.complexity.Query.DirectiveSingleNullableArg == nil {
+		if e.ComplexityRoot.Query.DirectiveSingleNullableArg == nil {
 			break
 		}
 
@@ -70,7 +60,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.DirectiveSingleNullableArg(childComplexity, args["arg1"].(*string)), true
+		return e.ComplexityRoot.Query.DirectiveSingleNullableArg(childComplexity, args["arg1"].(*string)), true
 
 	}
 	return 0, false

--- a/codegen/testserver/protogetters/generated.go
+++ b/codegen/testserver/protogetters/generated.go
@@ -23,12 +23,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -57,16 +52,11 @@ type QueryResolver interface {
 	User(ctx context.Context, id string) (*models.User, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -77,7 +67,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "Query.user":
-		if e.complexity.Query.User == nil {
+		if e.ComplexityRoot.Query.User == nil {
 			break
 		}
 
@@ -86,32 +76,32 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.User(childComplexity, args["id"].(string)), true
+		return e.ComplexityRoot.Query.User(childComplexity, args["id"].(string)), true
 
 	case "User.age":
-		if e.complexity.User.GetAge == nil {
+		if e.ComplexityRoot.User.GetAge == nil {
 			break
 		}
 
-		return e.complexity.User.GetAge(childComplexity), true
+		return e.ComplexityRoot.User.GetAge(childComplexity), true
 	case "User.email":
-		if e.complexity.User.GetEmail == nil {
+		if e.ComplexityRoot.User.GetEmail == nil {
 			break
 		}
 
-		return e.complexity.User.GetEmail(childComplexity), true
+		return e.ComplexityRoot.User.GetEmail(childComplexity), true
 	case "User.id":
-		if e.complexity.User.GetId == nil {
+		if e.ComplexityRoot.User.GetId == nil {
 			break
 		}
 
-		return e.complexity.User.GetId(childComplexity), true
+		return e.ComplexityRoot.User.GetId(childComplexity), true
 	case "User.name":
-		if e.complexity.User.GetName == nil {
+		if e.ComplexityRoot.User.GetName == nil {
 			break
 		}
 
-		return e.complexity.User.GetName(childComplexity), true
+		return e.ComplexityRoot.User.GetName(childComplexity), true
 
 	}
 	return 0, false
@@ -303,7 +293,7 @@ func (ec *executionContext) _Query_user(ctx context.Context, field graphql.Colle
 		ec.fieldContext_Query_user,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().User(ctx, fc.Args["id"].(string))
+			return ec.Resolvers.Query().User(ctx, fc.Args["id"].(string))
 		},
 		nil,
 		ec.marshalOUser2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋcodegenᚋtestserverᚋprotogettersᚋmodelsᚐUser,

--- a/codegen/testserver/singlefile/generated.go
+++ b/codegen/testserver/singlefile/generated.go
@@ -25,12 +25,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -657,16 +652,11 @@ type FieldsOrderInputResolver interface {
 	OverrideFirstField(ctx context.Context, obj *FieldsOrderInput, data *string) error
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -677,463 +667,463 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "A.id":
-		if e.complexity.A.ID == nil {
+		if e.ComplexityRoot.A.ID == nil {
 			break
 		}
 
-		return e.complexity.A.ID(childComplexity), true
+		return e.ComplexityRoot.A.ID(childComplexity), true
 
 	case "AIt.id":
-		if e.complexity.AIt.ID == nil {
+		if e.ComplexityRoot.AIt.ID == nil {
 			break
 		}
 
-		return e.complexity.AIt.ID(childComplexity), true
+		return e.ComplexityRoot.AIt.ID(childComplexity), true
 
 	case "AbIt.id":
-		if e.complexity.AbIt.ID == nil {
+		if e.ComplexityRoot.AbIt.ID == nil {
 			break
 		}
 
-		return e.complexity.AbIt.ID(childComplexity), true
+		return e.ComplexityRoot.AbIt.ID(childComplexity), true
 
 	case "Autobind.idInt":
-		if e.complexity.Autobind.IdInt == nil {
+		if e.ComplexityRoot.Autobind.IdInt == nil {
 			break
 		}
 
-		return e.complexity.Autobind.IdInt(childComplexity), true
+		return e.ComplexityRoot.Autobind.IdInt(childComplexity), true
 	case "Autobind.idStr":
-		if e.complexity.Autobind.IdStr == nil {
+		if e.ComplexityRoot.Autobind.IdStr == nil {
 			break
 		}
 
-		return e.complexity.Autobind.IdStr(childComplexity), true
+		return e.ComplexityRoot.Autobind.IdStr(childComplexity), true
 	case "Autobind.int":
-		if e.complexity.Autobind.Int == nil {
+		if e.ComplexityRoot.Autobind.Int == nil {
 			break
 		}
 
-		return e.complexity.Autobind.Int(childComplexity), true
+		return e.ComplexityRoot.Autobind.Int(childComplexity), true
 	case "Autobind.int32":
-		if e.complexity.Autobind.Int32 == nil {
+		if e.ComplexityRoot.Autobind.Int32 == nil {
 			break
 		}
 
-		return e.complexity.Autobind.Int32(childComplexity), true
+		return e.ComplexityRoot.Autobind.Int32(childComplexity), true
 	case "Autobind.int64":
-		if e.complexity.Autobind.Int64 == nil {
+		if e.ComplexityRoot.Autobind.Int64 == nil {
 			break
 		}
 
-		return e.complexity.Autobind.Int64(childComplexity), true
+		return e.ComplexityRoot.Autobind.Int64(childComplexity), true
 
 	case "B.id":
-		if e.complexity.B.ID == nil {
+		if e.ComplexityRoot.B.ID == nil {
 			break
 		}
 
-		return e.complexity.B.ID(childComplexity), true
+		return e.ComplexityRoot.B.ID(childComplexity), true
 
 	case "BackedByInterface.id":
-		if e.complexity.BackedByInterface.ID == nil {
+		if e.ComplexityRoot.BackedByInterface.ID == nil {
 			break
 		}
 
-		return e.complexity.BackedByInterface.ID(childComplexity), true
+		return e.ComplexityRoot.BackedByInterface.ID(childComplexity), true
 	case "BackedByInterface.thisShouldBind":
-		if e.complexity.BackedByInterface.ThisShouldBind == nil {
+		if e.ComplexityRoot.BackedByInterface.ThisShouldBind == nil {
 			break
 		}
 
-		return e.complexity.BackedByInterface.ThisShouldBind(childComplexity), true
+		return e.ComplexityRoot.BackedByInterface.ThisShouldBind(childComplexity), true
 	case "BackedByInterface.thisShouldBindWithError":
-		if e.complexity.BackedByInterface.ThisShouldBindWithError == nil {
+		if e.ComplexityRoot.BackedByInterface.ThisShouldBindWithError == nil {
 			break
 		}
 
-		return e.complexity.BackedByInterface.ThisShouldBindWithError(childComplexity), true
+		return e.ComplexityRoot.BackedByInterface.ThisShouldBindWithError(childComplexity), true
 
 	case "Cat.catBreed":
-		if e.complexity.Cat.CatBreed == nil {
+		if e.ComplexityRoot.Cat.CatBreed == nil {
 			break
 		}
 
-		return e.complexity.Cat.CatBreed(childComplexity), true
+		return e.ComplexityRoot.Cat.CatBreed(childComplexity), true
 	case "Cat.size":
-		if e.complexity.Cat.Size == nil {
+		if e.ComplexityRoot.Cat.Size == nil {
 			break
 		}
 
-		return e.complexity.Cat.Size(childComplexity), true
+		return e.ComplexityRoot.Cat.Size(childComplexity), true
 	case "Cat.species":
-		if e.complexity.Cat.Species == nil {
+		if e.ComplexityRoot.Cat.Species == nil {
 			break
 		}
 
-		return e.complexity.Cat.Species(childComplexity), true
+		return e.ComplexityRoot.Cat.Species(childComplexity), true
 
 	case "CheckIssue896.id":
-		if e.complexity.CheckIssue896.ID == nil {
+		if e.ComplexityRoot.CheckIssue896.ID == nil {
 			break
 		}
 
-		return e.complexity.CheckIssue896.ID(childComplexity), true
+		return e.ComplexityRoot.CheckIssue896.ID(childComplexity), true
 
 	case "Circle.area":
-		if e.complexity.Circle.Area == nil {
+		if e.ComplexityRoot.Circle.Area == nil {
 			break
 		}
 
-		return e.complexity.Circle.Area(childComplexity), true
+		return e.ComplexityRoot.Circle.Area(childComplexity), true
 	case "Circle.coordinates":
-		if e.complexity.Circle.Coordinates == nil {
+		if e.ComplexityRoot.Circle.Coordinates == nil {
 			break
 		}
 
-		return e.complexity.Circle.Coordinates(childComplexity), true
+		return e.ComplexityRoot.Circle.Coordinates(childComplexity), true
 	case "Circle.radius":
-		if e.complexity.Circle.Radius == nil {
+		if e.ComplexityRoot.Circle.Radius == nil {
 			break
 		}
 
-		return e.complexity.Circle.Radius(childComplexity), true
+		return e.ComplexityRoot.Circle.Radius(childComplexity), true
 
 	case "ConcreteNodeA.child":
-		if e.complexity.ConcreteNodeA.Child == nil {
+		if e.ComplexityRoot.ConcreteNodeA.Child == nil {
 			break
 		}
 
-		return e.complexity.ConcreteNodeA.Child(childComplexity), true
+		return e.ComplexityRoot.ConcreteNodeA.Child(childComplexity), true
 	case "ConcreteNodeA.id":
-		if e.complexity.ConcreteNodeA.ID == nil {
+		if e.ComplexityRoot.ConcreteNodeA.ID == nil {
 			break
 		}
 
-		return e.complexity.ConcreteNodeA.ID(childComplexity), true
+		return e.ComplexityRoot.ConcreteNodeA.ID(childComplexity), true
 	case "ConcreteNodeA.name":
-		if e.complexity.ConcreteNodeA.Name == nil {
+		if e.ComplexityRoot.ConcreteNodeA.Name == nil {
 			break
 		}
 
-		return e.complexity.ConcreteNodeA.Name(childComplexity), true
+		return e.ComplexityRoot.ConcreteNodeA.Name(childComplexity), true
 
 	case "ConcreteNodeInterface.child":
-		if e.complexity.ConcreteNodeInterface.Child == nil {
+		if e.ComplexityRoot.ConcreteNodeInterface.Child == nil {
 			break
 		}
 
-		return e.complexity.ConcreteNodeInterface.Child(childComplexity), true
+		return e.ComplexityRoot.ConcreteNodeInterface.Child(childComplexity), true
 	case "ConcreteNodeInterface.id":
-		if e.complexity.ConcreteNodeInterface.ID == nil {
+		if e.ComplexityRoot.ConcreteNodeInterface.ID == nil {
 			break
 		}
 
-		return e.complexity.ConcreteNodeInterface.ID(childComplexity), true
+		return e.ComplexityRoot.ConcreteNodeInterface.ID(childComplexity), true
 
 	case "Content_Post.foo":
-		if e.complexity.Content_Post.Foo == nil {
+		if e.ComplexityRoot.Content_Post.Foo == nil {
 			break
 		}
 
-		return e.complexity.Content_Post.Foo(childComplexity), true
+		return e.ComplexityRoot.Content_Post.Foo(childComplexity), true
 
 	case "Content_User.foo":
-		if e.complexity.Content_User.Foo == nil {
+		if e.ComplexityRoot.Content_User.Foo == nil {
 			break
 		}
 
-		return e.complexity.Content_User.Foo(childComplexity), true
+		return e.ComplexityRoot.Content_User.Foo(childComplexity), true
 
 	case "Coordinates.x":
-		if e.complexity.Coordinates.X == nil {
+		if e.ComplexityRoot.Coordinates.X == nil {
 			break
 		}
 
-		return e.complexity.Coordinates.X(childComplexity), true
+		return e.ComplexityRoot.Coordinates.X(childComplexity), true
 	case "Coordinates.y":
-		if e.complexity.Coordinates.Y == nil {
+		if e.ComplexityRoot.Coordinates.Y == nil {
 			break
 		}
 
-		return e.complexity.Coordinates.Y(childComplexity), true
+		return e.ComplexityRoot.Coordinates.Y(childComplexity), true
 
 	case "DefaultParametersMirror.falsyBoolean":
-		if e.complexity.DefaultParametersMirror.FalsyBoolean == nil {
+		if e.ComplexityRoot.DefaultParametersMirror.FalsyBoolean == nil {
 			break
 		}
 
-		return e.complexity.DefaultParametersMirror.FalsyBoolean(childComplexity), true
+		return e.ComplexityRoot.DefaultParametersMirror.FalsyBoolean(childComplexity), true
 	case "DefaultParametersMirror.truthyBoolean":
-		if e.complexity.DefaultParametersMirror.TruthyBoolean == nil {
+		if e.ComplexityRoot.DefaultParametersMirror.TruthyBoolean == nil {
 			break
 		}
 
-		return e.complexity.DefaultParametersMirror.TruthyBoolean(childComplexity), true
+		return e.ComplexityRoot.DefaultParametersMirror.TruthyBoolean(childComplexity), true
 
 	case "DeferModel.id":
-		if e.complexity.DeferModel.ID == nil {
+		if e.ComplexityRoot.DeferModel.ID == nil {
 			break
 		}
 
-		return e.complexity.DeferModel.ID(childComplexity), true
+		return e.ComplexityRoot.DeferModel.ID(childComplexity), true
 	case "DeferModel.name":
-		if e.complexity.DeferModel.Name == nil {
+		if e.ComplexityRoot.DeferModel.Name == nil {
 			break
 		}
 
-		return e.complexity.DeferModel.Name(childComplexity), true
+		return e.ComplexityRoot.DeferModel.Name(childComplexity), true
 	case "DeferModel.values":
-		if e.complexity.DeferModel.Values == nil {
+		if e.ComplexityRoot.DeferModel.Values == nil {
 			break
 		}
 
-		return e.complexity.DeferModel.Values(childComplexity), true
+		return e.ComplexityRoot.DeferModel.Values(childComplexity), true
 
 	case "Dog.dogBreed":
-		if e.complexity.Dog.DogBreed == nil {
+		if e.ComplexityRoot.Dog.DogBreed == nil {
 			break
 		}
 
-		return e.complexity.Dog.DogBreed(childComplexity), true
+		return e.ComplexityRoot.Dog.DogBreed(childComplexity), true
 	case "Dog.size":
-		if e.complexity.Dog.Size == nil {
+		if e.ComplexityRoot.Dog.Size == nil {
 			break
 		}
 
-		return e.complexity.Dog.Size(childComplexity), true
+		return e.ComplexityRoot.Dog.Size(childComplexity), true
 	case "Dog.species":
-		if e.complexity.Dog.Species == nil {
+		if e.ComplexityRoot.Dog.Species == nil {
 			break
 		}
 
-		return e.complexity.Dog.Species(childComplexity), true
+		return e.ComplexityRoot.Dog.Species(childComplexity), true
 
 	case "EmbeddedCase1.exportedEmbeddedPointerExportedMethod":
-		if e.complexity.EmbeddedCase1.ExportedEmbeddedPointerExportedMethod == nil {
+		if e.ComplexityRoot.EmbeddedCase1.ExportedEmbeddedPointerExportedMethod == nil {
 			break
 		}
 
-		return e.complexity.EmbeddedCase1.ExportedEmbeddedPointerExportedMethod(childComplexity), true
+		return e.ComplexityRoot.EmbeddedCase1.ExportedEmbeddedPointerExportedMethod(childComplexity), true
 
 	case "EmbeddedCase2.unexportedEmbeddedPointerExportedMethod":
-		if e.complexity.EmbeddedCase2.UnexportedEmbeddedPointerExportedMethod == nil {
+		if e.ComplexityRoot.EmbeddedCase2.UnexportedEmbeddedPointerExportedMethod == nil {
 			break
 		}
 
-		return e.complexity.EmbeddedCase2.UnexportedEmbeddedPointerExportedMethod(childComplexity), true
+		return e.ComplexityRoot.EmbeddedCase2.UnexportedEmbeddedPointerExportedMethod(childComplexity), true
 
 	case "EmbeddedCase3.unexportedEmbeddedInterfaceExportedMethod":
-		if e.complexity.EmbeddedCase3.UnexportedEmbeddedInterfaceExportedMethod == nil {
+		if e.ComplexityRoot.EmbeddedCase3.UnexportedEmbeddedInterfaceExportedMethod == nil {
 			break
 		}
 
-		return e.complexity.EmbeddedCase3.UnexportedEmbeddedInterfaceExportedMethod(childComplexity), true
+		return e.ComplexityRoot.EmbeddedCase3.UnexportedEmbeddedInterfaceExportedMethod(childComplexity), true
 
 	case "EmbeddedDefaultScalar.value":
-		if e.complexity.EmbeddedDefaultScalar.Value == nil {
+		if e.ComplexityRoot.EmbeddedDefaultScalar.Value == nil {
 			break
 		}
 
-		return e.complexity.EmbeddedDefaultScalar.Value(childComplexity), true
+		return e.ComplexityRoot.EmbeddedDefaultScalar.Value(childComplexity), true
 
 	case "EmbeddedPointer.ID":
-		if e.complexity.EmbeddedPointer.ID == nil {
+		if e.ComplexityRoot.EmbeddedPointer.ID == nil {
 			break
 		}
 
-		return e.complexity.EmbeddedPointer.ID(childComplexity), true
+		return e.ComplexityRoot.EmbeddedPointer.ID(childComplexity), true
 	case "EmbeddedPointer.Title":
-		if e.complexity.EmbeddedPointer.Title == nil {
+		if e.ComplexityRoot.EmbeddedPointer.Title == nil {
 			break
 		}
 
-		return e.complexity.EmbeddedPointer.Title(childComplexity), true
+		return e.ComplexityRoot.EmbeddedPointer.Title(childComplexity), true
 
 	case "Error.errorOnNonRequiredField":
-		if e.complexity.Error.ErrorOnNonRequiredField == nil {
+		if e.ComplexityRoot.Error.ErrorOnNonRequiredField == nil {
 			break
 		}
 
-		return e.complexity.Error.ErrorOnNonRequiredField(childComplexity), true
+		return e.ComplexityRoot.Error.ErrorOnNonRequiredField(childComplexity), true
 	case "Error.errorOnRequiredField":
-		if e.complexity.Error.ErrorOnRequiredField == nil {
+		if e.ComplexityRoot.Error.ErrorOnRequiredField == nil {
 			break
 		}
 
-		return e.complexity.Error.ErrorOnRequiredField(childComplexity), true
+		return e.ComplexityRoot.Error.ErrorOnRequiredField(childComplexity), true
 	case "Error.id":
-		if e.complexity.Error.ID == nil {
+		if e.ComplexityRoot.Error.ID == nil {
 			break
 		}
 
-		return e.complexity.Error.ID(childComplexity), true
+		return e.ComplexityRoot.Error.ID(childComplexity), true
 	case "Error.nilOnRequiredField":
-		if e.complexity.Error.NilOnRequiredField == nil {
+		if e.ComplexityRoot.Error.NilOnRequiredField == nil {
 			break
 		}
 
-		return e.complexity.Error.NilOnRequiredField(childComplexity), true
+		return e.ComplexityRoot.Error.NilOnRequiredField(childComplexity), true
 
 	case "Errors.a":
-		if e.complexity.Errors.A == nil {
+		if e.ComplexityRoot.Errors.A == nil {
 			break
 		}
 
-		return e.complexity.Errors.A(childComplexity), true
+		return e.ComplexityRoot.Errors.A(childComplexity), true
 	case "Errors.b":
-		if e.complexity.Errors.B == nil {
+		if e.ComplexityRoot.Errors.B == nil {
 			break
 		}
 
-		return e.complexity.Errors.B(childComplexity), true
+		return e.ComplexityRoot.Errors.B(childComplexity), true
 	case "Errors.c":
-		if e.complexity.Errors.C == nil {
+		if e.ComplexityRoot.Errors.C == nil {
 			break
 		}
 
-		return e.complexity.Errors.C(childComplexity), true
+		return e.ComplexityRoot.Errors.C(childComplexity), true
 	case "Errors.d":
-		if e.complexity.Errors.D == nil {
+		if e.ComplexityRoot.Errors.D == nil {
 			break
 		}
 
-		return e.complexity.Errors.D(childComplexity), true
+		return e.ComplexityRoot.Errors.D(childComplexity), true
 	case "Errors.e":
-		if e.complexity.Errors.E == nil {
+		if e.ComplexityRoot.Errors.E == nil {
 			break
 		}
 
-		return e.complexity.Errors.E(childComplexity), true
+		return e.ComplexityRoot.Errors.E(childComplexity), true
 
 	case "FieldsOrderPayload.firstFieldValue":
-		if e.complexity.FieldsOrderPayload.FirstFieldValue == nil {
+		if e.ComplexityRoot.FieldsOrderPayload.FirstFieldValue == nil {
 			break
 		}
 
-		return e.complexity.FieldsOrderPayload.FirstFieldValue(childComplexity), true
+		return e.ComplexityRoot.FieldsOrderPayload.FirstFieldValue(childComplexity), true
 
 	case "ForcedResolver.field":
-		if e.complexity.ForcedResolver.Field == nil {
+		if e.ComplexityRoot.ForcedResolver.Field == nil {
 			break
 		}
 
-		return e.complexity.ForcedResolver.Field(childComplexity), true
+		return e.ComplexityRoot.ForcedResolver.Field(childComplexity), true
 
 	case "Horse.horseBreed":
-		if e.complexity.Horse.HorseBreed == nil {
+		if e.ComplexityRoot.Horse.HorseBreed == nil {
 			break
 		}
 
-		return e.complexity.Horse.HorseBreed(childComplexity), true
+		return e.ComplexityRoot.Horse.HorseBreed(childComplexity), true
 	case "Horse.size":
-		if e.complexity.Horse.Size == nil {
+		if e.ComplexityRoot.Horse.Size == nil {
 			break
 		}
 
-		return e.complexity.Horse.Size(childComplexity), true
+		return e.ComplexityRoot.Horse.Size(childComplexity), true
 	case "Horse.species":
-		if e.complexity.Horse.Species == nil {
+		if e.ComplexityRoot.Horse.Species == nil {
 			break
 		}
 
-		return e.complexity.Horse.Species(childComplexity), true
+		return e.ComplexityRoot.Horse.Species(childComplexity), true
 
 	case "InnerObject.id":
-		if e.complexity.InnerObject.ID == nil {
+		if e.ComplexityRoot.InnerObject.ID == nil {
 			break
 		}
 
-		return e.complexity.InnerObject.ID(childComplexity), true
+		return e.ComplexityRoot.InnerObject.ID(childComplexity), true
 
 	case "InvalidIdentifier.id":
-		if e.complexity.InvalidIdentifier.ID == nil {
+		if e.ComplexityRoot.InvalidIdentifier.ID == nil {
 			break
 		}
 
-		return e.complexity.InvalidIdentifier.ID(childComplexity), true
+		return e.ComplexityRoot.InvalidIdentifier.ID(childComplexity), true
 
 	case "It.id":
-		if e.complexity.It.ID == nil {
+		if e.ComplexityRoot.It.ID == nil {
 			break
 		}
 
-		return e.complexity.It.ID(childComplexity), true
+		return e.ComplexityRoot.It.ID(childComplexity), true
 
 	case "LoopA.b":
-		if e.complexity.LoopA.B == nil {
+		if e.ComplexityRoot.LoopA.B == nil {
 			break
 		}
 
-		return e.complexity.LoopA.B(childComplexity), true
+		return e.ComplexityRoot.LoopA.B(childComplexity), true
 
 	case "LoopB.a":
-		if e.complexity.LoopB.A == nil {
+		if e.ComplexityRoot.LoopB.A == nil {
 			break
 		}
 
-		return e.complexity.LoopB.A(childComplexity), true
+		return e.ComplexityRoot.LoopB.A(childComplexity), true
 
 	case "Map.id":
-		if e.complexity.Map.ID == nil {
+		if e.ComplexityRoot.Map.ID == nil {
 			break
 		}
 
-		return e.complexity.Map.ID(childComplexity), true
+		return e.ComplexityRoot.Map.ID(childComplexity), true
 
 	case "MapNested.value":
-		if e.complexity.MapNested.Value == nil {
+		if e.ComplexityRoot.MapNested.Value == nil {
 			break
 		}
 
-		return e.complexity.MapNested.Value(childComplexity), true
+		return e.ComplexityRoot.MapNested.Value(childComplexity), true
 
 	case "MapStringInterfaceType.a":
-		if e.complexity.MapStringInterfaceType.A == nil {
+		if e.ComplexityRoot.MapStringInterfaceType.A == nil {
 			break
 		}
 
-		return e.complexity.MapStringInterfaceType.A(childComplexity), true
+		return e.ComplexityRoot.MapStringInterfaceType.A(childComplexity), true
 	case "MapStringInterfaceType.b":
-		if e.complexity.MapStringInterfaceType.B == nil {
+		if e.ComplexityRoot.MapStringInterfaceType.B == nil {
 			break
 		}
 
-		return e.complexity.MapStringInterfaceType.B(childComplexity), true
+		return e.ComplexityRoot.MapStringInterfaceType.B(childComplexity), true
 	case "MapStringInterfaceType.c":
-		if e.complexity.MapStringInterfaceType.C == nil {
+		if e.ComplexityRoot.MapStringInterfaceType.C == nil {
 			break
 		}
 
-		return e.complexity.MapStringInterfaceType.C(childComplexity), true
+		return e.ComplexityRoot.MapStringInterfaceType.C(childComplexity), true
 	case "MapStringInterfaceType.nested":
-		if e.complexity.MapStringInterfaceType.Nested == nil {
+		if e.ComplexityRoot.MapStringInterfaceType.Nested == nil {
 			break
 		}
 
-		return e.complexity.MapStringInterfaceType.Nested(childComplexity), true
+		return e.ComplexityRoot.MapStringInterfaceType.Nested(childComplexity), true
 
 	case "ModelMethods.noContext":
-		if e.complexity.ModelMethods.NoContext == nil {
+		if e.ComplexityRoot.ModelMethods.NoContext == nil {
 			break
 		}
 
-		return e.complexity.ModelMethods.NoContext(childComplexity), true
+		return e.ComplexityRoot.ModelMethods.NoContext(childComplexity), true
 	case "ModelMethods.resolverField":
-		if e.complexity.ModelMethods.ResolverField == nil {
+		if e.ComplexityRoot.ModelMethods.ResolverField == nil {
 			break
 		}
 
-		return e.complexity.ModelMethods.ResolverField(childComplexity), true
+		return e.ComplexityRoot.ModelMethods.ResolverField(childComplexity), true
 	case "ModelMethods.withContext":
-		if e.complexity.ModelMethods.WithContext == nil {
+		if e.ComplexityRoot.ModelMethods.WithContext == nil {
 			break
 		}
 
-		return e.complexity.ModelMethods.WithContext(childComplexity), true
+		return e.ComplexityRoot.ModelMethods.WithContext(childComplexity), true
 
 	case "Mutation.defaultInput":
-		if e.complexity.Mutation.DefaultInput == nil {
+		if e.ComplexityRoot.Mutation.DefaultInput == nil {
 			break
 		}
 
@@ -1142,9 +1132,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.DefaultInput(childComplexity, args["input"].(DefaultInput)), true
+		return e.ComplexityRoot.Mutation.DefaultInput(childComplexity, args["input"].(DefaultInput)), true
 	case "Mutation.overrideValueViaInput":
-		if e.complexity.Mutation.OverrideValueViaInput == nil {
+		if e.ComplexityRoot.Mutation.OverrideValueViaInput == nil {
 			break
 		}
 
@@ -1153,9 +1143,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.OverrideValueViaInput(childComplexity, args["input"].(FieldsOrderInput)), true
+		return e.ComplexityRoot.Mutation.OverrideValueViaInput(childComplexity, args["input"].(FieldsOrderInput)), true
 	case "Mutation.updateProduct":
-		if e.complexity.Mutation.UpdateProduct == nil {
+		if e.ComplexityRoot.Mutation.UpdateProduct == nil {
 			break
 		}
 
@@ -1164,9 +1154,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.UpdateProduct(childComplexity, args["id"].(string), args["name"].(*string), args["price"].(*float64)), true
+		return e.ComplexityRoot.Mutation.UpdateProduct(childComplexity, args["id"].(string), args["name"].(*string), args["price"].(*float64)), true
 	case "Mutation.updatePtrToPtr":
-		if e.complexity.Mutation.UpdatePtrToPtr == nil {
+		if e.ComplexityRoot.Mutation.UpdatePtrToPtr == nil {
 			break
 		}
 
@@ -1175,9 +1165,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.UpdatePtrToPtr(childComplexity, args["input"].(UpdatePtrToPtrOuter)), true
+		return e.ComplexityRoot.Mutation.UpdatePtrToPtr(childComplexity, args["input"].(UpdatePtrToPtrOuter)), true
 	case "Mutation.updateSomething":
-		if e.complexity.Mutation.UpdateSomething == nil {
+		if e.ComplexityRoot.Mutation.UpdateSomething == nil {
 			break
 		}
 
@@ -1186,62 +1176,62 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.UpdateSomething(childComplexity, args["input"].(SpecialInput)), true
+		return e.ComplexityRoot.Mutation.UpdateSomething(childComplexity, args["input"].(SpecialInput)), true
 
 	case "ObjectDirectives.nullableText":
-		if e.complexity.ObjectDirectives.NullableText == nil {
+		if e.ComplexityRoot.ObjectDirectives.NullableText == nil {
 			break
 		}
 
-		return e.complexity.ObjectDirectives.NullableText(childComplexity), true
+		return e.ComplexityRoot.ObjectDirectives.NullableText(childComplexity), true
 	case "ObjectDirectives.order":
-		if e.complexity.ObjectDirectives.Order == nil {
+		if e.ComplexityRoot.ObjectDirectives.Order == nil {
 			break
 		}
 
-		return e.complexity.ObjectDirectives.Order(childComplexity), true
+		return e.ComplexityRoot.ObjectDirectives.Order(childComplexity), true
 	case "ObjectDirectives.text":
-		if e.complexity.ObjectDirectives.Text == nil {
+		if e.ComplexityRoot.ObjectDirectives.Text == nil {
 			break
 		}
 
-		return e.complexity.ObjectDirectives.Text(childComplexity), true
+		return e.ComplexityRoot.ObjectDirectives.Text(childComplexity), true
 
 	case "ObjectDirectivesWithCustomGoModel.nullableText":
-		if e.complexity.ObjectDirectivesWithCustomGoModel.NullableText == nil {
+		if e.ComplexityRoot.ObjectDirectivesWithCustomGoModel.NullableText == nil {
 			break
 		}
 
-		return e.complexity.ObjectDirectivesWithCustomGoModel.NullableText(childComplexity), true
+		return e.ComplexityRoot.ObjectDirectivesWithCustomGoModel.NullableText(childComplexity), true
 
 	case "OuterObject.inner":
-		if e.complexity.OuterObject.Inner == nil {
+		if e.ComplexityRoot.OuterObject.Inner == nil {
 			break
 		}
 
-		return e.complexity.OuterObject.Inner(childComplexity), true
+		return e.ComplexityRoot.OuterObject.Inner(childComplexity), true
 
 	case "OverlappingFields.oneFoo", "OverlappingFields.twoFoo":
-		if e.complexity.OverlappingFields.Foo == nil {
+		if e.ComplexityRoot.OverlappingFields.Foo == nil {
 			break
 		}
 
-		return e.complexity.OverlappingFields.Foo(childComplexity), true
+		return e.ComplexityRoot.OverlappingFields.Foo(childComplexity), true
 	case "OverlappingFields.newFoo", "OverlappingFields.new_foo":
-		if e.complexity.OverlappingFields.NewFoo == nil {
+		if e.ComplexityRoot.OverlappingFields.NewFoo == nil {
 			break
 		}
 
-		return e.complexity.OverlappingFields.NewFoo(childComplexity), true
+		return e.ComplexityRoot.OverlappingFields.NewFoo(childComplexity), true
 	case "OverlappingFields.oldFoo":
-		if e.complexity.OverlappingFields.OldFoo == nil {
+		if e.ComplexityRoot.OverlappingFields.OldFoo == nil {
 			break
 		}
 
-		return e.complexity.OverlappingFields.OldFoo(childComplexity), true
+		return e.ComplexityRoot.OverlappingFields.OldFoo(childComplexity), true
 
 	case "Panics.argUnmarshal":
-		if e.complexity.Panics.ArgUnmarshal == nil {
+		if e.ComplexityRoot.Panics.ArgUnmarshal == nil {
 			break
 		}
 
@@ -1250,9 +1240,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Panics.ArgUnmarshal(childComplexity, args["u"].([]MarshalPanic)), true
+		return e.ComplexityRoot.Panics.ArgUnmarshal(childComplexity, args["u"].([]MarshalPanic)), true
 	case "Panics.fieldFuncMarshal":
-		if e.complexity.Panics.FieldFuncMarshal == nil {
+		if e.ComplexityRoot.Panics.FieldFuncMarshal == nil {
 			break
 		}
 
@@ -1261,16 +1251,16 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Panics.FieldFuncMarshal(childComplexity, args["u"].([]MarshalPanic)), true
+		return e.ComplexityRoot.Panics.FieldFuncMarshal(childComplexity, args["u"].([]MarshalPanic)), true
 	case "Panics.fieldScalarMarshal":
-		if e.complexity.Panics.FieldScalarMarshal == nil {
+		if e.ComplexityRoot.Panics.FieldScalarMarshal == nil {
 			break
 		}
 
-		return e.complexity.Panics.FieldScalarMarshal(childComplexity), true
+		return e.ComplexityRoot.Panics.FieldScalarMarshal(childComplexity), true
 
 	case "Pet.friends":
-		if e.complexity.Pet.Friends == nil {
+		if e.ComplexityRoot.Pet.Friends == nil {
 			break
 		}
 
@@ -1279,118 +1269,118 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Pet.Friends(childComplexity, args["limit"].(*int)), true
+		return e.ComplexityRoot.Pet.Friends(childComplexity, args["limit"].(*int)), true
 	case "Pet.id":
-		if e.complexity.Pet.ID == nil {
+		if e.ComplexityRoot.Pet.ID == nil {
 			break
 		}
 
-		return e.complexity.Pet.ID(childComplexity), true
+		return e.ComplexityRoot.Pet.ID(childComplexity), true
 
 	case "Primitive.squared":
-		if e.complexity.Primitive.Squared == nil {
+		if e.ComplexityRoot.Primitive.Squared == nil {
 			break
 		}
 
-		return e.complexity.Primitive.Squared(childComplexity), true
+		return e.ComplexityRoot.Primitive.Squared(childComplexity), true
 	case "Primitive.value":
-		if e.complexity.Primitive.Value == nil {
+		if e.ComplexityRoot.Primitive.Value == nil {
 			break
 		}
 
-		return e.complexity.Primitive.Value(childComplexity), true
+		return e.ComplexityRoot.Primitive.Value(childComplexity), true
 
 	case "PrimitiveString.doubled":
-		if e.complexity.PrimitiveString.Doubled == nil {
+		if e.ComplexityRoot.PrimitiveString.Doubled == nil {
 			break
 		}
 
-		return e.complexity.PrimitiveString.Doubled(childComplexity), true
+		return e.ComplexityRoot.PrimitiveString.Doubled(childComplexity), true
 	case "PrimitiveString.len":
-		if e.complexity.PrimitiveString.Len == nil {
+		if e.ComplexityRoot.PrimitiveString.Len == nil {
 			break
 		}
 
-		return e.complexity.PrimitiveString.Len(childComplexity), true
+		return e.ComplexityRoot.PrimitiveString.Len(childComplexity), true
 	case "PrimitiveString.value":
-		if e.complexity.PrimitiveString.Value == nil {
+		if e.ComplexityRoot.PrimitiveString.Value == nil {
 			break
 		}
 
-		return e.complexity.PrimitiveString.Value(childComplexity), true
+		return e.ComplexityRoot.PrimitiveString.Value(childComplexity), true
 
 	case "PtrToAnyContainer.binding":
-		if e.complexity.PtrToAnyContainer.Binding == nil {
+		if e.ComplexityRoot.PtrToAnyContainer.Binding == nil {
 			break
 		}
 
-		return e.complexity.PtrToAnyContainer.Binding(childComplexity), true
+		return e.ComplexityRoot.PtrToAnyContainer.Binding(childComplexity), true
 	case "PtrToAnyContainer.ptrToAny":
-		if e.complexity.PtrToAnyContainer.PtrToAny == nil {
+		if e.ComplexityRoot.PtrToAnyContainer.PtrToAny == nil {
 			break
 		}
 
-		return e.complexity.PtrToAnyContainer.PtrToAny(childComplexity), true
+		return e.ComplexityRoot.PtrToAnyContainer.PtrToAny(childComplexity), true
 
 	case "PtrToPtrInner.key":
-		if e.complexity.PtrToPtrInner.Key == nil {
+		if e.ComplexityRoot.PtrToPtrInner.Key == nil {
 			break
 		}
 
-		return e.complexity.PtrToPtrInner.Key(childComplexity), true
+		return e.ComplexityRoot.PtrToPtrInner.Key(childComplexity), true
 	case "PtrToPtrInner.value":
-		if e.complexity.PtrToPtrInner.Value == nil {
+		if e.ComplexityRoot.PtrToPtrInner.Value == nil {
 			break
 		}
 
-		return e.complexity.PtrToPtrInner.Value(childComplexity), true
+		return e.ComplexityRoot.PtrToPtrInner.Value(childComplexity), true
 
 	case "PtrToPtrOuter.inner":
-		if e.complexity.PtrToPtrOuter.Inner == nil {
+		if e.ComplexityRoot.PtrToPtrOuter.Inner == nil {
 			break
 		}
 
-		return e.complexity.PtrToPtrOuter.Inner(childComplexity), true
+		return e.ComplexityRoot.PtrToPtrOuter.Inner(childComplexity), true
 	case "PtrToPtrOuter.name":
-		if e.complexity.PtrToPtrOuter.Name == nil {
+		if e.ComplexityRoot.PtrToPtrOuter.Name == nil {
 			break
 		}
 
-		return e.complexity.PtrToPtrOuter.Name(childComplexity), true
+		return e.ComplexityRoot.PtrToPtrOuter.Name(childComplexity), true
 	case "PtrToPtrOuter.stupidInner":
-		if e.complexity.PtrToPtrOuter.StupidInner == nil {
+		if e.ComplexityRoot.PtrToPtrOuter.StupidInner == nil {
 			break
 		}
 
-		return e.complexity.PtrToPtrOuter.StupidInner(childComplexity), true
+		return e.ComplexityRoot.PtrToPtrOuter.StupidInner(childComplexity), true
 
 	case "PtrToSliceContainer.ptrToSlice":
-		if e.complexity.PtrToSliceContainer.PtrToSlice == nil {
+		if e.ComplexityRoot.PtrToSliceContainer.PtrToSlice == nil {
 			break
 		}
 
-		return e.complexity.PtrToSliceContainer.PtrToSlice(childComplexity), true
+		return e.ComplexityRoot.PtrToSliceContainer.PtrToSlice(childComplexity), true
 
 	case "Query.animal":
-		if e.complexity.Query.Animal == nil {
+		if e.ComplexityRoot.Query.Animal == nil {
 			break
 		}
 
-		return e.complexity.Query.Animal(childComplexity), true
+		return e.ComplexityRoot.Query.Animal(childComplexity), true
 	case "Query.autobind":
-		if e.complexity.Query.Autobind == nil {
+		if e.ComplexityRoot.Query.Autobind == nil {
 			break
 		}
 
-		return e.complexity.Query.Autobind(childComplexity), true
+		return e.ComplexityRoot.Query.Autobind(childComplexity), true
 	case "Query.collision":
-		if e.complexity.Query.Collision == nil {
+		if e.ComplexityRoot.Query.Collision == nil {
 			break
 		}
 
-		return e.complexity.Query.Collision(childComplexity), true
+		return e.ComplexityRoot.Query.Collision(childComplexity), true
 	case "Query.defaultParameters":
-		if e.complexity.Query.DefaultParameters == nil {
+		if e.ComplexityRoot.Query.DefaultParameters == nil {
 			break
 		}
 
@@ -1399,9 +1389,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.DefaultParameters(childComplexity, args["falsyBoolean"].(*bool), args["truthyBoolean"].(*bool)), true
+		return e.ComplexityRoot.Query.DefaultParameters(childComplexity, args["falsyBoolean"].(*bool), args["truthyBoolean"].(*bool)), true
 	case "Query.defaultScalar":
-		if e.complexity.Query.DefaultScalar == nil {
+		if e.ComplexityRoot.Query.DefaultScalar == nil {
 			break
 		}
 
@@ -1410,27 +1400,27 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.DefaultScalar(childComplexity, args["arg"].(string)), true
+		return e.ComplexityRoot.Query.DefaultScalar(childComplexity, args["arg"].(string)), true
 	case "Query.deferMultiple":
-		if e.complexity.Query.DeferMultiple == nil {
+		if e.ComplexityRoot.Query.DeferMultiple == nil {
 			break
 		}
 
-		return e.complexity.Query.DeferMultiple(childComplexity), true
+		return e.ComplexityRoot.Query.DeferMultiple(childComplexity), true
 	case "Query.deferSingle":
-		if e.complexity.Query.DeferSingle == nil {
+		if e.ComplexityRoot.Query.DeferSingle == nil {
 			break
 		}
 
-		return e.complexity.Query.DeferSingle(childComplexity), true
+		return e.ComplexityRoot.Query.DeferSingle(childComplexity), true
 	case "Query.deprecatedField":
-		if e.complexity.Query.DeprecatedField == nil {
+		if e.ComplexityRoot.Query.DeprecatedField == nil {
 			break
 		}
 
-		return e.complexity.Query.DeprecatedField(childComplexity), true
+		return e.ComplexityRoot.Query.DeprecatedField(childComplexity), true
 	case "Query.directiveArg":
-		if e.complexity.Query.DirectiveArg == nil {
+		if e.ComplexityRoot.Query.DirectiveArg == nil {
 			break
 		}
 
@@ -1439,21 +1429,21 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.DirectiveArg(childComplexity, args["arg"].(string)), true
+		return e.ComplexityRoot.Query.DirectiveArg(childComplexity, args["arg"].(string)), true
 	case "Query.directiveDouble":
-		if e.complexity.Query.DirectiveDouble == nil {
+		if e.ComplexityRoot.Query.DirectiveDouble == nil {
 			break
 		}
 
-		return e.complexity.Query.DirectiveDouble(childComplexity), true
+		return e.ComplexityRoot.Query.DirectiveDouble(childComplexity), true
 	case "Query.directiveField":
-		if e.complexity.Query.DirectiveField == nil {
+		if e.ComplexityRoot.Query.DirectiveField == nil {
 			break
 		}
 
-		return e.complexity.Query.DirectiveField(childComplexity), true
+		return e.ComplexityRoot.Query.DirectiveField(childComplexity), true
 	case "Query.directiveFieldDef":
-		if e.complexity.Query.DirectiveFieldDef == nil {
+		if e.ComplexityRoot.Query.DirectiveFieldDef == nil {
 			break
 		}
 
@@ -1462,9 +1452,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.DirectiveFieldDef(childComplexity, args["ret"].(string)), true
+		return e.ComplexityRoot.Query.DirectiveFieldDef(childComplexity, args["ret"].(string)), true
 	case "Query.directiveInput":
-		if e.complexity.Query.DirectiveInput == nil {
+		if e.ComplexityRoot.Query.DirectiveInput == nil {
 			break
 		}
 
@@ -1473,9 +1463,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.DirectiveInput(childComplexity, args["arg"].(InputDirectives)), true
+		return e.ComplexityRoot.Query.DirectiveInput(childComplexity, args["arg"].(InputDirectives)), true
 	case "Query.directiveInputNullable":
-		if e.complexity.Query.DirectiveInputNullable == nil {
+		if e.ComplexityRoot.Query.DirectiveInputNullable == nil {
 			break
 		}
 
@@ -1484,9 +1474,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.DirectiveInputNullable(childComplexity, args["arg"].(*InputDirectives)), true
+		return e.ComplexityRoot.Query.DirectiveInputNullable(childComplexity, args["arg"].(*InputDirectives)), true
 	case "Query.directiveInputType":
-		if e.complexity.Query.DirectiveInputType == nil {
+		if e.ComplexityRoot.Query.DirectiveInputType == nil {
 			break
 		}
 
@@ -1495,9 +1485,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.DirectiveInputType(childComplexity, args["arg"].(InnerInput)), true
+		return e.ComplexityRoot.Query.DirectiveInputType(childComplexity, args["arg"].(InnerInput)), true
 	case "Query.directiveNullableArg":
-		if e.complexity.Query.DirectiveNullableArg == nil {
+		if e.ComplexityRoot.Query.DirectiveNullableArg == nil {
 			break
 		}
 
@@ -1506,21 +1496,21 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.DirectiveNullableArg(childComplexity, args["arg"].(*int), args["arg2"].(*int), args["arg3"].(*string)), true
+		return e.ComplexityRoot.Query.DirectiveNullableArg(childComplexity, args["arg"].(*int), args["arg2"].(*int), args["arg3"].(*string)), true
 	case "Query.directiveObject":
-		if e.complexity.Query.DirectiveObject == nil {
+		if e.ComplexityRoot.Query.DirectiveObject == nil {
 			break
 		}
 
-		return e.complexity.Query.DirectiveObject(childComplexity), true
+		return e.ComplexityRoot.Query.DirectiveObject(childComplexity), true
 	case "Query.directiveObjectWithCustomGoModel":
-		if e.complexity.Query.DirectiveObjectWithCustomGoModel == nil {
+		if e.ComplexityRoot.Query.DirectiveObjectWithCustomGoModel == nil {
 			break
 		}
 
-		return e.complexity.Query.DirectiveObjectWithCustomGoModel(childComplexity), true
+		return e.ComplexityRoot.Query.DirectiveObjectWithCustomGoModel(childComplexity), true
 	case "Query.directiveSingleNullableArg":
-		if e.complexity.Query.DirectiveSingleNullableArg == nil {
+		if e.ComplexityRoot.Query.DirectiveSingleNullableArg == nil {
 			break
 		}
 
@@ -1529,39 +1519,39 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.DirectiveSingleNullableArg(childComplexity, args["arg1"].(*string)), true
+		return e.ComplexityRoot.Query.DirectiveSingleNullableArg(childComplexity, args["arg1"].(*string)), true
 	case "Query.directiveUnimplemented":
-		if e.complexity.Query.DirectiveUnimplemented == nil {
+		if e.ComplexityRoot.Query.DirectiveUnimplemented == nil {
 			break
 		}
 
-		return e.complexity.Query.DirectiveUnimplemented(childComplexity), true
+		return e.ComplexityRoot.Query.DirectiveUnimplemented(childComplexity), true
 	case "Query.dog":
-		if e.complexity.Query.Dog == nil {
+		if e.ComplexityRoot.Query.Dog == nil {
 			break
 		}
 
-		return e.complexity.Query.Dog(childComplexity), true
+		return e.ComplexityRoot.Query.Dog(childComplexity), true
 	case "Query.embeddedCase1":
-		if e.complexity.Query.EmbeddedCase1 == nil {
+		if e.ComplexityRoot.Query.EmbeddedCase1 == nil {
 			break
 		}
 
-		return e.complexity.Query.EmbeddedCase1(childComplexity), true
+		return e.ComplexityRoot.Query.EmbeddedCase1(childComplexity), true
 	case "Query.embeddedCase2":
-		if e.complexity.Query.EmbeddedCase2 == nil {
+		if e.ComplexityRoot.Query.EmbeddedCase2 == nil {
 			break
 		}
 
-		return e.complexity.Query.EmbeddedCase2(childComplexity), true
+		return e.ComplexityRoot.Query.EmbeddedCase2(childComplexity), true
 	case "Query.embeddedCase3":
-		if e.complexity.Query.EmbeddedCase3 == nil {
+		if e.ComplexityRoot.Query.EmbeddedCase3 == nil {
 			break
 		}
 
-		return e.complexity.Query.EmbeddedCase3(childComplexity), true
+		return e.ComplexityRoot.Query.EmbeddedCase3(childComplexity), true
 	case "Query.enumInInput":
-		if e.complexity.Query.EnumInInput == nil {
+		if e.ComplexityRoot.Query.EnumInInput == nil {
 			break
 		}
 
@@ -1570,33 +1560,33 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.EnumInInput(childComplexity, args["input"].(*InputWithEnumValue)), true
+		return e.ComplexityRoot.Query.EnumInInput(childComplexity, args["input"].(*InputWithEnumValue)), true
 	case "Query.errorBubble":
-		if e.complexity.Query.ErrorBubble == nil {
+		if e.ComplexityRoot.Query.ErrorBubble == nil {
 			break
 		}
 
-		return e.complexity.Query.ErrorBubble(childComplexity), true
+		return e.ComplexityRoot.Query.ErrorBubble(childComplexity), true
 	case "Query.errorBubbleList":
-		if e.complexity.Query.ErrorBubbleList == nil {
+		if e.ComplexityRoot.Query.ErrorBubbleList == nil {
 			break
 		}
 
-		return e.complexity.Query.ErrorBubbleList(childComplexity), true
+		return e.ComplexityRoot.Query.ErrorBubbleList(childComplexity), true
 	case "Query.errorList":
-		if e.complexity.Query.ErrorList == nil {
+		if e.ComplexityRoot.Query.ErrorList == nil {
 			break
 		}
 
-		return e.complexity.Query.ErrorList(childComplexity), true
+		return e.ComplexityRoot.Query.ErrorList(childComplexity), true
 	case "Query.errors":
-		if e.complexity.Query.Errors == nil {
+		if e.ComplexityRoot.Query.Errors == nil {
 			break
 		}
 
-		return e.complexity.Query.Errors(childComplexity), true
+		return e.ComplexityRoot.Query.Errors(childComplexity), true
 	case "Query.fallback":
-		if e.complexity.Query.Fallback == nil {
+		if e.ComplexityRoot.Query.Fallback == nil {
 			break
 		}
 
@@ -1605,9 +1595,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Fallback(childComplexity, args["arg"].(FallbackToStringEncoding)), true
+		return e.ComplexityRoot.Query.Fallback(childComplexity, args["arg"].(FallbackToStringEncoding)), true
 	case "Query.fieldWithDeprecatedArg":
-		if e.complexity.Query.FieldWithDeprecatedArg == nil {
+		if e.ComplexityRoot.Query.FieldWithDeprecatedArg == nil {
 			break
 		}
 
@@ -1616,9 +1606,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.FieldWithDeprecatedArg(childComplexity, args["oldArg"].(*int), args["newArg"].(*int)), true
+		return e.ComplexityRoot.Query.FieldWithDeprecatedArg(childComplexity, args["oldArg"].(*int), args["newArg"].(*int)), true
 	case "Query.filterProducts":
-		if e.complexity.Query.FilterProducts == nil {
+		if e.ComplexityRoot.Query.FilterProducts == nil {
 			break
 		}
 
@@ -1627,9 +1617,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.FilterProducts(childComplexity, args["query"].(*string), args["category"].(*string), args["minPrice"].(*int)), true
+		return e.ComplexityRoot.Query.FilterProducts(childComplexity, args["query"].(*string), args["category"].(*string), args["minPrice"].(*int)), true
 	case "Query.findProducts":
-		if e.complexity.Query.FindProducts == nil {
+		if e.ComplexityRoot.Query.FindProducts == nil {
 			break
 		}
 
@@ -1638,15 +1628,15 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.FindProducts(childComplexity, args["query"].(*string), args["category"].(*string), args["minPrice"].(*int)), true
+		return e.ComplexityRoot.Query.FindProducts(childComplexity, args["query"].(*string), args["category"].(*string), args["minPrice"].(*int)), true
 	case "Query.infinity":
-		if e.complexity.Query.Infinity == nil {
+		if e.ComplexityRoot.Query.Infinity == nil {
 			break
 		}
 
-		return e.complexity.Query.Infinity(childComplexity), true
+		return e.ComplexityRoot.Query.Infinity(childComplexity), true
 	case "Query.inputNullableSlice":
-		if e.complexity.Query.InputNullableSlice == nil {
+		if e.ComplexityRoot.Query.InputNullableSlice == nil {
 			break
 		}
 
@@ -1655,9 +1645,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.InputNullableSlice(childComplexity, args["arg"].([]string)), true
+		return e.ComplexityRoot.Query.InputNullableSlice(childComplexity, args["arg"].([]string)), true
 	case "Query.inputOmittable":
-		if e.complexity.Query.InputOmittable == nil {
+		if e.ComplexityRoot.Query.InputOmittable == nil {
 			break
 		}
 
@@ -1666,9 +1656,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.InputOmittable(childComplexity, args["arg"].(OmittableInput)), true
+		return e.ComplexityRoot.Query.InputOmittable(childComplexity, args["arg"].(OmittableInput)), true
 	case "Query.inputSlice":
-		if e.complexity.Query.InputSlice == nil {
+		if e.ComplexityRoot.Query.InputSlice == nil {
 			break
 		}
 
@@ -1677,27 +1667,27 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.InputSlice(childComplexity, args["arg"].([]string)), true
+		return e.ComplexityRoot.Query.InputSlice(childComplexity, args["arg"].([]string)), true
 	case "Query.invalid":
-		if e.complexity.Query.Invalid == nil {
+		if e.ComplexityRoot.Query.Invalid == nil {
 			break
 		}
 
-		return e.complexity.Query.Invalid(childComplexity), true
+		return e.ComplexityRoot.Query.Invalid(childComplexity), true
 	case "Query.invalidIdentifier":
-		if e.complexity.Query.InvalidIdentifier == nil {
+		if e.ComplexityRoot.Query.InvalidIdentifier == nil {
 			break
 		}
 
-		return e.complexity.Query.InvalidIdentifier(childComplexity), true
+		return e.ComplexityRoot.Query.InvalidIdentifier(childComplexity), true
 	case "Query.issue896a":
-		if e.complexity.Query.Issue896a == nil {
+		if e.ComplexityRoot.Query.Issue896a == nil {
 			break
 		}
 
-		return e.complexity.Query.Issue896a(childComplexity), true
+		return e.ComplexityRoot.Query.Issue896a(childComplexity), true
 	case "Query.mapInput":
-		if e.complexity.Query.MapInput == nil {
+		if e.ComplexityRoot.Query.MapInput == nil {
 			break
 		}
 
@@ -1706,9 +1696,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.MapInput(childComplexity, args["input"].(map[string]any)), true
+		return e.ComplexityRoot.Query.MapInput(childComplexity, args["input"].(map[string]any)), true
 	case "Query.mapNestedMapSlice":
-		if e.complexity.Query.MapNestedMapSlice == nil {
+		if e.ComplexityRoot.Query.MapNestedMapSlice == nil {
 			break
 		}
 
@@ -1717,9 +1707,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.MapNestedMapSlice(childComplexity, args["input"].(map[string]any)), true
+		return e.ComplexityRoot.Query.MapNestedMapSlice(childComplexity, args["input"].(map[string]any)), true
 	case "Query.mapNestedStringInterface":
-		if e.complexity.Query.MapNestedStringInterface == nil {
+		if e.ComplexityRoot.Query.MapNestedStringInterface == nil {
 			break
 		}
 
@@ -1728,9 +1718,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.MapNestedStringInterface(childComplexity, args["in"].(*NestedMapInput)), true
+		return e.ComplexityRoot.Query.MapNestedStringInterface(childComplexity, args["in"].(*NestedMapInput)), true
 	case "Query.mapStringInterface":
-		if e.complexity.Query.MapStringInterface == nil {
+		if e.ComplexityRoot.Query.MapStringInterface == nil {
 			break
 		}
 
@@ -1739,15 +1729,15 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.MapStringInterface(childComplexity, args["in"].(map[string]any)), true
+		return e.ComplexityRoot.Query.MapStringInterface(childComplexity, args["in"].(map[string]any)), true
 	case "Query.modelMethods":
-		if e.complexity.Query.ModelMethods == nil {
+		if e.ComplexityRoot.Query.ModelMethods == nil {
 			break
 		}
 
-		return e.complexity.Query.ModelMethods(childComplexity), true
+		return e.ComplexityRoot.Query.ModelMethods(childComplexity), true
 	case "Query.nestedInputs":
-		if e.complexity.Query.NestedInputs == nil {
+		if e.ComplexityRoot.Query.NestedInputs == nil {
 			break
 		}
 
@@ -1756,39 +1746,39 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.NestedInputs(childComplexity, args["input"].([][]*OuterInput)), true
+		return e.ComplexityRoot.Query.NestedInputs(childComplexity, args["input"].([][]*OuterInput)), true
 	case "Query.nestedOutputs":
-		if e.complexity.Query.NestedOutputs == nil {
+		if e.ComplexityRoot.Query.NestedOutputs == nil {
 			break
 		}
 
-		return e.complexity.Query.NestedOutputs(childComplexity), true
+		return e.ComplexityRoot.Query.NestedOutputs(childComplexity), true
 	case "Query.noShape":
-		if e.complexity.Query.NoShape == nil {
+		if e.ComplexityRoot.Query.NoShape == nil {
 			break
 		}
 
-		return e.complexity.Query.NoShape(childComplexity), true
+		return e.ComplexityRoot.Query.NoShape(childComplexity), true
 	case "Query.noShapeTypedNil":
-		if e.complexity.Query.NoShapeTypedNil == nil {
+		if e.ComplexityRoot.Query.NoShapeTypedNil == nil {
 			break
 		}
 
-		return e.complexity.Query.NoShapeTypedNil(childComplexity), true
+		return e.ComplexityRoot.Query.NoShapeTypedNil(childComplexity), true
 	case "Query.node":
-		if e.complexity.Query.Node == nil {
+		if e.ComplexityRoot.Query.Node == nil {
 			break
 		}
 
-		return e.complexity.Query.Node(childComplexity), true
+		return e.ComplexityRoot.Query.Node(childComplexity), true
 	case "Query.notAnInterface":
-		if e.complexity.Query.NotAnInterface == nil {
+		if e.ComplexityRoot.Query.NotAnInterface == nil {
 			break
 		}
 
-		return e.complexity.Query.NotAnInterface(childComplexity), true
+		return e.ComplexityRoot.Query.NotAnInterface(childComplexity), true
 	case "Query.nullableArg":
-		if e.complexity.Query.NullableArg == nil {
+		if e.ComplexityRoot.Query.NullableArg == nil {
 			break
 		}
 
@@ -1797,51 +1787,51 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.NullableArg(childComplexity, args["arg"].(*int)), true
+		return e.ComplexityRoot.Query.NullableArg(childComplexity, args["arg"].(*int)), true
 	case "Query.optionalUnion":
-		if e.complexity.Query.OptionalUnion == nil {
+		if e.ComplexityRoot.Query.OptionalUnion == nil {
 			break
 		}
 
-		return e.complexity.Query.OptionalUnion(childComplexity), true
+		return e.ComplexityRoot.Query.OptionalUnion(childComplexity), true
 	case "Query.overlapping":
-		if e.complexity.Query.Overlapping == nil {
+		if e.ComplexityRoot.Query.Overlapping == nil {
 			break
 		}
 
-		return e.complexity.Query.Overlapping(childComplexity), true
+		return e.ComplexityRoot.Query.Overlapping(childComplexity), true
 	case "Query.panics":
-		if e.complexity.Query.Panics == nil {
+		if e.ComplexityRoot.Query.Panics == nil {
 			break
 		}
 
-		return e.complexity.Query.Panics(childComplexity), true
+		return e.ComplexityRoot.Query.Panics(childComplexity), true
 	case "Query.primitiveObject":
-		if e.complexity.Query.PrimitiveObject == nil {
+		if e.ComplexityRoot.Query.PrimitiveObject == nil {
 			break
 		}
 
-		return e.complexity.Query.PrimitiveObject(childComplexity), true
+		return e.ComplexityRoot.Query.PrimitiveObject(childComplexity), true
 	case "Query.primitiveStringObject":
-		if e.complexity.Query.PrimitiveStringObject == nil {
+		if e.ComplexityRoot.Query.PrimitiveStringObject == nil {
 			break
 		}
 
-		return e.complexity.Query.PrimitiveStringObject(childComplexity), true
+		return e.ComplexityRoot.Query.PrimitiveStringObject(childComplexity), true
 	case "Query.ptrToAnyContainer":
-		if e.complexity.Query.PtrToAnyContainer == nil {
+		if e.ComplexityRoot.Query.PtrToAnyContainer == nil {
 			break
 		}
 
-		return e.complexity.Query.PtrToAnyContainer(childComplexity), true
+		return e.ComplexityRoot.Query.PtrToAnyContainer(childComplexity), true
 	case "Query.ptrToSliceContainer":
-		if e.complexity.Query.PtrToSliceContainer == nil {
+		if e.ComplexityRoot.Query.PtrToSliceContainer == nil {
 			break
 		}
 
-		return e.complexity.Query.PtrToSliceContainer(childComplexity), true
+		return e.ComplexityRoot.Query.PtrToSliceContainer(childComplexity), true
 	case "Query.recursive":
-		if e.complexity.Query.Recursive == nil {
+		if e.ComplexityRoot.Query.Recursive == nil {
 			break
 		}
 
@@ -1850,15 +1840,15 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Recursive(childComplexity, args["input"].(*RecursiveInputSlice)), true
+		return e.ComplexityRoot.Query.Recursive(childComplexity, args["input"].(*RecursiveInputSlice)), true
 	case "Query.scalarSlice":
-		if e.complexity.Query.ScalarSlice == nil {
+		if e.ComplexityRoot.Query.ScalarSlice == nil {
 			break
 		}
 
-		return e.complexity.Query.ScalarSlice(childComplexity), true
+		return e.ComplexityRoot.Query.ScalarSlice(childComplexity), true
 	case "Query.searchMixed":
-		if e.complexity.Query.SearchMixed == nil {
+		if e.ComplexityRoot.Query.SearchMixed == nil {
 			break
 		}
 
@@ -1867,9 +1857,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.SearchMixed(childComplexity, args["query"].(*string), args["category"].(*string), args["minPrice"].(*int), args["limit"].(*int), args["offset"].(*int), args["sortBy"].(*string)), true
+		return e.ComplexityRoot.Query.SearchMixed(childComplexity, args["query"].(*string), args["category"].(*string), args["minPrice"].(*int), args["limit"].(*int), args["offset"].(*int), args["sortBy"].(*string)), true
 	case "Query.searchProducts":
-		if e.complexity.Query.SearchProducts == nil {
+		if e.ComplexityRoot.Query.SearchProducts == nil {
 			break
 		}
 
@@ -1878,9 +1868,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.SearchProducts(childComplexity, args["query"].(*string), args["category"].(*string), args["minPrice"].(*int)), true
+		return e.ComplexityRoot.Query.SearchProducts(childComplexity, args["query"].(*string), args["category"].(*string), args["minPrice"].(*int)), true
 	case "Query.searchProductsNormal":
-		if e.complexity.Query.SearchProductsNormal == nil {
+		if e.ComplexityRoot.Query.SearchProductsNormal == nil {
 			break
 		}
 
@@ -1889,9 +1879,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.SearchProductsNormal(childComplexity, args["filters"].(map[string]any)), true
+		return e.ComplexityRoot.Query.SearchProductsNormal(childComplexity, args["filters"].(map[string]any)), true
 	case "Query.searchRequired":
-		if e.complexity.Query.SearchRequired == nil {
+		if e.ComplexityRoot.Query.SearchRequired == nil {
 			break
 		}
 
@@ -1900,9 +1890,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.SearchRequired(childComplexity, args["name"].(string), args["age"].(int)), true
+		return e.ComplexityRoot.Query.SearchRequired(childComplexity, args["name"].(string), args["age"].(int)), true
 	case "Query.searchWithDefaults":
-		if e.complexity.Query.SearchWithDefaults == nil {
+		if e.ComplexityRoot.Query.SearchWithDefaults == nil {
 			break
 		}
 
@@ -1911,9 +1901,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.SearchWithDefaults(childComplexity, args["query"].(*string), args["limit"].(*int), args["includeArchived"].(*bool)), true
+		return e.ComplexityRoot.Query.SearchWithDefaults(childComplexity, args["query"].(*string), args["limit"].(*int), args["includeArchived"].(*bool)), true
 	case "Query.searchWithDirectives":
-		if e.complexity.Query.SearchWithDirectives == nil {
+		if e.ComplexityRoot.Query.SearchWithDirectives == nil {
 			break
 		}
 
@@ -1922,45 +1912,45 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.SearchWithDirectives(childComplexity, args["oldField"].(*string), args["newField"].(*string)), true
+		return e.ComplexityRoot.Query.SearchWithDirectives(childComplexity, args["oldField"].(*string), args["newField"].(*string)), true
 	case "Query.shapeUnion":
-		if e.complexity.Query.ShapeUnion == nil {
+		if e.ComplexityRoot.Query.ShapeUnion == nil {
 			break
 		}
 
-		return e.complexity.Query.ShapeUnion(childComplexity), true
+		return e.ComplexityRoot.Query.ShapeUnion(childComplexity), true
 	case "Query.shapes":
-		if e.complexity.Query.Shapes == nil {
+		if e.ComplexityRoot.Query.Shapes == nil {
 			break
 		}
 
-		return e.complexity.Query.Shapes(childComplexity), true
+		return e.ComplexityRoot.Query.Shapes(childComplexity), true
 	case "Query.skipInclude":
-		if e.complexity.Query.SkipInclude == nil {
+		if e.ComplexityRoot.Query.SkipInclude == nil {
 			break
 		}
 
-		return e.complexity.Query.SkipInclude(childComplexity), true
+		return e.ComplexityRoot.Query.SkipInclude(childComplexity), true
 	case "Query.slices":
-		if e.complexity.Query.Slices == nil {
+		if e.ComplexityRoot.Query.Slices == nil {
 			break
 		}
 
-		return e.complexity.Query.Slices(childComplexity), true
+		return e.ComplexityRoot.Query.Slices(childComplexity), true
 	case "Query.stringFromContextFunction":
-		if e.complexity.Query.StringFromContextFunction == nil {
+		if e.ComplexityRoot.Query.StringFromContextFunction == nil {
 			break
 		}
 
-		return e.complexity.Query.StringFromContextFunction(childComplexity), true
+		return e.ComplexityRoot.Query.StringFromContextFunction(childComplexity), true
 	case "Query.stringFromContextInterface":
-		if e.complexity.Query.StringFromContextInterface == nil {
+		if e.ComplexityRoot.Query.StringFromContextInterface == nil {
 			break
 		}
 
-		return e.complexity.Query.StringFromContextInterface(childComplexity), true
+		return e.ComplexityRoot.Query.StringFromContextInterface(childComplexity), true
 	case "Query.user":
-		if e.complexity.Query.User == nil {
+		if e.ComplexityRoot.Query.User == nil {
 			break
 		}
 
@@ -1969,140 +1959,140 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.User(childComplexity, args["id"].(int)), true
+		return e.ComplexityRoot.Query.User(childComplexity, args["id"].(int)), true
 	case "Query.vOkCaseNil":
-		if e.complexity.Query.VOkCaseNil == nil {
+		if e.ComplexityRoot.Query.VOkCaseNil == nil {
 			break
 		}
 
-		return e.complexity.Query.VOkCaseNil(childComplexity), true
+		return e.ComplexityRoot.Query.VOkCaseNil(childComplexity), true
 	case "Query.vOkCaseValue":
-		if e.complexity.Query.VOkCaseValue == nil {
+		if e.ComplexityRoot.Query.VOkCaseValue == nil {
 			break
 		}
 
-		return e.complexity.Query.VOkCaseValue(childComplexity), true
+		return e.ComplexityRoot.Query.VOkCaseValue(childComplexity), true
 	case "Query.valid":
-		if e.complexity.Query.Valid == nil {
+		if e.ComplexityRoot.Query.Valid == nil {
 			break
 		}
 
-		return e.complexity.Query.Valid(childComplexity), true
+		return e.ComplexityRoot.Query.Valid(childComplexity), true
 	case "Query.validType":
-		if e.complexity.Query.ValidType == nil {
+		if e.ComplexityRoot.Query.ValidType == nil {
 			break
 		}
 
-		return e.complexity.Query.ValidType(childComplexity), true
+		return e.ComplexityRoot.Query.ValidType(childComplexity), true
 	case "Query.variadicModel":
-		if e.complexity.Query.VariadicModel == nil {
+		if e.ComplexityRoot.Query.VariadicModel == nil {
 			break
 		}
 
-		return e.complexity.Query.VariadicModel(childComplexity), true
+		return e.ComplexityRoot.Query.VariadicModel(childComplexity), true
 	case "Query.wrappedMap":
-		if e.complexity.Query.WrappedMap == nil {
+		if e.ComplexityRoot.Query.WrappedMap == nil {
 			break
 		}
 
-		return e.complexity.Query.WrappedMap(childComplexity), true
+		return e.ComplexityRoot.Query.WrappedMap(childComplexity), true
 	case "Query.wrappedScalar":
-		if e.complexity.Query.WrappedScalar == nil {
+		if e.ComplexityRoot.Query.WrappedScalar == nil {
 			break
 		}
 
-		return e.complexity.Query.WrappedScalar(childComplexity), true
+		return e.ComplexityRoot.Query.WrappedScalar(childComplexity), true
 	case "Query.wrappedSlice":
-		if e.complexity.Query.WrappedSlice == nil {
+		if e.ComplexityRoot.Query.WrappedSlice == nil {
 			break
 		}
 
-		return e.complexity.Query.WrappedSlice(childComplexity), true
+		return e.ComplexityRoot.Query.WrappedSlice(childComplexity), true
 	case "Query.wrappedStruct":
-		if e.complexity.Query.WrappedStruct == nil {
+		if e.ComplexityRoot.Query.WrappedStruct == nil {
 			break
 		}
 
-		return e.complexity.Query.WrappedStruct(childComplexity), true
+		return e.ComplexityRoot.Query.WrappedStruct(childComplexity), true
 
 	case "Rectangle.area":
-		if e.complexity.Rectangle.Area == nil {
+		if e.ComplexityRoot.Rectangle.Area == nil {
 			break
 		}
 
-		return e.complexity.Rectangle.Area(childComplexity), true
+		return e.ComplexityRoot.Rectangle.Area(childComplexity), true
 	case "Rectangle.coordinates":
-		if e.complexity.Rectangle.Coordinates == nil {
+		if e.ComplexityRoot.Rectangle.Coordinates == nil {
 			break
 		}
 
-		return e.complexity.Rectangle.Coordinates(childComplexity), true
+		return e.ComplexityRoot.Rectangle.Coordinates(childComplexity), true
 	case "Rectangle.length":
-		if e.complexity.Rectangle.Length == nil {
+		if e.ComplexityRoot.Rectangle.Length == nil {
 			break
 		}
 
-		return e.complexity.Rectangle.Length(childComplexity), true
+		return e.ComplexityRoot.Rectangle.Length(childComplexity), true
 	case "Rectangle.width":
-		if e.complexity.Rectangle.Width == nil {
+		if e.ComplexityRoot.Rectangle.Width == nil {
 			break
 		}
 
-		return e.complexity.Rectangle.Width(childComplexity), true
+		return e.ComplexityRoot.Rectangle.Width(childComplexity), true
 
 	case "Size.height":
-		if e.complexity.Size.Height == nil {
+		if e.ComplexityRoot.Size.Height == nil {
 			break
 		}
 
-		return e.complexity.Size.Height(childComplexity), true
+		return e.ComplexityRoot.Size.Height(childComplexity), true
 	case "Size.weight":
-		if e.complexity.Size.Weight == nil {
+		if e.ComplexityRoot.Size.Weight == nil {
 			break
 		}
 
-		return e.complexity.Size.Weight(childComplexity), true
+		return e.ComplexityRoot.Size.Weight(childComplexity), true
 
 	case "SkipIncludeTestType.a":
-		if e.complexity.SkipIncludeTestType.A == nil {
+		if e.ComplexityRoot.SkipIncludeTestType.A == nil {
 			break
 		}
 
-		return e.complexity.SkipIncludeTestType.A(childComplexity), true
+		return e.ComplexityRoot.SkipIncludeTestType.A(childComplexity), true
 	case "SkipIncludeTestType.b":
-		if e.complexity.SkipIncludeTestType.B == nil {
+		if e.ComplexityRoot.SkipIncludeTestType.B == nil {
 			break
 		}
 
-		return e.complexity.SkipIncludeTestType.B(childComplexity), true
+		return e.ComplexityRoot.SkipIncludeTestType.B(childComplexity), true
 
 	case "Slices.test1":
-		if e.complexity.Slices.Test1 == nil {
+		if e.ComplexityRoot.Slices.Test1 == nil {
 			break
 		}
 
-		return e.complexity.Slices.Test1(childComplexity), true
+		return e.ComplexityRoot.Slices.Test1(childComplexity), true
 	case "Slices.test2":
-		if e.complexity.Slices.Test2 == nil {
+		if e.ComplexityRoot.Slices.Test2 == nil {
 			break
 		}
 
-		return e.complexity.Slices.Test2(childComplexity), true
+		return e.ComplexityRoot.Slices.Test2(childComplexity), true
 	case "Slices.test3":
-		if e.complexity.Slices.Test3 == nil {
+		if e.ComplexityRoot.Slices.Test3 == nil {
 			break
 		}
 
-		return e.complexity.Slices.Test3(childComplexity), true
+		return e.ComplexityRoot.Slices.Test3(childComplexity), true
 	case "Slices.test4":
-		if e.complexity.Slices.Test4 == nil {
+		if e.ComplexityRoot.Slices.Test4 == nil {
 			break
 		}
 
-		return e.complexity.Slices.Test4(childComplexity), true
+		return e.ComplexityRoot.Slices.Test4(childComplexity), true
 
 	case "Subscription.directiveArg":
-		if e.complexity.Subscription.DirectiveArg == nil {
+		if e.ComplexityRoot.Subscription.DirectiveArg == nil {
 			break
 		}
 
@@ -2111,15 +2101,15 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Subscription.DirectiveArg(childComplexity, args["arg"].(string)), true
+		return e.ComplexityRoot.Subscription.DirectiveArg(childComplexity, args["arg"].(string)), true
 	case "Subscription.directiveDouble":
-		if e.complexity.Subscription.DirectiveDouble == nil {
+		if e.ComplexityRoot.Subscription.DirectiveDouble == nil {
 			break
 		}
 
-		return e.complexity.Subscription.DirectiveDouble(childComplexity), true
+		return e.ComplexityRoot.Subscription.DirectiveDouble(childComplexity), true
 	case "Subscription.directiveNullableArg":
-		if e.complexity.Subscription.DirectiveNullableArg == nil {
+		if e.ComplexityRoot.Subscription.DirectiveNullableArg == nil {
 			break
 		}
 
@@ -2128,58 +2118,58 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Subscription.DirectiveNullableArg(childComplexity, args["arg"].(*int), args["arg2"].(*int), args["arg3"].(*string)), true
+		return e.ComplexityRoot.Subscription.DirectiveNullableArg(childComplexity, args["arg"].(*int), args["arg2"].(*int), args["arg3"].(*string)), true
 	case "Subscription.directiveUnimplemented":
-		if e.complexity.Subscription.DirectiveUnimplemented == nil {
+		if e.ComplexityRoot.Subscription.DirectiveUnimplemented == nil {
 			break
 		}
 
-		return e.complexity.Subscription.DirectiveUnimplemented(childComplexity), true
+		return e.ComplexityRoot.Subscription.DirectiveUnimplemented(childComplexity), true
 	case "Subscription.errorRequired":
-		if e.complexity.Subscription.ErrorRequired == nil {
+		if e.ComplexityRoot.Subscription.ErrorRequired == nil {
 			break
 		}
 
-		return e.complexity.Subscription.ErrorRequired(childComplexity), true
+		return e.ComplexityRoot.Subscription.ErrorRequired(childComplexity), true
 	case "Subscription.initPayload":
-		if e.complexity.Subscription.InitPayload == nil {
+		if e.ComplexityRoot.Subscription.InitPayload == nil {
 			break
 		}
 
-		return e.complexity.Subscription.InitPayload(childComplexity), true
+		return e.ComplexityRoot.Subscription.InitPayload(childComplexity), true
 	case "Subscription.issue896b":
-		if e.complexity.Subscription.Issue896b == nil {
+		if e.ComplexityRoot.Subscription.Issue896b == nil {
 			break
 		}
 
-		return e.complexity.Subscription.Issue896b(childComplexity), true
+		return e.ComplexityRoot.Subscription.Issue896b(childComplexity), true
 	case "Subscription.updated":
-		if e.complexity.Subscription.Updated == nil {
+		if e.ComplexityRoot.Subscription.Updated == nil {
 			break
 		}
 
-		return e.complexity.Subscription.Updated(childComplexity), true
+		return e.ComplexityRoot.Subscription.Updated(childComplexity), true
 
 	case "User.created":
-		if e.complexity.User.Created == nil {
+		if e.ComplexityRoot.User.Created == nil {
 			break
 		}
 
-		return e.complexity.User.Created(childComplexity), true
+		return e.ComplexityRoot.User.Created(childComplexity), true
 	case "User.friends":
-		if e.complexity.User.Friends == nil {
+		if e.ComplexityRoot.User.Friends == nil {
 			break
 		}
 
-		return e.complexity.User.Friends(childComplexity), true
+		return e.ComplexityRoot.User.Friends(childComplexity), true
 	case "User.id":
-		if e.complexity.User.ID == nil {
+		if e.ComplexityRoot.User.ID == nil {
 			break
 		}
 
-		return e.complexity.User.ID(childComplexity), true
+		return e.ComplexityRoot.User.ID(childComplexity), true
 	case "User.pets":
-		if e.complexity.User.Pets == nil {
+		if e.ComplexityRoot.User.Pets == nil {
 			break
 		}
 
@@ -2188,42 +2178,42 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.User.Pets(childComplexity, args["limit"].(*int)), true
+		return e.ComplexityRoot.User.Pets(childComplexity, args["limit"].(*int)), true
 	case "User.updated":
-		if e.complexity.User.Updated == nil {
+		if e.ComplexityRoot.User.Updated == nil {
 			break
 		}
 
-		return e.complexity.User.Updated(childComplexity), true
+		return e.ComplexityRoot.User.Updated(childComplexity), true
 
 	case "VOkCaseNil.value":
-		if e.complexity.VOkCaseNil.Value == nil {
+		if e.ComplexityRoot.VOkCaseNil.Value == nil {
 			break
 		}
 
-		return e.complexity.VOkCaseNil.Value(childComplexity), true
+		return e.ComplexityRoot.VOkCaseNil.Value(childComplexity), true
 
 	case "VOkCaseValue.value":
-		if e.complexity.VOkCaseValue.Value == nil {
+		if e.ComplexityRoot.VOkCaseValue.Value == nil {
 			break
 		}
 
-		return e.complexity.VOkCaseValue.Value(childComplexity), true
+		return e.ComplexityRoot.VOkCaseValue.Value(childComplexity), true
 
 	case "ValidType.differentCase":
-		if e.complexity.ValidType.DifferentCase == nil {
+		if e.ComplexityRoot.ValidType.DifferentCase == nil {
 			break
 		}
 
-		return e.complexity.ValidType.DifferentCase(childComplexity), true
+		return e.ComplexityRoot.ValidType.DifferentCase(childComplexity), true
 	case "ValidType.different_case":
-		if e.complexity.ValidType.DifferentCaseOld == nil {
+		if e.ComplexityRoot.ValidType.DifferentCaseOld == nil {
 			break
 		}
 
-		return e.complexity.ValidType.DifferentCaseOld(childComplexity), true
+		return e.ComplexityRoot.ValidType.DifferentCaseOld(childComplexity), true
 	case "ValidType.validArgs":
-		if e.complexity.ValidType.ValidArgs == nil {
+		if e.ComplexityRoot.ValidType.ValidArgs == nil {
 			break
 		}
 
@@ -2232,9 +2222,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.ValidType.ValidArgs(childComplexity, args["break"].(string), args["default"].(string), args["func"].(string), args["interface"].(string), args["select"].(string), args["case"].(string), args["defer"].(string), args["go"].(string), args["map"].(string), args["struct"].(string), args["chan"].(string), args["else"].(string), args["goto"].(string), args["package"].(string), args["switch"].(string), args["const"].(string), args["fallthrough"].(string), args["if"].(string), args["range"].(string), args["type"].(string), args["continue"].(string), args["for"].(string), args["import"].(string), args["return"].(string), args["var"].(string), args["_"].(string)), true
+		return e.ComplexityRoot.ValidType.ValidArgs(childComplexity, args["break"].(string), args["default"].(string), args["func"].(string), args["interface"].(string), args["select"].(string), args["case"].(string), args["defer"].(string), args["go"].(string), args["map"].(string), args["struct"].(string), args["chan"].(string), args["else"].(string), args["goto"].(string), args["package"].(string), args["switch"].(string), args["const"].(string), args["fallthrough"].(string), args["if"].(string), args["range"].(string), args["type"].(string), args["continue"].(string), args["for"].(string), args["import"].(string), args["return"].(string), args["var"].(string), args["_"].(string)), true
 	case "ValidType.validInputKeywords":
-		if e.complexity.ValidType.ValidInputKeywords == nil {
+		if e.ComplexityRoot.ValidType.ValidInputKeywords == nil {
 			break
 		}
 
@@ -2243,10 +2233,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.ValidType.ValidInputKeywords(childComplexity, args["input"].(*ValidInput)), true
+		return e.ComplexityRoot.ValidType.ValidInputKeywords(childComplexity, args["input"].(*ValidInput)), true
 
 	case "VariadicModel.value":
-		if e.complexity.VariadicModel.Value == nil {
+		if e.ComplexityRoot.VariadicModel.Value == nil {
 			break
 		}
 
@@ -2255,10 +2245,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.VariadicModel.Value(childComplexity, args["rank"].(int)), true
+		return e.ComplexityRoot.VariadicModel.Value(childComplexity, args["rank"].(int)), true
 
 	case "WrappedMap.get":
-		if e.complexity.WrappedMap.Get == nil {
+		if e.ComplexityRoot.WrappedMap.Get == nil {
 			break
 		}
 
@@ -2267,10 +2257,10 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.WrappedMap.Get(childComplexity, args["key"].(string)), true
+		return e.ComplexityRoot.WrappedMap.Get(childComplexity, args["key"].(string)), true
 
 	case "WrappedSlice.get":
-		if e.complexity.WrappedSlice.Get == nil {
+		if e.ComplexityRoot.WrappedSlice.Get == nil {
 			break
 		}
 
@@ -2279,48 +2269,48 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.WrappedSlice.Get(childComplexity, args["idx"].(int)), true
+		return e.ComplexityRoot.WrappedSlice.Get(childComplexity, args["idx"].(int)), true
 
 	case "WrappedStruct.desc":
-		if e.complexity.WrappedStruct.Desc == nil {
+		if e.ComplexityRoot.WrappedStruct.Desc == nil {
 			break
 		}
 
-		return e.complexity.WrappedStruct.Desc(childComplexity), true
+		return e.ComplexityRoot.WrappedStruct.Desc(childComplexity), true
 	case "WrappedStruct.name":
-		if e.complexity.WrappedStruct.Name == nil {
+		if e.ComplexityRoot.WrappedStruct.Name == nil {
 			break
 		}
 
-		return e.complexity.WrappedStruct.Name(childComplexity), true
+		return e.ComplexityRoot.WrappedStruct.Name(childComplexity), true
 
 	case "XXIt.id":
-		if e.complexity.XXIt.ID == nil {
+		if e.ComplexityRoot.XXIt.ID == nil {
 			break
 		}
 
-		return e.complexity.XXIt.ID(childComplexity), true
+		return e.ComplexityRoot.XXIt.ID(childComplexity), true
 
 	case "XxIt.id":
-		if e.complexity.XxIt.ID == nil {
+		if e.ComplexityRoot.XxIt.ID == nil {
 			break
 		}
 
-		return e.complexity.XxIt.ID(childComplexity), true
+		return e.ComplexityRoot.XxIt.ID(childComplexity), true
 
 	case "asdfIt.id":
-		if e.complexity.AsdfIt.ID == nil {
+		if e.ComplexityRoot.AsdfIt.ID == nil {
 			break
 		}
 
-		return e.complexity.AsdfIt.ID(childComplexity), true
+		return e.ComplexityRoot.AsdfIt.ID(childComplexity), true
 
 	case "iIt.id":
-		if e.complexity.IIt.ID == nil {
+		if e.ComplexityRoot.IIt.ID == nil {
 			break
 		}
 
-		return e.complexity.IIt.ID(childComplexity), true
+		return e.ComplexityRoot.IIt.ID(childComplexity), true
 
 	}
 	return 0, false
@@ -3318,11 +3308,11 @@ func (ec *executionContext) field_Query_directiveArg_argsArg(
 			var zeroVal string
 			return zeroVal, err
 		}
-		if ec.directives.Length == nil {
+		if ec.Directives.Length == nil {
 			var zeroVal string
 			return zeroVal, errors.New("directive length is not implemented")
 		}
-		return ec.directives.Length(ctx, rawArgs, directive0, min, max, message)
+		return ec.Directives.Length(ctx, rawArgs, directive0, min, max, message)
 	}
 
 	tmp, err := directive1(ctx)
@@ -3392,11 +3382,11 @@ func (ec *executionContext) field_Query_directiveInputType_argsArg(
 	}
 
 	directive1 := func(ctx context.Context) (any, error) {
-		if ec.directives.Custom == nil {
+		if ec.Directives.Custom == nil {
 			var zeroVal InnerInput
 			return zeroVal, errors.New("directive custom is not implemented")
 		}
-		return ec.directives.Custom(ctx, rawArgs, directive0)
+		return ec.Directives.Custom(ctx, rawArgs, directive0)
 	}
 
 	tmp, err := directive1(ctx)
@@ -3472,11 +3462,11 @@ func (ec *executionContext) field_Query_directiveNullableArg_argsArg(
 			var zeroVal *int
 			return zeroVal, err
 		}
-		if ec.directives.Range == nil {
+		if ec.Directives.Range == nil {
 			var zeroVal *int
 			return zeroVal, errors.New("directive range is not implemented")
 		}
-		return ec.directives.Range(ctx, rawArgs, directive0, min, nil)
+		return ec.Directives.Range(ctx, rawArgs, directive0, min, nil)
 	}
 
 	tmp, err := directive1(ctx)
@@ -3520,11 +3510,11 @@ func (ec *executionContext) field_Query_directiveNullableArg_argsArg2(
 			var zeroVal *int
 			return zeroVal, err
 		}
-		if ec.directives.Range == nil {
+		if ec.Directives.Range == nil {
 			var zeroVal *int
 			return zeroVal, errors.New("directive range is not implemented")
 		}
-		return ec.directives.Range(ctx, rawArgs, directive0, min, nil)
+		return ec.Directives.Range(ctx, rawArgs, directive0, min, nil)
 	}
 
 	tmp, err := directive1(ctx)
@@ -3563,11 +3553,11 @@ func (ec *executionContext) field_Query_directiveNullableArg_argsArg3(
 	}
 
 	directive1 := func(ctx context.Context) (any, error) {
-		if ec.directives.ToNull == nil {
+		if ec.Directives.ToNull == nil {
 			var zeroVal *string
 			return zeroVal, errors.New("directive toNull is not implemented")
 		}
-		return ec.directives.ToNull(ctx, rawArgs, directive0)
+		return ec.Directives.ToNull(ctx, rawArgs, directive0)
 	}
 
 	tmp, err := directive1(ctx)
@@ -3623,18 +3613,18 @@ func (ec *executionContext) field_Query_directiveSingleNullableArg_argsArg1(
 			var zeroVal *string
 			return zeroVal, err
 		}
-		if ec.directives.Populate == nil {
+		if ec.Directives.Populate == nil {
 			var zeroVal *string
 			return zeroVal, errors.New("directive populate is not implemented")
 		}
-		return ec.directives.Populate(ctx, rawArgs, directive0, value)
+		return ec.Directives.Populate(ctx, rawArgs, directive0, value)
 	}
 	directive2 := func(ctx context.Context) (any, error) {
-		if ec.directives.Noop == nil {
+		if ec.Directives.Noop == nil {
 			var zeroVal *string
 			return zeroVal, errors.New("directive noop is not implemented")
 		}
-		return ec.directives.Noop(ctx, rawArgs, directive1)
+		return ec.Directives.Noop(ctx, rawArgs, directive1)
 	}
 
 	tmp, err := directive2(ctx)
@@ -4022,11 +4012,11 @@ func (ec *executionContext) field_Subscription_directiveArg_argsArg(
 			var zeroVal string
 			return zeroVal, err
 		}
-		if ec.directives.Length == nil {
+		if ec.Directives.Length == nil {
 			var zeroVal string
 			return zeroVal, errors.New("directive length is not implemented")
 		}
-		return ec.directives.Length(ctx, rawArgs, directive0, min, max, message)
+		return ec.Directives.Length(ctx, rawArgs, directive0, min, max, message)
 	}
 
 	tmp, err := directive1(ctx)
@@ -4091,11 +4081,11 @@ func (ec *executionContext) field_Subscription_directiveNullableArg_argsArg(
 			var zeroVal *int
 			return zeroVal, err
 		}
-		if ec.directives.Range == nil {
+		if ec.Directives.Range == nil {
 			var zeroVal *int
 			return zeroVal, errors.New("directive range is not implemented")
 		}
-		return ec.directives.Range(ctx, rawArgs, directive0, min, nil)
+		return ec.Directives.Range(ctx, rawArgs, directive0, min, nil)
 	}
 
 	tmp, err := directive1(ctx)
@@ -4139,11 +4129,11 @@ func (ec *executionContext) field_Subscription_directiveNullableArg_argsArg2(
 			var zeroVal *int
 			return zeroVal, err
 		}
-		if ec.directives.Range == nil {
+		if ec.Directives.Range == nil {
 			var zeroVal *int
 			return zeroVal, errors.New("directive range is not implemented")
 		}
-		return ec.directives.Range(ctx, rawArgs, directive0, min, nil)
+		return ec.Directives.Range(ctx, rawArgs, directive0, min, nil)
 	}
 
 	tmp, err := directive1(ctx)
@@ -4182,11 +4172,11 @@ func (ec *executionContext) field_Subscription_directiveNullableArg_argsArg3(
 	}
 
 	directive1 := func(ctx context.Context) (any, error) {
-		if ec.directives.ToNull == nil {
+		if ec.Directives.ToNull == nil {
 			var zeroVal *string
 			return zeroVal, errors.New("directive toNull is not implemented")
 		}
-		return ec.directives.ToNull(ctx, rawArgs, directive0)
+		return ec.Directives.ToNull(ctx, rawArgs, directive0)
 	}
 
 	tmp, err := directive1(ctx)
@@ -4457,10 +4447,10 @@ func (ec *executionContext) _fieldMiddleware(ctx context.Context, obj any, next 
 			}
 			n := next
 			next = func(ctx context.Context) (any, error) {
-				if ec.directives.Logged == nil {
+				if ec.Directives.Logged == nil {
 					return nil, errors.New("directive logged is not implemented")
 				}
-				return ec.directives.Logged(ctx, obj, n, args["id"].(string))
+				return ec.Directives.Logged(ctx, obj, n, args["id"].(string))
 			}
 		}
 	}
@@ -4757,7 +4747,7 @@ func (ec *executionContext) _BackedByInterface_id(ctx context.Context, field gra
 		field,
 		ec.fieldContext_BackedByInterface_id,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.BackedByInterface().ID(ctx, obj)
+			return ec.Resolvers.BackedByInterface().ID(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -5482,7 +5472,7 @@ func (ec *executionContext) _DeferModel_values(ctx context.Context, field graphq
 		field,
 		ec.fieldContext_DeferModel_values,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.DeferModel().Values(ctx, obj)
+			return ec.Resolvers.DeferModel().Values(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -5922,7 +5912,7 @@ func (ec *executionContext) _Errors_a(ctx context.Context, field graphql.Collect
 		field,
 		ec.fieldContext_Errors_a,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Errors().A(ctx, obj)
+			return ec.Resolvers.Errors().A(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -5963,7 +5953,7 @@ func (ec *executionContext) _Errors_b(ctx context.Context, field graphql.Collect
 		field,
 		ec.fieldContext_Errors_b,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Errors().B(ctx, obj)
+			return ec.Resolvers.Errors().B(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -6004,7 +5994,7 @@ func (ec *executionContext) _Errors_c(ctx context.Context, field graphql.Collect
 		field,
 		ec.fieldContext_Errors_c,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Errors().C(ctx, obj)
+			return ec.Resolvers.Errors().C(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -6045,7 +6035,7 @@ func (ec *executionContext) _Errors_d(ctx context.Context, field graphql.Collect
 		field,
 		ec.fieldContext_Errors_d,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Errors().D(ctx, obj)
+			return ec.Resolvers.Errors().D(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -6086,7 +6076,7 @@ func (ec *executionContext) _Errors_e(ctx context.Context, field graphql.Collect
 		field,
 		ec.fieldContext_Errors_e,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Errors().E(ctx, obj)
+			return ec.Resolvers.Errors().E(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -6158,7 +6148,7 @@ func (ec *executionContext) _ForcedResolver_field(ctx context.Context, field gra
 		field,
 		ec.fieldContext_ForcedResolver_field,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.ForcedResolver().Field(ctx, obj)
+			return ec.Resolvers.ForcedResolver().Field(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -6685,7 +6675,7 @@ func (ec *executionContext) _ModelMethods_resolverField(ctx context.Context, fie
 		field,
 		ec.fieldContext_ModelMethods_resolverField,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.ModelMethods().ResolverField(ctx, obj)
+			return ec.Resolvers.ModelMethods().ResolverField(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -6779,7 +6769,7 @@ func (ec *executionContext) _Mutation_defaultInput(ctx context.Context, field gr
 		ec.fieldContext_Mutation_defaultInput,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().DefaultInput(ctx, fc.Args["input"].(DefaultInput))
+			return ec.Resolvers.Mutation().DefaultInput(ctx, fc.Args["input"].(DefaultInput))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -6828,7 +6818,7 @@ func (ec *executionContext) _Mutation_overrideValueViaInput(ctx context.Context,
 		ec.fieldContext_Mutation_overrideValueViaInput,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().OverrideValueViaInput(ctx, fc.Args["input"].(FieldsOrderInput))
+			return ec.Resolvers.Mutation().OverrideValueViaInput(ctx, fc.Args["input"].(FieldsOrderInput))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -6875,7 +6865,7 @@ func (ec *executionContext) _Mutation_updateProduct(ctx context.Context, field g
 		ec.fieldContext_Mutation_updateProduct,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().UpdateProduct(ctx, map[string]interface{}{
+			return ec.Resolvers.Mutation().UpdateProduct(ctx, map[string]interface{}{
 				"id":    fc.Args["id"].(string),
 				"name":  fc.Args["name"].(*string),
 				"price": fc.Args["price"].(*float64),
@@ -6922,7 +6912,7 @@ func (ec *executionContext) _Mutation_updateSomething(ctx context.Context, field
 		ec.fieldContext_Mutation_updateSomething,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().UpdateSomething(ctx, fc.Args["input"].(SpecialInput))
+			return ec.Resolvers.Mutation().UpdateSomething(ctx, fc.Args["input"].(SpecialInput))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -6965,7 +6955,7 @@ func (ec *executionContext) _Mutation_updatePtrToPtr(ctx context.Context, field 
 		ec.fieldContext_Mutation_updatePtrToPtr,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().UpdatePtrToPtr(ctx, fc.Args["input"].(UpdatePtrToPtrOuter))
+			return ec.Resolvers.Mutation().UpdatePtrToPtr(ctx, fc.Args["input"].(UpdatePtrToPtrOuter))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -7036,11 +7026,11 @@ func (ec *executionContext) _ObjectDirectives_text(ctx context.Context, field gr
 					var zeroVal string
 					return zeroVal, err
 				}
-				if ec.directives.Length == nil {
+				if ec.Directives.Length == nil {
 					var zeroVal string
 					return zeroVal, errors.New("directive length is not implemented")
 				}
-				return ec.directives.Length(ctx, obj, directive0, min, max, message)
+				return ec.Directives.Length(ctx, obj, directive0, min, max, message)
 			}
 
 			next = directive1
@@ -7078,11 +7068,11 @@ func (ec *executionContext) _ObjectDirectives_nullableText(ctx context.Context, 
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.ToNull == nil {
+				if ec.Directives.ToNull == nil {
 					var zeroVal *string
 					return zeroVal, errors.New("directive toNull is not implemented")
 				}
-				return ec.directives.ToNull(ctx, obj, directive0)
+				return ec.Directives.ToNull(ctx, obj, directive0)
 			}
 
 			next = directive1
@@ -7151,11 +7141,11 @@ func (ec *executionContext) _ObjectDirectivesWithCustomGoModel_nullableText(ctx 
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.ToNull == nil {
+				if ec.Directives.ToNull == nil {
 					var zeroVal string
 					return zeroVal, errors.New("directive toNull is not implemented")
 				}
-				return ec.directives.ToNull(ctx, obj, directive0)
+				return ec.Directives.ToNull(ctx, obj, directive0)
 			}
 
 			next = directive1
@@ -7284,7 +7274,7 @@ func (ec *executionContext) _OverlappingFields_oldFoo(ctx context.Context, field
 		field,
 		ec.fieldContext_OverlappingFields_oldFoo,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.OverlappingFields().OldFoo(ctx, obj)
+			return ec.Resolvers.OverlappingFields().OldFoo(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -7377,7 +7367,7 @@ func (ec *executionContext) _Panics_fieldScalarMarshal(ctx context.Context, fiel
 		field,
 		ec.fieldContext_Panics_fieldScalarMarshal,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Panics().FieldScalarMarshal(ctx, obj)
+			return ec.Resolvers.Panics().FieldScalarMarshal(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -7452,7 +7442,7 @@ func (ec *executionContext) _Panics_argUnmarshal(ctx context.Context, field grap
 		ec.fieldContext_Panics_argUnmarshal,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Panics().ArgUnmarshal(ctx, obj, fc.Args["u"].([]MarshalPanic))
+			return ec.Resolvers.Panics().ArgUnmarshal(ctx, obj, fc.Args["u"].([]MarshalPanic))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -7526,7 +7516,7 @@ func (ec *executionContext) _Pet_friends(ctx context.Context, field graphql.Coll
 		ec.fieldContext_Pet_friends,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Pet().Friends(ctx, obj, fc.Args["limit"].(*int))
+			return ec.Resolvers.Pet().Friends(ctx, obj, fc.Args["limit"].(*int))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -7574,7 +7564,7 @@ func (ec *executionContext) _Primitive_value(ctx context.Context, field graphql.
 		field,
 		ec.fieldContext_Primitive_value,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Primitive().Value(ctx, obj)
+			return ec.Resolvers.Primitive().Value(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -7636,7 +7626,7 @@ func (ec *executionContext) _PrimitiveString_value(ctx context.Context, field gr
 		field,
 		ec.fieldContext_PrimitiveString_value,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.PrimitiveString().Value(ctx, obj)
+			return ec.Resolvers.PrimitiveString().Value(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -7698,7 +7688,7 @@ func (ec *executionContext) _PrimitiveString_len(ctx context.Context, field grap
 		field,
 		ec.fieldContext_PrimitiveString_len,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.PrimitiveString().Len(ctx, obj)
+			return ec.Resolvers.PrimitiveString().Len(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -7989,7 +7979,7 @@ func (ec *executionContext) _Query_invalidIdentifier(ctx context.Context, field 
 		field,
 		ec.fieldContext_Query_invalidIdentifier,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().InvalidIdentifier(ctx)
+			return ec.Resolvers.Query().InvalidIdentifier(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8024,7 +8014,7 @@ func (ec *executionContext) _Query_collision(ctx context.Context, field graphql.
 		field,
 		ec.fieldContext_Query_collision,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Collision(ctx)
+			return ec.Resolvers.Query().Collision(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8060,7 +8050,7 @@ func (ec *executionContext) _Query_mapInput(ctx context.Context, field graphql.C
 		ec.fieldContext_Query_mapInput,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().MapInput(ctx, fc.Args["input"].(map[string]any))
+			return ec.Resolvers.Query().MapInput(ctx, fc.Args["input"].(map[string]any))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8103,7 +8093,7 @@ func (ec *executionContext) _Query_recursive(ctx context.Context, field graphql.
 		ec.fieldContext_Query_recursive,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Recursive(ctx, fc.Args["input"].(*RecursiveInputSlice))
+			return ec.Resolvers.Query().Recursive(ctx, fc.Args["input"].(*RecursiveInputSlice))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8146,7 +8136,7 @@ func (ec *executionContext) _Query_nestedInputs(ctx context.Context, field graph
 		ec.fieldContext_Query_nestedInputs,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().NestedInputs(ctx, fc.Args["input"].([][]*OuterInput))
+			return ec.Resolvers.Query().NestedInputs(ctx, fc.Args["input"].([][]*OuterInput))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8188,7 +8178,7 @@ func (ec *executionContext) _Query_nestedOutputs(ctx context.Context, field grap
 		field,
 		ec.fieldContext_Query_nestedOutputs,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().NestedOutputs(ctx)
+			return ec.Resolvers.Query().NestedOutputs(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8223,7 +8213,7 @@ func (ec *executionContext) _Query_modelMethods(ctx context.Context, field graph
 		field,
 		ec.fieldContext_Query_modelMethods,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().ModelMethods(ctx)
+			return ec.Resolvers.Query().ModelMethods(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8263,7 +8253,7 @@ func (ec *executionContext) _Query_user(ctx context.Context, field graphql.Colle
 		ec.fieldContext_Query_user,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().User(ctx, fc.Args["id"].(int))
+			return ec.Resolvers.Query().User(ctx, fc.Args["id"].(int))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8318,7 +8308,7 @@ func (ec *executionContext) _Query_nullableArg(ctx context.Context, field graphq
 		ec.fieldContext_Query_nullableArg,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().NullableArg(ctx, fc.Args["arg"].(*int))
+			return ec.Resolvers.Query().NullableArg(ctx, fc.Args["arg"].(*int))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8361,7 +8351,7 @@ func (ec *executionContext) _Query_inputSlice(ctx context.Context, field graphql
 		ec.fieldContext_Query_inputSlice,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().InputSlice(ctx, fc.Args["arg"].([]string))
+			return ec.Resolvers.Query().InputSlice(ctx, fc.Args["arg"].([]string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8404,7 +8394,7 @@ func (ec *executionContext) _Query_inputNullableSlice(ctx context.Context, field
 		ec.fieldContext_Query_inputNullableSlice,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().InputNullableSlice(ctx, fc.Args["arg"].([]string))
+			return ec.Resolvers.Query().InputNullableSlice(ctx, fc.Args["arg"].([]string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8447,7 +8437,7 @@ func (ec *executionContext) _Query_inputOmittable(ctx context.Context, field gra
 		ec.fieldContext_Query_inputOmittable,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().InputOmittable(ctx, fc.Args["arg"].(OmittableInput))
+			return ec.Resolvers.Query().InputOmittable(ctx, fc.Args["arg"].(OmittableInput))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8489,7 +8479,7 @@ func (ec *executionContext) _Query_shapeUnion(ctx context.Context, field graphql
 		field,
 		ec.fieldContext_Query_shapeUnion,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().ShapeUnion(ctx)
+			return ec.Resolvers.Query().ShapeUnion(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8520,7 +8510,7 @@ func (ec *executionContext) _Query_autobind(ctx context.Context, field graphql.C
 		field,
 		ec.fieldContext_Query_autobind,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Autobind(ctx)
+			return ec.Resolvers.Query().Autobind(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8563,7 +8553,7 @@ func (ec *executionContext) _Query_deprecatedField(ctx context.Context, field gr
 		field,
 		ec.fieldContext_Query_deprecatedField,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().DeprecatedField(ctx)
+			return ec.Resolvers.Query().DeprecatedField(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8595,7 +8585,7 @@ func (ec *executionContext) _Query_fieldWithDeprecatedArg(ctx context.Context, f
 		ec.fieldContext_Query_fieldWithDeprecatedArg,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().FieldWithDeprecatedArg(ctx, fc.Args["oldArg"].(*int), fc.Args["newArg"].(*int))
+			return ec.Resolvers.Query().FieldWithDeprecatedArg(ctx, fc.Args["oldArg"].(*int), fc.Args["newArg"].(*int))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8637,7 +8627,7 @@ func (ec *executionContext) _Query_overlapping(ctx context.Context, field graphq
 		field,
 		ec.fieldContext_Query_overlapping,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Overlapping(ctx)
+			return ec.Resolvers.Query().Overlapping(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8681,7 +8671,7 @@ func (ec *executionContext) _Query_defaultParameters(ctx context.Context, field 
 		ec.fieldContext_Query_defaultParameters,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().DefaultParameters(ctx, fc.Args["falsyBoolean"].(*bool), fc.Args["truthyBoolean"].(*bool))
+			return ec.Resolvers.Query().DefaultParameters(ctx, fc.Args["falsyBoolean"].(*bool), fc.Args["truthyBoolean"].(*bool))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8729,7 +8719,7 @@ func (ec *executionContext) _Query_deferSingle(ctx context.Context, field graphq
 		field,
 		ec.fieldContext_Query_deferSingle,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().DeferSingle(ctx)
+			return ec.Resolvers.Query().DeferSingle(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8768,7 +8758,7 @@ func (ec *executionContext) _Query_deferMultiple(ctx context.Context, field grap
 		field,
 		ec.fieldContext_Query_deferMultiple,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().DeferMultiple(ctx)
+			return ec.Resolvers.Query().DeferMultiple(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8808,7 +8798,7 @@ func (ec *executionContext) _Query_directiveArg(ctx context.Context, field graph
 		ec.fieldContext_Query_directiveArg,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().DirectiveArg(ctx, fc.Args["arg"].(string))
+			return ec.Resolvers.Query().DirectiveArg(ctx, fc.Args["arg"].(string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8851,7 +8841,7 @@ func (ec *executionContext) _Query_directiveNullableArg(ctx context.Context, fie
 		ec.fieldContext_Query_directiveNullableArg,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().DirectiveNullableArg(ctx, fc.Args["arg"].(*int), fc.Args["arg2"].(*int), fc.Args["arg3"].(*string))
+			return ec.Resolvers.Query().DirectiveNullableArg(ctx, fc.Args["arg"].(*int), fc.Args["arg2"].(*int), fc.Args["arg3"].(*string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8894,7 +8884,7 @@ func (ec *executionContext) _Query_directiveSingleNullableArg(ctx context.Contex
 		ec.fieldContext_Query_directiveSingleNullableArg,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().DirectiveSingleNullableArg(ctx, fc.Args["arg1"].(*string))
+			return ec.Resolvers.Query().DirectiveSingleNullableArg(ctx, fc.Args["arg1"].(*string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8937,7 +8927,7 @@ func (ec *executionContext) _Query_directiveInputNullable(ctx context.Context, f
 		ec.fieldContext_Query_directiveInputNullable,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().DirectiveInputNullable(ctx, fc.Args["arg"].(*InputDirectives))
+			return ec.Resolvers.Query().DirectiveInputNullable(ctx, fc.Args["arg"].(*InputDirectives))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -8980,7 +8970,7 @@ func (ec *executionContext) _Query_directiveInput(ctx context.Context, field gra
 		ec.fieldContext_Query_directiveInput,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().DirectiveInput(ctx, fc.Args["arg"].(InputDirectives))
+			return ec.Resolvers.Query().DirectiveInput(ctx, fc.Args["arg"].(InputDirectives))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -9023,7 +9013,7 @@ func (ec *executionContext) _Query_directiveInputType(ctx context.Context, field
 		ec.fieldContext_Query_directiveInputType,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().DirectiveInputType(ctx, fc.Args["arg"].(InnerInput))
+			return ec.Resolvers.Query().DirectiveInputType(ctx, fc.Args["arg"].(InnerInput))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -9065,7 +9055,7 @@ func (ec *executionContext) _Query_directiveObject(ctx context.Context, field gr
 		field,
 		ec.fieldContext_Query_directiveObject,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().DirectiveObject(ctx)
+			return ec.Resolvers.Query().DirectiveObject(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
@@ -9076,11 +9066,11 @@ func (ec *executionContext) _Query_directiveObject(ctx context.Context, field gr
 					var zeroVal *ObjectDirectives
 					return zeroVal, err
 				}
-				if ec.directives.Order1 == nil {
+				if ec.Directives.Order1 == nil {
 					var zeroVal *ObjectDirectives
 					return zeroVal, errors.New("directive order1 is not implemented")
 				}
-				return ec.directives.Order1(ctx, nil, directive0, location)
+				return ec.Directives.Order1(ctx, nil, directive0, location)
 			}
 			directive2 := func(ctx context.Context) (any, error) {
 				location, err := ec.unmarshalNString2string(ctx, "order1_2")
@@ -9088,11 +9078,11 @@ func (ec *executionContext) _Query_directiveObject(ctx context.Context, field gr
 					var zeroVal *ObjectDirectives
 					return zeroVal, err
 				}
-				if ec.directives.Order1 == nil {
+				if ec.Directives.Order1 == nil {
 					var zeroVal *ObjectDirectives
 					return zeroVal, errors.New("directive order1 is not implemented")
 				}
-				return ec.directives.Order1(ctx, nil, directive1, location)
+				return ec.Directives.Order1(ctx, nil, directive1, location)
 			}
 			directive3 := func(ctx context.Context) (any, error) {
 				location, err := ec.unmarshalNString2string(ctx, "order2_1")
@@ -9100,11 +9090,11 @@ func (ec *executionContext) _Query_directiveObject(ctx context.Context, field gr
 					var zeroVal *ObjectDirectives
 					return zeroVal, err
 				}
-				if ec.directives.Order2 == nil {
+				if ec.Directives.Order2 == nil {
 					var zeroVal *ObjectDirectives
 					return zeroVal, errors.New("directive order2 is not implemented")
 				}
-				return ec.directives.Order2(ctx, nil, directive2, location)
+				return ec.Directives.Order2(ctx, nil, directive2, location)
 			}
 			directive4 := func(ctx context.Context) (any, error) {
 				location, err := ec.unmarshalNString2string(ctx, "Query_field")
@@ -9112,11 +9102,11 @@ func (ec *executionContext) _Query_directiveObject(ctx context.Context, field gr
 					var zeroVal *ObjectDirectives
 					return zeroVal, err
 				}
-				if ec.directives.Order1 == nil {
+				if ec.Directives.Order1 == nil {
 					var zeroVal *ObjectDirectives
 					return zeroVal, errors.New("directive order1 is not implemented")
 				}
-				return ec.directives.Order1(ctx, nil, directive3, location)
+				return ec.Directives.Order1(ctx, nil, directive3, location)
 			}
 
 			next = directive4
@@ -9156,7 +9146,7 @@ func (ec *executionContext) _Query_directiveObjectWithCustomGoModel(ctx context.
 		field,
 		ec.fieldContext_Query_directiveObjectWithCustomGoModel,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().DirectiveObjectWithCustomGoModel(ctx)
+			return ec.Resolvers.Query().DirectiveObjectWithCustomGoModel(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -9192,7 +9182,7 @@ func (ec *executionContext) _Query_directiveFieldDef(ctx context.Context, field 
 		ec.fieldContext_Query_directiveFieldDef,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().DirectiveFieldDef(ctx, fc.Args["ret"].(string))
+			return ec.Resolvers.Query().DirectiveFieldDef(ctx, fc.Args["ret"].(string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
@@ -9208,11 +9198,11 @@ func (ec *executionContext) _Query_directiveFieldDef(ctx context.Context, field 
 					var zeroVal string
 					return zeroVal, err
 				}
-				if ec.directives.Length == nil {
+				if ec.Directives.Length == nil {
 					var zeroVal string
 					return zeroVal, errors.New("directive length is not implemented")
 				}
-				return ec.directives.Length(ctx, nil, directive0, min, nil, message)
+				return ec.Directives.Length(ctx, nil, directive0, min, nil, message)
 			}
 
 			next = directive1
@@ -9255,7 +9245,7 @@ func (ec *executionContext) _Query_directiveField(ctx context.Context, field gra
 		field,
 		ec.fieldContext_Query_directiveField,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().DirectiveField(ctx)
+			return ec.Resolvers.Query().DirectiveField(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -9286,24 +9276,24 @@ func (ec *executionContext) _Query_directiveDouble(ctx context.Context, field gr
 		field,
 		ec.fieldContext_Query_directiveDouble,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().DirectiveDouble(ctx)
+			return ec.Resolvers.Query().DirectiveDouble(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.Directive1 == nil {
+				if ec.Directives.Directive1 == nil {
 					var zeroVal *string
 					return zeroVal, errors.New("directive directive1 is not implemented")
 				}
-				return ec.directives.Directive1(ctx, nil, directive0)
+				return ec.Directives.Directive1(ctx, nil, directive0)
 			}
 			directive2 := func(ctx context.Context) (any, error) {
-				if ec.directives.Directive2 == nil {
+				if ec.Directives.Directive2 == nil {
 					var zeroVal *string
 					return zeroVal, errors.New("directive directive2 is not implemented")
 				}
-				return ec.directives.Directive2(ctx, nil, directive1)
+				return ec.Directives.Directive2(ctx, nil, directive1)
 			}
 
 			next = directive2
@@ -9335,17 +9325,17 @@ func (ec *executionContext) _Query_directiveUnimplemented(ctx context.Context, f
 		field,
 		ec.fieldContext_Query_directiveUnimplemented,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().DirectiveUnimplemented(ctx)
+			return ec.Resolvers.Query().DirectiveUnimplemented(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.Unimplemented == nil {
+				if ec.Directives.Unimplemented == nil {
 					var zeroVal *string
 					return zeroVal, errors.New("directive unimplemented is not implemented")
 				}
-				return ec.directives.Unimplemented(ctx, nil, directive0)
+				return ec.Directives.Unimplemented(ctx, nil, directive0)
 			}
 
 			next = directive1
@@ -9377,7 +9367,7 @@ func (ec *executionContext) _Query_embeddedCase1(ctx context.Context, field grap
 		field,
 		ec.fieldContext_Query_embeddedCase1,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().EmbeddedCase1(ctx)
+			return ec.Resolvers.Query().EmbeddedCase1(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -9412,7 +9402,7 @@ func (ec *executionContext) _Query_embeddedCase2(ctx context.Context, field grap
 		field,
 		ec.fieldContext_Query_embeddedCase2,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().EmbeddedCase2(ctx)
+			return ec.Resolvers.Query().EmbeddedCase2(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -9447,7 +9437,7 @@ func (ec *executionContext) _Query_embeddedCase3(ctx context.Context, field grap
 		field,
 		ec.fieldContext_Query_embeddedCase3,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().EmbeddedCase3(ctx)
+			return ec.Resolvers.Query().EmbeddedCase3(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -9483,7 +9473,7 @@ func (ec *executionContext) _Query_enumInInput(ctx context.Context, field graphq
 		ec.fieldContext_Query_enumInInput,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().EnumInInput(ctx, fc.Args["input"].(*InputWithEnumValue))
+			return ec.Resolvers.Query().EnumInInput(ctx, fc.Args["input"].(*InputWithEnumValue))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -9526,7 +9516,7 @@ func (ec *executionContext) _Query_searchProducts(ctx context.Context, field gra
 		ec.fieldContext_Query_searchProducts,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().SearchProducts(ctx, map[string]interface{}{
+			return ec.Resolvers.Query().SearchProducts(ctx, map[string]interface{}{
 				"query":    fc.Args["query"].(*string),
 				"category": fc.Args["category"].(*string),
 				"minPrice": fc.Args["minPrice"].(*int),
@@ -9573,7 +9563,7 @@ func (ec *executionContext) _Query_searchRequired(ctx context.Context, field gra
 		ec.fieldContext_Query_searchRequired,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().SearchRequired(ctx, map[string]interface{}{
+			return ec.Resolvers.Query().SearchRequired(ctx, map[string]interface{}{
 				"name": fc.Args["name"].(string),
 				"age":  fc.Args["age"].(int),
 			})
@@ -9619,7 +9609,7 @@ func (ec *executionContext) _Query_searchProductsNormal(ctx context.Context, fie
 		ec.fieldContext_Query_searchProductsNormal,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().SearchProductsNormal(ctx, fc.Args["filters"].(map[string]any))
+			return ec.Resolvers.Query().SearchProductsNormal(ctx, fc.Args["filters"].(map[string]any))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -9662,7 +9652,7 @@ func (ec *executionContext) _Query_searchWithDefaults(ctx context.Context, field
 		ec.fieldContext_Query_searchWithDefaults,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().SearchWithDefaults(ctx, map[string]interface{}{
+			return ec.Resolvers.Query().SearchWithDefaults(ctx, map[string]interface{}{
 				"query":           fc.Args["query"].(*string),
 				"limit":           fc.Args["limit"].(*int),
 				"includeArchived": fc.Args["includeArchived"].(*bool),
@@ -9709,7 +9699,7 @@ func (ec *executionContext) _Query_searchMixed(ctx context.Context, field graphq
 		ec.fieldContext_Query_searchMixed,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().SearchMixed(ctx, map[string]interface{}{
+			return ec.Resolvers.Query().SearchMixed(ctx, map[string]interface{}{
 				"query":    fc.Args["query"].(*string),
 				"category": fc.Args["category"].(*string),
 				"minPrice": fc.Args["minPrice"].(*int),
@@ -9756,7 +9746,7 @@ func (ec *executionContext) _Query_filterProducts(ctx context.Context, field gra
 		ec.fieldContext_Query_filterProducts,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().FilterProducts(ctx, map[string]interface{}{
+			return ec.Resolvers.Query().FilterProducts(ctx, map[string]interface{}{
 				"query":    fc.Args["query"].(*string),
 				"category": fc.Args["category"].(*string),
 				"minPrice": fc.Args["minPrice"].(*int),
@@ -9803,7 +9793,7 @@ func (ec *executionContext) _Query_findProducts(ctx context.Context, field graph
 		ec.fieldContext_Query_findProducts,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().FindProducts(ctx, map[string]interface{}{
+			return ec.Resolvers.Query().FindProducts(ctx, map[string]interface{}{
 				"query":    fc.Args["query"].(*string),
 				"category": fc.Args["category"].(*string),
 				"minPrice": fc.Args["minPrice"].(*int),
@@ -9850,7 +9840,7 @@ func (ec *executionContext) _Query_searchWithDirectives(ctx context.Context, fie
 		ec.fieldContext_Query_searchWithDirectives,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().SearchWithDirectives(ctx, map[string]interface{}{
+			return ec.Resolvers.Query().SearchWithDirectives(ctx, map[string]interface{}{
 				"oldField": fc.Args["oldField"].(*string),
 				"newField": fc.Args["newField"].(*string),
 			})
@@ -9895,7 +9885,7 @@ func (ec *executionContext) _Query_shapes(ctx context.Context, field graphql.Col
 		field,
 		ec.fieldContext_Query_shapes,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Shapes(ctx)
+			return ec.Resolvers.Query().Shapes(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -9926,17 +9916,17 @@ func (ec *executionContext) _Query_noShape(ctx context.Context, field graphql.Co
 		field,
 		ec.fieldContext_Query_noShape,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().NoShape(ctx)
+			return ec.Resolvers.Query().NoShape(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.MakeNil == nil {
+				if ec.Directives.MakeNil == nil {
 					var zeroVal Shape
 					return zeroVal, errors.New("directive makeNil is not implemented")
 				}
-				return ec.directives.MakeNil(ctx, nil, directive0)
+				return ec.Directives.MakeNil(ctx, nil, directive0)
 			}
 
 			next = directive1
@@ -9968,7 +9958,7 @@ func (ec *executionContext) _Query_node(ctx context.Context, field graphql.Colle
 		field,
 		ec.fieldContext_Query_node,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Node(ctx)
+			return ec.Resolvers.Query().Node(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -9999,17 +9989,17 @@ func (ec *executionContext) _Query_noShapeTypedNil(ctx context.Context, field gr
 		field,
 		ec.fieldContext_Query_noShapeTypedNil,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().NoShapeTypedNil(ctx)
+			return ec.Resolvers.Query().NoShapeTypedNil(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.MakeTypedNil == nil {
+				if ec.Directives.MakeTypedNil == nil {
 					var zeroVal Shape
 					return zeroVal, errors.New("directive makeTypedNil is not implemented")
 				}
-				return ec.directives.MakeTypedNil(ctx, nil, directive0)
+				return ec.Directives.MakeTypedNil(ctx, nil, directive0)
 			}
 
 			next = directive1
@@ -10041,17 +10031,17 @@ func (ec *executionContext) _Query_animal(ctx context.Context, field graphql.Col
 		field,
 		ec.fieldContext_Query_animal,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Animal(ctx)
+			return ec.Resolvers.Query().Animal(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.MakeTypedNil == nil {
+				if ec.Directives.MakeTypedNil == nil {
 					var zeroVal Animal
 					return zeroVal, errors.New("directive makeTypedNil is not implemented")
 				}
-				return ec.directives.MakeTypedNil(ctx, nil, directive0)
+				return ec.Directives.MakeTypedNil(ctx, nil, directive0)
 			}
 
 			next = directive1
@@ -10083,7 +10073,7 @@ func (ec *executionContext) _Query_notAnInterface(ctx context.Context, field gra
 		field,
 		ec.fieldContext_Query_notAnInterface,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().NotAnInterface(ctx)
+			return ec.Resolvers.Query().NotAnInterface(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10122,7 +10112,7 @@ func (ec *executionContext) _Query_dog(ctx context.Context, field graphql.Collec
 		field,
 		ec.fieldContext_Query_dog,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Dog(ctx)
+			return ec.Resolvers.Query().Dog(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10161,7 +10151,7 @@ func (ec *executionContext) _Query_issue896a(ctx context.Context, field graphql.
 		field,
 		ec.fieldContext_Query_issue896a,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Issue896a(ctx)
+			return ec.Resolvers.Query().Issue896a(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10197,7 +10187,7 @@ func (ec *executionContext) _Query_mapStringInterface(ctx context.Context, field
 		ec.fieldContext_Query_mapStringInterface,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().MapStringInterface(ctx, fc.Args["in"].(map[string]any))
+			return ec.Resolvers.Query().MapStringInterface(ctx, fc.Args["in"].(map[string]any))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10250,7 +10240,7 @@ func (ec *executionContext) _Query_mapNestedStringInterface(ctx context.Context,
 		ec.fieldContext_Query_mapNestedStringInterface,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().MapNestedStringInterface(ctx, fc.Args["in"].(*NestedMapInput))
+			return ec.Resolvers.Query().MapNestedStringInterface(ctx, fc.Args["in"].(*NestedMapInput))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10303,7 +10293,7 @@ func (ec *executionContext) _Query_mapNestedMapSlice(ctx context.Context, field 
 		ec.fieldContext_Query_mapNestedMapSlice,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().MapNestedMapSlice(ctx, fc.Args["input"].(map[string]any))
+			return ec.Resolvers.Query().MapNestedMapSlice(ctx, fc.Args["input"].(map[string]any))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10345,7 +10335,7 @@ func (ec *executionContext) _Query_errorBubble(ctx context.Context, field graphq
 		field,
 		ec.fieldContext_Query_errorBubble,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().ErrorBubble(ctx)
+			return ec.Resolvers.Query().ErrorBubble(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10386,7 +10376,7 @@ func (ec *executionContext) _Query_errorBubbleList(ctx context.Context, field gr
 		field,
 		ec.fieldContext_Query_errorBubbleList,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().ErrorBubbleList(ctx)
+			return ec.Resolvers.Query().ErrorBubbleList(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10427,7 +10417,7 @@ func (ec *executionContext) _Query_errorList(ctx context.Context, field graphql.
 		field,
 		ec.fieldContext_Query_errorList,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().ErrorList(ctx)
+			return ec.Resolvers.Query().ErrorList(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10468,7 +10458,7 @@ func (ec *executionContext) _Query_errors(ctx context.Context, field graphql.Col
 		field,
 		ec.fieldContext_Query_errors,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Errors(ctx)
+			return ec.Resolvers.Query().Errors(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10511,7 +10501,7 @@ func (ec *executionContext) _Query_valid(ctx context.Context, field graphql.Coll
 		field,
 		ec.fieldContext_Query_valid,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Valid(ctx)
+			return ec.Resolvers.Query().Valid(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10542,7 +10532,7 @@ func (ec *executionContext) _Query_invalid(ctx context.Context, field graphql.Co
 		field,
 		ec.fieldContext_Query_invalid,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Invalid(ctx)
+			return ec.Resolvers.Query().Invalid(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10573,7 +10563,7 @@ func (ec *executionContext) _Query_panics(ctx context.Context, field graphql.Col
 		field,
 		ec.fieldContext_Query_panics,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Panics(ctx)
+			return ec.Resolvers.Query().Panics(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10612,7 +10602,7 @@ func (ec *executionContext) _Query_primitiveObject(ctx context.Context, field gr
 		field,
 		ec.fieldContext_Query_primitiveObject,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().PrimitiveObject(ctx)
+			return ec.Resolvers.Query().PrimitiveObject(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10649,7 +10639,7 @@ func (ec *executionContext) _Query_primitiveStringObject(ctx context.Context, fi
 		field,
 		ec.fieldContext_Query_primitiveStringObject,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().PrimitiveStringObject(ctx)
+			return ec.Resolvers.Query().PrimitiveStringObject(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10688,7 +10678,7 @@ func (ec *executionContext) _Query_ptrToAnyContainer(ctx context.Context, field 
 		field,
 		ec.fieldContext_Query_ptrToAnyContainer,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().PtrToAnyContainer(ctx)
+			return ec.Resolvers.Query().PtrToAnyContainer(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10725,7 +10715,7 @@ func (ec *executionContext) _Query_ptrToSliceContainer(ctx context.Context, fiel
 		field,
 		ec.fieldContext_Query_ptrToSliceContainer,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().PtrToSliceContainer(ctx)
+			return ec.Resolvers.Query().PtrToSliceContainer(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10760,7 +10750,7 @@ func (ec *executionContext) _Query_infinity(ctx context.Context, field graphql.C
 		field,
 		ec.fieldContext_Query_infinity,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Infinity(ctx)
+			return ec.Resolvers.Query().Infinity(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10791,7 +10781,7 @@ func (ec *executionContext) _Query_stringFromContextInterface(ctx context.Contex
 		field,
 		ec.fieldContext_Query_stringFromContextInterface,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().StringFromContextInterface(ctx)
+			return ec.Resolvers.Query().StringFromContextInterface(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10822,7 +10812,7 @@ func (ec *executionContext) _Query_stringFromContextFunction(ctx context.Context
 		field,
 		ec.fieldContext_Query_stringFromContextFunction,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().StringFromContextFunction(ctx)
+			return ec.Resolvers.Query().StringFromContextFunction(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10854,7 +10844,7 @@ func (ec *executionContext) _Query_defaultScalar(ctx context.Context, field grap
 		ec.fieldContext_Query_defaultScalar,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().DefaultScalar(ctx, fc.Args["arg"].(string))
+			return ec.Resolvers.Query().DefaultScalar(ctx, fc.Args["arg"].(string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10896,7 +10886,7 @@ func (ec *executionContext) _Query_skipInclude(ctx context.Context, field graphq
 		field,
 		ec.fieldContext_Query_skipInclude,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().SkipInclude(ctx)
+			return ec.Resolvers.Query().SkipInclude(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10933,7 +10923,7 @@ func (ec *executionContext) _Query_slices(ctx context.Context, field graphql.Col
 		field,
 		ec.fieldContext_Query_slices,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Slices(ctx)
+			return ec.Resolvers.Query().Slices(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -10974,7 +10964,7 @@ func (ec *executionContext) _Query_scalarSlice(ctx context.Context, field graphq
 		field,
 		ec.fieldContext_Query_scalarSlice,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().ScalarSlice(ctx)
+			return ec.Resolvers.Query().ScalarSlice(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -11006,7 +10996,7 @@ func (ec *executionContext) _Query_fallback(ctx context.Context, field graphql.C
 		ec.fieldContext_Query_fallback,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Fallback(ctx, fc.Args["arg"].(FallbackToStringEncoding))
+			return ec.Resolvers.Query().Fallback(ctx, fc.Args["arg"].(FallbackToStringEncoding))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -11048,7 +11038,7 @@ func (ec *executionContext) _Query_optionalUnion(ctx context.Context, field grap
 		field,
 		ec.fieldContext_Query_optionalUnion,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().OptionalUnion(ctx)
+			return ec.Resolvers.Query().OptionalUnion(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -11079,7 +11069,7 @@ func (ec *executionContext) _Query_vOkCaseValue(ctx context.Context, field graph
 		field,
 		ec.fieldContext_Query_vOkCaseValue,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().VOkCaseValue(ctx)
+			return ec.Resolvers.Query().VOkCaseValue(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -11114,7 +11104,7 @@ func (ec *executionContext) _Query_vOkCaseNil(ctx context.Context, field graphql
 		field,
 		ec.fieldContext_Query_vOkCaseNil,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().VOkCaseNil(ctx)
+			return ec.Resolvers.Query().VOkCaseNil(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -11149,7 +11139,7 @@ func (ec *executionContext) _Query_validType(ctx context.Context, field graphql.
 		field,
 		ec.fieldContext_Query_validType,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().ValidType(ctx)
+			return ec.Resolvers.Query().ValidType(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -11190,7 +11180,7 @@ func (ec *executionContext) _Query_variadicModel(ctx context.Context, field grap
 		field,
 		ec.fieldContext_Query_variadicModel,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().VariadicModel(ctx)
+			return ec.Resolvers.Query().VariadicModel(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -11225,7 +11215,7 @@ func (ec *executionContext) _Query_wrappedStruct(ctx context.Context, field grap
 		field,
 		ec.fieldContext_Query_wrappedStruct,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().WrappedStruct(ctx)
+			return ec.Resolvers.Query().WrappedStruct(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -11262,7 +11252,7 @@ func (ec *executionContext) _Query_wrappedScalar(ctx context.Context, field grap
 		field,
 		ec.fieldContext_Query_wrappedScalar,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().WrappedScalar(ctx)
+			return ec.Resolvers.Query().WrappedScalar(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -11293,7 +11283,7 @@ func (ec *executionContext) _Query_wrappedMap(ctx context.Context, field graphql
 		field,
 		ec.fieldContext_Query_wrappedMap,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().WrappedMap(ctx)
+			return ec.Resolvers.Query().WrappedMap(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -11328,7 +11318,7 @@ func (ec *executionContext) _Query_wrappedSlice(ctx context.Context, field graph
 		field,
 		ec.fieldContext_Query_wrappedSlice,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().WrappedSlice(ctx)
+			return ec.Resolvers.Query().WrappedSlice(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -11853,7 +11843,7 @@ func (ec *executionContext) _Subscription_updated(ctx context.Context, field gra
 		field,
 		ec.fieldContext_Subscription_updated,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Subscription().Updated(ctx)
+			return ec.Resolvers.Subscription().Updated(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -11884,7 +11874,7 @@ func (ec *executionContext) _Subscription_initPayload(ctx context.Context, field
 		field,
 		ec.fieldContext_Subscription_initPayload,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Subscription().InitPayload(ctx)
+			return ec.Resolvers.Subscription().InitPayload(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -11916,7 +11906,7 @@ func (ec *executionContext) _Subscription_directiveArg(ctx context.Context, fiel
 		ec.fieldContext_Subscription_directiveArg,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Subscription().DirectiveArg(ctx, fc.Args["arg"].(string))
+			return ec.Resolvers.Subscription().DirectiveArg(ctx, fc.Args["arg"].(string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -11959,7 +11949,7 @@ func (ec *executionContext) _Subscription_directiveNullableArg(ctx context.Conte
 		ec.fieldContext_Subscription_directiveNullableArg,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Subscription().DirectiveNullableArg(ctx, fc.Args["arg"].(*int), fc.Args["arg2"].(*int), fc.Args["arg3"].(*string))
+			return ec.Resolvers.Subscription().DirectiveNullableArg(ctx, fc.Args["arg"].(*int), fc.Args["arg2"].(*int), fc.Args["arg3"].(*string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -12001,24 +11991,24 @@ func (ec *executionContext) _Subscription_directiveDouble(ctx context.Context, f
 		field,
 		ec.fieldContext_Subscription_directiveDouble,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Subscription().DirectiveDouble(ctx)
+			return ec.Resolvers.Subscription().DirectiveDouble(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.Directive1 == nil {
+				if ec.Directives.Directive1 == nil {
 					var zeroVal *string
 					return zeroVal, errors.New("directive directive1 is not implemented")
 				}
-				return ec.directives.Directive1(ctx, nil, directive0)
+				return ec.Directives.Directive1(ctx, nil, directive0)
 			}
 			directive2 := func(ctx context.Context) (any, error) {
-				if ec.directives.Directive2 == nil {
+				if ec.Directives.Directive2 == nil {
 					var zeroVal *string
 					return zeroVal, errors.New("directive directive2 is not implemented")
 				}
-				return ec.directives.Directive2(ctx, nil, directive1)
+				return ec.Directives.Directive2(ctx, nil, directive1)
 			}
 
 			next = directive2
@@ -12050,17 +12040,17 @@ func (ec *executionContext) _Subscription_directiveUnimplemented(ctx context.Con
 		field,
 		ec.fieldContext_Subscription_directiveUnimplemented,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Subscription().DirectiveUnimplemented(ctx)
+			return ec.Resolvers.Subscription().DirectiveUnimplemented(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.Unimplemented == nil {
+				if ec.Directives.Unimplemented == nil {
 					var zeroVal *string
 					return zeroVal, errors.New("directive unimplemented is not implemented")
 				}
-				return ec.directives.Unimplemented(ctx, nil, directive0)
+				return ec.Directives.Unimplemented(ctx, nil, directive0)
 			}
 
 			next = directive1
@@ -12092,7 +12082,7 @@ func (ec *executionContext) _Subscription_issue896b(ctx context.Context, field g
 		field,
 		ec.fieldContext_Subscription_issue896b,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Subscription().Issue896b(ctx)
+			return ec.Resolvers.Subscription().Issue896b(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -12127,7 +12117,7 @@ func (ec *executionContext) _Subscription_errorRequired(ctx context.Context, fie
 		field,
 		ec.fieldContext_Subscription_errorRequired,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Subscription().ErrorRequired(ctx)
+			return ec.Resolvers.Subscription().ErrorRequired(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, nil, next)
@@ -12199,7 +12189,7 @@ func (ec *executionContext) _User_friends(ctx context.Context, field graphql.Col
 		field,
 		ec.fieldContext_User_friends,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.User().Friends(ctx, obj)
+			return ec.Resolvers.User().Friends(ctx, obj)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -12305,7 +12295,7 @@ func (ec *executionContext) _User_pets(ctx context.Context, field graphql.Collec
 		ec.fieldContext_User_pets,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.User().Pets(ctx, obj, fc.Args["limit"].(*int))
+			return ec.Resolvers.User().Pets(ctx, obj, fc.Args["limit"].(*int))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -12613,7 +12603,7 @@ func (ec *executionContext) _WrappedMap_get(ctx context.Context, field graphql.C
 		ec.fieldContext_WrappedMap_get,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.WrappedMap().Get(ctx, obj, fc.Args["key"].(string))
+			return ec.Resolvers.WrappedMap().Get(ctx, obj, fc.Args["key"].(string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -12656,7 +12646,7 @@ func (ec *executionContext) _WrappedSlice_get(ctx context.Context, field graphql
 		ec.fieldContext_WrappedSlice_get,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.WrappedSlice().Get(ctx, obj, fc.Args["idx"].(int))
+			return ec.Resolvers.WrappedSlice().Get(ctx, obj, fc.Args["idx"].(int))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			return ec._fieldMiddleware(ctx, obj, next)
@@ -14535,7 +14525,7 @@ func (ec *executionContext) unmarshalInputFieldsOrderInput(ctx context.Context, 
 			if err != nil {
 				return it, err
 			}
-			if err = ec.resolvers.FieldsOrderInput().OverrideFirstField(ctx, &it, data); err != nil {
+			if err = ec.Resolvers.FieldsOrderInput().OverrideFirstField(ctx, &it, data); err != nil {
 				return it, err
 			}
 		}
@@ -14573,11 +14563,11 @@ func (ec *executionContext) unmarshalInputInnerDirectives(ctx context.Context, o
 					var zeroVal string
 					return zeroVal, err
 				}
-				if ec.directives.Length == nil {
+				if ec.Directives.Length == nil {
 					var zeroVal string
 					return zeroVal, errors.New("directive length is not implemented")
 				}
-				return ec.directives.Length(ctx, obj, directive0, min, nil, message)
+				return ec.Directives.Length(ctx, obj, directive0, min, nil, message)
 			}
 
 			tmp, err := directive1(ctx)
@@ -14642,11 +14632,11 @@ func (ec *executionContext) unmarshalInputInputDirectives(ctx context.Context, o
 			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalNString2string(ctx, v) }
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.Directive3 == nil {
+				if ec.Directives.Directive3 == nil {
 					var zeroVal string
 					return zeroVal, errors.New("directive directive3 is not implemented")
 				}
-				return ec.directives.Directive3(ctx, obj, directive0)
+				return ec.Directives.Directive3(ctx, obj, directive0)
 			}
 			directive2 := func(ctx context.Context) (any, error) {
 				min, err := ec.unmarshalNInt2int(ctx, 0)
@@ -14664,11 +14654,11 @@ func (ec *executionContext) unmarshalInputInputDirectives(ctx context.Context, o
 					var zeroVal string
 					return zeroVal, err
 				}
-				if ec.directives.Length == nil {
+				if ec.Directives.Length == nil {
 					var zeroVal string
 					return zeroVal, errors.New("directive length is not implemented")
 				}
-				return ec.directives.Length(ctx, obj, directive1, min, max, message)
+				return ec.Directives.Length(ctx, obj, directive1, min, max, message)
 			}
 
 			tmp, err := directive2(ctx)
@@ -14686,18 +14676,18 @@ func (ec *executionContext) unmarshalInputInputDirectives(ctx context.Context, o
 			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.Directive3 == nil {
+				if ec.Directives.Directive3 == nil {
 					var zeroVal *string
 					return zeroVal, errors.New("directive directive3 is not implemented")
 				}
-				return ec.directives.Directive3(ctx, obj, directive0)
+				return ec.Directives.Directive3(ctx, obj, directive0)
 			}
 			directive2 := func(ctx context.Context) (any, error) {
-				if ec.directives.ToNull == nil {
+				if ec.Directives.ToNull == nil {
 					var zeroVal *string
 					return zeroVal, errors.New("directive toNull is not implemented")
 				}
-				return ec.directives.ToNull(ctx, obj, directive1)
+				return ec.Directives.ToNull(ctx, obj, directive1)
 			}
 
 			tmp, err := directive2(ctx)
@@ -14719,11 +14709,11 @@ func (ec *executionContext) unmarshalInputInputDirectives(ctx context.Context, o
 			}
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.Directive3 == nil {
+				if ec.Directives.Directive3 == nil {
 					var zeroVal *InnerDirectives
 					return zeroVal, errors.New("directive directive3 is not implemented")
 				}
-				return ec.directives.Directive3(ctx, obj, directive0)
+				return ec.Directives.Directive3(ctx, obj, directive0)
 			}
 
 			tmp, err := directive1(ctx)
@@ -14745,11 +14735,11 @@ func (ec *executionContext) unmarshalInputInputDirectives(ctx context.Context, o
 			}
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.Directive3 == nil {
+				if ec.Directives.Directive3 == nil {
 					var zeroVal *InnerDirectives
 					return zeroVal, errors.New("directive directive3 is not implemented")
 				}
-				return ec.directives.Directive3(ctx, obj, directive0)
+				return ec.Directives.Directive3(ctx, obj, directive0)
 			}
 
 			tmp, err := directive1(ctx)
@@ -14771,11 +14761,11 @@ func (ec *executionContext) unmarshalInputInputDirectives(ctx context.Context, o
 			}
 
 			directive1 := func(ctx context.Context) (any, error) {
-				if ec.directives.Directive3 == nil {
+				if ec.Directives.Directive3 == nil {
 					var zeroVal *ThirdParty
 					return zeroVal, errors.New("directive directive3 is not implemented")
 				}
-				return ec.directives.Directive3(ctx, obj, directive0)
+				return ec.Directives.Directive3(ctx, obj, directive0)
 			}
 			directive2 := func(ctx context.Context) (any, error) {
 				min, err := ec.unmarshalNInt2int(ctx, 0)
@@ -14788,11 +14778,11 @@ func (ec *executionContext) unmarshalInputInputDirectives(ctx context.Context, o
 					var zeroVal *ThirdParty
 					return zeroVal, err
 				}
-				if ec.directives.Length == nil {
+				if ec.Directives.Length == nil {
 					var zeroVal *ThirdParty
 					return zeroVal, errors.New("directive length is not implemented")
 				}
-				return ec.directives.Length(ctx, obj, directive1, min, max, nil)
+				return ec.Directives.Length(ctx, obj, directive1, min, max, nil)
 			}
 
 			tmp, err := directive2(ctx)

--- a/codegen/testserver/usefunctionsyntaxforexecutioncontext/generated.go
+++ b/codegen/testserver/usefunctionsyntaxforexecutioncontext/generated.go
@@ -22,12 +22,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -93,16 +88,11 @@ type SubscriptionResolver interface {
 	UserCreated(ctx context.Context) (<-chan *User, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -113,32 +103,32 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "Admin.createdAt":
-		if e.complexity.Admin.CreatedAt == nil {
+		if e.ComplexityRoot.Admin.CreatedAt == nil {
 			break
 		}
 
-		return e.complexity.Admin.CreatedAt(childComplexity), true
+		return e.ComplexityRoot.Admin.CreatedAt(childComplexity), true
 	case "Admin.id":
-		if e.complexity.Admin.ID == nil {
+		if e.ComplexityRoot.Admin.ID == nil {
 			break
 		}
 
-		return e.complexity.Admin.ID(childComplexity), true
+		return e.ComplexityRoot.Admin.ID(childComplexity), true
 	case "Admin.name":
-		if e.complexity.Admin.Name == nil {
+		if e.ComplexityRoot.Admin.Name == nil {
 			break
 		}
 
-		return e.complexity.Admin.Name(childComplexity), true
+		return e.ComplexityRoot.Admin.Name(childComplexity), true
 	case "Admin.permissions":
-		if e.complexity.Admin.Permissions == nil {
+		if e.ComplexityRoot.Admin.Permissions == nil {
 			break
 		}
 
-		return e.complexity.Admin.Permissions(childComplexity), true
+		return e.ComplexityRoot.Admin.Permissions(childComplexity), true
 
 	case "Mutation.createUser":
-		if e.complexity.Mutation.CreateUser == nil {
+		if e.ComplexityRoot.Mutation.CreateUser == nil {
 			break
 		}
 
@@ -147,9 +137,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.CreateUser(childComplexity, args["input"].(CreateUserInput)), true
+		return e.ComplexityRoot.Mutation.CreateUser(childComplexity, args["input"].(CreateUserInput)), true
 	case "Mutation.deleteUser":
-		if e.complexity.Mutation.DeleteUser == nil {
+		if e.ComplexityRoot.Mutation.DeleteUser == nil {
 			break
 		}
 
@@ -158,23 +148,23 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.DeleteUser(childComplexity, args["id"].(string)), true
+		return e.ComplexityRoot.Mutation.DeleteUser(childComplexity, args["id"].(string)), true
 
 	case "MutationResponse.message":
-		if e.complexity.MutationResponse.Message == nil {
+		if e.ComplexityRoot.MutationResponse.Message == nil {
 			break
 		}
 
-		return e.complexity.MutationResponse.Message(childComplexity), true
+		return e.ComplexityRoot.MutationResponse.Message(childComplexity), true
 	case "MutationResponse.success":
-		if e.complexity.MutationResponse.Success == nil {
+		if e.ComplexityRoot.MutationResponse.Success == nil {
 			break
 		}
 
-		return e.complexity.MutationResponse.Success(childComplexity), true
+		return e.ComplexityRoot.MutationResponse.Success(childComplexity), true
 
 	case "Query.getEntity":
-		if e.complexity.Query.GetEntity == nil {
+		if e.ComplexityRoot.Query.GetEntity == nil {
 			break
 		}
 
@@ -183,9 +173,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.GetEntity(childComplexity, args["id"].(string)), true
+		return e.ComplexityRoot.Query.GetEntity(childComplexity, args["id"].(string)), true
 	case "Query.getUser":
-		if e.complexity.Query.GetUser == nil {
+		if e.ComplexityRoot.Query.GetUser == nil {
 			break
 		}
 
@@ -194,9 +184,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.GetUser(childComplexity, args["id"].(string)), true
+		return e.ComplexityRoot.Query.GetUser(childComplexity, args["id"].(string)), true
 	case "Query.listUsers":
-		if e.complexity.Query.ListUsers == nil {
+		if e.ComplexityRoot.Query.ListUsers == nil {
 			break
 		}
 
@@ -205,51 +195,51 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.ListUsers(childComplexity, args["filter"].(*UserFilter)), true
+		return e.ComplexityRoot.Query.ListUsers(childComplexity, args["filter"].(*UserFilter)), true
 
 	case "Subscription.userCreated":
-		if e.complexity.Subscription.UserCreated == nil {
+		if e.ComplexityRoot.Subscription.UserCreated == nil {
 			break
 		}
 
-		return e.complexity.Subscription.UserCreated(childComplexity), true
+		return e.ComplexityRoot.Subscription.UserCreated(childComplexity), true
 
 	case "User.age":
-		if e.complexity.User.Age == nil {
+		if e.ComplexityRoot.User.Age == nil {
 			break
 		}
 
-		return e.complexity.User.Age(childComplexity), true
+		return e.ComplexityRoot.User.Age(childComplexity), true
 	case "User.createdAt":
-		if e.complexity.User.CreatedAt == nil {
+		if e.ComplexityRoot.User.CreatedAt == nil {
 			break
 		}
 
-		return e.complexity.User.CreatedAt(childComplexity), true
+		return e.ComplexityRoot.User.CreatedAt(childComplexity), true
 	case "User.email":
-		if e.complexity.User.Email == nil {
+		if e.ComplexityRoot.User.Email == nil {
 			break
 		}
 
-		return e.complexity.User.Email(childComplexity), true
+		return e.ComplexityRoot.User.Email(childComplexity), true
 	case "User.id":
-		if e.complexity.User.ID == nil {
+		if e.ComplexityRoot.User.ID == nil {
 			break
 		}
 
-		return e.complexity.User.ID(childComplexity), true
+		return e.ComplexityRoot.User.ID(childComplexity), true
 	case "User.name":
-		if e.complexity.User.Name == nil {
+		if e.ComplexityRoot.User.Name == nil {
 			break
 		}
 
-		return e.complexity.User.Name(childComplexity), true
+		return e.ComplexityRoot.User.Name(childComplexity), true
 	case "User.role":
-		if e.complexity.User.Role == nil {
+		if e.ComplexityRoot.User.Role == nil {
 			break
 		}
 
-		return e.complexity.User.Role(childComplexity), true
+		return e.ComplexityRoot.User.Role(childComplexity), true
 
 	}
 	return 0, false
@@ -665,7 +655,7 @@ func _Mutation_createUser(ctx context.Context, ec *executionContext, field graph
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().CreateUser(ctx, fc.Args["input"].(CreateUserInput))
+			return ec.Resolvers.Mutation().CreateUser(ctx, fc.Args["input"].(CreateUserInput))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
@@ -676,11 +666,11 @@ func _Mutation_createUser(ctx context.Context, ec *executionContext, field graph
 					var zeroVal *User
 					return zeroVal, err
 				}
-				if ec.directives.Log == nil {
+				if ec.Directives.Log == nil {
 					var zeroVal *User
 					return zeroVal, errors.New("directive log is not implemented")
 				}
-				return ec.directives.Log(ctx, nil, directive0, message)
+				return ec.Directives.Log(ctx, nil, directive0, message)
 			}
 
 			next = directive1
@@ -742,7 +732,7 @@ func _Mutation_deleteUser(ctx context.Context, ec *executionContext, field graph
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().DeleteUser(ctx, fc.Args["id"].(string))
+			return ec.Resolvers.Mutation().DeleteUser(ctx, fc.Args["id"].(string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
@@ -753,11 +743,11 @@ func _Mutation_deleteUser(ctx context.Context, ec *executionContext, field graph
 					var zeroVal *MutationResponse
 					return zeroVal, err
 				}
-				if ec.directives.Log == nil {
+				if ec.Directives.Log == nil {
 					var zeroVal *MutationResponse
 					return zeroVal, errors.New("directive log is not implemented")
 				}
-				return ec.directives.Log(ctx, nil, directive0, message)
+				return ec.Directives.Log(ctx, nil, directive0, message)
 			}
 
 			next = directive1
@@ -877,7 +867,7 @@ func _Query_getUser(ctx context.Context, ec *executionContext, field graphql.Col
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().GetUser(ctx, fc.Args["id"].(string))
+			return ec.Resolvers.Query().GetUser(ctx, fc.Args["id"].(string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
@@ -888,11 +878,11 @@ func _Query_getUser(ctx context.Context, ec *executionContext, field graphql.Col
 					var zeroVal *User
 					return zeroVal, err
 				}
-				if ec.directives.Log == nil {
+				if ec.Directives.Log == nil {
 					var zeroVal *User
 					return zeroVal, errors.New("directive log is not implemented")
 				}
-				return ec.directives.Log(ctx, nil, directive0, message)
+				return ec.Directives.Log(ctx, nil, directive0, message)
 			}
 
 			next = directive1
@@ -954,7 +944,7 @@ func _Query_listUsers(ctx context.Context, ec *executionContext, field graphql.C
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().ListUsers(ctx, fc.Args["filter"].(*UserFilter))
+			return ec.Resolvers.Query().ListUsers(ctx, fc.Args["filter"].(*UserFilter))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
@@ -965,11 +955,11 @@ func _Query_listUsers(ctx context.Context, ec *executionContext, field graphql.C
 					var zeroVal []*User
 					return zeroVal, err
 				}
-				if ec.directives.Log == nil {
+				if ec.Directives.Log == nil {
 					var zeroVal []*User
 					return zeroVal, errors.New("directive log is not implemented")
 				}
-				return ec.directives.Log(ctx, nil, directive0, message)
+				return ec.Directives.Log(ctx, nil, directive0, message)
 			}
 
 			next = directive1
@@ -1031,7 +1021,7 @@ func _Query_getEntity(ctx context.Context, ec *executionContext, field graphql.C
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().GetEntity(ctx, fc.Args["id"].(string))
+			return ec.Resolvers.Query().GetEntity(ctx, fc.Args["id"].(string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
@@ -1042,11 +1032,11 @@ func _Query_getEntity(ctx context.Context, ec *executionContext, field graphql.C
 					var zeroVal Entity
 					return zeroVal, err
 				}
-				if ec.directives.Log == nil {
+				if ec.Directives.Log == nil {
 					var zeroVal Entity
 					return zeroVal, errors.New("directive log is not implemented")
 				}
-				return ec.directives.Log(ctx, nil, directive0, message)
+				return ec.Directives.Log(ctx, nil, directive0, message)
 			}
 
 			next = directive1
@@ -1209,7 +1199,7 @@ func _Subscription_userCreated(ctx context.Context, ec *executionContext, field 
 			return fieldContext_Subscription_userCreated(ctx, ec, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Subscription().UserCreated(ctx)
+			return ec.Resolvers.Subscription().UserCreated(ctx)
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
@@ -1220,11 +1210,11 @@ func _Subscription_userCreated(ctx context.Context, ec *executionContext, field 
 					var zeroVal *User
 					return zeroVal, err
 				}
-				if ec.directives.Log == nil {
+				if ec.Directives.Log == nil {
 					var zeroVal *User
 					return zeroVal, errors.New("directive log is not implemented")
 				}
-				return ec.directives.Log(ctx, nil, directive0, message)
+				return ec.Directives.Log(ctx, nil, directive0, message)
 			}
 
 			next = directive1

--- a/graphql/executable_schema_state.go
+++ b/graphql/executable_schema_state.go
@@ -1,0 +1,12 @@
+package graphql
+
+import "github.com/vektah/gqlparser/v2/ast"
+
+// ExecutableSchemaState stores generated executable schema dependencies.
+// Generated code defines its local executableSchema type from this one.
+type ExecutableSchemaState[R any, D any, C any] struct {
+	SchemaData     *ast.Schema
+	Resolvers      R
+	Directives     D
+	ComplexityRoot C
+}

--- a/integration/server/generated.go
+++ b/integration/server/generated.go
@@ -25,12 +25,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -96,16 +91,11 @@ type UserResolver interface {
 	Likes(ctx context.Context, obj *remote_api.User) ([]string, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -116,26 +106,26 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "Element.child":
-		if e.complexity.Element.Child == nil {
+		if e.ComplexityRoot.Element.Child == nil {
 			break
 		}
 
-		return e.complexity.Element.Child(childComplexity), true
+		return e.ComplexityRoot.Element.Child(childComplexity), true
 	case "Element.error":
-		if e.complexity.Element.Error == nil {
+		if e.ComplexityRoot.Element.Error == nil {
 			break
 		}
 
-		return e.complexity.Element.Error(childComplexity), true
+		return e.ComplexityRoot.Element.Error(childComplexity), true
 	case "Element.mismatched":
-		if e.complexity.Element.Mismatched == nil {
+		if e.ComplexityRoot.Element.Mismatched == nil {
 			break
 		}
 
-		return e.complexity.Element.Mismatched(childComplexity), true
+		return e.ComplexityRoot.Element.Mismatched(childComplexity), true
 
 	case "Query.coercion":
-		if e.complexity.Query.Coercion == nil {
+		if e.ComplexityRoot.Query.Coercion == nil {
 			break
 		}
 
@@ -144,9 +134,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Coercion(childComplexity, args["value"].([]*models.ListCoercion)), true
+		return e.ComplexityRoot.Query.Coercion(childComplexity, args["value"].([]*models.ListCoercion)), true
 	case "Query.complexity":
-		if e.complexity.Query.Complexity == nil {
+		if e.ComplexityRoot.Query.Complexity == nil {
 			break
 		}
 
@@ -155,9 +145,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Complexity(childComplexity, args["value"].(int)), true
+		return e.ComplexityRoot.Query.Complexity(childComplexity, args["value"].(int)), true
 	case "Query.date":
-		if e.complexity.Query.Date == nil {
+		if e.ComplexityRoot.Query.Date == nil {
 			break
 		}
 
@@ -166,9 +156,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Date(childComplexity, args["filter"].(models.DateFilter)), true
+		return e.ComplexityRoot.Query.Date(childComplexity, args["filter"].(models.DateFilter)), true
 	case "Query.error":
-		if e.complexity.Query.Error == nil {
+		if e.ComplexityRoot.Query.Error == nil {
 			break
 		}
 
@@ -177,64 +167,64 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Error(childComplexity, args["type"].(*models.ErrorType)), true
+		return e.ComplexityRoot.Query.Error(childComplexity, args["type"].(*models.ErrorType)), true
 	case "Query.jsonEncoding":
-		if e.complexity.Query.JSONEncoding == nil {
+		if e.ComplexityRoot.Query.JSONEncoding == nil {
 			break
 		}
 
-		return e.complexity.Query.JSONEncoding(childComplexity), true
+		return e.ComplexityRoot.Query.JSONEncoding(childComplexity), true
 	case "Query.path":
-		if e.complexity.Query.Path == nil {
+		if e.ComplexityRoot.Query.Path == nil {
 			break
 		}
 
-		return e.complexity.Query.Path(childComplexity), true
+		return e.ComplexityRoot.Query.Path(childComplexity), true
 	case "Query.viewer":
-		if e.complexity.Query.Viewer == nil {
+		if e.ComplexityRoot.Query.Viewer == nil {
 			break
 		}
 
-		return e.complexity.Query.Viewer(childComplexity), true
+		return e.ComplexityRoot.Query.Viewer(childComplexity), true
 
 	case "RemoteModelWithOmitempty.newDesc":
-		if e.complexity.RemoteModelWithOmitempty.Description == nil {
+		if e.ComplexityRoot.RemoteModelWithOmitempty.Description == nil {
 			break
 		}
 
-		return e.complexity.RemoteModelWithOmitempty.Description(childComplexity), true
+		return e.ComplexityRoot.RemoteModelWithOmitempty.Description(childComplexity), true
 
 	case "User.likes":
-		if e.complexity.User.Likes == nil {
+		if e.ComplexityRoot.User.Likes == nil {
 			break
 		}
 
-		return e.complexity.User.Likes(childComplexity), true
+		return e.ComplexityRoot.User.Likes(childComplexity), true
 	case "User.name":
-		if e.complexity.User.Name == nil {
+		if e.ComplexityRoot.User.Name == nil {
 			break
 		}
 
-		return e.complexity.User.Name(childComplexity), true
+		return e.ComplexityRoot.User.Name(childComplexity), true
 	case "User.phoneNumber":
-		if e.complexity.User.PhoneNumber == nil {
+		if e.ComplexityRoot.User.PhoneNumber == nil {
 			break
 		}
 
-		return e.complexity.User.PhoneNumber(childComplexity), true
+		return e.ComplexityRoot.User.PhoneNumber(childComplexity), true
 	case "User.query":
-		if e.complexity.User.Query == nil {
+		if e.ComplexityRoot.User.Query == nil {
 			break
 		}
 
-		return e.complexity.User.Query(childComplexity), true
+		return e.ComplexityRoot.User.Query(childComplexity), true
 
 	case "Viewer.user":
-		if e.complexity.Viewer.User == nil {
+		if e.ComplexityRoot.Viewer.User == nil {
 			break
 		}
 
-		return e.complexity.Viewer.User(childComplexity), true
+		return e.ComplexityRoot.Viewer.User(childComplexity), true
 
 	}
 	return 0, false
@@ -474,7 +464,7 @@ func (ec *executionContext) _Element_child(ctx context.Context, field graphql.Co
 		field,
 		ec.fieldContext_Element_child,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Element().Child(ctx, obj)
+			return ec.Resolvers.Element().Child(ctx, obj)
 		},
 		nil,
 		ec.marshalNElement2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋserverᚋmodelsᚑgoᚐElement,
@@ -511,7 +501,7 @@ func (ec *executionContext) _Element_error(ctx context.Context, field graphql.Co
 		field,
 		ec.fieldContext_Element_error,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Element().Error(ctx, obj)
+			return ec.Resolvers.Element().Error(ctx, obj)
 		},
 		nil,
 		ec.marshalNBoolean2bool,
@@ -540,7 +530,7 @@ func (ec *executionContext) _Element_mismatched(ctx context.Context, field graph
 		field,
 		ec.fieldContext_Element_mismatched,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Element().Mismatched(ctx, obj)
+			return ec.Resolvers.Element().Mismatched(ctx, obj)
 		},
 		nil,
 		ec.marshalOBoolean2ᚕboolᚄ,
@@ -569,7 +559,7 @@ func (ec *executionContext) _Query_path(ctx context.Context, field graphql.Colle
 		field,
 		ec.fieldContext_Query_path,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Path(ctx)
+			return ec.Resolvers.Query().Path(ctx)
 		},
 		nil,
 		ec.marshalOElement2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋserverᚋmodelsᚑgoᚐElement,
@@ -607,7 +597,7 @@ func (ec *executionContext) _Query_date(ctx context.Context, field graphql.Colle
 		ec.fieldContext_Query_date,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Date(ctx, fc.Args["filter"].(models.DateFilter))
+			return ec.Resolvers.Query().Date(ctx, fc.Args["filter"].(models.DateFilter))
 		},
 		nil,
 		ec.marshalNBoolean2bool,
@@ -647,7 +637,7 @@ func (ec *executionContext) _Query_viewer(ctx context.Context, field graphql.Col
 		field,
 		ec.fieldContext_Query_viewer,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Viewer(ctx)
+			return ec.Resolvers.Query().Viewer(ctx)
 		},
 		nil,
 		ec.marshalOViewer2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋintegrationᚋserverᚋmodelsᚑgoᚐViewer,
@@ -680,7 +670,7 @@ func (ec *executionContext) _Query_jsonEncoding(ctx context.Context, field graph
 		field,
 		ec.fieldContext_Query_jsonEncoding,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().JSONEncoding(ctx)
+			return ec.Resolvers.Query().JSONEncoding(ctx)
 		},
 		nil,
 		ec.marshalNString2string,
@@ -710,7 +700,7 @@ func (ec *executionContext) _Query_error(ctx context.Context, field graphql.Coll
 		ec.fieldContext_Query_error,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Error(ctx, fc.Args["type"].(*models.ErrorType))
+			return ec.Resolvers.Query().Error(ctx, fc.Args["type"].(*models.ErrorType))
 		},
 		nil,
 		ec.marshalNBoolean2bool,
@@ -751,7 +741,7 @@ func (ec *executionContext) _Query_complexity(ctx context.Context, field graphql
 		ec.fieldContext_Query_complexity,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Complexity(ctx, fc.Args["value"].(int))
+			return ec.Resolvers.Query().Complexity(ctx, fc.Args["value"].(int))
 		},
 		nil,
 		ec.marshalNBoolean2bool,
@@ -792,7 +782,7 @@ func (ec *executionContext) _Query_coercion(ctx context.Context, field graphql.C
 		ec.fieldContext_Query_coercion,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Coercion(ctx, fc.Args["value"].([]*models.ListCoercion))
+			return ec.Resolvers.Query().Coercion(ctx, fc.Args["value"].([]*models.ListCoercion))
 		},
 		nil,
 		ec.marshalNBoolean2bool,
@@ -998,7 +988,7 @@ func (ec *executionContext) _User_likes(ctx context.Context, field graphql.Colle
 		field,
 		ec.fieldContext_User_likes,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.User().Likes(ctx, obj)
+			return ec.Resolvers.User().Likes(ctx, obj)
 		},
 		nil,
 		ec.marshalNString2ᚕstringᚄ,

--- a/plugin/federation/federation.gotpl
+++ b/plugin/federation/federation.gotpl
@@ -180,7 +180,7 @@ func (ec *executionContext) resolveEntity(
 							return nil, fmt.Errorf(`unmarshalling param {{$j}} for {{$resolver.ResolverName}}(): %w`, err)
 							}
 						{{- end}}
-						entity, err := ec.resolvers.Entity().{{.ResolverName | go}}(ctx, {{- range $j, $_ := .KeyFields -}} id{{$j}}, {{end}})
+						entity, err := ec.Resolvers.Entity().{{.ResolverName | go}}(ctx, {{- range $j, $_ := .KeyFields -}} id{{$j}}, {{end}})
 						if err != nil {
 							return nil, fmt.Errorf(`resolving Entity "{{$entity.Def.Name}}": %w`, err)
 						}
@@ -258,7 +258,7 @@ func (ec *executionContext) resolveManyEntities(
 							}
 						}
 
-					entities, err := ec.resolvers.Entity().{{.ResolverName | go}}(ctx, typedReps)
+					entities, err := ec.Resolvers.Entity().{{.ResolverName | go}}(ctx, typedReps)
 						if err != nil {
 							return err
 						}

--- a/plugin/federation/testdata/allthethings/generated/federation.go
+++ b/plugin/federation/testdata/allthethings/generated/federation.go
@@ -168,7 +168,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findExternalExtensionByUpc(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindExternalExtensionByUpc(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindExternalExtensionByUpc(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "ExternalExtension": %w`, err)
 			}
@@ -187,7 +187,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findHelloByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindHelloByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindHelloByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "Hello": %w`, err)
 			}
@@ -210,7 +210,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 1 for findNestedKeyByIDAndHelloName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindNestedKeyByIDAndHelloName(ctx, id0, id1)
+			entity, err := ec.Resolvers.Entity().FindNestedKeyByIDAndHelloName(ctx, id0, id1)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "NestedKey": %w`, err)
 			}
@@ -245,7 +245,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 4 for findVeryNestedKeyByIDAndHelloNameAndWorldFooAndWorldBarAndMoreWorldFoo(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindVeryNestedKeyByIDAndHelloNameAndWorldFooAndWorldBarAndMoreWorldFoo(ctx, id0, id1, id2, id3, id4)
+			entity, err := ec.Resolvers.Entity().FindVeryNestedKeyByIDAndHelloNameAndWorldFooAndWorldBarAndMoreWorldFoo(ctx, id0, id1, id2, id3, id4)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "VeryNestedKey": %w`, err)
 			}
@@ -272,7 +272,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findWorldByFoo(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindWorldByFoo(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindWorldByFoo(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "World": %w`, err)
 			}
@@ -283,7 +283,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findWorldByBar(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindWorldByBar(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindWorldByBar(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "World": %w`, err)
 			}
@@ -332,7 +332,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloMultiKeyByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiHelloMultiKeyByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}
@@ -356,7 +356,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloMultiKeyByKey2s(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiHelloMultiKeyByKey2s(ctx, typedReps)
 			if err != nil {
 				return err
 			}

--- a/plugin/federation/testdata/computedrequires/generated/exec.go
+++ b/plugin/federation/testdata/computedrequires/generated/exec.go
@@ -23,12 +23,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -121,16 +116,11 @@ var (
 	}
 )
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -1167,7 +1157,7 @@ func (ec *executionContext) _Entity_findHelloByName(ctx context.Context, field g
 		ec.fieldContext_Entity_findHelloByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindHelloByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindHelloByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNHello2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋcomputedrequiresᚋgeneratedᚋmodelsᚐHello,
@@ -1214,7 +1204,7 @@ func (ec *executionContext) _Entity_findHelloMultiSingleKeysByKey1AndKey2(ctx co
 		ec.fieldContext_Entity_findHelloMultiSingleKeysByKey1AndKey2,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindHelloMultiSingleKeysByKey1AndKey2(ctx, fc.Args["key1"].(string), fc.Args["key2"].(string))
+			return ec.Resolvers.Entity().FindHelloMultiSingleKeysByKey1AndKey2(ctx, fc.Args["key1"].(string), fc.Args["key2"].(string))
 		},
 		nil,
 		ec.marshalNHelloMultiSingleKeys2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋcomputedrequiresᚋgeneratedᚋmodelsᚐHelloMultiSingleKeys,
@@ -1261,7 +1251,7 @@ func (ec *executionContext) _Entity_findHelloWithErrorsByName(ctx context.Contex
 		ec.fieldContext_Entity_findHelloWithErrorsByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindHelloWithErrorsByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindHelloWithErrorsByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNHelloWithErrors2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋcomputedrequiresᚋgeneratedᚋmodelsᚐHelloWithErrors,
@@ -1306,7 +1296,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloByNames(ctx context.Contex
 		ec.fieldContext_Entity_findManyMultiHelloByNames,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiHelloByNames(ctx, fc.Args["reps"].([]*model.MultiHelloByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiHelloByNames(ctx, fc.Args["reps"].([]*model.MultiHelloByNamesInput))
 		},
 		nil,
 		ec.marshalOMultiHello2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋcomputedrequiresᚋgeneratedᚋmodelsᚐMultiHello,
@@ -1351,7 +1341,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloMultipleRequiresByNames(ct
 		ec.fieldContext_Entity_findManyMultiHelloMultipleRequiresByNames,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiHelloMultipleRequiresByNames(ctx, fc.Args["reps"].([]*model.MultiHelloMultipleRequiresByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiHelloMultipleRequiresByNames(ctx, fc.Args["reps"].([]*model.MultiHelloMultipleRequiresByNamesInput))
 		},
 		nil,
 		ec.marshalOMultiHelloMultipleRequires2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋcomputedrequiresᚋgeneratedᚋmodelsᚐMultiHelloMultipleRequires,
@@ -1402,7 +1392,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloRequiresByNames(ctx contex
 		ec.fieldContext_Entity_findManyMultiHelloRequiresByNames,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiHelloRequiresByNames(ctx, fc.Args["reps"].([]*model.MultiHelloRequiresByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiHelloRequiresByNames(ctx, fc.Args["reps"].([]*model.MultiHelloRequiresByNamesInput))
 		},
 		nil,
 		ec.marshalOMultiHelloRequires2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋcomputedrequiresᚋgeneratedᚋmodelsᚐMultiHelloRequires,
@@ -1451,7 +1441,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloWithErrorByNames(ctx conte
 		ec.fieldContext_Entity_findManyMultiHelloWithErrorByNames,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiHelloWithErrorByNames(ctx, fc.Args["reps"].([]*model.MultiHelloWithErrorByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiHelloWithErrorByNames(ctx, fc.Args["reps"].([]*model.MultiHelloWithErrorByNamesInput))
 		},
 		nil,
 		ec.marshalOMultiHelloWithError2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋcomputedrequiresᚋgeneratedᚋmodelsᚐMultiHelloWithError,
@@ -1496,7 +1486,7 @@ func (ec *executionContext) _Entity_findManyMultiPlanetRequiresNestedByNames(ctx
 		ec.fieldContext_Entity_findManyMultiPlanetRequiresNestedByNames,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiPlanetRequiresNestedByNames(ctx, fc.Args["reps"].([]*model.MultiPlanetRequiresNestedByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiPlanetRequiresNestedByNames(ctx, fc.Args["reps"].([]*model.MultiPlanetRequiresNestedByNamesInput))
 		},
 		nil,
 		ec.marshalOMultiPlanetRequiresNested2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋcomputedrequiresᚋgeneratedᚋmodelsᚐMultiPlanetRequiresNested,
@@ -1549,7 +1539,7 @@ func (ec *executionContext) _Entity_findPersonByName(ctx context.Context, field 
 		ec.fieldContext_Entity_findPersonByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindPersonByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindPersonByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNPerson2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋcomputedrequiresᚋgeneratedᚋmodelsᚐPerson,
@@ -1598,7 +1588,7 @@ func (ec *executionContext) _Entity_findPlanetMultipleRequiresByName(ctx context
 		ec.fieldContext_Entity_findPlanetMultipleRequiresByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindPlanetMultipleRequiresByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindPlanetMultipleRequiresByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNPlanetMultipleRequires2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋcomputedrequiresᚋgeneratedᚋmodelsᚐPlanetMultipleRequires,
@@ -1651,7 +1641,7 @@ func (ec *executionContext) _Entity_findPlanetRequiresByName(ctx context.Context
 		ec.fieldContext_Entity_findPlanetRequiresByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindPlanetRequiresByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindPlanetRequiresByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNPlanetRequires2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋcomputedrequiresᚋgeneratedᚋmodelsᚐPlanetRequires,
@@ -1700,7 +1690,7 @@ func (ec *executionContext) _Entity_findPlanetRequiresNestedByName(ctx context.C
 		ec.fieldContext_Entity_findPlanetRequiresNestedByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindPlanetRequiresNestedByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindPlanetRequiresNestedByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNPlanetRequiresNested2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋcomputedrequiresᚋgeneratedᚋmodelsᚐPlanetRequiresNested,
@@ -1753,7 +1743,7 @@ func (ec *executionContext) _Entity_findWorldByHelloNameAndFoo(ctx context.Conte
 		ec.fieldContext_Entity_findWorldByHelloNameAndFoo,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindWorldByHelloNameAndFoo(ctx, fc.Args["helloName"].(string), fc.Args["foo"].(string))
+			return ec.Resolvers.Entity().FindWorldByHelloNameAndFoo(ctx, fc.Args["helloName"].(string), fc.Args["foo"].(string))
 		},
 		nil,
 		ec.marshalNWorld2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋcomputedrequiresᚋgeneratedᚋmodelsᚐWorld,
@@ -1802,7 +1792,7 @@ func (ec *executionContext) _Entity_findWorldNameByName(ctx context.Context, fie
 		ec.fieldContext_Entity_findWorldNameByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindWorldNameByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindWorldNameByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNWorldName2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋcomputedrequiresᚋgeneratedᚋmodelsᚐWorldName,
@@ -1847,7 +1837,7 @@ func (ec *executionContext) _Entity_findWorldWithMultipleKeysByHelloNameAndFoo(c
 		ec.fieldContext_Entity_findWorldWithMultipleKeysByHelloNameAndFoo,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindWorldWithMultipleKeysByHelloNameAndFoo(ctx, fc.Args["helloName"].(string), fc.Args["foo"].(string))
+			return ec.Resolvers.Entity().FindWorldWithMultipleKeysByHelloNameAndFoo(ctx, fc.Args["helloName"].(string), fc.Args["foo"].(string))
 		},
 		nil,
 		ec.marshalNWorldWithMultipleKeys2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋcomputedrequiresᚋgeneratedᚋmodelsᚐWorldWithMultipleKeys,
@@ -1896,7 +1886,7 @@ func (ec *executionContext) _Entity_findWorldWithMultipleKeysByBar(ctx context.C
 		ec.fieldContext_Entity_findWorldWithMultipleKeysByBar,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindWorldWithMultipleKeysByBar(ctx, fc.Args["bar"].(int))
+			return ec.Resolvers.Entity().FindWorldWithMultipleKeysByBar(ctx, fc.Args["bar"].(int))
 		},
 		nil,
 		ec.marshalNWorldWithMultipleKeys2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋcomputedrequiresᚋgeneratedᚋmodelsᚐWorldWithMultipleKeys,
@@ -2264,7 +2254,7 @@ func (ec *executionContext) _MultiHelloMultipleRequires_key3(ctx context.Context
 		ec.fieldContext_MultiHelloMultipleRequires_key3,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.MultiHelloMultipleRequires().Key3(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
+			return ec.Resolvers.MultiHelloMultipleRequires().Key3(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
 		},
 		nil,
 		ec.marshalNString2string,
@@ -2363,7 +2353,7 @@ func (ec *executionContext) _MultiHelloRequires_key2(ctx context.Context, field 
 		ec.fieldContext_MultiHelloRequires_key2,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.MultiHelloRequires().Key2(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
+			return ec.Resolvers.MultiHelloRequires().Key2(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
 		},
 		nil,
 		ec.marshalNString2string,
@@ -2536,7 +2526,7 @@ func (ec *executionContext) _MultiPlanetRequiresNested_size(ctx context.Context,
 		ec.fieldContext_MultiPlanetRequiresNested_size,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.MultiPlanetRequiresNested().Size(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
+			return ec.Resolvers.MultiPlanetRequiresNested().Size(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
 		},
 		nil,
 		ec.marshalNInt2int,
@@ -2577,7 +2567,7 @@ func (ec *executionContext) _MultiPlanetRequiresNested_sizes(ctx context.Context
 		ec.fieldContext_MultiPlanetRequiresNested_sizes,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.MultiPlanetRequiresNested().Sizes(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
+			return ec.Resolvers.MultiPlanetRequiresNested().Sizes(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
 		},
 		nil,
 		ec.marshalOInt2ᚕintᚄ,
@@ -2676,7 +2666,7 @@ func (ec *executionContext) _Person_welcomeMessage(ctx context.Context, field gr
 		ec.fieldContext_Person_welcomeMessage,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Person().WelcomeMessage(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
+			return ec.Resolvers.Person().WelcomeMessage(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
 		},
 		nil,
 		ec.marshalOString2ᚖstring,
@@ -2804,7 +2794,7 @@ func (ec *executionContext) _PlanetMultipleRequires_weight(ctx context.Context, 
 		ec.fieldContext_PlanetMultipleRequires_weight,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.PlanetMultipleRequires().Weight(ctx, obj, fc.Args["foo"].(*string), fc.Args["_federationRequires"].(map[string]any))
+			return ec.Resolvers.PlanetMultipleRequires().Weight(ctx, obj, fc.Args["foo"].(*string), fc.Args["_federationRequires"].(map[string]any))
 		},
 		nil,
 		ec.marshalNInt2int,
@@ -2914,7 +2904,7 @@ func (ec *executionContext) _PlanetRequires_size(ctx context.Context, field grap
 		ec.fieldContext_PlanetRequires_size,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.PlanetRequires().Size(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
+			return ec.Resolvers.PlanetRequires().Size(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
 		},
 		nil,
 		ec.marshalNInt2int,
@@ -3087,7 +3077,7 @@ func (ec *executionContext) _PlanetRequiresNested_size(ctx context.Context, fiel
 		ec.fieldContext_PlanetRequiresNested_size,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.PlanetRequiresNested().Size(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
+			return ec.Resolvers.PlanetRequiresNested().Size(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
 		},
 		nil,
 		ec.marshalNInt2int,
@@ -3128,7 +3118,7 @@ func (ec *executionContext) _PlanetRequiresNested_sizes(ctx context.Context, fie
 		ec.fieldContext_PlanetRequiresNested_sizes,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.PlanetRequiresNested().Sizes(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
+			return ec.Resolvers.PlanetRequiresNested().Sizes(ctx, obj, fc.Args["_federationRequires"].(map[string]any))
 		},
 		nil,
 		ec.marshalOInt2ᚕintᚄ,
@@ -3168,7 +3158,7 @@ func (ec *executionContext) _Query_test(ctx context.Context, field graphql.Colle
 		field,
 		ec.fieldContext_Query_test,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Query().Test(ctx)
+			return ec.Resolvers.Query().Test(ctx)
 		},
 		nil,
 		ec.marshalOString2ᚖstring,

--- a/plugin/federation/testdata/computedrequires/generated/federation.go
+++ b/plugin/federation/testdata/computedrequires/generated/federation.go
@@ -176,7 +176,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findHelloByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindHelloByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindHelloByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "Hello": %w`, err)
 			}
@@ -199,7 +199,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 1 for findHelloMultiSingleKeysByKey1AndKey2(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindHelloMultiSingleKeysByKey1AndKey2(ctx, id0, id1)
+			entity, err := ec.Resolvers.Entity().FindHelloMultiSingleKeysByKey1AndKey2(ctx, id0, id1)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "HelloMultiSingleKeys": %w`, err)
 			}
@@ -218,7 +218,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findHelloWithErrorsByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindHelloWithErrorsByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindHelloWithErrorsByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "HelloWithErrors": %w`, err)
 			}
@@ -237,7 +237,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findPersonByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindPersonByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindPersonByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "Person": %w`, err)
 			}
@@ -256,7 +256,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findPlanetMultipleRequiresByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindPlanetMultipleRequiresByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindPlanetMultipleRequiresByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "PlanetMultipleRequires": %w`, err)
 			}
@@ -275,7 +275,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findPlanetRequiresByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindPlanetRequiresByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindPlanetRequiresByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "PlanetRequires": %w`, err)
 			}
@@ -294,7 +294,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findPlanetRequiresNestedByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindPlanetRequiresNestedByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindPlanetRequiresNestedByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "PlanetRequiresNested": %w`, err)
 			}
@@ -317,7 +317,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 1 for findWorldByHelloNameAndFoo(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindWorldByHelloNameAndFoo(ctx, id0, id1)
+			entity, err := ec.Resolvers.Entity().FindWorldByHelloNameAndFoo(ctx, id0, id1)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "World": %w`, err)
 			}
@@ -336,7 +336,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findWorldNameByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindWorldNameByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindWorldNameByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "WorldName": %w`, err)
 			}
@@ -359,7 +359,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 1 for findWorldWithMultipleKeysByHelloNameAndFoo(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindWorldWithMultipleKeysByHelloNameAndFoo(ctx, id0, id1)
+			entity, err := ec.Resolvers.Entity().FindWorldWithMultipleKeysByHelloNameAndFoo(ctx, id0, id1)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "WorldWithMultipleKeys": %w`, err)
 			}
@@ -370,7 +370,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findWorldWithMultipleKeysByBar(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindWorldWithMultipleKeysByBar(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindWorldWithMultipleKeysByBar(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "WorldWithMultipleKeys": %w`, err)
 			}
@@ -419,7 +419,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiHelloByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}
@@ -454,7 +454,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloMultipleRequiresByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiHelloMultipleRequiresByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}
@@ -490,7 +490,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloRequiresByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiHelloRequiresByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}
@@ -526,7 +526,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloWithErrorByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiHelloWithErrorByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}
@@ -561,7 +561,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiPlanetRequiresNestedByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiPlanetRequiresNestedByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}

--- a/plugin/federation/testdata/entityresolver/generated/exec.go
+++ b/plugin/federation/testdata/entityresolver/generated/exec.go
@@ -23,12 +23,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -163,16 +158,11 @@ type EntityResolver interface {
 	FindWorldWithMultipleKeysByBar(ctx context.Context, bar int) (*model.WorldWithMultipleKeys, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -183,7 +173,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "Entity.findHelloByName":
-		if e.complexity.Entity.FindHelloByName == nil {
+		if e.ComplexityRoot.Entity.FindHelloByName == nil {
 			break
 		}
 
@@ -192,9 +182,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindHelloByName(childComplexity, args["name"].(string)), true
+		return e.ComplexityRoot.Entity.FindHelloByName(childComplexity, args["name"].(string)), true
 	case "Entity.findHelloMultiSingleKeysByKey1AndKey2":
-		if e.complexity.Entity.FindHelloMultiSingleKeysByKey1AndKey2 == nil {
+		if e.ComplexityRoot.Entity.FindHelloMultiSingleKeysByKey1AndKey2 == nil {
 			break
 		}
 
@@ -203,9 +193,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindHelloMultiSingleKeysByKey1AndKey2(childComplexity, args["key1"].(string), args["key2"].(string)), true
+		return e.ComplexityRoot.Entity.FindHelloMultiSingleKeysByKey1AndKey2(childComplexity, args["key1"].(string), args["key2"].(string)), true
 	case "Entity.findHelloWithErrorsByName":
-		if e.complexity.Entity.FindHelloWithErrorsByName == nil {
+		if e.ComplexityRoot.Entity.FindHelloWithErrorsByName == nil {
 			break
 		}
 
@@ -214,9 +204,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindHelloWithErrorsByName(childComplexity, args["name"].(string)), true
+		return e.ComplexityRoot.Entity.FindHelloWithErrorsByName(childComplexity, args["name"].(string)), true
 	case "Entity.findManyMultiHelloByNames":
-		if e.complexity.Entity.FindManyMultiHelloByNames == nil {
+		if e.ComplexityRoot.Entity.FindManyMultiHelloByNames == nil {
 			break
 		}
 
@@ -225,9 +215,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindManyMultiHelloByNames(childComplexity, args["reps"].([]*model.MultiHelloByNamesInput)), true
+		return e.ComplexityRoot.Entity.FindManyMultiHelloByNames(childComplexity, args["reps"].([]*model.MultiHelloByNamesInput)), true
 	case "Entity.findManyMultiHelloMultipleRequiresByNames":
-		if e.complexity.Entity.FindManyMultiHelloMultipleRequiresByNames == nil {
+		if e.ComplexityRoot.Entity.FindManyMultiHelloMultipleRequiresByNames == nil {
 			break
 		}
 
@@ -236,9 +226,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindManyMultiHelloMultipleRequiresByNames(childComplexity, args["reps"].([]*model.MultiHelloMultipleRequiresByNamesInput)), true
+		return e.ComplexityRoot.Entity.FindManyMultiHelloMultipleRequiresByNames(childComplexity, args["reps"].([]*model.MultiHelloMultipleRequiresByNamesInput)), true
 	case "Entity.findManyMultiHelloRequiresByNames":
-		if e.complexity.Entity.FindManyMultiHelloRequiresByNames == nil {
+		if e.ComplexityRoot.Entity.FindManyMultiHelloRequiresByNames == nil {
 			break
 		}
 
@@ -247,9 +237,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindManyMultiHelloRequiresByNames(childComplexity, args["reps"].([]*model.MultiHelloRequiresByNamesInput)), true
+		return e.ComplexityRoot.Entity.FindManyMultiHelloRequiresByNames(childComplexity, args["reps"].([]*model.MultiHelloRequiresByNamesInput)), true
 	case "Entity.findManyMultiHelloWithErrorByNames":
-		if e.complexity.Entity.FindManyMultiHelloWithErrorByNames == nil {
+		if e.ComplexityRoot.Entity.FindManyMultiHelloWithErrorByNames == nil {
 			break
 		}
 
@@ -258,9 +248,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindManyMultiHelloWithErrorByNames(childComplexity, args["reps"].([]*model.MultiHelloWithErrorByNamesInput)), true
+		return e.ComplexityRoot.Entity.FindManyMultiHelloWithErrorByNames(childComplexity, args["reps"].([]*model.MultiHelloWithErrorByNamesInput)), true
 	case "Entity.findManyMultiPlanetRequiresNestedByNames":
-		if e.complexity.Entity.FindManyMultiPlanetRequiresNestedByNames == nil {
+		if e.ComplexityRoot.Entity.FindManyMultiPlanetRequiresNestedByNames == nil {
 			break
 		}
 
@@ -269,9 +259,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindManyMultiPlanetRequiresNestedByNames(childComplexity, args["reps"].([]*model.MultiPlanetRequiresNestedByNamesInput)), true
+		return e.ComplexityRoot.Entity.FindManyMultiPlanetRequiresNestedByNames(childComplexity, args["reps"].([]*model.MultiPlanetRequiresNestedByNamesInput)), true
 	case "Entity.findPlanetMultipleRequiresByName":
-		if e.complexity.Entity.FindPlanetMultipleRequiresByName == nil {
+		if e.ComplexityRoot.Entity.FindPlanetMultipleRequiresByName == nil {
 			break
 		}
 
@@ -280,9 +270,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindPlanetMultipleRequiresByName(childComplexity, args["name"].(string)), true
+		return e.ComplexityRoot.Entity.FindPlanetMultipleRequiresByName(childComplexity, args["name"].(string)), true
 	case "Entity.findPlanetRequiresByName":
-		if e.complexity.Entity.FindPlanetRequiresByName == nil {
+		if e.ComplexityRoot.Entity.FindPlanetRequiresByName == nil {
 			break
 		}
 
@@ -291,9 +281,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindPlanetRequiresByName(childComplexity, args["name"].(string)), true
+		return e.ComplexityRoot.Entity.FindPlanetRequiresByName(childComplexity, args["name"].(string)), true
 	case "Entity.findPlanetRequiresNestedByName":
-		if e.complexity.Entity.FindPlanetRequiresNestedByName == nil {
+		if e.ComplexityRoot.Entity.FindPlanetRequiresNestedByName == nil {
 			break
 		}
 
@@ -302,9 +292,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindPlanetRequiresNestedByName(childComplexity, args["name"].(string)), true
+		return e.ComplexityRoot.Entity.FindPlanetRequiresNestedByName(childComplexity, args["name"].(string)), true
 	case "Entity.findWorldByHelloNameAndFoo":
-		if e.complexity.Entity.FindWorldByHelloNameAndFoo == nil {
+		if e.ComplexityRoot.Entity.FindWorldByHelloNameAndFoo == nil {
 			break
 		}
 
@@ -313,9 +303,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindWorldByHelloNameAndFoo(childComplexity, args["helloName"].(string), args["foo"].(string)), true
+		return e.ComplexityRoot.Entity.FindWorldByHelloNameAndFoo(childComplexity, args["helloName"].(string), args["foo"].(string)), true
 	case "Entity.findWorldNameByName":
-		if e.complexity.Entity.FindWorldNameByName == nil {
+		if e.ComplexityRoot.Entity.FindWorldNameByName == nil {
 			break
 		}
 
@@ -324,9 +314,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindWorldNameByName(childComplexity, args["name"].(string)), true
+		return e.ComplexityRoot.Entity.FindWorldNameByName(childComplexity, args["name"].(string)), true
 	case "Entity.findWorldWithMultipleKeysByBar":
-		if e.complexity.Entity.FindWorldWithMultipleKeysByBar == nil {
+		if e.ComplexityRoot.Entity.FindWorldWithMultipleKeysByBar == nil {
 			break
 		}
 
@@ -335,9 +325,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindWorldWithMultipleKeysByBar(childComplexity, args["bar"].(int)), true
+		return e.ComplexityRoot.Entity.FindWorldWithMultipleKeysByBar(childComplexity, args["bar"].(int)), true
 	case "Entity.findWorldWithMultipleKeysByHelloNameAndFoo":
-		if e.complexity.Entity.FindWorldWithMultipleKeysByHelloNameAndFoo == nil {
+		if e.ComplexityRoot.Entity.FindWorldWithMultipleKeysByHelloNameAndFoo == nil {
 			break
 		}
 
@@ -346,189 +336,189 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindWorldWithMultipleKeysByHelloNameAndFoo(childComplexity, args["helloName"].(string), args["foo"].(string)), true
+		return e.ComplexityRoot.Entity.FindWorldWithMultipleKeysByHelloNameAndFoo(childComplexity, args["helloName"].(string), args["foo"].(string)), true
 
 	case "Hello.name":
-		if e.complexity.Hello.Name == nil {
+		if e.ComplexityRoot.Hello.Name == nil {
 			break
 		}
 
-		return e.complexity.Hello.Name(childComplexity), true
+		return e.ComplexityRoot.Hello.Name(childComplexity), true
 	case "Hello.secondary":
-		if e.complexity.Hello.Secondary == nil {
+		if e.ComplexityRoot.Hello.Secondary == nil {
 			break
 		}
 
-		return e.complexity.Hello.Secondary(childComplexity), true
+		return e.ComplexityRoot.Hello.Secondary(childComplexity), true
 
 	case "HelloMultiSingleKeys.key1":
-		if e.complexity.HelloMultiSingleKeys.Key1 == nil {
+		if e.ComplexityRoot.HelloMultiSingleKeys.Key1 == nil {
 			break
 		}
 
-		return e.complexity.HelloMultiSingleKeys.Key1(childComplexity), true
+		return e.ComplexityRoot.HelloMultiSingleKeys.Key1(childComplexity), true
 	case "HelloMultiSingleKeys.key2":
-		if e.complexity.HelloMultiSingleKeys.Key2 == nil {
+		if e.ComplexityRoot.HelloMultiSingleKeys.Key2 == nil {
 			break
 		}
 
-		return e.complexity.HelloMultiSingleKeys.Key2(childComplexity), true
+		return e.ComplexityRoot.HelloMultiSingleKeys.Key2(childComplexity), true
 
 	case "HelloWithErrors.name":
-		if e.complexity.HelloWithErrors.Name == nil {
+		if e.ComplexityRoot.HelloWithErrors.Name == nil {
 			break
 		}
 
-		return e.complexity.HelloWithErrors.Name(childComplexity), true
+		return e.ComplexityRoot.HelloWithErrors.Name(childComplexity), true
 
 	case "MultiHello.name":
-		if e.complexity.MultiHello.Name == nil {
+		if e.ComplexityRoot.MultiHello.Name == nil {
 			break
 		}
 
-		return e.complexity.MultiHello.Name(childComplexity), true
+		return e.ComplexityRoot.MultiHello.Name(childComplexity), true
 
 	case "MultiHelloMultipleRequires.key1":
-		if e.complexity.MultiHelloMultipleRequires.Key1 == nil {
+		if e.ComplexityRoot.MultiHelloMultipleRequires.Key1 == nil {
 			break
 		}
 
-		return e.complexity.MultiHelloMultipleRequires.Key1(childComplexity), true
+		return e.ComplexityRoot.MultiHelloMultipleRequires.Key1(childComplexity), true
 	case "MultiHelloMultipleRequires.key2":
-		if e.complexity.MultiHelloMultipleRequires.Key2 == nil {
+		if e.ComplexityRoot.MultiHelloMultipleRequires.Key2 == nil {
 			break
 		}
 
-		return e.complexity.MultiHelloMultipleRequires.Key2(childComplexity), true
+		return e.ComplexityRoot.MultiHelloMultipleRequires.Key2(childComplexity), true
 	case "MultiHelloMultipleRequires.key3":
-		if e.complexity.MultiHelloMultipleRequires.Key3 == nil {
+		if e.ComplexityRoot.MultiHelloMultipleRequires.Key3 == nil {
 			break
 		}
 
-		return e.complexity.MultiHelloMultipleRequires.Key3(childComplexity), true
+		return e.ComplexityRoot.MultiHelloMultipleRequires.Key3(childComplexity), true
 	case "MultiHelloMultipleRequires.name":
-		if e.complexity.MultiHelloMultipleRequires.Name == nil {
+		if e.ComplexityRoot.MultiHelloMultipleRequires.Name == nil {
 			break
 		}
 
-		return e.complexity.MultiHelloMultipleRequires.Name(childComplexity), true
+		return e.ComplexityRoot.MultiHelloMultipleRequires.Name(childComplexity), true
 
 	case "MultiHelloRequires.key1":
-		if e.complexity.MultiHelloRequires.Key1 == nil {
+		if e.ComplexityRoot.MultiHelloRequires.Key1 == nil {
 			break
 		}
 
-		return e.complexity.MultiHelloRequires.Key1(childComplexity), true
+		return e.ComplexityRoot.MultiHelloRequires.Key1(childComplexity), true
 	case "MultiHelloRequires.key2":
-		if e.complexity.MultiHelloRequires.Key2 == nil {
+		if e.ComplexityRoot.MultiHelloRequires.Key2 == nil {
 			break
 		}
 
-		return e.complexity.MultiHelloRequires.Key2(childComplexity), true
+		return e.ComplexityRoot.MultiHelloRequires.Key2(childComplexity), true
 	case "MultiHelloRequires.name":
-		if e.complexity.MultiHelloRequires.Name == nil {
+		if e.ComplexityRoot.MultiHelloRequires.Name == nil {
 			break
 		}
 
-		return e.complexity.MultiHelloRequires.Name(childComplexity), true
+		return e.ComplexityRoot.MultiHelloRequires.Name(childComplexity), true
 
 	case "MultiHelloWithError.name":
-		if e.complexity.MultiHelloWithError.Name == nil {
+		if e.ComplexityRoot.MultiHelloWithError.Name == nil {
 			break
 		}
 
-		return e.complexity.MultiHelloWithError.Name(childComplexity), true
+		return e.ComplexityRoot.MultiHelloWithError.Name(childComplexity), true
 
 	case "MultiPlanetRequiresNested.name":
-		if e.complexity.MultiPlanetRequiresNested.Name == nil {
+		if e.ComplexityRoot.MultiPlanetRequiresNested.Name == nil {
 			break
 		}
 
-		return e.complexity.MultiPlanetRequiresNested.Name(childComplexity), true
+		return e.ComplexityRoot.MultiPlanetRequiresNested.Name(childComplexity), true
 	case "MultiPlanetRequiresNested.size":
-		if e.complexity.MultiPlanetRequiresNested.Size == nil {
+		if e.ComplexityRoot.MultiPlanetRequiresNested.Size == nil {
 			break
 		}
 
-		return e.complexity.MultiPlanetRequiresNested.Size(childComplexity), true
+		return e.ComplexityRoot.MultiPlanetRequiresNested.Size(childComplexity), true
 	case "MultiPlanetRequiresNested.world":
-		if e.complexity.MultiPlanetRequiresNested.World == nil {
+		if e.ComplexityRoot.MultiPlanetRequiresNested.World == nil {
 			break
 		}
 
-		return e.complexity.MultiPlanetRequiresNested.World(childComplexity), true
+		return e.ComplexityRoot.MultiPlanetRequiresNested.World(childComplexity), true
 
 	case "PlanetMultipleRequires.density":
-		if e.complexity.PlanetMultipleRequires.Density == nil {
+		if e.ComplexityRoot.PlanetMultipleRequires.Density == nil {
 			break
 		}
 
-		return e.complexity.PlanetMultipleRequires.Density(childComplexity), true
+		return e.ComplexityRoot.PlanetMultipleRequires.Density(childComplexity), true
 	case "PlanetMultipleRequires.diameter":
-		if e.complexity.PlanetMultipleRequires.Diameter == nil {
+		if e.ComplexityRoot.PlanetMultipleRequires.Diameter == nil {
 			break
 		}
 
-		return e.complexity.PlanetMultipleRequires.Diameter(childComplexity), true
+		return e.ComplexityRoot.PlanetMultipleRequires.Diameter(childComplexity), true
 	case "PlanetMultipleRequires.name":
-		if e.complexity.PlanetMultipleRequires.Name == nil {
+		if e.ComplexityRoot.PlanetMultipleRequires.Name == nil {
 			break
 		}
 
-		return e.complexity.PlanetMultipleRequires.Name(childComplexity), true
+		return e.ComplexityRoot.PlanetMultipleRequires.Name(childComplexity), true
 	case "PlanetMultipleRequires.weight":
-		if e.complexity.PlanetMultipleRequires.Weight == nil {
+		if e.ComplexityRoot.PlanetMultipleRequires.Weight == nil {
 			break
 		}
 
-		return e.complexity.PlanetMultipleRequires.Weight(childComplexity), true
+		return e.ComplexityRoot.PlanetMultipleRequires.Weight(childComplexity), true
 
 	case "PlanetRequires.diameter":
-		if e.complexity.PlanetRequires.Diameter == nil {
+		if e.ComplexityRoot.PlanetRequires.Diameter == nil {
 			break
 		}
 
-		return e.complexity.PlanetRequires.Diameter(childComplexity), true
+		return e.ComplexityRoot.PlanetRequires.Diameter(childComplexity), true
 	case "PlanetRequires.name":
-		if e.complexity.PlanetRequires.Name == nil {
+		if e.ComplexityRoot.PlanetRequires.Name == nil {
 			break
 		}
 
-		return e.complexity.PlanetRequires.Name(childComplexity), true
+		return e.ComplexityRoot.PlanetRequires.Name(childComplexity), true
 	case "PlanetRequires.size":
-		if e.complexity.PlanetRequires.Size == nil {
+		if e.ComplexityRoot.PlanetRequires.Size == nil {
 			break
 		}
 
-		return e.complexity.PlanetRequires.Size(childComplexity), true
+		return e.ComplexityRoot.PlanetRequires.Size(childComplexity), true
 
 	case "PlanetRequiresNested.name":
-		if e.complexity.PlanetRequiresNested.Name == nil {
+		if e.ComplexityRoot.PlanetRequiresNested.Name == nil {
 			break
 		}
 
-		return e.complexity.PlanetRequiresNested.Name(childComplexity), true
+		return e.ComplexityRoot.PlanetRequiresNested.Name(childComplexity), true
 	case "PlanetRequiresNested.size":
-		if e.complexity.PlanetRequiresNested.Size == nil {
+		if e.ComplexityRoot.PlanetRequiresNested.Size == nil {
 			break
 		}
 
-		return e.complexity.PlanetRequiresNested.Size(childComplexity), true
+		return e.ComplexityRoot.PlanetRequiresNested.Size(childComplexity), true
 	case "PlanetRequiresNested.world":
-		if e.complexity.PlanetRequiresNested.World == nil {
+		if e.ComplexityRoot.PlanetRequiresNested.World == nil {
 			break
 		}
 
-		return e.complexity.PlanetRequiresNested.World(childComplexity), true
+		return e.ComplexityRoot.PlanetRequiresNested.World(childComplexity), true
 
 	case "Query._service":
-		if e.complexity.Query.__resolve__service == nil {
+		if e.ComplexityRoot.Query.__resolve__service == nil {
 			break
 		}
 
-		return e.complexity.Query.__resolve__service(childComplexity), true
+		return e.ComplexityRoot.Query.__resolve__service(childComplexity), true
 	case "Query._entities":
-		if e.complexity.Query.__resolve_entities == nil {
+		if e.ComplexityRoot.Query.__resolve_entities == nil {
 			break
 		}
 
@@ -537,59 +527,59 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.__resolve_entities(childComplexity, args["representations"].([]map[string]any)), true
+		return e.ComplexityRoot.Query.__resolve_entities(childComplexity, args["representations"].([]map[string]any)), true
 
 	case "World.bar":
-		if e.complexity.World.Bar == nil {
+		if e.ComplexityRoot.World.Bar == nil {
 			break
 		}
 
-		return e.complexity.World.Bar(childComplexity), true
+		return e.ComplexityRoot.World.Bar(childComplexity), true
 	case "World.foo":
-		if e.complexity.World.Foo == nil {
+		if e.ComplexityRoot.World.Foo == nil {
 			break
 		}
 
-		return e.complexity.World.Foo(childComplexity), true
+		return e.ComplexityRoot.World.Foo(childComplexity), true
 	case "World.hello":
-		if e.complexity.World.Hello == nil {
+		if e.ComplexityRoot.World.Hello == nil {
 			break
 		}
 
-		return e.complexity.World.Hello(childComplexity), true
+		return e.ComplexityRoot.World.Hello(childComplexity), true
 
 	case "WorldName.name":
-		if e.complexity.WorldName.Name == nil {
+		if e.ComplexityRoot.WorldName.Name == nil {
 			break
 		}
 
-		return e.complexity.WorldName.Name(childComplexity), true
+		return e.ComplexityRoot.WorldName.Name(childComplexity), true
 
 	case "WorldWithMultipleKeys.bar":
-		if e.complexity.WorldWithMultipleKeys.Bar == nil {
+		if e.ComplexityRoot.WorldWithMultipleKeys.Bar == nil {
 			break
 		}
 
-		return e.complexity.WorldWithMultipleKeys.Bar(childComplexity), true
+		return e.ComplexityRoot.WorldWithMultipleKeys.Bar(childComplexity), true
 	case "WorldWithMultipleKeys.foo":
-		if e.complexity.WorldWithMultipleKeys.Foo == nil {
+		if e.ComplexityRoot.WorldWithMultipleKeys.Foo == nil {
 			break
 		}
 
-		return e.complexity.WorldWithMultipleKeys.Foo(childComplexity), true
+		return e.ComplexityRoot.WorldWithMultipleKeys.Foo(childComplexity), true
 	case "WorldWithMultipleKeys.hello":
-		if e.complexity.WorldWithMultipleKeys.Hello == nil {
+		if e.ComplexityRoot.WorldWithMultipleKeys.Hello == nil {
 			break
 		}
 
-		return e.complexity.WorldWithMultipleKeys.Hello(childComplexity), true
+		return e.ComplexityRoot.WorldWithMultipleKeys.Hello(childComplexity), true
 
 	case "_Service.sdl":
-		if e.complexity._Service.SDL == nil {
+		if e.ComplexityRoot._Service.SDL == nil {
 			break
 		}
 
-		return e.complexity._Service.SDL(childComplexity), true
+		return e.ComplexityRoot._Service.SDL(childComplexity), true
 
 	}
 	return 0, false
@@ -1094,7 +1084,7 @@ func (ec *executionContext) _Entity_findHelloByName(ctx context.Context, field g
 		ec.fieldContext_Entity_findHelloByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindHelloByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindHelloByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNHello2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚋmodelᚐHello,
@@ -1141,7 +1131,7 @@ func (ec *executionContext) _Entity_findHelloMultiSingleKeysByKey1AndKey2(ctx co
 		ec.fieldContext_Entity_findHelloMultiSingleKeysByKey1AndKey2,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindHelloMultiSingleKeysByKey1AndKey2(ctx, fc.Args["key1"].(string), fc.Args["key2"].(string))
+			return ec.Resolvers.Entity().FindHelloMultiSingleKeysByKey1AndKey2(ctx, fc.Args["key1"].(string), fc.Args["key2"].(string))
 		},
 		nil,
 		ec.marshalNHelloMultiSingleKeys2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚋmodelᚐHelloMultiSingleKeys,
@@ -1188,7 +1178,7 @@ func (ec *executionContext) _Entity_findHelloWithErrorsByName(ctx context.Contex
 		ec.fieldContext_Entity_findHelloWithErrorsByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindHelloWithErrorsByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindHelloWithErrorsByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNHelloWithErrors2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚋmodelᚐHelloWithErrors,
@@ -1233,7 +1223,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloByNames(ctx context.Contex
 		ec.fieldContext_Entity_findManyMultiHelloByNames,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiHelloByNames(ctx, fc.Args["reps"].([]*model.MultiHelloByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiHelloByNames(ctx, fc.Args["reps"].([]*model.MultiHelloByNamesInput))
 		},
 		nil,
 		ec.marshalOMultiHello2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚋmodelᚐMultiHello,
@@ -1278,7 +1268,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloMultipleRequiresByNames(ct
 		ec.fieldContext_Entity_findManyMultiHelloMultipleRequiresByNames,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiHelloMultipleRequiresByNames(ctx, fc.Args["reps"].([]*model.MultiHelloMultipleRequiresByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiHelloMultipleRequiresByNames(ctx, fc.Args["reps"].([]*model.MultiHelloMultipleRequiresByNamesInput))
 		},
 		nil,
 		ec.marshalOMultiHelloMultipleRequires2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚋmodelᚐMultiHelloMultipleRequires,
@@ -1329,7 +1319,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloRequiresByNames(ctx contex
 		ec.fieldContext_Entity_findManyMultiHelloRequiresByNames,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiHelloRequiresByNames(ctx, fc.Args["reps"].([]*model.MultiHelloRequiresByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiHelloRequiresByNames(ctx, fc.Args["reps"].([]*model.MultiHelloRequiresByNamesInput))
 		},
 		nil,
 		ec.marshalOMultiHelloRequires2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚋmodelᚐMultiHelloRequires,
@@ -1378,7 +1368,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloWithErrorByNames(ctx conte
 		ec.fieldContext_Entity_findManyMultiHelloWithErrorByNames,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiHelloWithErrorByNames(ctx, fc.Args["reps"].([]*model.MultiHelloWithErrorByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiHelloWithErrorByNames(ctx, fc.Args["reps"].([]*model.MultiHelloWithErrorByNamesInput))
 		},
 		nil,
 		ec.marshalOMultiHelloWithError2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚋmodelᚐMultiHelloWithError,
@@ -1423,7 +1413,7 @@ func (ec *executionContext) _Entity_findManyMultiPlanetRequiresNestedByNames(ctx
 		ec.fieldContext_Entity_findManyMultiPlanetRequiresNestedByNames,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiPlanetRequiresNestedByNames(ctx, fc.Args["reps"].([]*model.MultiPlanetRequiresNestedByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiPlanetRequiresNestedByNames(ctx, fc.Args["reps"].([]*model.MultiPlanetRequiresNestedByNamesInput))
 		},
 		nil,
 		ec.marshalOMultiPlanetRequiresNested2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚋmodelᚐMultiPlanetRequiresNested,
@@ -1472,7 +1462,7 @@ func (ec *executionContext) _Entity_findPlanetMultipleRequiresByName(ctx context
 		ec.fieldContext_Entity_findPlanetMultipleRequiresByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindPlanetMultipleRequiresByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindPlanetMultipleRequiresByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNPlanetMultipleRequires2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚋmodelᚐPlanetMultipleRequires,
@@ -1523,7 +1513,7 @@ func (ec *executionContext) _Entity_findPlanetRequiresByName(ctx context.Context
 		ec.fieldContext_Entity_findPlanetRequiresByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindPlanetRequiresByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindPlanetRequiresByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNPlanetRequires2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚋmodelᚐPlanetRequires,
@@ -1572,7 +1562,7 @@ func (ec *executionContext) _Entity_findPlanetRequiresNestedByName(ctx context.C
 		ec.fieldContext_Entity_findPlanetRequiresNestedByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindPlanetRequiresNestedByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindPlanetRequiresNestedByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNPlanetRequiresNested2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚋmodelᚐPlanetRequiresNested,
@@ -1621,7 +1611,7 @@ func (ec *executionContext) _Entity_findWorldByHelloNameAndFoo(ctx context.Conte
 		ec.fieldContext_Entity_findWorldByHelloNameAndFoo,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindWorldByHelloNameAndFoo(ctx, fc.Args["helloName"].(string), fc.Args["foo"].(string))
+			return ec.Resolvers.Entity().FindWorldByHelloNameAndFoo(ctx, fc.Args["helloName"].(string), fc.Args["foo"].(string))
 		},
 		nil,
 		ec.marshalNWorld2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚋmodelᚐWorld,
@@ -1670,7 +1660,7 @@ func (ec *executionContext) _Entity_findWorldNameByName(ctx context.Context, fie
 		ec.fieldContext_Entity_findWorldNameByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindWorldNameByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindWorldNameByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNWorldName2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚋmodelᚐWorldName,
@@ -1715,7 +1705,7 @@ func (ec *executionContext) _Entity_findWorldWithMultipleKeysByHelloNameAndFoo(c
 		ec.fieldContext_Entity_findWorldWithMultipleKeysByHelloNameAndFoo,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindWorldWithMultipleKeysByHelloNameAndFoo(ctx, fc.Args["helloName"].(string), fc.Args["foo"].(string))
+			return ec.Resolvers.Entity().FindWorldWithMultipleKeysByHelloNameAndFoo(ctx, fc.Args["helloName"].(string), fc.Args["foo"].(string))
 		},
 		nil,
 		ec.marshalNWorldWithMultipleKeys2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚋmodelᚐWorldWithMultipleKeys,
@@ -1764,7 +1754,7 @@ func (ec *executionContext) _Entity_findWorldWithMultipleKeysByBar(ctx context.C
 		ec.fieldContext_Entity_findWorldWithMultipleKeysByBar,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindWorldWithMultipleKeysByBar(ctx, fc.Args["bar"].(int))
+			return ec.Resolvers.Entity().FindWorldWithMultipleKeysByBar(ctx, fc.Args["bar"].(int))
 		},
 		nil,
 		ec.marshalNWorldWithMultipleKeys2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋentityresolverᚋgeneratedᚋmodelᚐWorldWithMultipleKeys,

--- a/plugin/federation/testdata/entityresolver/generated/federation.go
+++ b/plugin/federation/testdata/entityresolver/generated/federation.go
@@ -176,7 +176,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findHelloByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindHelloByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindHelloByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "Hello": %w`, err)
 			}
@@ -199,7 +199,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 1 for findHelloMultiSingleKeysByKey1AndKey2(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindHelloMultiSingleKeysByKey1AndKey2(ctx, id0, id1)
+			entity, err := ec.Resolvers.Entity().FindHelloMultiSingleKeysByKey1AndKey2(ctx, id0, id1)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "HelloMultiSingleKeys": %w`, err)
 			}
@@ -218,7 +218,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findHelloWithErrorsByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindHelloWithErrorsByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindHelloWithErrorsByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "HelloWithErrors": %w`, err)
 			}
@@ -237,7 +237,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findPlanetMultipleRequiresByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindPlanetMultipleRequiresByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindPlanetMultipleRequiresByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "PlanetMultipleRequires": %w`, err)
 			}
@@ -264,7 +264,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findPlanetRequiresByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindPlanetRequiresByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindPlanetRequiresByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "PlanetRequires": %w`, err)
 			}
@@ -287,7 +287,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findPlanetRequiresNestedByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindPlanetRequiresNestedByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindPlanetRequiresNestedByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "PlanetRequiresNested": %w`, err)
 			}
@@ -314,7 +314,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 1 for findWorldByHelloNameAndFoo(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindWorldByHelloNameAndFoo(ctx, id0, id1)
+			entity, err := ec.Resolvers.Entity().FindWorldByHelloNameAndFoo(ctx, id0, id1)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "World": %w`, err)
 			}
@@ -333,7 +333,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findWorldNameByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindWorldNameByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindWorldNameByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "WorldName": %w`, err)
 			}
@@ -356,7 +356,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 1 for findWorldWithMultipleKeysByHelloNameAndFoo(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindWorldWithMultipleKeysByHelloNameAndFoo(ctx, id0, id1)
+			entity, err := ec.Resolvers.Entity().FindWorldWithMultipleKeysByHelloNameAndFoo(ctx, id0, id1)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "WorldWithMultipleKeys": %w`, err)
 			}
@@ -367,7 +367,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findWorldWithMultipleKeysByBar(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindWorldWithMultipleKeysByBar(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindWorldWithMultipleKeysByBar(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "WorldWithMultipleKeys": %w`, err)
 			}
@@ -416,7 +416,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiHelloByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}
@@ -451,7 +451,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloMultipleRequiresByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiHelloMultipleRequiresByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}
@@ -494,7 +494,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloRequiresByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiHelloRequiresByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}
@@ -533,7 +533,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloWithErrorByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiHelloWithErrorByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}
@@ -568,7 +568,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiPlanetRequiresNestedByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiPlanetRequiresNestedByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}

--- a/plugin/federation/testdata/explicitrequires/generated/exec.go
+++ b/plugin/federation/testdata/explicitrequires/generated/exec.go
@@ -22,12 +22,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -61,16 +56,11 @@ type EntityResolver interface {
 	FindWorldWithMultipleKeysByBar(ctx context.Context, bar int) (*WorldWithMultipleKeys, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -613,7 +603,7 @@ func (ec *executionContext) _Entity_findHelloByName(ctx context.Context, field g
 		ec.fieldContext_Entity_findHelloByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindHelloByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindHelloByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNHello2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋexplicitrequiresᚋgeneratedᚐHello,
@@ -660,7 +650,7 @@ func (ec *executionContext) _Entity_findHelloMultiSingleKeysByKey1AndKey2(ctx co
 		ec.fieldContext_Entity_findHelloMultiSingleKeysByKey1AndKey2,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindHelloMultiSingleKeysByKey1AndKey2(ctx, fc.Args["key1"].(string), fc.Args["key2"].(string))
+			return ec.Resolvers.Entity().FindHelloMultiSingleKeysByKey1AndKey2(ctx, fc.Args["key1"].(string), fc.Args["key2"].(string))
 		},
 		nil,
 		ec.marshalNHelloMultiSingleKeys2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋexplicitrequiresᚋgeneratedᚐHelloMultiSingleKeys,
@@ -707,7 +697,7 @@ func (ec *executionContext) _Entity_findHelloWithErrorsByName(ctx context.Contex
 		ec.fieldContext_Entity_findHelloWithErrorsByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindHelloWithErrorsByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindHelloWithErrorsByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNHelloWithErrors2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋexplicitrequiresᚋgeneratedᚐHelloWithErrors,
@@ -752,7 +742,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloByNames(ctx context.Contex
 		ec.fieldContext_Entity_findManyMultiHelloByNames,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiHelloByNames(ctx, fc.Args["reps"].([]*MultiHelloByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiHelloByNames(ctx, fc.Args["reps"].([]*MultiHelloByNamesInput))
 		},
 		nil,
 		ec.marshalOMultiHello2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋexplicitrequiresᚋgeneratedᚐMultiHello,
@@ -797,7 +787,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloMultipleRequiresByNames(ct
 		ec.fieldContext_Entity_findManyMultiHelloMultipleRequiresByNames,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiHelloMultipleRequiresByNames(ctx, fc.Args["reps"].([]*MultiHelloMultipleRequiresByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiHelloMultipleRequiresByNames(ctx, fc.Args["reps"].([]*MultiHelloMultipleRequiresByNamesInput))
 		},
 		nil,
 		ec.marshalOMultiHelloMultipleRequires2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋexplicitrequiresᚋgeneratedᚐMultiHelloMultipleRequires,
@@ -848,7 +838,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloRequiresByNames(ctx contex
 		ec.fieldContext_Entity_findManyMultiHelloRequiresByNames,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiHelloRequiresByNames(ctx, fc.Args["reps"].([]*MultiHelloRequiresByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiHelloRequiresByNames(ctx, fc.Args["reps"].([]*MultiHelloRequiresByNamesInput))
 		},
 		nil,
 		ec.marshalOMultiHelloRequires2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋexplicitrequiresᚋgeneratedᚐMultiHelloRequires,
@@ -897,7 +887,7 @@ func (ec *executionContext) _Entity_findManyMultiHelloWithErrorByNames(ctx conte
 		ec.fieldContext_Entity_findManyMultiHelloWithErrorByNames,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiHelloWithErrorByNames(ctx, fc.Args["reps"].([]*MultiHelloWithErrorByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiHelloWithErrorByNames(ctx, fc.Args["reps"].([]*MultiHelloWithErrorByNamesInput))
 		},
 		nil,
 		ec.marshalOMultiHelloWithError2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋexplicitrequiresᚋgeneratedᚐMultiHelloWithError,
@@ -942,7 +932,7 @@ func (ec *executionContext) _Entity_findManyMultiPlanetRequiresNestedByNames(ctx
 		ec.fieldContext_Entity_findManyMultiPlanetRequiresNestedByNames,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiPlanetRequiresNestedByNames(ctx, fc.Args["reps"].([]*MultiPlanetRequiresNestedByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiPlanetRequiresNestedByNames(ctx, fc.Args["reps"].([]*MultiPlanetRequiresNestedByNamesInput))
 		},
 		nil,
 		ec.marshalOMultiPlanetRequiresNested2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋexplicitrequiresᚋgeneratedᚐMultiPlanetRequiresNested,
@@ -995,7 +985,7 @@ func (ec *executionContext) _Entity_findPersonByName(ctx context.Context, field 
 		ec.fieldContext_Entity_findPersonByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindPersonByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindPersonByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNPerson2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋexplicitrequiresᚋgeneratedᚐPerson,
@@ -1044,7 +1034,7 @@ func (ec *executionContext) _Entity_findPlanetMultipleRequiresByName(ctx context
 		ec.fieldContext_Entity_findPlanetMultipleRequiresByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindPlanetMultipleRequiresByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindPlanetMultipleRequiresByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNPlanetMultipleRequires2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋexplicitrequiresᚋgeneratedᚐPlanetMultipleRequires,
@@ -1095,7 +1085,7 @@ func (ec *executionContext) _Entity_findPlanetRequiresByName(ctx context.Context
 		ec.fieldContext_Entity_findPlanetRequiresByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindPlanetRequiresByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindPlanetRequiresByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNPlanetRequires2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋexplicitrequiresᚋgeneratedᚐPlanetRequires,
@@ -1144,7 +1134,7 @@ func (ec *executionContext) _Entity_findPlanetRequiresNestedByName(ctx context.C
 		ec.fieldContext_Entity_findPlanetRequiresNestedByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindPlanetRequiresNestedByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindPlanetRequiresNestedByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNPlanetRequiresNested2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋexplicitrequiresᚋgeneratedᚐPlanetRequiresNested,
@@ -1197,7 +1187,7 @@ func (ec *executionContext) _Entity_findWorldByHelloNameAndFoo(ctx context.Conte
 		ec.fieldContext_Entity_findWorldByHelloNameAndFoo,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindWorldByHelloNameAndFoo(ctx, fc.Args["helloName"].(string), fc.Args["foo"].(string))
+			return ec.Resolvers.Entity().FindWorldByHelloNameAndFoo(ctx, fc.Args["helloName"].(string), fc.Args["foo"].(string))
 		},
 		nil,
 		ec.marshalNWorld2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋexplicitrequiresᚋgeneratedᚐWorld,
@@ -1246,7 +1236,7 @@ func (ec *executionContext) _Entity_findWorldNameByName(ctx context.Context, fie
 		ec.fieldContext_Entity_findWorldNameByName,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindWorldNameByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindWorldNameByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		ec.marshalNWorldName2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋexplicitrequiresᚋgeneratedᚐWorldName,
@@ -1291,7 +1281,7 @@ func (ec *executionContext) _Entity_findWorldWithMultipleKeysByHelloNameAndFoo(c
 		ec.fieldContext_Entity_findWorldWithMultipleKeysByHelloNameAndFoo,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindWorldWithMultipleKeysByHelloNameAndFoo(ctx, fc.Args["helloName"].(string), fc.Args["foo"].(string))
+			return ec.Resolvers.Entity().FindWorldWithMultipleKeysByHelloNameAndFoo(ctx, fc.Args["helloName"].(string), fc.Args["foo"].(string))
 		},
 		nil,
 		ec.marshalNWorldWithMultipleKeys2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋexplicitrequiresᚋgeneratedᚐWorldWithMultipleKeys,
@@ -1340,7 +1330,7 @@ func (ec *executionContext) _Entity_findWorldWithMultipleKeysByBar(ctx context.C
 		ec.fieldContext_Entity_findWorldWithMultipleKeysByBar,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindWorldWithMultipleKeysByBar(ctx, fc.Args["bar"].(int))
+			return ec.Resolvers.Entity().FindWorldWithMultipleKeysByBar(ctx, fc.Args["bar"].(int))
 		},
 		nil,
 		ec.marshalNWorldWithMultipleKeys2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋtestdataᚋexplicitrequiresᚋgeneratedᚐWorldWithMultipleKeys,

--- a/plugin/federation/testdata/explicitrequires/generated/federation.go
+++ b/plugin/federation/testdata/explicitrequires/generated/federation.go
@@ -175,7 +175,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findHelloByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindHelloByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindHelloByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "Hello": %w`, err)
 			}
@@ -198,7 +198,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 1 for findHelloMultiSingleKeysByKey1AndKey2(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindHelloMultiSingleKeysByKey1AndKey2(ctx, id0, id1)
+			entity, err := ec.Resolvers.Entity().FindHelloMultiSingleKeysByKey1AndKey2(ctx, id0, id1)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "HelloMultiSingleKeys": %w`, err)
 			}
@@ -217,7 +217,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findHelloWithErrorsByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindHelloWithErrorsByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindHelloWithErrorsByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "HelloWithErrors": %w`, err)
 			}
@@ -236,7 +236,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findPersonByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindPersonByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindPersonByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "Person": %w`, err)
 			}
@@ -258,7 +258,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findPlanetMultipleRequiresByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindPlanetMultipleRequiresByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindPlanetMultipleRequiresByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "PlanetMultipleRequires": %w`, err)
 			}
@@ -280,7 +280,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findPlanetRequiresByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindPlanetRequiresByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindPlanetRequiresByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "PlanetRequires": %w`, err)
 			}
@@ -302,7 +302,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findPlanetRequiresNestedByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindPlanetRequiresNestedByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindPlanetRequiresNestedByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "PlanetRequiresNested": %w`, err)
 			}
@@ -328,7 +328,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 1 for findWorldByHelloNameAndFoo(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindWorldByHelloNameAndFoo(ctx, id0, id1)
+			entity, err := ec.Resolvers.Entity().FindWorldByHelloNameAndFoo(ctx, id0, id1)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "World": %w`, err)
 			}
@@ -347,7 +347,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findWorldNameByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindWorldNameByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindWorldNameByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "WorldName": %w`, err)
 			}
@@ -370,7 +370,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 1 for findWorldWithMultipleKeysByHelloNameAndFoo(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindWorldWithMultipleKeysByHelloNameAndFoo(ctx, id0, id1)
+			entity, err := ec.Resolvers.Entity().FindWorldWithMultipleKeysByHelloNameAndFoo(ctx, id0, id1)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "WorldWithMultipleKeys": %w`, err)
 			}
@@ -381,7 +381,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findWorldWithMultipleKeysByBar(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindWorldWithMultipleKeysByBar(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindWorldWithMultipleKeysByBar(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "WorldWithMultipleKeys": %w`, err)
 			}
@@ -430,7 +430,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiHelloByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}
@@ -465,7 +465,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloMultipleRequiresByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiHelloMultipleRequiresByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}
@@ -505,7 +505,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloRequiresByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiHelloRequiresByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}
@@ -545,7 +545,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloWithErrorByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiHelloWithErrorByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}
@@ -580,7 +580,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiPlanetRequiresNestedByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiPlanetRequiresNestedByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}

--- a/plugin/federation/testdata/federation2/generated/federation.go
+++ b/plugin/federation/testdata/federation2/generated/federation.go
@@ -165,7 +165,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findExternalExtensionByUpc(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindExternalExtensionByUpc(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindExternalExtensionByUpc(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "ExternalExtension": %w`, err)
 			}

--- a/plugin/federation/testdata/usefunctionsyntaxforexecutioncontext/generated/exec.go
+++ b/plugin/federation/testdata/usefunctionsyntaxforexecutioncontext/generated/exec.go
@@ -23,12 +23,7 @@ import (
 
 // NewExecutableSchema creates an ExecutableSchema from the ResolverRoot interface.
 func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
-	return &executableSchema{
-		schema:     cfg.Schema,
-		resolvers:  cfg.Resolvers,
-		directives: cfg.Directives,
-		complexity: cfg.Complexity,
-	}
+	return &executableSchema{SchemaData: cfg.Schema, Resolvers: cfg.Resolvers, Directives: cfg.Directives, ComplexityRoot: cfg.Complexity}
 }
 
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -163,16 +158,11 @@ type EntityResolver interface {
 	FindWorldWithMultipleKeysByBar(ctx context.Context, bar int) (*model.WorldWithMultipleKeys, error)
 }
 
-type executableSchema struct {
-	schema     *ast.Schema
-	resolvers  ResolverRoot
-	directives DirectiveRoot
-	complexity ComplexityRoot
-}
+type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 func (e *executableSchema) Schema() *ast.Schema {
-	if e.schema != nil {
-		return e.schema
+	if e.SchemaData != nil {
+		return e.SchemaData
 	}
 	return parsedSchema
 }
@@ -183,7 +173,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	switch typeName + "." + field {
 
 	case "Entity.findHelloByName":
-		if e.complexity.Entity.FindHelloByName == nil {
+		if e.ComplexityRoot.Entity.FindHelloByName == nil {
 			break
 		}
 
@@ -192,9 +182,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindHelloByName(childComplexity, args["name"].(string)), true
+		return e.ComplexityRoot.Entity.FindHelloByName(childComplexity, args["name"].(string)), true
 	case "Entity.findHelloMultiSingleKeysByKey1AndKey2":
-		if e.complexity.Entity.FindHelloMultiSingleKeysByKey1AndKey2 == nil {
+		if e.ComplexityRoot.Entity.FindHelloMultiSingleKeysByKey1AndKey2 == nil {
 			break
 		}
 
@@ -203,9 +193,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindHelloMultiSingleKeysByKey1AndKey2(childComplexity, args["key1"].(string), args["key2"].(string)), true
+		return e.ComplexityRoot.Entity.FindHelloMultiSingleKeysByKey1AndKey2(childComplexity, args["key1"].(string), args["key2"].(string)), true
 	case "Entity.findHelloWithErrorsByName":
-		if e.complexity.Entity.FindHelloWithErrorsByName == nil {
+		if e.ComplexityRoot.Entity.FindHelloWithErrorsByName == nil {
 			break
 		}
 
@@ -214,9 +204,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindHelloWithErrorsByName(childComplexity, args["name"].(string)), true
+		return e.ComplexityRoot.Entity.FindHelloWithErrorsByName(childComplexity, args["name"].(string)), true
 	case "Entity.findManyMultiHelloByNames":
-		if e.complexity.Entity.FindManyMultiHelloByNames == nil {
+		if e.ComplexityRoot.Entity.FindManyMultiHelloByNames == nil {
 			break
 		}
 
@@ -225,9 +215,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindManyMultiHelloByNames(childComplexity, args["reps"].([]*model.MultiHelloByNamesInput)), true
+		return e.ComplexityRoot.Entity.FindManyMultiHelloByNames(childComplexity, args["reps"].([]*model.MultiHelloByNamesInput)), true
 	case "Entity.findManyMultiHelloMultipleRequiresByNames":
-		if e.complexity.Entity.FindManyMultiHelloMultipleRequiresByNames == nil {
+		if e.ComplexityRoot.Entity.FindManyMultiHelloMultipleRequiresByNames == nil {
 			break
 		}
 
@@ -236,9 +226,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindManyMultiHelloMultipleRequiresByNames(childComplexity, args["reps"].([]*model.MultiHelloMultipleRequiresByNamesInput)), true
+		return e.ComplexityRoot.Entity.FindManyMultiHelloMultipleRequiresByNames(childComplexity, args["reps"].([]*model.MultiHelloMultipleRequiresByNamesInput)), true
 	case "Entity.findManyMultiHelloRequiresByNames":
-		if e.complexity.Entity.FindManyMultiHelloRequiresByNames == nil {
+		if e.ComplexityRoot.Entity.FindManyMultiHelloRequiresByNames == nil {
 			break
 		}
 
@@ -247,9 +237,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindManyMultiHelloRequiresByNames(childComplexity, args["reps"].([]*model.MultiHelloRequiresByNamesInput)), true
+		return e.ComplexityRoot.Entity.FindManyMultiHelloRequiresByNames(childComplexity, args["reps"].([]*model.MultiHelloRequiresByNamesInput)), true
 	case "Entity.findManyMultiHelloWithErrorByNames":
-		if e.complexity.Entity.FindManyMultiHelloWithErrorByNames == nil {
+		if e.ComplexityRoot.Entity.FindManyMultiHelloWithErrorByNames == nil {
 			break
 		}
 
@@ -258,9 +248,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindManyMultiHelloWithErrorByNames(childComplexity, args["reps"].([]*model.MultiHelloWithErrorByNamesInput)), true
+		return e.ComplexityRoot.Entity.FindManyMultiHelloWithErrorByNames(childComplexity, args["reps"].([]*model.MultiHelloWithErrorByNamesInput)), true
 	case "Entity.findManyMultiPlanetRequiresNestedByNames":
-		if e.complexity.Entity.FindManyMultiPlanetRequiresNestedByNames == nil {
+		if e.ComplexityRoot.Entity.FindManyMultiPlanetRequiresNestedByNames == nil {
 			break
 		}
 
@@ -269,9 +259,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindManyMultiPlanetRequiresNestedByNames(childComplexity, args["reps"].([]*model.MultiPlanetRequiresNestedByNamesInput)), true
+		return e.ComplexityRoot.Entity.FindManyMultiPlanetRequiresNestedByNames(childComplexity, args["reps"].([]*model.MultiPlanetRequiresNestedByNamesInput)), true
 	case "Entity.findPlanetMultipleRequiresByName":
-		if e.complexity.Entity.FindPlanetMultipleRequiresByName == nil {
+		if e.ComplexityRoot.Entity.FindPlanetMultipleRequiresByName == nil {
 			break
 		}
 
@@ -280,9 +270,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindPlanetMultipleRequiresByName(childComplexity, args["name"].(string)), true
+		return e.ComplexityRoot.Entity.FindPlanetMultipleRequiresByName(childComplexity, args["name"].(string)), true
 	case "Entity.findPlanetRequiresByName":
-		if e.complexity.Entity.FindPlanetRequiresByName == nil {
+		if e.ComplexityRoot.Entity.FindPlanetRequiresByName == nil {
 			break
 		}
 
@@ -291,9 +281,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindPlanetRequiresByName(childComplexity, args["name"].(string)), true
+		return e.ComplexityRoot.Entity.FindPlanetRequiresByName(childComplexity, args["name"].(string)), true
 	case "Entity.findPlanetRequiresNestedByName":
-		if e.complexity.Entity.FindPlanetRequiresNestedByName == nil {
+		if e.ComplexityRoot.Entity.FindPlanetRequiresNestedByName == nil {
 			break
 		}
 
@@ -302,9 +292,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindPlanetRequiresNestedByName(childComplexity, args["name"].(string)), true
+		return e.ComplexityRoot.Entity.FindPlanetRequiresNestedByName(childComplexity, args["name"].(string)), true
 	case "Entity.findWorldByHelloNameAndFoo":
-		if e.complexity.Entity.FindWorldByHelloNameAndFoo == nil {
+		if e.ComplexityRoot.Entity.FindWorldByHelloNameAndFoo == nil {
 			break
 		}
 
@@ -313,9 +303,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindWorldByHelloNameAndFoo(childComplexity, args["helloName"].(string), args["foo"].(string)), true
+		return e.ComplexityRoot.Entity.FindWorldByHelloNameAndFoo(childComplexity, args["helloName"].(string), args["foo"].(string)), true
 	case "Entity.findWorldNameByName":
-		if e.complexity.Entity.FindWorldNameByName == nil {
+		if e.ComplexityRoot.Entity.FindWorldNameByName == nil {
 			break
 		}
 
@@ -324,9 +314,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindWorldNameByName(childComplexity, args["name"].(string)), true
+		return e.ComplexityRoot.Entity.FindWorldNameByName(childComplexity, args["name"].(string)), true
 	case "Entity.findWorldWithMultipleKeysByBar":
-		if e.complexity.Entity.FindWorldWithMultipleKeysByBar == nil {
+		if e.ComplexityRoot.Entity.FindWorldWithMultipleKeysByBar == nil {
 			break
 		}
 
@@ -335,9 +325,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindWorldWithMultipleKeysByBar(childComplexity, args["bar"].(int)), true
+		return e.ComplexityRoot.Entity.FindWorldWithMultipleKeysByBar(childComplexity, args["bar"].(int)), true
 	case "Entity.findWorldWithMultipleKeysByHelloNameAndFoo":
-		if e.complexity.Entity.FindWorldWithMultipleKeysByHelloNameAndFoo == nil {
+		if e.ComplexityRoot.Entity.FindWorldWithMultipleKeysByHelloNameAndFoo == nil {
 			break
 		}
 
@@ -346,189 +336,189 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Entity.FindWorldWithMultipleKeysByHelloNameAndFoo(childComplexity, args["helloName"].(string), args["foo"].(string)), true
+		return e.ComplexityRoot.Entity.FindWorldWithMultipleKeysByHelloNameAndFoo(childComplexity, args["helloName"].(string), args["foo"].(string)), true
 
 	case "Hello.name":
-		if e.complexity.Hello.Name == nil {
+		if e.ComplexityRoot.Hello.Name == nil {
 			break
 		}
 
-		return e.complexity.Hello.Name(childComplexity), true
+		return e.ComplexityRoot.Hello.Name(childComplexity), true
 	case "Hello.secondary":
-		if e.complexity.Hello.Secondary == nil {
+		if e.ComplexityRoot.Hello.Secondary == nil {
 			break
 		}
 
-		return e.complexity.Hello.Secondary(childComplexity), true
+		return e.ComplexityRoot.Hello.Secondary(childComplexity), true
 
 	case "HelloMultiSingleKeys.key1":
-		if e.complexity.HelloMultiSingleKeys.Key1 == nil {
+		if e.ComplexityRoot.HelloMultiSingleKeys.Key1 == nil {
 			break
 		}
 
-		return e.complexity.HelloMultiSingleKeys.Key1(childComplexity), true
+		return e.ComplexityRoot.HelloMultiSingleKeys.Key1(childComplexity), true
 	case "HelloMultiSingleKeys.key2":
-		if e.complexity.HelloMultiSingleKeys.Key2 == nil {
+		if e.ComplexityRoot.HelloMultiSingleKeys.Key2 == nil {
 			break
 		}
 
-		return e.complexity.HelloMultiSingleKeys.Key2(childComplexity), true
+		return e.ComplexityRoot.HelloMultiSingleKeys.Key2(childComplexity), true
 
 	case "HelloWithErrors.name":
-		if e.complexity.HelloWithErrors.Name == nil {
+		if e.ComplexityRoot.HelloWithErrors.Name == nil {
 			break
 		}
 
-		return e.complexity.HelloWithErrors.Name(childComplexity), true
+		return e.ComplexityRoot.HelloWithErrors.Name(childComplexity), true
 
 	case "MultiHello.name":
-		if e.complexity.MultiHello.Name == nil {
+		if e.ComplexityRoot.MultiHello.Name == nil {
 			break
 		}
 
-		return e.complexity.MultiHello.Name(childComplexity), true
+		return e.ComplexityRoot.MultiHello.Name(childComplexity), true
 
 	case "MultiHelloMultipleRequires.key1":
-		if e.complexity.MultiHelloMultipleRequires.Key1 == nil {
+		if e.ComplexityRoot.MultiHelloMultipleRequires.Key1 == nil {
 			break
 		}
 
-		return e.complexity.MultiHelloMultipleRequires.Key1(childComplexity), true
+		return e.ComplexityRoot.MultiHelloMultipleRequires.Key1(childComplexity), true
 	case "MultiHelloMultipleRequires.key2":
-		if e.complexity.MultiHelloMultipleRequires.Key2 == nil {
+		if e.ComplexityRoot.MultiHelloMultipleRequires.Key2 == nil {
 			break
 		}
 
-		return e.complexity.MultiHelloMultipleRequires.Key2(childComplexity), true
+		return e.ComplexityRoot.MultiHelloMultipleRequires.Key2(childComplexity), true
 	case "MultiHelloMultipleRequires.key3":
-		if e.complexity.MultiHelloMultipleRequires.Key3 == nil {
+		if e.ComplexityRoot.MultiHelloMultipleRequires.Key3 == nil {
 			break
 		}
 
-		return e.complexity.MultiHelloMultipleRequires.Key3(childComplexity), true
+		return e.ComplexityRoot.MultiHelloMultipleRequires.Key3(childComplexity), true
 	case "MultiHelloMultipleRequires.name":
-		if e.complexity.MultiHelloMultipleRequires.Name == nil {
+		if e.ComplexityRoot.MultiHelloMultipleRequires.Name == nil {
 			break
 		}
 
-		return e.complexity.MultiHelloMultipleRequires.Name(childComplexity), true
+		return e.ComplexityRoot.MultiHelloMultipleRequires.Name(childComplexity), true
 
 	case "MultiHelloRequires.key1":
-		if e.complexity.MultiHelloRequires.Key1 == nil {
+		if e.ComplexityRoot.MultiHelloRequires.Key1 == nil {
 			break
 		}
 
-		return e.complexity.MultiHelloRequires.Key1(childComplexity), true
+		return e.ComplexityRoot.MultiHelloRequires.Key1(childComplexity), true
 	case "MultiHelloRequires.key2":
-		if e.complexity.MultiHelloRequires.Key2 == nil {
+		if e.ComplexityRoot.MultiHelloRequires.Key2 == nil {
 			break
 		}
 
-		return e.complexity.MultiHelloRequires.Key2(childComplexity), true
+		return e.ComplexityRoot.MultiHelloRequires.Key2(childComplexity), true
 	case "MultiHelloRequires.name":
-		if e.complexity.MultiHelloRequires.Name == nil {
+		if e.ComplexityRoot.MultiHelloRequires.Name == nil {
 			break
 		}
 
-		return e.complexity.MultiHelloRequires.Name(childComplexity), true
+		return e.ComplexityRoot.MultiHelloRequires.Name(childComplexity), true
 
 	case "MultiHelloWithError.name":
-		if e.complexity.MultiHelloWithError.Name == nil {
+		if e.ComplexityRoot.MultiHelloWithError.Name == nil {
 			break
 		}
 
-		return e.complexity.MultiHelloWithError.Name(childComplexity), true
+		return e.ComplexityRoot.MultiHelloWithError.Name(childComplexity), true
 
 	case "MultiPlanetRequiresNested.name":
-		if e.complexity.MultiPlanetRequiresNested.Name == nil {
+		if e.ComplexityRoot.MultiPlanetRequiresNested.Name == nil {
 			break
 		}
 
-		return e.complexity.MultiPlanetRequiresNested.Name(childComplexity), true
+		return e.ComplexityRoot.MultiPlanetRequiresNested.Name(childComplexity), true
 	case "MultiPlanetRequiresNested.size":
-		if e.complexity.MultiPlanetRequiresNested.Size == nil {
+		if e.ComplexityRoot.MultiPlanetRequiresNested.Size == nil {
 			break
 		}
 
-		return e.complexity.MultiPlanetRequiresNested.Size(childComplexity), true
+		return e.ComplexityRoot.MultiPlanetRequiresNested.Size(childComplexity), true
 	case "MultiPlanetRequiresNested.world":
-		if e.complexity.MultiPlanetRequiresNested.World == nil {
+		if e.ComplexityRoot.MultiPlanetRequiresNested.World == nil {
 			break
 		}
 
-		return e.complexity.MultiPlanetRequiresNested.World(childComplexity), true
+		return e.ComplexityRoot.MultiPlanetRequiresNested.World(childComplexity), true
 
 	case "PlanetMultipleRequires.density":
-		if e.complexity.PlanetMultipleRequires.Density == nil {
+		if e.ComplexityRoot.PlanetMultipleRequires.Density == nil {
 			break
 		}
 
-		return e.complexity.PlanetMultipleRequires.Density(childComplexity), true
+		return e.ComplexityRoot.PlanetMultipleRequires.Density(childComplexity), true
 	case "PlanetMultipleRequires.diameter":
-		if e.complexity.PlanetMultipleRequires.Diameter == nil {
+		if e.ComplexityRoot.PlanetMultipleRequires.Diameter == nil {
 			break
 		}
 
-		return e.complexity.PlanetMultipleRequires.Diameter(childComplexity), true
+		return e.ComplexityRoot.PlanetMultipleRequires.Diameter(childComplexity), true
 	case "PlanetMultipleRequires.name":
-		if e.complexity.PlanetMultipleRequires.Name == nil {
+		if e.ComplexityRoot.PlanetMultipleRequires.Name == nil {
 			break
 		}
 
-		return e.complexity.PlanetMultipleRequires.Name(childComplexity), true
+		return e.ComplexityRoot.PlanetMultipleRequires.Name(childComplexity), true
 	case "PlanetMultipleRequires.weight":
-		if e.complexity.PlanetMultipleRequires.Weight == nil {
+		if e.ComplexityRoot.PlanetMultipleRequires.Weight == nil {
 			break
 		}
 
-		return e.complexity.PlanetMultipleRequires.Weight(childComplexity), true
+		return e.ComplexityRoot.PlanetMultipleRequires.Weight(childComplexity), true
 
 	case "PlanetRequires.diameter":
-		if e.complexity.PlanetRequires.Diameter == nil {
+		if e.ComplexityRoot.PlanetRequires.Diameter == nil {
 			break
 		}
 
-		return e.complexity.PlanetRequires.Diameter(childComplexity), true
+		return e.ComplexityRoot.PlanetRequires.Diameter(childComplexity), true
 	case "PlanetRequires.name":
-		if e.complexity.PlanetRequires.Name == nil {
+		if e.ComplexityRoot.PlanetRequires.Name == nil {
 			break
 		}
 
-		return e.complexity.PlanetRequires.Name(childComplexity), true
+		return e.ComplexityRoot.PlanetRequires.Name(childComplexity), true
 	case "PlanetRequires.size":
-		if e.complexity.PlanetRequires.Size == nil {
+		if e.ComplexityRoot.PlanetRequires.Size == nil {
 			break
 		}
 
-		return e.complexity.PlanetRequires.Size(childComplexity), true
+		return e.ComplexityRoot.PlanetRequires.Size(childComplexity), true
 
 	case "PlanetRequiresNested.name":
-		if e.complexity.PlanetRequiresNested.Name == nil {
+		if e.ComplexityRoot.PlanetRequiresNested.Name == nil {
 			break
 		}
 
-		return e.complexity.PlanetRequiresNested.Name(childComplexity), true
+		return e.ComplexityRoot.PlanetRequiresNested.Name(childComplexity), true
 	case "PlanetRequiresNested.size":
-		if e.complexity.PlanetRequiresNested.Size == nil {
+		if e.ComplexityRoot.PlanetRequiresNested.Size == nil {
 			break
 		}
 
-		return e.complexity.PlanetRequiresNested.Size(childComplexity), true
+		return e.ComplexityRoot.PlanetRequiresNested.Size(childComplexity), true
 	case "PlanetRequiresNested.world":
-		if e.complexity.PlanetRequiresNested.World == nil {
+		if e.ComplexityRoot.PlanetRequiresNested.World == nil {
 			break
 		}
 
-		return e.complexity.PlanetRequiresNested.World(childComplexity), true
+		return e.ComplexityRoot.PlanetRequiresNested.World(childComplexity), true
 
 	case "Query._service":
-		if e.complexity.Query.__resolve__service == nil {
+		if e.ComplexityRoot.Query.__resolve__service == nil {
 			break
 		}
 
-		return e.complexity.Query.__resolve__service(childComplexity), true
+		return e.ComplexityRoot.Query.__resolve__service(childComplexity), true
 	case "Query._entities":
-		if e.complexity.Query.__resolve_entities == nil {
+		if e.ComplexityRoot.Query.__resolve_entities == nil {
 			break
 		}
 
@@ -537,59 +527,59 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.__resolve_entities(childComplexity, args["representations"].([]map[string]any)), true
+		return e.ComplexityRoot.Query.__resolve_entities(childComplexity, args["representations"].([]map[string]any)), true
 
 	case "World.bar":
-		if e.complexity.World.Bar == nil {
+		if e.ComplexityRoot.World.Bar == nil {
 			break
 		}
 
-		return e.complexity.World.Bar(childComplexity), true
+		return e.ComplexityRoot.World.Bar(childComplexity), true
 	case "World.foo":
-		if e.complexity.World.Foo == nil {
+		if e.ComplexityRoot.World.Foo == nil {
 			break
 		}
 
-		return e.complexity.World.Foo(childComplexity), true
+		return e.ComplexityRoot.World.Foo(childComplexity), true
 	case "World.hello":
-		if e.complexity.World.Hello == nil {
+		if e.ComplexityRoot.World.Hello == nil {
 			break
 		}
 
-		return e.complexity.World.Hello(childComplexity), true
+		return e.ComplexityRoot.World.Hello(childComplexity), true
 
 	case "WorldName.name":
-		if e.complexity.WorldName.Name == nil {
+		if e.ComplexityRoot.WorldName.Name == nil {
 			break
 		}
 
-		return e.complexity.WorldName.Name(childComplexity), true
+		return e.ComplexityRoot.WorldName.Name(childComplexity), true
 
 	case "WorldWithMultipleKeys.bar":
-		if e.complexity.WorldWithMultipleKeys.Bar == nil {
+		if e.ComplexityRoot.WorldWithMultipleKeys.Bar == nil {
 			break
 		}
 
-		return e.complexity.WorldWithMultipleKeys.Bar(childComplexity), true
+		return e.ComplexityRoot.WorldWithMultipleKeys.Bar(childComplexity), true
 	case "WorldWithMultipleKeys.foo":
-		if e.complexity.WorldWithMultipleKeys.Foo == nil {
+		if e.ComplexityRoot.WorldWithMultipleKeys.Foo == nil {
 			break
 		}
 
-		return e.complexity.WorldWithMultipleKeys.Foo(childComplexity), true
+		return e.ComplexityRoot.WorldWithMultipleKeys.Foo(childComplexity), true
 	case "WorldWithMultipleKeys.hello":
-		if e.complexity.WorldWithMultipleKeys.Hello == nil {
+		if e.ComplexityRoot.WorldWithMultipleKeys.Hello == nil {
 			break
 		}
 
-		return e.complexity.WorldWithMultipleKeys.Hello(childComplexity), true
+		return e.ComplexityRoot.WorldWithMultipleKeys.Hello(childComplexity), true
 
 	case "_Service.sdl":
-		if e.complexity._Service.SDL == nil {
+		if e.ComplexityRoot._Service.SDL == nil {
 			break
 		}
 
-		return e.complexity._Service.SDL(childComplexity), true
+		return e.ComplexityRoot._Service.SDL(childComplexity), true
 
 	}
 	return 0, false
@@ -1096,7 +1086,7 @@ func _Entity_findHelloByName(ctx context.Context, ec *executionContext, field gr
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindHelloByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindHelloByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *model.Hello) graphql.Marshaler {
@@ -1147,7 +1137,7 @@ func _Entity_findHelloMultiSingleKeysByKey1AndKey2(ctx context.Context, ec *exec
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindHelloMultiSingleKeysByKey1AndKey2(ctx, fc.Args["key1"].(string), fc.Args["key2"].(string))
+			return ec.Resolvers.Entity().FindHelloMultiSingleKeysByKey1AndKey2(ctx, fc.Args["key1"].(string), fc.Args["key2"].(string))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *model.HelloMultiSingleKeys) graphql.Marshaler {
@@ -1198,7 +1188,7 @@ func _Entity_findHelloWithErrorsByName(ctx context.Context, ec *executionContext
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindHelloWithErrorsByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindHelloWithErrorsByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *model.HelloWithErrors) graphql.Marshaler {
@@ -1247,7 +1237,7 @@ func _Entity_findManyMultiHelloByNames(ctx context.Context, ec *executionContext
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiHelloByNames(ctx, fc.Args["reps"].([]*model.MultiHelloByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiHelloByNames(ctx, fc.Args["reps"].([]*model.MultiHelloByNamesInput))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v []*model.MultiHello) graphql.Marshaler {
@@ -1296,7 +1286,7 @@ func _Entity_findManyMultiHelloMultipleRequiresByNames(ctx context.Context, ec *
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiHelloMultipleRequiresByNames(ctx, fc.Args["reps"].([]*model.MultiHelloMultipleRequiresByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiHelloMultipleRequiresByNames(ctx, fc.Args["reps"].([]*model.MultiHelloMultipleRequiresByNamesInput))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v []*model.MultiHelloMultipleRequires) graphql.Marshaler {
@@ -1351,7 +1341,7 @@ func _Entity_findManyMultiHelloRequiresByNames(ctx context.Context, ec *executio
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiHelloRequiresByNames(ctx, fc.Args["reps"].([]*model.MultiHelloRequiresByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiHelloRequiresByNames(ctx, fc.Args["reps"].([]*model.MultiHelloRequiresByNamesInput))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v []*model.MultiHelloRequires) graphql.Marshaler {
@@ -1404,7 +1394,7 @@ func _Entity_findManyMultiHelloWithErrorByNames(ctx context.Context, ec *executi
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiHelloWithErrorByNames(ctx, fc.Args["reps"].([]*model.MultiHelloWithErrorByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiHelloWithErrorByNames(ctx, fc.Args["reps"].([]*model.MultiHelloWithErrorByNamesInput))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v []*model.MultiHelloWithError) graphql.Marshaler {
@@ -1453,7 +1443,7 @@ func _Entity_findManyMultiPlanetRequiresNestedByNames(ctx context.Context, ec *e
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindManyMultiPlanetRequiresNestedByNames(ctx, fc.Args["reps"].([]*model.MultiPlanetRequiresNestedByNamesInput))
+			return ec.Resolvers.Entity().FindManyMultiPlanetRequiresNestedByNames(ctx, fc.Args["reps"].([]*model.MultiPlanetRequiresNestedByNamesInput))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v []*model.MultiPlanetRequiresNested) graphql.Marshaler {
@@ -1506,7 +1496,7 @@ func _Entity_findPlanetMultipleRequiresByName(ctx context.Context, ec *execution
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindPlanetMultipleRequiresByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindPlanetMultipleRequiresByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *model.PlanetMultipleRequires) graphql.Marshaler {
@@ -1561,7 +1551,7 @@ func _Entity_findPlanetRequiresByName(ctx context.Context, ec *executionContext,
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindPlanetRequiresByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindPlanetRequiresByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *model.PlanetRequires) graphql.Marshaler {
@@ -1614,7 +1604,7 @@ func _Entity_findPlanetRequiresNestedByName(ctx context.Context, ec *executionCo
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindPlanetRequiresNestedByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindPlanetRequiresNestedByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *model.PlanetRequiresNested) graphql.Marshaler {
@@ -1667,7 +1657,7 @@ func _Entity_findWorldByHelloNameAndFoo(ctx context.Context, ec *executionContex
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindWorldByHelloNameAndFoo(ctx, fc.Args["helloName"].(string), fc.Args["foo"].(string))
+			return ec.Resolvers.Entity().FindWorldByHelloNameAndFoo(ctx, fc.Args["helloName"].(string), fc.Args["foo"].(string))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *model.World) graphql.Marshaler {
@@ -1720,7 +1710,7 @@ func _Entity_findWorldNameByName(ctx context.Context, ec *executionContext, fiel
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindWorldNameByName(ctx, fc.Args["name"].(string))
+			return ec.Resolvers.Entity().FindWorldNameByName(ctx, fc.Args["name"].(string))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *model.WorldName) graphql.Marshaler {
@@ -1769,7 +1759,7 @@ func _Entity_findWorldWithMultipleKeysByHelloNameAndFoo(ctx context.Context, ec 
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindWorldWithMultipleKeysByHelloNameAndFoo(ctx, fc.Args["helloName"].(string), fc.Args["foo"].(string))
+			return ec.Resolvers.Entity().FindWorldWithMultipleKeysByHelloNameAndFoo(ctx, fc.Args["helloName"].(string), fc.Args["foo"].(string))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *model.WorldWithMultipleKeys) graphql.Marshaler {
@@ -1822,7 +1812,7 @@ func _Entity_findWorldWithMultipleKeysByBar(ctx context.Context, ec *executionCo
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Entity().FindWorldWithMultipleKeysByBar(ctx, fc.Args["bar"].(int))
+			return ec.Resolvers.Entity().FindWorldWithMultipleKeysByBar(ctx, fc.Args["bar"].(int))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *model.WorldWithMultipleKeys) graphql.Marshaler {

--- a/plugin/federation/testdata/usefunctionsyntaxforexecutioncontext/generated/federation.go
+++ b/plugin/federation/testdata/usefunctionsyntaxforexecutioncontext/generated/federation.go
@@ -176,7 +176,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findHelloByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindHelloByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindHelloByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "Hello": %w`, err)
 			}
@@ -199,7 +199,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 1 for findHelloMultiSingleKeysByKey1AndKey2(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindHelloMultiSingleKeysByKey1AndKey2(ctx, id0, id1)
+			entity, err := ec.Resolvers.Entity().FindHelloMultiSingleKeysByKey1AndKey2(ctx, id0, id1)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "HelloMultiSingleKeys": %w`, err)
 			}
@@ -218,7 +218,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findHelloWithErrorsByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindHelloWithErrorsByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindHelloWithErrorsByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "HelloWithErrors": %w`, err)
 			}
@@ -237,7 +237,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findPlanetMultipleRequiresByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindPlanetMultipleRequiresByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindPlanetMultipleRequiresByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "PlanetMultipleRequires": %w`, err)
 			}
@@ -264,7 +264,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findPlanetRequiresByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindPlanetRequiresByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindPlanetRequiresByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "PlanetRequires": %w`, err)
 			}
@@ -287,7 +287,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findPlanetRequiresNestedByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindPlanetRequiresNestedByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindPlanetRequiresNestedByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "PlanetRequiresNested": %w`, err)
 			}
@@ -314,7 +314,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 1 for findWorldByHelloNameAndFoo(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindWorldByHelloNameAndFoo(ctx, id0, id1)
+			entity, err := ec.Resolvers.Entity().FindWorldByHelloNameAndFoo(ctx, id0, id1)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "World": %w`, err)
 			}
@@ -333,7 +333,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findWorldNameByName(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindWorldNameByName(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindWorldNameByName(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "WorldName": %w`, err)
 			}
@@ -356,7 +356,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 1 for findWorldWithMultipleKeysByHelloNameAndFoo(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindWorldWithMultipleKeysByHelloNameAndFoo(ctx, id0, id1)
+			entity, err := ec.Resolvers.Entity().FindWorldWithMultipleKeysByHelloNameAndFoo(ctx, id0, id1)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "WorldWithMultipleKeys": %w`, err)
 			}
@@ -367,7 +367,7 @@ func (ec *executionContext) resolveEntity(
 			if err != nil {
 				return nil, fmt.Errorf(`unmarshalling param 0 for findWorldWithMultipleKeysByBar(): %w`, err)
 			}
-			entity, err := ec.resolvers.Entity().FindWorldWithMultipleKeysByBar(ctx, id0)
+			entity, err := ec.Resolvers.Entity().FindWorldWithMultipleKeysByBar(ctx, id0)
 			if err != nil {
 				return nil, fmt.Errorf(`resolving Entity "WorldWithMultipleKeys": %w`, err)
 			}
@@ -416,7 +416,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiHelloByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}
@@ -451,7 +451,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloMultipleRequiresByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiHelloMultipleRequiresByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}
@@ -494,7 +494,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloRequiresByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiHelloRequiresByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}
@@ -533,7 +533,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiHelloWithErrorByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiHelloWithErrorByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}
@@ -568,7 +568,7 @@ func (ec *executionContext) resolveManyEntities(
 				}
 			}
 
-			entities, err := ec.resolvers.Entity().FindManyMultiPlanetRequiresNestedByNames(ctx, typedReps)
+			entities, err := ec.Resolvers.Entity().FindManyMultiPlanetRequiresNestedByNames(ctx, typedReps)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### Description
> Some of the code currently living in the templates doesn't need to be part of the generated output. Moving these pieces into static .go files helps keep generated.go simpler and easier to maintain.
There are several places where this applies, so I'll be sending a series of smaller PRs rather than one large change. As a first step, this PR extracts the Config struct into the graphql package.

> quoted from #4017

This PR shares the same goal as #4017, simplifying the code in `generated.go`.
I plan to continue making incremental progress toward this goal.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

---

Being able to create branches directly on gqlgen made things so much easier! Thanks for the collaborator invite 😊