### PR TITLE
Add nested batch resolver tests and documentation to batchresolver example

### DIFF
--- a/_examples/batchresolver/batchresolver_test.go
+++ b/_examples/batchresolver/batchresolver_test.go
@@ -554,6 +554,125 @@ func TestBatchResolver_Nested_CallCount(t *testing.T) {
 	)
 }
 
+func TestBatchResolver_Nested_Connection_CallCount(t *testing.T) {
+	const n = 10
+	users := make([]*User, n)
+	profiles := make([]*Profile, n)
+	images := make([]*Image, n)
+	for i := 0; i < n; i++ {
+		users[i] = &User{}
+		profiles[i] = &Profile{ID: fmt.Sprintf("p%d", i)}
+		images[i] = &Image{URL: fmt.Sprintf("https://img/%d", i)}
+	}
+	resolver := &Resolver{
+		users:         users,
+		profiles:      profiles,
+		images:        images,
+		profileErrIdx: -1,
+	}
+	client := newTestClient(resolver)
+
+	type graphqlResp struct {
+		Users []struct {
+			Conn *struct {
+				Edges []struct {
+					Node *struct {
+						ID    string `json:"id"`
+						Cover *struct {
+							URL string `json:"url"`
+						} `json:"cover"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"conn"`
+		} `json:"users"`
+	}
+
+	assertData := func(t *testing.T, resp graphqlResp, label string) {
+		t.Helper()
+		require.Len(t, resp.Users, n)
+		for i, u := range resp.Users {
+			require.NotNil(t, u.Conn, "%s user %d connection nil", label, i)
+			require.Len(t, u.Conn.Edges, 1, "%s user %d edges", label, i)
+			node := u.Conn.Edges[0].Node
+			require.NotNil(t, node, "%s user %d node nil", label, i)
+			require.Equal(t, fmt.Sprintf("p%d", i), node.ID)
+			require.NotNil(t, node.Cover, "%s user %d cover nil", label, i)
+			require.Equal(t, fmt.Sprintf("https://img/%d", i), node.Cover.URL)
+		}
+	}
+
+	// --- Batch path ---
+
+	var batchResp graphqlResp
+	err := client.Post(`query {
+		users {
+			conn: profileConnectionBatch {
+				edges {
+					node {
+						id
+						cover: coverBatch { url }
+					}
+				}
+			}
+		}
+	}`, &batchResp)
+	require.NoError(t, err)
+	assertData(t, batchResp, "batch")
+	require.Equal(
+		t,
+		int32(1),
+		resolver.profileConnectionBatchCalls.Load(),
+		"profileConnectionBatch should be called once for all users",
+	)
+	// TODO: coverBatch is not batched because the immediate parent (Profile)
+	// and its edge are not batched — only the connection is. This should be 1
+	// once nested batching propagates through non-batched intermediate types.
+	require.Equal(
+		t,
+		int32(n),
+		resolver.coverBatchCalls.Load(),
+		"coverBatch called once per profile (immediate parent not batched)",
+	)
+
+	// --- Non-batch path ---
+
+	var nonBatchResp graphqlResp
+	err = client.Post(`query {
+		users {
+			conn: profileConnectionNonBatch {
+				edges {
+					node {
+						id
+						cover: coverNonBatch { url }
+					}
+				}
+			}
+		}
+	}`, &nonBatchResp)
+	require.NoError(t, err)
+	assertData(t, nonBatchResp, "non-batch")
+	require.Equal(
+		t,
+		int32(n),
+		resolver.profileConnectionNonBatchCalls.Load(),
+		"profileConnectionNonBatch should be called once per user",
+	)
+	require.Equal(
+		t,
+		int32(n),
+		resolver.coverNonBatchCalls.Load(),
+		"coverNonBatch should be called once per profile",
+	)
+
+	// --- Verify both paths produce identical data ---
+	require.Equal(
+		t,
+		marshalJSON(t, batchResp),
+		marshalJSON(t, nonBatchResp),
+		"batch and non-batch should return identical data",
+	)
+}
+
 func BenchmarkBatchResolver_SingleLevel(b *testing.B) {
 	const n = 100
 	users := make([]*User, n)

--- a/_examples/batchresolver/batchresolver_test.go
+++ b/_examples/batchresolver/batchresolver_test.go
@@ -502,8 +502,8 @@ func TestBatchResolver_Nested_CallCount(t *testing.T) {
 	assertData(t, batchResp, "batch")
 	require.Equal(
 		t,
-		1,
-		resolver.profileBatchCalls,
+		int32(1),
+		resolver.profileBatchCalls.Load(),
 		"profileBatch should be called once for all users",
 	)
 	// TODO: coverBatch is called once per profile (not batched) because profiles
@@ -513,8 +513,8 @@ func TestBatchResolver_Nested_CallCount(t *testing.T) {
 	// resolver results so coverBatchCalls == 1 here.
 	require.Equal(
 		t,
-		n,
-		resolver.coverBatchCalls,
+		int32(n),
+		resolver.coverBatchCalls.Load(),
 		"coverBatch called once per profile (no list parent context)",
 	)
 
@@ -534,14 +534,14 @@ func TestBatchResolver_Nested_CallCount(t *testing.T) {
 	assertData(t, nonBatchResp, "non-batch")
 	require.Equal(
 		t,
-		n,
-		resolver.profileNonBatchCalls,
+		int32(n),
+		resolver.profileNonBatchCalls.Load(),
 		"profileNonBatch should be called once per user",
 	)
 	require.Equal(
 		t,
-		n,
-		resolver.coverNonBatchCalls,
+		int32(n),
+		resolver.coverNonBatchCalls.Load(),
 		"coverNonBatch should be called once per profile",
 	)
 

--- a/_examples/batchresolver/batchresolver_test.go
+++ b/_examples/batchresolver/batchresolver_test.go
@@ -444,3 +444,202 @@ func TestBatchResolver_BatchErrors_ListPerIndex_AddsMultipleErrors(t *testing.T)
 		marshalJSON(t, resp),
 	)
 }
+
+func TestBatchResolver_Nested_CallCount(t *testing.T) {
+	const n = 10
+	users := make([]*User, n)
+	profiles := make([]*Profile, n)
+	images := make([]*Image, n)
+	for i := 0; i < n; i++ {
+		users[i] = &User{}
+		profiles[i] = &Profile{ID: fmt.Sprintf("p%d", i)}
+		images[i] = &Image{URL: fmt.Sprintf("https://img/%d", i)}
+	}
+	resolver := &Resolver{
+		users:         users,
+		profiles:      profiles,
+		images:        images,
+		profileErrIdx: -1,
+	}
+	client := newTestClient(resolver)
+
+	type graphqlResp struct {
+		Users []struct {
+			Profile *struct {
+				ID    string `json:"id"`
+				Cover *struct {
+					URL string `json:"url"`
+				} `json:"cover"`
+			} `json:"profile"`
+		} `json:"users"`
+	}
+
+	assertData := func(t *testing.T, resp graphqlResp, label string) {
+		t.Helper()
+		require.Len(t, resp.Users, n)
+		for i, u := range resp.Users {
+			require.NotNil(t, u.Profile, "%s user %d profile nil", label, i)
+			require.Equal(t, fmt.Sprintf("p%d", i), u.Profile.ID)
+			require.NotNil(t, u.Profile.Cover, "%s user %d cover nil", label, i)
+			require.Equal(t, fmt.Sprintf("https://img/%d", i), u.Profile.Cover.URL)
+		}
+	}
+
+	// --- Batch path ---
+
+	var batchResp graphqlResp
+	err := client.Post(`query {
+		users {
+			profile: profileBatch {
+				id
+				cover: coverBatch {
+					url
+				}
+			}
+		}
+	}`, &batchResp)
+	require.NoError(t, err)
+	assertData(t, batchResp, "batch")
+	require.Equal(
+		t,
+		1,
+		resolver.profileBatchCalls,
+		"profileBatch should be called once for all users",
+	)
+	// TODO: coverBatch is called once per profile (not batched) because profiles
+	// are resolved as individual values, not as a list. The batch parent context
+	// for "Profile" is only set when marshalling a [Profile] list field.
+	// Nested batching should propagate the batch parent context from batch
+	// resolver results so coverBatchCalls == 1 here.
+	require.Equal(
+		t,
+		n,
+		resolver.coverBatchCalls,
+		"coverBatch called once per profile (no list parent context)",
+	)
+
+	// --- Non-batch path ---
+	var nonBatchResp graphqlResp
+	err = client.Post(`query {
+		users {
+			profile: profileNonBatch {
+				id
+				cover: coverNonBatch {
+					url
+				}
+			}
+		}
+	}`, &nonBatchResp)
+	require.NoError(t, err)
+	assertData(t, nonBatchResp, "non-batch")
+	require.Equal(
+		t,
+		n,
+		resolver.profileNonBatchCalls,
+		"profileNonBatch should be called once per user",
+	)
+	require.Equal(
+		t,
+		n,
+		resolver.coverNonBatchCalls,
+		"coverNonBatch should be called once per profile",
+	)
+
+	// --- Verify both paths produce identical data ---
+	require.Equal(
+		t,
+		marshalJSON(t, batchResp),
+		marshalJSON(t, nonBatchResp),
+		"batch and non-batch should return identical data",
+	)
+}
+
+func BenchmarkBatchResolver_SingleLevel(b *testing.B) {
+	const n = 100
+	users := make([]*User, n)
+	profiles := make([]*Profile, n)
+	for i := 0; i < n; i++ {
+		users[i] = &User{}
+		profiles[i] = &Profile{ID: fmt.Sprintf("p%d", i)}
+	}
+
+	b.Run("batch", func(b *testing.B) {
+		resolver := &Resolver{
+			users:         users,
+			profiles:      profiles,
+			profileErrIdx: -1,
+		}
+		c := newTestClient(resolver)
+		var resp json.RawMessage
+		for b.Loop() {
+			_ = c.Post(`query { users { nullableBatch { id } } }`, &resp)
+		}
+	})
+
+	b.Run("non-batch", func(b *testing.B) {
+		resolver := &Resolver{
+			users:         users,
+			profiles:      profiles,
+			profileErrIdx: -1,
+		}
+		c := newTestClient(resolver)
+		var resp json.RawMessage
+		for b.Loop() {
+			_ = c.Post(`query { users { nullableNonBatch { id } } }`, &resp)
+		}
+	})
+}
+
+func BenchmarkBatchResolver_Nested(b *testing.B) {
+	const n = 100
+	users := make([]*User, n)
+	profiles := make([]*Profile, n)
+	images := make([]*Image, n)
+	for i := 0; i < n; i++ {
+		users[i] = &User{}
+		profiles[i] = &Profile{ID: fmt.Sprintf("p%d", i)}
+		images[i] = &Image{URL: fmt.Sprintf("https://img/%d", i)}
+	}
+
+	b.Run("batch", func(b *testing.B) {
+		resolver := &Resolver{
+			users:         users,
+			profiles:      profiles,
+			images:        images,
+			profileErrIdx: -1,
+		}
+		c := newTestClient(resolver)
+		var resp json.RawMessage
+		for b.Loop() {
+			_ = c.Post(`query {
+				users {
+					profile: profileBatch {
+						id
+						cover: coverBatch { url }
+					}
+				}
+			}`, &resp)
+		}
+	})
+
+	b.Run("non-batch", func(b *testing.B) {
+		resolver := &Resolver{
+			users:         users,
+			profiles:      profiles,
+			images:        images,
+			profileErrIdx: -1,
+		}
+		c := newTestClient(resolver)
+		var resp json.RawMessage
+		for b.Loop() {
+			_ = c.Post(`query {
+				users {
+					profile: profileNonBatch {
+						id
+						cover: coverNonBatch { url }
+					}
+				}
+			}`, &resp)
+		}
+	})
+}

--- a/_examples/batchresolver/generated.go
+++ b/_examples/batchresolver/generated.go
@@ -46,19 +46,31 @@ type ComplexityRoot struct {
 		ID            func(childComplexity int) int
 	}
 
+	ProfileEdge struct {
+		Cursor func(childComplexity int) int
+		Node   func(childComplexity int) int
+	}
+
+	ProfilesConnection struct {
+		Edges      func(childComplexity int) int
+		TotalCount func(childComplexity int) int
+	}
+
 	Query struct {
 		Users func(childComplexity int) int
 	}
 
 	User struct {
-		NonNullableBatch        func(childComplexity int) int
-		NonNullableNonBatch     func(childComplexity int) int
-		NullableBatch           func(childComplexity int) int
-		NullableBatchWithArg    func(childComplexity int, offset int) int
-		NullableNonBatch        func(childComplexity int) int
-		NullableNonBatchWithArg func(childComplexity int, offset int) int
-		ProfileBatch            func(childComplexity int) int
-		ProfileNonBatch         func(childComplexity int) int
+		NonNullableBatch          func(childComplexity int) int
+		NonNullableNonBatch       func(childComplexity int) int
+		NullableBatch             func(childComplexity int) int
+		NullableBatchWithArg      func(childComplexity int, offset int) int
+		NullableNonBatch          func(childComplexity int) int
+		NullableNonBatchWithArg   func(childComplexity int, offset int) int
+		ProfileBatch              func(childComplexity int) int
+		ProfileConnectionBatch    func(childComplexity int) int
+		ProfileConnectionNonBatch func(childComplexity int) int
+		ProfileNonBatch           func(childComplexity int) int
 	}
 }
 
@@ -78,6 +90,8 @@ type UserResolver interface {
 	NonNullableNonBatch(ctx context.Context, obj *User) (*Profile, error)
 	ProfileBatch(ctx context.Context, objs []*User) ([]*Profile, error)
 	ProfileNonBatch(ctx context.Context, obj *User) (*Profile, error)
+	ProfileConnectionBatch(ctx context.Context, objs []*User) ([]*ProfilesConnection, error)
+	ProfileConnectionNonBatch(ctx context.Context, obj *User) (*ProfilesConnection, error)
 }
 
 type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -119,6 +133,32 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Profile.ID(childComplexity), true
+
+	case "ProfileEdge.cursor":
+		if e.ComplexityRoot.ProfileEdge.Cursor == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ProfileEdge.Cursor(childComplexity), true
+	case "ProfileEdge.node":
+		if e.ComplexityRoot.ProfileEdge.Node == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ProfileEdge.Node(childComplexity), true
+
+	case "ProfilesConnection.edges":
+		if e.ComplexityRoot.ProfilesConnection.Edges == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ProfilesConnection.Edges(childComplexity), true
+	case "ProfilesConnection.totalCount":
+		if e.ComplexityRoot.ProfilesConnection.TotalCount == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ProfilesConnection.TotalCount(childComplexity), true
 
 	case "Query.users":
 		if e.ComplexityRoot.Query.Users == nil {
@@ -179,6 +219,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.User.ProfileBatch(childComplexity), true
+	case "User.profileConnectionBatch":
+		if e.ComplexityRoot.User.ProfileConnectionBatch == nil {
+			break
+		}
+
+		return e.ComplexityRoot.User.ProfileConnectionBatch(childComplexity), true
+	case "User.profileConnectionNonBatch":
+		if e.ComplexityRoot.User.ProfileConnectionNonBatch == nil {
+			break
+		}
+
+		return e.ComplexityRoot.User.ProfileConnectionNonBatch(childComplexity), true
 	case "User.profileNonBatch":
 		if e.ComplexityRoot.User.ProfileNonBatch == nil {
 			break
@@ -515,6 +567,136 @@ func (ec *executionContext) fieldContext_Profile_coverNonBatch(_ context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _ProfileEdge_node(ctx context.Context, field graphql.CollectedField, obj *ProfileEdge) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ProfileEdge_node,
+		func(ctx context.Context) (any, error) {
+			return obj.Node, nil
+		},
+		nil,
+		ec.marshalNProfile2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfile,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ProfileEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ProfileEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Profile_id(ctx, field)
+			case "coverBatch":
+				return ec.fieldContext_Profile_coverBatch(ctx, field)
+			case "coverNonBatch":
+				return ec.fieldContext_Profile_coverNonBatch(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Profile", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ProfileEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *ProfileEdge) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ProfileEdge_cursor,
+		func(ctx context.Context) (any, error) {
+			return obj.Cursor, nil
+		},
+		nil,
+		ec.marshalNID2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ProfileEdge_cursor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ProfileEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ProfilesConnection_edges(ctx context.Context, field graphql.CollectedField, obj *ProfilesConnection) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ProfilesConnection_edges,
+		func(ctx context.Context) (any, error) {
+			return obj.Edges, nil
+		},
+		nil,
+		ec.marshalNProfileEdge2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfileEdgeᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ProfilesConnection_edges(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ProfilesConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "node":
+				return ec.fieldContext_ProfileEdge_node(ctx, field)
+			case "cursor":
+				return ec.fieldContext_ProfileEdge_cursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ProfileEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ProfilesConnection_totalCount(ctx context.Context, field graphql.CollectedField, obj *ProfilesConnection) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ProfilesConnection_totalCount,
+		func(ctx context.Context) (any, error) {
+			return obj.TotalCount, nil
+		},
+		nil,
+		ec.marshalNInt2int,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ProfilesConnection_totalCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ProfilesConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_users(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -555,6 +737,10 @@ func (ec *executionContext) fieldContext_Query_users(_ context.Context, field gr
 				return ec.fieldContext_User_profileBatch(ctx, field)
 			case "profileNonBatch":
 				return ec.fieldContext_User_profileNonBatch(ctx, field)
+			case "profileConnectionBatch":
+				return ec.fieldContext_User_profileConnectionBatch(ctx, field)
+			case "profileConnectionNonBatch":
+				return ec.fieldContext_User_profileConnectionNonBatch(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -1121,6 +1307,110 @@ func (ec *executionContext) fieldContext_User_profileNonBatch(_ context.Context,
 				return ec.fieldContext_Profile_coverNonBatch(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Profile", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _User_profileConnectionBatch(ctx context.Context, field graphql.CollectedField, obj *User) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_User_profileConnectionBatch,
+		func(ctx context.Context) (any, error) {
+			return ec.resolveBatch_User_profileConnectionBatch(ctx, field, obj)
+		},
+		nil,
+		ec.marshalOProfilesConnection2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfilesConnection,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_User_profileConnectionBatch(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "edges":
+				return ec.fieldContext_ProfilesConnection_edges(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_ProfilesConnection_totalCount(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ProfilesConnection", field.Name)
+		},
+	}
+	return fc, nil
+}
+func (ec *executionContext) resolveBatch_User_profileConnectionBatch(ctx context.Context, field graphql.CollectedField, obj *User) (any, error) {
+	resolver := ec.Resolvers.User()
+	group := graphql.GetBatchParentGroup(ctx, "User")
+	if group != nil {
+		parents, ok := group.Parents.([]*User)
+		if ok {
+			idx, ok := graphql.BatchParentIndex(ctx)
+			if ok {
+				key := field.Alias
+				if key == "" {
+					key = field.Name
+				}
+				result := group.GetFieldResult(key, func() (any, error) {
+					return resolver.ProfileConnectionBatch(ctx, parents)
+				})
+				return graphql.ResolveBatchGroupResult[*ProfilesConnection](
+					ctx,
+					idx,
+					len(parents),
+					result,
+					"User.profileConnectionBatch",
+				)
+			}
+		}
+	}
+
+	results, err := resolver.ProfileConnectionBatch(ctx, []*User{obj})
+	return graphql.ResolveBatchSingleResult[*ProfilesConnection](
+		ctx,
+		results,
+		err,
+		"User.profileConnectionBatch",
+	)
+}
+
+func (ec *executionContext) _User_profileConnectionNonBatch(ctx context.Context, field graphql.CollectedField, obj *User) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_User_profileConnectionNonBatch,
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.User().ProfileConnectionNonBatch(ctx, obj)
+		},
+		nil,
+		ec.marshalOProfilesConnection2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfilesConnection,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_User_profileConnectionNonBatch(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "edges":
+				return ec.fieldContext_ProfilesConnection_edges(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_ProfilesConnection_totalCount(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ProfilesConnection", field.Name)
 		},
 	}
 	return fc, nil
@@ -2724,6 +3014,94 @@ func (ec *executionContext) _Profile(ctx context.Context, sel ast.SelectionSet, 
 	return out
 }
 
+var profileEdgeImplementors = []string{"ProfileEdge"}
+
+func (ec *executionContext) _ProfileEdge(ctx context.Context, sel ast.SelectionSet, obj *ProfileEdge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, profileEdgeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ProfileEdge")
+		case "node":
+			out.Values[i] = ec._ProfileEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "cursor":
+			out.Values[i] = ec._ProfileEdge_cursor(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var profilesConnectionImplementors = []string{"ProfilesConnection"}
+
+func (ec *executionContext) _ProfilesConnection(ctx context.Context, sel ast.SelectionSet, obj *ProfilesConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, profilesConnectionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ProfilesConnection")
+		case "edges":
+			out.Values[i] = ec._ProfilesConnection_edges(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "totalCount":
+			out.Values[i] = ec._ProfilesConnection_totalCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var queryImplementors = []string{"Query"}
 
 func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) graphql.Marshaler {
@@ -3054,6 +3432,72 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 					}
 				}()
 				res = ec._User_profileNonBatch(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "profileConnectionBatch":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._User_profileConnectionBatch(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "profileConnectionNonBatch":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._User_profileConnectionNonBatch(ctx, field, obj)
 				return res
 			}
 
@@ -3497,6 +3941,33 @@ func (ec *executionContext) marshalNProfile2ᚖgithubᚗcomᚋ99designsᚋgqlgen
 	return ec._Profile(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNProfileEdge2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfileEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*ProfileEdge) graphql.Marshaler {
+	ctx = graphql.WithBatchParents(ctx, "ProfileEdge", v)
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNProfileEdge2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfileEdge(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNProfileEdge2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfileEdge(ctx context.Context, sel ast.SelectionSet, v *ProfileEdge) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ProfileEdge(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v any) (string, error) {
 	res, err := graphql.UnmarshalString(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -3726,6 +4197,13 @@ func (ec *executionContext) marshalOProfile2ᚖgithubᚗcomᚋ99designsᚋgqlgen
 		return graphql.Null
 	}
 	return ec._Profile(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOProfilesConnection2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfilesConnection(ctx context.Context, sel ast.SelectionSet, v *ProfilesConnection) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._ProfilesConnection(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v any) (*string, error) {

--- a/_examples/batchresolver/generated.go
+++ b/_examples/batchresolver/generated.go
@@ -27,6 +27,7 @@ func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 type ResolverRoot interface {
+	Profile() ProfileResolver
 	Query() QueryResolver
 	User() UserResolver
 }
@@ -35,8 +36,14 @@ type DirectiveRoot struct {
 }
 
 type ComplexityRoot struct {
+	Image struct {
+		URL func(childComplexity int) int
+	}
+
 	Profile struct {
-		ID func(childComplexity int) int
+		CoverBatch    func(childComplexity int) int
+		CoverNonBatch func(childComplexity int) int
+		ID            func(childComplexity int) int
 	}
 
 	Query struct {
@@ -50,9 +57,15 @@ type ComplexityRoot struct {
 		NullableBatchWithArg    func(childComplexity int, offset int) int
 		NullableNonBatch        func(childComplexity int) int
 		NullableNonBatchWithArg func(childComplexity int, offset int) int
+		ProfileBatch            func(childComplexity int) int
+		ProfileNonBatch         func(childComplexity int) int
 	}
 }
 
+type ProfileResolver interface {
+	CoverBatch(ctx context.Context, objs []*Profile) ([]*Image, error)
+	CoverNonBatch(ctx context.Context, obj *Profile) (*Image, error)
+}
 type QueryResolver interface {
 	Users(ctx context.Context) ([]*User, error)
 }
@@ -63,6 +76,8 @@ type UserResolver interface {
 	NullableNonBatchWithArg(ctx context.Context, obj *User, offset int) (*Profile, error)
 	NonNullableBatch(ctx context.Context, objs []*User) ([]*Profile, error)
 	NonNullableNonBatch(ctx context.Context, obj *User) (*Profile, error)
+	ProfileBatch(ctx context.Context, objs []*User) ([]*Profile, error)
+	ProfileNonBatch(ctx context.Context, obj *User) (*Profile, error)
 }
 
 type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -79,6 +94,25 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	_ = ec
 	switch typeName + "." + field {
 
+	case "Image.url":
+		if e.ComplexityRoot.Image.URL == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Image.URL(childComplexity), true
+
+	case "Profile.coverBatch":
+		if e.ComplexityRoot.Profile.CoverBatch == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Profile.CoverBatch(childComplexity), true
+	case "Profile.coverNonBatch":
+		if e.ComplexityRoot.Profile.CoverNonBatch == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Profile.CoverNonBatch(childComplexity), true
 	case "Profile.id":
 		if e.ComplexityRoot.Profile.ID == nil {
 			break
@@ -139,6 +173,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.User.NullableNonBatchWithArg(childComplexity, args["offset"].(int)), true
+	case "User.profileBatch":
+		if e.ComplexityRoot.User.ProfileBatch == nil {
+			break
+		}
+
+		return e.ComplexityRoot.User.ProfileBatch(childComplexity), true
+	case "User.profileNonBatch":
+		if e.ComplexityRoot.User.ProfileNonBatch == nil {
+			break
+		}
+
+		return e.ComplexityRoot.User.ProfileNonBatch(childComplexity), true
 
 	}
 	return 0, false
@@ -311,6 +357,35 @@ func (ec *executionContext) field___Type_fields_args(ctx context.Context, rawArg
 
 // region    **************************** field.gotpl *****************************
 
+func (ec *executionContext) _Image_url(ctx context.Context, field graphql.CollectedField, obj *Image) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Image_url,
+		func(ctx context.Context) (any, error) {
+			return obj.URL, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Image_url(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Image",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Profile_id(ctx context.Context, field graphql.CollectedField, obj *Profile) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -335,6 +410,106 @@ func (ec *executionContext) fieldContext_Profile_id(_ context.Context, field gra
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Profile_coverBatch(ctx context.Context, field graphql.CollectedField, obj *Profile) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Profile_coverBatch,
+		func(ctx context.Context) (any, error) {
+			return ec.resolveBatch_Profile_coverBatch(ctx, field, obj)
+		},
+		nil,
+		ec.marshalOImage2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐImage,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_Profile_coverBatch(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Profile",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "url":
+				return ec.fieldContext_Image_url(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Image", field.Name)
+		},
+	}
+	return fc, nil
+}
+func (ec *executionContext) resolveBatch_Profile_coverBatch(ctx context.Context, field graphql.CollectedField, obj *Profile) (any, error) {
+	resolver := ec.Resolvers.Profile()
+	group := graphql.GetBatchParentGroup(ctx, "Profile")
+	if group != nil {
+		parents, ok := group.Parents.([]*Profile)
+		if ok {
+			idx, ok := graphql.BatchParentIndex(ctx)
+			if ok {
+				key := field.Alias
+				if key == "" {
+					key = field.Name
+				}
+				result := group.GetFieldResult(key, func() (any, error) {
+					return resolver.CoverBatch(ctx, parents)
+				})
+				return graphql.ResolveBatchGroupResult[*Image](
+					ctx,
+					idx,
+					len(parents),
+					result,
+					"Profile.coverBatch",
+				)
+			}
+		}
+	}
+
+	results, err := resolver.CoverBatch(ctx, []*Profile{obj})
+	return graphql.ResolveBatchSingleResult[*Image](
+		ctx,
+		results,
+		err,
+		"Profile.coverBatch",
+	)
+}
+
+func (ec *executionContext) _Profile_coverNonBatch(ctx context.Context, field graphql.CollectedField, obj *Profile) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Profile_coverNonBatch,
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.Profile().CoverNonBatch(ctx, obj)
+		},
+		nil,
+		ec.marshalOImage2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐImage,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_Profile_coverNonBatch(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Profile",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "url":
+				return ec.fieldContext_Image_url(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Image", field.Name)
 		},
 	}
 	return fc, nil
@@ -376,6 +551,10 @@ func (ec *executionContext) fieldContext_Query_users(_ context.Context, field gr
 				return ec.fieldContext_User_nonNullableBatch(ctx, field)
 			case "nonNullableNonBatch":
 				return ec.fieldContext_User_nonNullableNonBatch(ctx, field)
+			case "profileBatch":
+				return ec.fieldContext_User_profileBatch(ctx, field)
+			case "profileNonBatch":
+				return ec.fieldContext_User_profileNonBatch(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -517,6 +696,10 @@ func (ec *executionContext) fieldContext_User_nullableBatch(_ context.Context, f
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Profile_id(ctx, field)
+			case "coverBatch":
+				return ec.fieldContext_Profile_coverBatch(ctx, field)
+			case "coverNonBatch":
+				return ec.fieldContext_Profile_coverNonBatch(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Profile", field.Name)
 		},
@@ -584,6 +767,10 @@ func (ec *executionContext) fieldContext_User_nullableNonBatch(_ context.Context
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Profile_id(ctx, field)
+			case "coverBatch":
+				return ec.fieldContext_Profile_coverBatch(ctx, field)
+			case "coverNonBatch":
+				return ec.fieldContext_Profile_coverNonBatch(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Profile", field.Name)
 		},
@@ -617,6 +804,10 @@ func (ec *executionContext) fieldContext_User_nullableBatchWithArg(ctx context.C
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Profile_id(ctx, field)
+			case "coverBatch":
+				return ec.fieldContext_Profile_coverBatch(ctx, field)
+			case "coverNonBatch":
+				return ec.fieldContext_Profile_coverNonBatch(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Profile", field.Name)
 		},
@@ -697,6 +888,10 @@ func (ec *executionContext) fieldContext_User_nullableNonBatchWithArg(ctx contex
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Profile_id(ctx, field)
+			case "coverBatch":
+				return ec.fieldContext_Profile_coverBatch(ctx, field)
+			case "coverNonBatch":
+				return ec.fieldContext_Profile_coverNonBatch(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Profile", field.Name)
 		},
@@ -741,6 +936,10 @@ func (ec *executionContext) fieldContext_User_nonNullableBatch(_ context.Context
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Profile_id(ctx, field)
+			case "coverBatch":
+				return ec.fieldContext_Profile_coverBatch(ctx, field)
+			case "coverNonBatch":
+				return ec.fieldContext_Profile_coverNonBatch(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Profile", field.Name)
 		},
@@ -808,6 +1007,118 @@ func (ec *executionContext) fieldContext_User_nonNullableNonBatch(_ context.Cont
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Profile_id(ctx, field)
+			case "coverBatch":
+				return ec.fieldContext_Profile_coverBatch(ctx, field)
+			case "coverNonBatch":
+				return ec.fieldContext_Profile_coverNonBatch(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Profile", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _User_profileBatch(ctx context.Context, field graphql.CollectedField, obj *User) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_User_profileBatch,
+		func(ctx context.Context) (any, error) {
+			return ec.resolveBatch_User_profileBatch(ctx, field, obj)
+		},
+		nil,
+		ec.marshalOProfile2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfile,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_User_profileBatch(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Profile_id(ctx, field)
+			case "coverBatch":
+				return ec.fieldContext_Profile_coverBatch(ctx, field)
+			case "coverNonBatch":
+				return ec.fieldContext_Profile_coverNonBatch(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Profile", field.Name)
+		},
+	}
+	return fc, nil
+}
+func (ec *executionContext) resolveBatch_User_profileBatch(ctx context.Context, field graphql.CollectedField, obj *User) (any, error) {
+	resolver := ec.Resolvers.User()
+	group := graphql.GetBatchParentGroup(ctx, "User")
+	if group != nil {
+		parents, ok := group.Parents.([]*User)
+		if ok {
+			idx, ok := graphql.BatchParentIndex(ctx)
+			if ok {
+				key := field.Alias
+				if key == "" {
+					key = field.Name
+				}
+				result := group.GetFieldResult(key, func() (any, error) {
+					return resolver.ProfileBatch(ctx, parents)
+				})
+				return graphql.ResolveBatchGroupResult[*Profile](
+					ctx,
+					idx,
+					len(parents),
+					result,
+					"User.profileBatch",
+				)
+			}
+		}
+	}
+
+	results, err := resolver.ProfileBatch(ctx, []*User{obj})
+	return graphql.ResolveBatchSingleResult[*Profile](
+		ctx,
+		results,
+		err,
+		"User.profileBatch",
+	)
+}
+
+func (ec *executionContext) _User_profileNonBatch(ctx context.Context, field graphql.CollectedField, obj *User) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_User_profileNonBatch,
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.User().ProfileNonBatch(ctx, obj)
+		},
+		nil,
+		ec.marshalOProfile2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfile,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_User_profileNonBatch(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Profile_id(ctx, field)
+			case "coverBatch":
+				return ec.fieldContext_Profile_coverBatch(ctx, field)
+			case "coverNonBatch":
+				return ec.fieldContext_Profile_coverNonBatch(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Profile", field.Name)
 		},
@@ -2269,6 +2580,45 @@ func (ec *executionContext) fieldContext___Type_isOneOf(_ context.Context, field
 
 // region    **************************** object.gotpl ****************************
 
+var imageImplementors = []string{"Image"}
+
+func (ec *executionContext) _Image(ctx context.Context, sel ast.SelectionSet, obj *Image) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, imageImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Image")
+		case "url":
+			out.Values[i] = ec._Image_url(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var profileImplementors = []string{"Profile"}
 
 func (ec *executionContext) _Profile(ctx context.Context, sel ast.SelectionSet, obj *Profile) graphql.Marshaler {
@@ -2283,8 +2633,74 @@ func (ec *executionContext) _Profile(ctx context.Context, sel ast.SelectionSet, 
 		case "id":
 			out.Values[i] = ec._Profile_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "coverBatch":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Profile_coverBatch(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "coverNonBatch":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Profile_coverNonBatch(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -2572,6 +2988,72 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "profileBatch":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._User_profileBatch(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "profileNonBatch":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._User_profileNonBatch(ctx, field, obj)
 				return res
 			}
 
@@ -3230,6 +3712,13 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 	_ = ctx
 	res := graphql.MarshalBoolean(*v)
 	return res
+}
+
+func (ec *executionContext) marshalOImage2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐImage(ctx context.Context, sel ast.SelectionSet, v *Image) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Image(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOProfile2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfile(ctx context.Context, sel ast.SelectionSet, v *Profile) graphql.Marshaler {

--- a/_examples/batchresolver/gqlgen.yml
+++ b/_examples/batchresolver/gqlgen.yml
@@ -37,6 +37,11 @@ models:
           batch: true
       profileNonBatch:
           resolver: true
+      profileConnectionBatch:
+          resolver: true
+          batch: true
+      profileConnectionNonBatch:
+          resolver: true
   Profile:
     fields:
       coverBatch:

--- a/_examples/batchresolver/gqlgen.yml
+++ b/_examples/batchresolver/gqlgen.yml
@@ -32,3 +32,15 @@ models:
         batch: true
       nonNullableNonBatch:
         resolver: true
+      profileBatch:
+          resolver: true
+          batch: true
+      profileNonBatch:
+          resolver: true
+  Profile:
+    fields:
+      coverBatch:
+          resolver: true
+          batch: true
+      coverNonBatch:
+          resolver: true

--- a/_examples/batchresolver/models_gen.go
+++ b/_examples/batchresolver/models_gen.go
@@ -2,8 +2,14 @@
 
 package batchresolver
 
+type Image struct {
+	URL string `json:"url"`
+}
+
 type Profile struct {
-	ID string `json:"id"`
+	ID            string `json:"id"`
+	CoverBatch    *Image `json:"coverBatch,omitempty"`
+	CoverNonBatch *Image `json:"coverNonBatch,omitempty"`
 }
 
 type Query struct {
@@ -16,4 +22,6 @@ type User struct {
 	NullableNonBatchWithArg *Profile `json:"nullableNonBatchWithArg,omitempty"`
 	NonNullableBatch        *Profile `json:"nonNullableBatch"`
 	NonNullableNonBatch     *Profile `json:"nonNullableNonBatch"`
+	ProfileBatch            *Profile `json:"profileBatch,omitempty"`
+	ProfileNonBatch         *Profile `json:"profileNonBatch,omitempty"`
 }

--- a/_examples/batchresolver/models_gen.go
+++ b/_examples/batchresolver/models_gen.go
@@ -12,16 +12,28 @@ type Profile struct {
 	CoverNonBatch *Image `json:"coverNonBatch,omitempty"`
 }
 
+type ProfileEdge struct {
+	Node   *Profile `json:"node"`
+	Cursor string   `json:"cursor"`
+}
+
+type ProfilesConnection struct {
+	Edges      []*ProfileEdge `json:"edges"`
+	TotalCount int            `json:"totalCount"`
+}
+
 type Query struct {
 }
 
 type User struct {
-	NullableBatch           *Profile `json:"nullableBatch,omitempty"`
-	NullableNonBatch        *Profile `json:"nullableNonBatch,omitempty"`
-	NullableBatchWithArg    *Profile `json:"nullableBatchWithArg,omitempty"`
-	NullableNonBatchWithArg *Profile `json:"nullableNonBatchWithArg,omitempty"`
-	NonNullableBatch        *Profile `json:"nonNullableBatch"`
-	NonNullableNonBatch     *Profile `json:"nonNullableNonBatch"`
-	ProfileBatch            *Profile `json:"profileBatch,omitempty"`
-	ProfileNonBatch         *Profile `json:"profileNonBatch,omitempty"`
+	NullableBatch             *Profile            `json:"nullableBatch,omitempty"`
+	NullableNonBatch          *Profile            `json:"nullableNonBatch,omitempty"`
+	NullableBatchWithArg      *Profile            `json:"nullableBatchWithArg,omitempty"`
+	NullableNonBatchWithArg   *Profile            `json:"nullableNonBatchWithArg,omitempty"`
+	NonNullableBatch          *Profile            `json:"nonNullableBatch"`
+	NonNullableNonBatch       *Profile            `json:"nonNullableNonBatch"`
+	ProfileBatch              *Profile            `json:"profileBatch,omitempty"`
+	ProfileNonBatch           *Profile            `json:"profileNonBatch,omitempty"`
+	ProfileConnectionBatch    *ProfilesConnection `json:"profileConnectionBatch,omitempty"`
+	ProfileConnectionNonBatch *ProfilesConnection `json:"profileConnectionNonBatch,omitempty"`
 }

--- a/_examples/batchresolver/readme.md
+++ b/_examples/batchresolver/readme.md
@@ -55,6 +55,19 @@ return results, graphql.BatchErrorList(errs)
 
 Each entry in the error slice corresponds to the parent at the same index. Individual errors can also be `gqlerror.List` to report multiple errors for a single item.
 
+## Nested Batching
+
+The schema also demonstrates **nested batch resolvers** through the path `User → Profile → Image`:
+
+| Parent    | Field             | Batch | Target  |
+|-----------|-------------------|-------|---------|
+| `User`    | `profileBatch`    | yes   | Profile |
+| `User`    | `profileNonBatch` | no    | Profile |
+| `Profile` | `coverBatch`      | yes   | Image   |
+| `Profile` | `coverNonBatch`   | no    | Image   |
+
+With 10 users, the batch path resolves all profiles in **1 call** (vs 10 for non-batch). However, `coverBatch` is still called **once per profile** (10 calls) rather than once for all profiles. This happens because profiles returned by a batch resolver are marshalled as individual values, not as a list — the batch parent context for `Profile` is only set when marshalling a `[Profile]` list field. Ideally, nested batching should propagate the batch parent context from batch resolver results so that `coverBatch` is called only once for all 10 profiles. The `TestBatchResolver_Nested_CallCount` test documents these current call counts and confirms both paths return identical data.
+
 ## Tests
 
 The tests verify **parity** between batch and non-batch resolvers — both must produce identical data and errors for the same inputs. Covered scenarios include:
@@ -66,3 +79,8 @@ The tests verify **parity** between batch and non-batch resolvers — both must 
 - `gqlerror.Error` with and without a custom path
 - Non-null field error propagation (parent nulled out)
 - Wrong result/error slice lengths (produces per-parent error messages)
+- Nested batch call count verification (`User → Profile → Image`)
+
+## Benchmarks
+
+`BenchmarkBatchResolver_SingleLevel` and `BenchmarkBatchResolver_Nested` compare batch vs non-batch execution time. Note that these benchmarks use in-memory resolvers with no I/O, so they only measure the framework overhead of batching. In a real-world scenario the main benefit of batching is reducing the number of round-trips to external services (databases, APIs, etc.), which these benchmarks do not capture.

--- a/_examples/batchresolver/readme.md
+++ b/_examples/batchresolver/readme.md
@@ -1,0 +1,68 @@
+# Batch Resolver Example
+
+This example demonstrates **batch field resolvers** in gqlgen — resolvers that receive a slice of parent objects and return results for all of them in a single call, instead of being invoked once per parent.
+
+## Schema
+
+A `User` type has six `Profile` fields covering the key variations:
+
+| Field                      | Nullable | Batch | Has Args |
+|----------------------------|----------|-------|----------|
+| `nullableBatch`            | yes      | yes   | no       |
+| `nullableNonBatch`         | yes      | no    | no       |
+| `nullableBatchWithArg`     | yes      | yes   | yes      |
+| `nullableNonBatchWithArg`  | yes      | no    | yes      |
+| `nonNullableBatch`         | no       | yes   | no       |
+| `nonNullableNonBatch`      | no       | no    | no       |
+
+## Configuration
+
+In `gqlgen.yml`, batch resolvers are enabled per-field:
+
+```yaml
+models:
+  User:
+    fields:
+      nullableBatch:
+        resolver: true
+        batch: true
+```
+
+This changes the generated resolver signature from the standard single-object form:
+
+```go
+NullableNonBatch(ctx context.Context, obj *User) (*Profile, error)
+```
+
+to a batch form that receives all parents at once:
+
+```go
+NullableBatch(ctx context.Context, objs []*User) ([]*Profile, error)
+```
+
+## Per-Item Errors
+
+Batch resolvers can return per-item errors using `graphql.BatchErrorList`:
+
+```go
+results := make([]*Profile, len(objs))
+errs := make([]error, len(objs))
+for i, obj := range objs {
+    results[i], errs[i] = resolve(obj)
+}
+return results, graphql.BatchErrorList(errs)
+```
+
+Each entry in the error slice corresponds to the parent at the same index. Individual errors can also be `gqlerror.List` to report multiple errors for a single item.
+
+## Tests
+
+The tests verify **parity** between batch and non-batch resolvers — both must produce identical data and errors for the same inputs. Covered scenarios include:
+
+- Successful resolution
+- Arguments passed through correctly
+- Errors at specific indices
+- `gqlerror.List` expansion
+- `gqlerror.Error` with and without a custom path
+- Non-null field error propagation (parent nulled out)
+- Wrong result/error slice lengths (produces per-parent error messages)

--- a/_examples/batchresolver/resolver.go
+++ b/_examples/batchresolver/resolver.go
@@ -5,6 +5,8 @@ package batchresolver
 // It serves as dependency injection for your app, add any dependencies you require
 // here.
 
+import "sync/atomic"
+
 type Resolver struct {
 	users                   []*User
 	profiles                []*Profile
@@ -21,11 +23,11 @@ type Resolver struct {
 	batchResultsLen         int
 	batchErrListIdxs        map[int]struct{}
 
-	// Call counters for the nested batch performance test
-	profileBatchCalls    int
-	profileNonBatchCalls int
-	coverBatchCalls      int
-	coverNonBatchCalls   int
+	// Call counters for the nested batch performance test (atomic for -race safety)
+	profileBatchCalls    atomic.Int32
+	profileNonBatchCalls atomic.Int32
+	coverBatchCalls      atomic.Int32
+	coverNonBatchCalls   atomic.Int32
 }
 
 func (r *Resolver) userIndex(obj *User) int {

--- a/_examples/batchresolver/resolver.go
+++ b/_examples/batchresolver/resolver.go
@@ -24,10 +24,12 @@ type Resolver struct {
 	batchErrListIdxs        map[int]struct{}
 
 	// Call counters for the nested batch performance test (atomic for -race safety)
-	profileBatchCalls    atomic.Int32
-	profileNonBatchCalls atomic.Int32
-	coverBatchCalls      atomic.Int32
-	coverNonBatchCalls   atomic.Int32
+	profileBatchCalls              atomic.Int32
+	profileNonBatchCalls           atomic.Int32
+	coverBatchCalls                atomic.Int32
+	coverNonBatchCalls             atomic.Int32
+	profileConnectionBatchCalls    atomic.Int32
+	profileConnectionNonBatchCalls atomic.Int32
 }
 
 func (r *Resolver) userIndex(obj *User) int {

--- a/_examples/batchresolver/resolver.go
+++ b/_examples/batchresolver/resolver.go
@@ -8,6 +8,7 @@ package batchresolver
 type Resolver struct {
 	users                   []*User
 	profiles                []*Profile
+	images                  []*Image
 	profileErrIdx           int
 	profileErrWithValueIdxs map[int]struct{}
 	profileErrListIdxs      map[int]struct{}
@@ -19,6 +20,12 @@ type Resolver struct {
 	batchResultsWrongLen    bool
 	batchResultsLen         int
 	batchErrListIdxs        map[int]struct{}
+
+	// Call counters for the nested batch performance test
+	profileBatchCalls    int
+	profileNonBatchCalls int
+	coverBatchCalls      int
+	coverNonBatchCalls   int
 }
 
 func (r *Resolver) userIndex(obj *User) int {
@@ -27,6 +34,18 @@ func (r *Resolver) userIndex(obj *User) int {
 	}
 	for i := range r.users {
 		if r.users[i] == obj {
+			return i
+		}
+	}
+	return -1
+}
+
+func (r *Resolver) profileIndex(obj *Profile) int {
+	if obj == nil {
+		return -1
+	}
+	for i := range r.profiles {
+		if r.profiles[i] == obj {
 			return i
 		}
 	}

--- a/_examples/batchresolver/resolver_helpers.go
+++ b/_examples/batchresolver/resolver_helpers.go
@@ -46,3 +46,10 @@ func resolveProfile(r *Resolver, idx int) (*Profile, error) {
 	}
 	return r.profiles[idx], nil
 }
+
+func resolveImage(r *Resolver, idx int) (*Image, error) {
+	if idx < 0 || idx >= len(r.images) {
+		return nil, fmt.Errorf("image not set at index %d", idx)
+	}
+	return r.images[idx], nil
+}

--- a/_examples/batchresolver/schema.graphql
+++ b/_examples/batchresolver/schema.graphql
@@ -9,8 +9,18 @@ type User {
     nullableNonBatchWithArg(offset: Int!): Profile
     nonNullableBatch: Profile!
     nonNullableNonBatch: Profile!
+
+    profileBatch: Profile
+    profileNonBatch: Profile
 }
 
 type Profile {
     id: ID!
+    coverBatch: Image
+    coverNonBatch: Image
+}
+
+
+type Image {
+    url: String!
 }

--- a/_examples/batchresolver/schema.graphql
+++ b/_examples/batchresolver/schema.graphql
@@ -12,6 +12,8 @@ type User {
 
     profileBatch: Profile
     profileNonBatch: Profile
+    profileConnectionBatch: ProfilesConnection
+    profileConnectionNonBatch: ProfilesConnection
 }
 
 type Profile {
@@ -23,4 +25,14 @@ type Profile {
 
 type Image {
     url: String!
+}
+
+type ProfilesConnection {
+    edges: [ProfileEdge!]!
+    totalCount: Int!
+}
+
+type ProfileEdge {
+    node: Profile!
+    cursor: ID!
 }

--- a/_examples/batchresolver/schema.resolvers.go
+++ b/_examples/batchresolver/schema.resolvers.go
@@ -8,10 +8,29 @@ package batchresolver
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
+
+// CoverBatch is the batch resolver for the coverBatch field.
+func (r *profileResolver) CoverBatch(ctx context.Context, objs []*Profile) ([]*Image, error) {
+	r.coverBatchCalls++
+	results := make([]*Image, len(objs))
+	for i, obj := range objs {
+		idx := r.profileIndex(obj)
+		results[i], _ = resolveImage(r.Resolver, idx)
+	}
+	return results, nil
+}
+
+// CoverNonBatch is the resolver for the coverNonBatch field.
+func (r *profileResolver) CoverNonBatch(ctx context.Context, obj *Profile) (*Image, error) {
+	r.coverNonBatchCalls++
+	idx := r.profileIndex(obj)
+	return resolveImage(r.Resolver, idx)
+}
 
 // Users is the resolver for the users field.
 func (r *queryResolver) Users(ctx context.Context) ([]*User, error) {
@@ -153,11 +172,38 @@ func (r *userResolver) NonNullableNonBatch(ctx context.Context, obj *User) (*Pro
 	return resolveProfile(r.Resolver, idx)
 }
 
+// ProfileBatch is the batch resolver for the profileBatch field.
+func (r *userResolver) ProfileBatch(ctx context.Context, objs []*User) ([]*Profile, error) {
+	r.profileBatchCalls++
+	results := make([]*Profile, len(objs))
+	for i, obj := range objs {
+		idx := r.userIndex(obj)
+		if idx >= 0 && idx < len(r.profiles) {
+			results[i] = r.profiles[idx]
+		}
+	}
+	return results, nil
+}
+
+// ProfileNonBatch is the resolver for the profileNonBatch field.
+func (r *userResolver) ProfileNonBatch(ctx context.Context, obj *User) (*Profile, error) {
+	r.profileNonBatchCalls++
+	idx := r.userIndex(obj)
+	if idx < 0 || idx >= len(r.profiles) {
+		return nil, fmt.Errorf("profile not set at index %d", idx)
+	}
+	return r.profiles[idx], nil
+}
+
+// Profile returns ProfileResolver implementation.
+func (r *Resolver) Profile() ProfileResolver { return &profileResolver{r} }
+
 // Query returns QueryResolver implementation.
 func (r *Resolver) Query() QueryResolver { return &queryResolver{r} }
 
 // User returns UserResolver implementation.
 func (r *Resolver) User() UserResolver { return &userResolver{r} }
 
+type profileResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
 type userResolver struct{ *Resolver }

--- a/_examples/batchresolver/schema.resolvers.go
+++ b/_examples/batchresolver/schema.resolvers.go
@@ -16,7 +16,7 @@ import (
 
 // CoverBatch is the batch resolver for the coverBatch field.
 func (r *profileResolver) CoverBatch(ctx context.Context, objs []*Profile) ([]*Image, error) {
-	r.coverBatchCalls++
+	r.coverBatchCalls.Add(1)
 	results := make([]*Image, len(objs))
 	for i, obj := range objs {
 		idx := r.profileIndex(obj)
@@ -27,7 +27,7 @@ func (r *profileResolver) CoverBatch(ctx context.Context, objs []*Profile) ([]*I
 
 // CoverNonBatch is the resolver for the coverNonBatch field.
 func (r *profileResolver) CoverNonBatch(ctx context.Context, obj *Profile) (*Image, error) {
-	r.coverNonBatchCalls++
+	r.coverNonBatchCalls.Add(1)
 	idx := r.profileIndex(obj)
 	return resolveImage(r.Resolver, idx)
 }
@@ -174,7 +174,7 @@ func (r *userResolver) NonNullableNonBatch(ctx context.Context, obj *User) (*Pro
 
 // ProfileBatch is the batch resolver for the profileBatch field.
 func (r *userResolver) ProfileBatch(ctx context.Context, objs []*User) ([]*Profile, error) {
-	r.profileBatchCalls++
+	r.profileBatchCalls.Add(1)
 	results := make([]*Profile, len(objs))
 	for i, obj := range objs {
 		idx := r.userIndex(obj)
@@ -187,7 +187,7 @@ func (r *userResolver) ProfileBatch(ctx context.Context, objs []*User) ([]*Profi
 
 // ProfileNonBatch is the resolver for the profileNonBatch field.
 func (r *userResolver) ProfileNonBatch(ctx context.Context, obj *User) (*Profile, error) {
-	r.profileNonBatchCalls++
+	r.profileNonBatchCalls.Add(1)
 	idx := r.userIndex(obj)
 	if idx < 0 || idx >= len(r.profiles) {
 		return nil, fmt.Errorf("profile not set at index %d", idx)

--- a/_examples/batchresolver/schema.resolvers.go
+++ b/_examples/batchresolver/schema.resolvers.go
@@ -195,6 +195,38 @@ func (r *userResolver) ProfileNonBatch(ctx context.Context, obj *User) (*Profile
 	return r.profiles[idx], nil
 }
 
+// ProfileConnectionBatch is the batch resolver for the profileConnectionBatch field.
+func (r *userResolver) ProfileConnectionBatch(ctx context.Context, objs []*User) ([]*ProfilesConnection, error) {
+	r.profileConnectionBatchCalls.Add(1)
+	results := make([]*ProfilesConnection, len(objs))
+	for i, obj := range objs {
+		idx := r.userIndex(obj)
+		var profile *Profile
+		if idx >= 0 && idx < len(r.profiles) {
+			profile = r.profiles[idx]
+		}
+		results[i] = &ProfilesConnection{
+			Edges:      []*ProfileEdge{{Node: profile, Cursor: fmt.Sprintf("cursor-%d", idx)}},
+			TotalCount: 1,
+		}
+	}
+	return results, nil
+}
+
+// ProfileConnectionNonBatch is the resolver for the profileConnectionNonBatch field.
+func (r *userResolver) ProfileConnectionNonBatch(ctx context.Context, obj *User) (*ProfilesConnection, error) {
+	r.profileConnectionNonBatchCalls.Add(1)
+	idx := r.userIndex(obj)
+	var profile *Profile
+	if idx >= 0 && idx < len(r.profiles) {
+		profile = r.profiles[idx]
+	}
+	return &ProfilesConnection{
+		Edges:      []*ProfileEdge{{Node: profile, Cursor: fmt.Sprintf("cursor-%d", idx)}},
+		TotalCount: 1,
+	}, nil
+}
+
 // Profile returns ProfileResolver implementation.
 func (r *Resolver) Profile() ProfileResolver { return &profileResolver{r} }
 


### PR DESCRIPTION
## Summary
- Add nested batch resolver example (`User → Profile → Image`) with both batch and non-batch paths to document current batching behavior
- Add `TestBatchResolver_Nested_CallCount` that verifies batch call counts and documents that nested batch parent context is not yet propagated (coverBatch is called N times instead of 1)
- Add benchmarks comparing batch vs non-batch for single-level and nested resolution
- Add readme.md documenting the batchresolver example

## Test plan
- `go test ./_examples/batchresolver/...` passes
- Benchmarks run: `go test -bench=. ./_examples/batchresolver/`