### PR TITLE
Fixes a bug that causes excessive pruning

### DIFF
--- a/codegen/templates/import.go
+++ b/codegen/templates/import.go
@@ -23,7 +23,7 @@ type Imports struct {
 }
 
 func (i *Import) String() string {
-	if strings.HasSuffix(i.Path, i.Alias) {
+	if strings.HasSuffix(i.Path, i.Alias) && i.Alias == i.Name {
 		return strconv.Quote(i.Path)
 	}
 


### PR DESCRIPTION
The bug was in Import.String() which used strings.HasSuffix(i.Path, i.Alias) to decide if an alias is redundant. This fails when a Go package name differs from its directory name (e.g., directory common but package typescommon). The alias common matched the path     
  suffix so it was dropped, but without the explicit alias, Go would use the actual package name typescommon, causing a mismatch with code using common.X. The pruner then removed the "unused" import.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
