### PR TITLE
Update gqlparser to v2.5.32

### DIFF
--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/rs/cors v1.11.1
 	github.com/stretchr/testify v1.11.1
 	github.com/vektah/dataloaden v0.3.0
-	github.com/vektah/gqlparser/v2 v2.5.31
+	github.com/vektah/gqlparser/v2 v2.5.32
 	golang.org/x/sync v0.19.0
 )
 

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -47,8 +47,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/vektah/dataloaden v0.3.0 h1:ZfVN2QD6swgvp+tDqdH/OIT/wu3Dhu0cus0k5gIZS84=
 github.com/vektah/dataloaden v0.3.0/go.mod h1:/HUdMve7rvxZma+2ZELQeNh88+003LL7Pf/CZ089j8U=
-github.com/vektah/gqlparser/v2 v2.5.31 h1:YhWGA1mfTjID7qJhd1+Vxhpk5HTgydrGU9IgkWBTJ7k=
-github.com/vektah/gqlparser/v2 v2.5.31/go.mod h1:c1I28gSOVNzlfc4WuDlqU7voQnsqI6OG2amkBAFmgts=
+github.com/vektah/gqlparser/v2 v2.5.32 h1:k9QPJd4sEDTL+qB4ncPLflqTJ3MmjB9SrVzJrawpFSc=
+github.com/vektah/gqlparser/v2 v2.5.32/go.mod h1:c1I28gSOVNzlfc4WuDlqU7voQnsqI6OG2amkBAFmgts=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=
 golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/sosodev/duration v1.3.1
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v3 v3.6.2
-	github.com/vektah/gqlparser/v2 v2.5.31
+	github.com/vektah/gqlparser/v2 v2.5.32
 	golang.org/x/text v0.34.0
 	golang.org/x/tools v0.42.0
 	google.golang.org/protobuf v1.36.11

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/urfave/cli/v3 v3.6.2 h1:lQuqiPrZ1cIz8hz+HcrG0TNZFxU70dPZ3Yl+pSrH9A8=
 github.com/urfave/cli/v3 v3.6.2/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
-github.com/vektah/gqlparser/v2 v2.5.31 h1:YhWGA1mfTjID7qJhd1+Vxhpk5HTgydrGU9IgkWBTJ7k=
-github.com/vektah/gqlparser/v2 v2.5.31/go.mod h1:c1I28gSOVNzlfc4WuDlqU7voQnsqI6OG2amkBAFmgts=
+github.com/vektah/gqlparser/v2 v2.5.32 h1:k9QPJd4sEDTL+qB4ncPLflqTJ3MmjB9SrVzJrawpFSc=
+github.com/vektah/gqlparser/v2 v2.5.32/go.mod h1:c1I28gSOVNzlfc4WuDlqU7voQnsqI6OG2amkBAFmgts=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=


### PR DESCRIPTION
Update of gqlparser. See https://github.com/vektah/gqlparser/releases/tag/v2.5.32

## What's Changed
* lint and format by @StevenACoffman in https://github.com/vektah/gqlparser/pull/414
* Add `formatter.WithNonIntrospectionBuiltin` by @fredzqm in https://github.com/vektah/gqlparser/pull/415
* [Refactor] Fix linter error in `dumper.go` & `path.go` by @fredzqm in https://github.com/vektah/gqlparser/pull/416
* Bump golangci/golangci-lint-action from 8.0.0 to 9.0.0 in the actions-deps group by @dependabot[bot] in https://github.com/vektah/gqlparser/pull/398
* Bump js-yaml from 4.1.0 to 4.1.1 in /validator/imported by @dependabot[bot] in https://github.com/vektah/gqlparser/pull/399
* Bump chai from 6.2.0 to 6.2.1 in /validator/imported in the actions-deps group by @dependabot[bot] in https://github.com/vektah/gqlparser/pull/400
* Bump the actions-deps group with 2 updates by @dependabot[bot] in https://github.com/vektah/gqlparser/pull/402
* Bump prettier from 3.6.2 to 3.7.3 in /validator/imported in the actions-deps group by @dependabot[bot] in https://github.com/vektah/gqlparser/pull/403
* Bump golangci/golangci-lint-action from 9.1.0 to 9.2.0 in the actions-deps group by @dependabot[bot] in https://github.com/vektah/gqlparser/pull/405
* Bump prettier from 3.7.3 to 3.7.4 in /validator/imported in the actions-deps group by @dependabot[bot] in https://github.com/vektah/gqlparser/pull/404
* Bump chai from 6.2.1 to 6.2.2 in /validator/imported in the actions-deps group by @dependabot[bot] in https://github.com/vektah/gqlparser/pull/406
* Bump the actions-deps group across 1 directory with 6 updates by @dependabot[bot] in https://github.com/vektah/gqlparser/pull/410
* Bump the actions-deps group across 1 directory with 4 updates by @dependabot[bot] in https://github.com/vektah/gqlparser/pull/412

**Full Changelog**: https://github.com/vektah/gqlparser/compare/v2.5.31...v2.5.32