### PR TITLE
feat: support @goField(batch: true) directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ directive @goField(
 	type: String
 	autoBindGetterHaser: Boolean
 	forceGenerate: Boolean
+	batch: Boolean
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 type User @goModel(model: "github.com/you/pkg/model.User") {

--- a/_examples/batchresolver/batchresolver_test.go
+++ b/_examples/batchresolver/batchresolver_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/99designs/gqlgen/client"
+	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 )
@@ -414,6 +415,32 @@ func TestBatchResolver_BatchErrors_ResultLenMismatch_AddsErrorPerParent(t *testi
 		`{"users":[{"nullableBatch":null},{"nullableBatch":null}]}`,
 		marshalJSON(t, resp),
 	)
+}
+
+func TestBatchDirectiveConfig(t *testing.T) {
+	cfg, err := config.LoadConfig("gqlgen.yml")
+	require.NoError(t, err)
+	require.NoError(t, cfg.Init())
+
+	userFields := cfg.Models["User"].Fields
+
+	// YAML-configured fields
+	require.True(t, userFields["nullableBatch"].Batch)
+	require.True(t, userFields["nullableBatchWithArg"].Batch)
+	require.True(t, userFields["nonNullableBatch"].Batch)
+
+	require.False(t, userFields["nullableNonBatch"].Batch)
+	require.False(t, userFields["nullableNonBatchWithArg"].Batch)
+	require.False(t, userFields["nonNullableNonBatch"].Batch)
+
+	// Directive-configured fields
+	require.True(t, userFields["directiveNullableBatch"].Batch)
+	require.True(t, userFields["directiveNullableBatchWithArg"].Batch)
+	require.True(t, userFields["directiveNonNullableBatch"].Batch)
+
+	require.False(t, userFields["directiveNullableNonBatch"].Batch)
+	require.False(t, userFields["directiveNullableNonBatchWithArg"].Batch)
+	require.False(t, userFields["directiveNonNullableNonBatch"].Batch)
 }
 
 func TestBatchResolver_BatchErrors_ListPerIndex_AddsMultipleErrors(t *testing.T) {

--- a/_examples/batchresolver/generated.go
+++ b/_examples/batchresolver/generated.go
@@ -61,16 +61,22 @@ type ComplexityRoot struct {
 	}
 
 	User struct {
-		NonNullableBatch          func(childComplexity int) int
-		NonNullableNonBatch       func(childComplexity int) int
-		NullableBatch             func(childComplexity int) int
-		NullableBatchWithArg      func(childComplexity int, offset int) int
-		NullableNonBatch          func(childComplexity int) int
-		NullableNonBatchWithArg   func(childComplexity int, offset int) int
-		ProfileBatch              func(childComplexity int) int
-		ProfileConnectionBatch    func(childComplexity int) int
-		ProfileConnectionNonBatch func(childComplexity int) int
-		ProfileNonBatch           func(childComplexity int) int
+		DirectiveNonNullableBatch        func(childComplexity int) int
+		DirectiveNonNullableNonBatch     func(childComplexity int) int
+		DirectiveNullableBatch           func(childComplexity int) int
+		DirectiveNullableBatchWithArg    func(childComplexity int, offset int) int
+		DirectiveNullableNonBatch        func(childComplexity int) int
+		DirectiveNullableNonBatchWithArg func(childComplexity int, offset int) int
+		NonNullableBatch                 func(childComplexity int) int
+		NonNullableNonBatch              func(childComplexity int) int
+		NullableBatch                    func(childComplexity int) int
+		NullableBatchWithArg             func(childComplexity int, offset int) int
+		NullableNonBatch                 func(childComplexity int) int
+		NullableNonBatchWithArg          func(childComplexity int, offset int) int
+		ProfileBatch                     func(childComplexity int) int
+		ProfileConnectionBatch           func(childComplexity int) int
+		ProfileConnectionNonBatch        func(childComplexity int) int
+		ProfileNonBatch                  func(childComplexity int) int
 	}
 }
 
@@ -88,6 +94,12 @@ type UserResolver interface {
 	NullableNonBatchWithArg(ctx context.Context, obj *User, offset int) (*Profile, error)
 	NonNullableBatch(ctx context.Context, objs []*User) ([]*Profile, error)
 	NonNullableNonBatch(ctx context.Context, obj *User) (*Profile, error)
+	DirectiveNullableBatch(ctx context.Context, objs []*User) ([]*Profile, error)
+	DirectiveNullableNonBatch(ctx context.Context, obj *User) (*Profile, error)
+	DirectiveNullableBatchWithArg(ctx context.Context, objs []*User, offset int) ([]*Profile, error)
+	DirectiveNullableNonBatchWithArg(ctx context.Context, obj *User, offset int) (*Profile, error)
+	DirectiveNonNullableBatch(ctx context.Context, objs []*User) ([]*Profile, error)
+	DirectiveNonNullableNonBatch(ctx context.Context, obj *User) (*Profile, error)
 	ProfileBatch(ctx context.Context, objs []*User) ([]*Profile, error)
 	ProfileNonBatch(ctx context.Context, obj *User) (*Profile, error)
 	ProfileConnectionBatch(ctx context.Context, objs []*User) ([]*ProfilesConnection, error)
@@ -167,6 +179,52 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.Query.Users(childComplexity), true
 
+	case "User.directiveNonNullableBatch":
+		if e.ComplexityRoot.User.DirectiveNonNullableBatch == nil {
+			break
+		}
+
+		return e.ComplexityRoot.User.DirectiveNonNullableBatch(childComplexity), true
+	case "User.directiveNonNullableNonBatch":
+		if e.ComplexityRoot.User.DirectiveNonNullableNonBatch == nil {
+			break
+		}
+
+		return e.ComplexityRoot.User.DirectiveNonNullableNonBatch(childComplexity), true
+	case "User.directiveNullableBatch":
+		if e.ComplexityRoot.User.DirectiveNullableBatch == nil {
+			break
+		}
+
+		return e.ComplexityRoot.User.DirectiveNullableBatch(childComplexity), true
+	case "User.directiveNullableBatchWithArg":
+		if e.ComplexityRoot.User.DirectiveNullableBatchWithArg == nil {
+			break
+		}
+
+		args, err := ec.field_User_directiveNullableBatchWithArg_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.User.DirectiveNullableBatchWithArg(childComplexity, args["offset"].(int)), true
+	case "User.directiveNullableNonBatch":
+		if e.ComplexityRoot.User.DirectiveNullableNonBatch == nil {
+			break
+		}
+
+		return e.ComplexityRoot.User.DirectiveNullableNonBatch(childComplexity), true
+	case "User.directiveNullableNonBatchWithArg":
+		if e.ComplexityRoot.User.DirectiveNullableNonBatchWithArg == nil {
+			break
+		}
+
+		args, err := ec.field_User_directiveNullableNonBatchWithArg_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.User.DirectiveNullableNonBatchWithArg(childComplexity, args["offset"].(int)), true
 	case "User.nonNullableBatch":
 		if e.ComplexityRoot.User.NonNullableBatch == nil {
 			break
@@ -332,6 +390,28 @@ func (ec *executionContext) field_Query___type_args(ctx context.Context, rawArgs
 		return nil, err
 	}
 	args["name"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_User_directiveNullableBatchWithArg_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "offset", ec.unmarshalNInt2int)
+	if err != nil {
+		return nil, err
+	}
+	args["offset"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_User_directiveNullableNonBatchWithArg_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "offset", ec.unmarshalNInt2int)
+	if err != nil {
+		return nil, err
+	}
+	args["offset"] = arg0
 	return args, nil
 }
 
@@ -733,6 +813,18 @@ func (ec *executionContext) fieldContext_Query_users(_ context.Context, field gr
 				return ec.fieldContext_User_nonNullableBatch(ctx, field)
 			case "nonNullableNonBatch":
 				return ec.fieldContext_User_nonNullableNonBatch(ctx, field)
+			case "directiveNullableBatch":
+				return ec.fieldContext_User_directiveNullableBatch(ctx, field)
+			case "directiveNullableNonBatch":
+				return ec.fieldContext_User_directiveNullableNonBatch(ctx, field)
+			case "directiveNullableBatchWithArg":
+				return ec.fieldContext_User_directiveNullableBatchWithArg(ctx, field)
+			case "directiveNullableNonBatchWithArg":
+				return ec.fieldContext_User_directiveNullableNonBatchWithArg(ctx, field)
+			case "directiveNonNullableBatch":
+				return ec.fieldContext_User_directiveNonNullableBatch(ctx, field)
+			case "directiveNonNullableNonBatch":
+				return ec.fieldContext_User_directiveNonNullableNonBatch(ctx, field)
 			case "profileBatch":
 				return ec.fieldContext_User_profileBatch(ctx, field)
 			case "profileNonBatch":
@@ -1184,6 +1276,354 @@ func (ec *executionContext) _User_nonNullableNonBatch(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext_User_nonNullableNonBatch(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Profile_id(ctx, field)
+			case "coverBatch":
+				return ec.fieldContext_Profile_coverBatch(ctx, field)
+			case "coverNonBatch":
+				return ec.fieldContext_Profile_coverNonBatch(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Profile", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _User_directiveNullableBatch(ctx context.Context, field graphql.CollectedField, obj *User) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_User_directiveNullableBatch,
+		func(ctx context.Context) (any, error) {
+			return ec.resolveBatch_User_directiveNullableBatch(ctx, field, obj)
+		},
+		nil,
+		ec.marshalOProfile2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfile,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_User_directiveNullableBatch(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Profile_id(ctx, field)
+			case "coverBatch":
+				return ec.fieldContext_Profile_coverBatch(ctx, field)
+			case "coverNonBatch":
+				return ec.fieldContext_Profile_coverNonBatch(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Profile", field.Name)
+		},
+	}
+	return fc, nil
+}
+func (ec *executionContext) resolveBatch_User_directiveNullableBatch(ctx context.Context, field graphql.CollectedField, obj *User) (any, error) {
+	resolver := ec.Resolvers.User()
+	group := graphql.GetBatchParentGroup(ctx, "User")
+	if group != nil {
+		parents, ok := group.Parents.([]*User)
+		if ok {
+			idx, ok := graphql.BatchParentIndex(ctx)
+			if ok {
+				key := field.Alias
+				if key == "" {
+					key = field.Name
+				}
+				result := group.GetFieldResult(key, func() (any, error) {
+					return resolver.DirectiveNullableBatch(ctx, parents)
+				})
+				return graphql.ResolveBatchGroupResult[*Profile](
+					ctx,
+					idx,
+					len(parents),
+					result,
+					"User.directiveNullableBatch",
+				)
+			}
+		}
+	}
+
+	results, err := resolver.DirectiveNullableBatch(ctx, []*User{obj})
+	return graphql.ResolveBatchSingleResult[*Profile](
+		ctx,
+		results,
+		err,
+		"User.directiveNullableBatch",
+	)
+}
+
+func (ec *executionContext) _User_directiveNullableNonBatch(ctx context.Context, field graphql.CollectedField, obj *User) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_User_directiveNullableNonBatch,
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.User().DirectiveNullableNonBatch(ctx, obj)
+		},
+		nil,
+		ec.marshalOProfile2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfile,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_User_directiveNullableNonBatch(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Profile_id(ctx, field)
+			case "coverBatch":
+				return ec.fieldContext_Profile_coverBatch(ctx, field)
+			case "coverNonBatch":
+				return ec.fieldContext_Profile_coverNonBatch(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Profile", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _User_directiveNullableBatchWithArg(ctx context.Context, field graphql.CollectedField, obj *User) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_User_directiveNullableBatchWithArg,
+		func(ctx context.Context) (any, error) {
+			return ec.resolveBatch_User_directiveNullableBatchWithArg(ctx, field, obj)
+		},
+		nil,
+		ec.marshalOProfile2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfile,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_User_directiveNullableBatchWithArg(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Profile_id(ctx, field)
+			case "coverBatch":
+				return ec.fieldContext_Profile_coverBatch(ctx, field)
+			case "coverNonBatch":
+				return ec.fieldContext_Profile_coverNonBatch(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Profile", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_User_directiveNullableBatchWithArg_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+func (ec *executionContext) resolveBatch_User_directiveNullableBatchWithArg(ctx context.Context, field graphql.CollectedField, obj *User) (any, error) {
+	resolver := ec.Resolvers.User()
+	fc := graphql.GetFieldContext(ctx)
+	group := graphql.GetBatchParentGroup(ctx, "User")
+	if group != nil {
+		parents, ok := group.Parents.([]*User)
+		if ok {
+			idx, ok := graphql.BatchParentIndex(ctx)
+			if ok {
+				key := field.Alias
+				if key == "" {
+					key = field.Name
+				}
+				result := group.GetFieldResult(key, func() (any, error) {
+					return resolver.DirectiveNullableBatchWithArg(ctx, parents, fc.Args["offset"].(int))
+				})
+				return graphql.ResolveBatchGroupResult[*Profile](
+					ctx,
+					idx,
+					len(parents),
+					result,
+					"User.directiveNullableBatchWithArg",
+				)
+			}
+		}
+	}
+
+	results, err := resolver.DirectiveNullableBatchWithArg(ctx, []*User{obj}, fc.Args["offset"].(int))
+	return graphql.ResolveBatchSingleResult[*Profile](
+		ctx,
+		results,
+		err,
+		"User.directiveNullableBatchWithArg",
+	)
+}
+
+func (ec *executionContext) _User_directiveNullableNonBatchWithArg(ctx context.Context, field graphql.CollectedField, obj *User) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_User_directiveNullableNonBatchWithArg,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.User().DirectiveNullableNonBatchWithArg(ctx, obj, fc.Args["offset"].(int))
+		},
+		nil,
+		ec.marshalOProfile2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfile,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_User_directiveNullableNonBatchWithArg(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Profile_id(ctx, field)
+			case "coverBatch":
+				return ec.fieldContext_Profile_coverBatch(ctx, field)
+			case "coverNonBatch":
+				return ec.fieldContext_Profile_coverNonBatch(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Profile", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_User_directiveNullableNonBatchWithArg_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _User_directiveNonNullableBatch(ctx context.Context, field graphql.CollectedField, obj *User) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_User_directiveNonNullableBatch,
+		func(ctx context.Context) (any, error) {
+			return ec.resolveBatch_User_directiveNonNullableBatch(ctx, field, obj)
+		},
+		nil,
+		ec.marshalNProfile2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfile,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_User_directiveNonNullableBatch(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Profile_id(ctx, field)
+			case "coverBatch":
+				return ec.fieldContext_Profile_coverBatch(ctx, field)
+			case "coverNonBatch":
+				return ec.fieldContext_Profile_coverNonBatch(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Profile", field.Name)
+		},
+	}
+	return fc, nil
+}
+func (ec *executionContext) resolveBatch_User_directiveNonNullableBatch(ctx context.Context, field graphql.CollectedField, obj *User) (any, error) {
+	resolver := ec.Resolvers.User()
+	group := graphql.GetBatchParentGroup(ctx, "User")
+	if group != nil {
+		parents, ok := group.Parents.([]*User)
+		if ok {
+			idx, ok := graphql.BatchParentIndex(ctx)
+			if ok {
+				key := field.Alias
+				if key == "" {
+					key = field.Name
+				}
+				result := group.GetFieldResult(key, func() (any, error) {
+					return resolver.DirectiveNonNullableBatch(ctx, parents)
+				})
+				return graphql.ResolveBatchGroupResult[*Profile](
+					ctx,
+					idx,
+					len(parents),
+					result,
+					"User.directiveNonNullableBatch",
+				)
+			}
+		}
+	}
+
+	results, err := resolver.DirectiveNonNullableBatch(ctx, []*User{obj})
+	return graphql.ResolveBatchSingleResult[*Profile](
+		ctx,
+		results,
+		err,
+		"User.directiveNonNullableBatch",
+	)
+}
+
+func (ec *executionContext) _User_directiveNonNullableNonBatch(ctx context.Context, field graphql.CollectedField, obj *User) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_User_directiveNonNullableNonBatch,
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.User().DirectiveNonNullableNonBatch(ctx, obj)
+		},
+		nil,
+		ec.marshalNProfile2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfile,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_User_directiveNonNullableNonBatch(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -3363,6 +3803,210 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 					}
 				}()
 				res = ec._User_nonNullableNonBatch(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "directiveNullableBatch":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._User_directiveNullableBatch(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "directiveNullableNonBatch":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._User_directiveNullableNonBatch(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "directiveNullableBatchWithArg":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._User_directiveNullableBatchWithArg(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "directiveNullableNonBatchWithArg":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._User_directiveNullableNonBatchWithArg(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "directiveNonNullableBatch":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._User_directiveNonNullableBatch(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "directiveNonNullableNonBatch":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._User_directiveNonNullableNonBatch(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/_examples/batchresolver/models_gen.go
+++ b/_examples/batchresolver/models_gen.go
@@ -26,14 +26,20 @@ type Query struct {
 }
 
 type User struct {
-	NullableBatch             *Profile            `json:"nullableBatch,omitempty"`
-	NullableNonBatch          *Profile            `json:"nullableNonBatch,omitempty"`
-	NullableBatchWithArg      *Profile            `json:"nullableBatchWithArg,omitempty"`
-	NullableNonBatchWithArg   *Profile            `json:"nullableNonBatchWithArg,omitempty"`
-	NonNullableBatch          *Profile            `json:"nonNullableBatch"`
-	NonNullableNonBatch       *Profile            `json:"nonNullableNonBatch"`
-	ProfileBatch              *Profile            `json:"profileBatch,omitempty"`
-	ProfileNonBatch           *Profile            `json:"profileNonBatch,omitempty"`
-	ProfileConnectionBatch    *ProfilesConnection `json:"profileConnectionBatch,omitempty"`
-	ProfileConnectionNonBatch *ProfilesConnection `json:"profileConnectionNonBatch,omitempty"`
+	NullableBatch                    *Profile            `json:"nullableBatch,omitempty"`
+	NullableNonBatch                 *Profile            `json:"nullableNonBatch,omitempty"`
+	NullableBatchWithArg             *Profile            `json:"nullableBatchWithArg,omitempty"`
+	NullableNonBatchWithArg          *Profile            `json:"nullableNonBatchWithArg,omitempty"`
+	NonNullableBatch                 *Profile            `json:"nonNullableBatch"`
+	NonNullableNonBatch              *Profile            `json:"nonNullableNonBatch"`
+	DirectiveNullableBatch           *Profile            `json:"directiveNullableBatch,omitempty"`
+	DirectiveNullableNonBatch        *Profile            `json:"directiveNullableNonBatch,omitempty"`
+	DirectiveNullableBatchWithArg    *Profile            `json:"directiveNullableBatchWithArg,omitempty"`
+	DirectiveNullableNonBatchWithArg *Profile            `json:"directiveNullableNonBatchWithArg,omitempty"`
+	DirectiveNonNullableBatch        *Profile            `json:"directiveNonNullableBatch"`
+	DirectiveNonNullableNonBatch     *Profile            `json:"directiveNonNullableNonBatch"`
+	ProfileBatch                     *Profile            `json:"profileBatch,omitempty"`
+	ProfileNonBatch                  *Profile            `json:"profileNonBatch,omitempty"`
+	ProfileConnectionBatch           *ProfilesConnection `json:"profileConnectionBatch,omitempty"`
+	ProfileConnectionNonBatch        *ProfilesConnection `json:"profileConnectionNonBatch,omitempty"`
 }

--- a/_examples/batchresolver/schema.graphql
+++ b/_examples/batchresolver/schema.graphql
@@ -1,3 +1,10 @@
+directive @goField(
+	forceResolver: Boolean
+	name: String
+	omittable: Boolean
+	batch: Boolean
+) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+
 type Query {
     users: [User!]!
 }
@@ -9,6 +16,13 @@ type User {
     nullableNonBatchWithArg(offset: Int!): Profile
     nonNullableBatch: Profile!
     nonNullableNonBatch: Profile!
+
+    directiveNullableBatch: Profile @goField(batch: true)
+    directiveNullableNonBatch: Profile @goField(forceResolver: true)
+    directiveNullableBatchWithArg(offset: Int!): Profile @goField(batch: true)
+    directiveNullableNonBatchWithArg(offset: Int!): Profile @goField(forceResolver: true)
+    directiveNonNullableBatch: Profile! @goField(batch: true)
+    directiveNonNullableNonBatch: Profile! @goField(forceResolver: true)
 
     profileBatch: Profile
     profileNonBatch: Profile

--- a/_examples/batchresolver/schema.resolvers.go
+++ b/_examples/batchresolver/schema.resolvers.go
@@ -172,6 +172,36 @@ func (r *userResolver) NonNullableNonBatch(ctx context.Context, obj *User) (*Pro
 	return resolveProfile(r.Resolver, idx)
 }
 
+// DirectiveNullableBatch is the batch resolver for the directiveNullableBatch field.
+func (r *userResolver) DirectiveNullableBatch(ctx context.Context, objs []*User) ([]*Profile, error) {
+	return r.NullableBatch(ctx, objs)
+}
+
+// DirectiveNullableNonBatch is the resolver for the directiveNullableNonBatch field.
+func (r *userResolver) DirectiveNullableNonBatch(ctx context.Context, obj *User) (*Profile, error) {
+	return r.NullableNonBatch(ctx, obj)
+}
+
+// DirectiveNullableBatchWithArg is the batch resolver for the directiveNullableBatchWithArg field.
+func (r *userResolver) DirectiveNullableBatchWithArg(ctx context.Context, objs []*User, offset int) ([]*Profile, error) {
+	return r.NullableBatchWithArg(ctx, objs, offset)
+}
+
+// DirectiveNullableNonBatchWithArg is the resolver for the directiveNullableNonBatchWithArg field.
+func (r *userResolver) DirectiveNullableNonBatchWithArg(ctx context.Context, obj *User, offset int) (*Profile, error) {
+	return r.NullableNonBatchWithArg(ctx, obj, offset)
+}
+
+// DirectiveNonNullableBatch is the batch resolver for the directiveNonNullableBatch field.
+func (r *userResolver) DirectiveNonNullableBatch(ctx context.Context, objs []*User) ([]*Profile, error) {
+	return r.NonNullableBatch(ctx, objs)
+}
+
+// DirectiveNonNullableNonBatch is the resolver for the directiveNonNullableNonBatch field.
+func (r *userResolver) DirectiveNonNullableNonBatch(ctx context.Context, obj *User) (*Profile, error) {
+	return r.NonNullableNonBatch(ctx, obj)
+}
+
 // ProfileBatch is the batch resolver for the profileBatch field.
 func (r *userResolver) ProfileBatch(ctx context.Context, objs []*User) ([]*Profile, error) {
 	r.profileBatchCalls.Add(1)

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -86,6 +86,7 @@ const (
 	DirArgDescription         = "description"
 	DirArgOmittable           = "omittable"
 	DirArgAutoBindGetterHaser = "autoBindGetterHaser"
+	DirArgBatch               = "batch"
 )
 
 var cfgFilenames = []string{".gqlgen.yml", "gqlgen.yml", "gqlgen.yaml"}
@@ -430,6 +431,12 @@ func (c *Config) injectTypesFromSchema() error {
 						if k, err := arg.Value.Value(nil); err == nil {
 							val := k.(bool)
 							typeMapFieldEntry.AutoBindGetterHaser = &val
+						}
+					}
+
+					if arg := fd.Arguments.ForName(DirArgBatch); arg != nil {
+						if k, err := arg.Value.Value(nil); err == nil {
+							typeMapFieldEntry.Batch = k.(bool)
 						}
 					}
 

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -204,6 +204,7 @@ directive @goField(
 	name: String
 	omittable: Boolean
 	type: String
+	batch: Boolean
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 directive @goTag(


### PR DESCRIPTION
## Summary

- Add `batch` argument to the `@goField` directive, allowing batch resolver configuration directly in the schema instead of only via `gqlgen.yml`
- Update the `batchresolver` example with directive-configured fields alongside the existing YAML-configured ones
- Add `TestBatchDirectiveConfig` to verify directive parsing

As suggested in https://github.com/99designs/gqlgen/pull/4008#discussion_r2747348032.

## Test plan

- [x] `go generate` produces correct batch resolver signatures for directive-annotated fields
- [x] `TestBatchDirectiveConfig` verifies `cfg.Init()` parses `batch: true` from directives
- [x] All existing `TestBatchResolver_*` tests continue to pass