### PR TITLE
Remove duplicated buildField batch flag block

### DIFF
--- a/codegen/field.go
+++ b/codegen/field.go
@@ -103,22 +103,6 @@ func (b *builder) buildField(obj *Object, field *ast.FieldDefinition) (*Field, e
 		f.TypeReference = b.Binder.PointerTo(f.TypeReference)
 	}
 
-	// Set Batch flag from config (independent of resolver setting)
-	if fieldCfg, ok := b.Config.Models[obj.Name]; ok {
-		if fieldEntry, ok := fieldCfg.Fields[field.Name]; ok {
-			f.Batch = fieldEntry.Batch
-			if f.Batch {
-				// batch resolvers are always user-provided
-				f.IsResolver = true
-			}
-		}
-	}
-
-	if f.IsResolver && b.Config.ResolversAlwaysReturnPointers && !f.TypeReference.IsPtr() &&
-		f.TypeReference.IsStruct() {
-		f.TypeReference = b.Binder.PointerTo(f.TypeReference)
-	}
-
 	return &f, nil
 }
 


### PR DESCRIPTION
The batch flag + pointer logic block was accidentally duplicated in `buildField`, causing it to run twice per field. I removed the second copy.