### PR TITLE
Remove use_light_mode_prefetch option

### DIFF
--- a/api/generate_test.go
+++ b/api/generate_test.go
@@ -128,3 +128,143 @@ func TestGenerateWithSchemaMutator(t *testing.T) {
 		})
 	}
 }
+
+// TestPerformanceOptionsWithAutobind tests that the three working performance
+// optimization options (fast_validation, skip_import_grouping, use_buffer_pooling)
+// work correctly with autobind and @goModel type mappings.
+//
+// This test validates that enabling these options doesn't cause:
+// 1. Import cycles due to incorrect type detection
+// 2. Missing or incorrect type mappings
+// 3. Code generation failures
+//
+// The test scenario mirrors a common production pattern:
+// - external package has LocationInfo type (mapped via @goModel)
+// - model package (autobind) has Connection type referencing LocationInfo
+// - external package imports model package (creating potential cycle)
+func TestPerformanceOptionsWithAutobind(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	workDir := filepath.Join(wd, "testdata", "perf_options")
+	t.Cleanup(func() {
+		cleanup(workDir)
+		t.Chdir(wd)
+	})
+
+	t.Chdir(workDir)
+
+	cfg, err := config.LoadConfigFromDefaultLocations()
+	require.NoError(t, err, "failed to load config")
+
+	// Verify all three performance options are enabled
+	require.True(t, cfg.GetFastValidation(), "fast_validation should be enabled")
+	require.True(t, cfg.GetSkipImportGrouping(), "skip_import_grouping should be enabled")
+	require.True(t, cfg.GetUseBufferPooling(), "use_buffer_pooling should be enabled")
+
+	// Generate code with all optimization options enabled
+	err = Generate(cfg)
+	require.NoError(t, err, "generation failed with performance options enabled")
+
+	// Read the generated models file to verify correctness
+	modelsPath := filepath.Join(workDir, "graph", "model", "models_gen.go")
+	content, err := os.ReadFile(modelsPath)
+	require.NoError(t, err, "failed to read generated models file")
+
+	contentStr := string(content)
+
+	// The generated file should NOT import the external package directly.
+	// If it does, it means optimization options broke autobind detection.
+	require.NotContains(
+		t,
+		contentStr,
+		`"github.com/99designs/gqlgen/api/testdata/perf_options/external"`,
+		"models_gen.go should not import external package - this would cause an import cycle",
+	)
+
+	// Verify that Connection and Session types are NOT regenerated
+	// (they should be used from the autobind package)
+	require.NotContains(t, contentStr, "type Connection struct",
+		"Connection should not be regenerated - it's in the autobind package")
+	require.NotContains(t, contentStr, "type Session struct",
+		"Session should not be regenerated - it's in the autobind package")
+
+	// Verify the generated code includes expected content
+	require.Contains(t, contentStr, "package model",
+		"generated file should be in model package")
+}
+
+// TestPerformanceOptionsIndividually tests each performance option in isolation
+// to ensure they don't interfere with correct code generation.
+func TestPerformanceOptionsIndividually(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name               string
+		fastValidation     bool
+		skipImportGrouping bool
+		useBufferPooling   bool
+	}{
+		{
+			name:               "fast_validation_only",
+			fastValidation:     true,
+			skipImportGrouping: false,
+			useBufferPooling:   false,
+		},
+		{
+			name:               "skip_import_grouping_only",
+			fastValidation:     false,
+			skipImportGrouping: true,
+			useBufferPooling:   false,
+		},
+		{
+			name:               "use_buffer_pooling_only",
+			fastValidation:     false,
+			skipImportGrouping: false,
+			useBufferPooling:   true,
+		},
+		{
+			name:               "all_options_enabled",
+			fastValidation:     true,
+			skipImportGrouping: true,
+			useBufferPooling:   true,
+		},
+		{
+			name:               "no_options_enabled",
+			fastValidation:     false,
+			skipImportGrouping: false,
+			useBufferPooling:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workDir := filepath.Join(wd, "testdata", "default")
+			t.Cleanup(func() {
+				cleanup(workDir)
+				t.Chdir(wd)
+			})
+
+			t.Chdir(workDir)
+
+			cfg, err := config.LoadConfigFromDefaultLocations()
+			require.NoError(t, err, "failed to load config")
+
+			// Override performance options for this test
+			cfg.FastValidation = &tt.fastValidation
+			cfg.SkipImportGrouping = &tt.skipImportGrouping
+			cfg.UseBufferPooling = &tt.useBufferPooling
+
+			// Generate code
+			err = Generate(cfg)
+			require.NoError(t, err, "generation failed with %s", tt.name)
+
+			// Verify generated file exists and is valid
+			modelsPath := filepath.Join(workDir, "graph", "model", "models_gen.go")
+			content, err := os.ReadFile(modelsPath)
+			require.NoError(t, err, "failed to read generated models file")
+			require.Contains(t, string(content), "package model")
+		})
+	}
+}

--- a/api/testdata/perf_options/external/types.go
+++ b/api/testdata/perf_options/external/types.go
@@ -1,0 +1,23 @@
+// Package external contains types that are mapped via @goModel directive.
+// This package is separate from the model package to test that gqlgen
+// correctly handles type mappings with performance options enabled.
+package external
+
+// LocationInfo is a type that will be mapped via @goModel directive.
+type LocationInfo struct {
+	Country   string
+	City      string
+	Latitude  float64
+	Longitude float64
+}
+
+// NewLocationInfo creates a new LocationInfo
+func NewLocationInfo(country, city string, lat, lng float64) *LocationInfo {
+	return &LocationInfo{
+		Country:   country,
+		City:      city,
+		Latitude:  lat,
+		Longitude: lng,
+	}
+}
+

--- a/api/testdata/perf_options/gqlgen.yml
+++ b/api/testdata/perf_options/gqlgen.yml
@@ -1,0 +1,46 @@
+# Test configuration for performance optimization options
+# Tests that fast_validation, skip_import_grouping, and use_buffer_pooling
+# work correctly with autobind and @goModel type mappings.
+
+schema:
+  - graph/*.graphqls
+
+exec:
+  filename: graph/generated.go
+  package: graph
+
+model:
+  filename: graph/model/models_gen.go
+  package: model
+
+resolver:
+  layout: follow-schema
+  dir: graph
+  package: graph
+
+# Enable all three working performance options
+fast_validation: true
+skip_import_grouping: true
+use_buffer_pooling: true
+
+# Autobind to the model package - gqlgen should detect types here
+autobind:
+  - "github.com/99designs/gqlgen/api/testdata/perf_options/graph/model"
+
+# Map LocationInfo to the external package
+models:
+  ID:
+    model:
+      - github.com/99designs/gqlgen/graphql.ID
+      - github.com/99designs/gqlgen/graphql.Int
+      - github.com/99designs/gqlgen/graphql.Int64
+      - github.com/99designs/gqlgen/graphql.Int32
+  Int:
+    model:
+      - github.com/99designs/gqlgen/graphql.Int
+      - github.com/99designs/gqlgen/graphql.Int64
+      - github.com/99designs/gqlgen/graphql.Int32
+  LocationInfo:
+    model:
+      - github.com/99designs/gqlgen/api/testdata/perf_options/external.LocationInfo
+

--- a/api/testdata/perf_options/graph/model/models.go
+++ b/api/testdata/perf_options/graph/model/models.go
@@ -1,0 +1,26 @@
+// Package model contains types that are autobound by gqlgen.
+// These types should be detected and used instead of being regenerated.
+package model
+
+// Metadata is a simple type for testing
+type Metadata struct {
+	Version   string
+	CreatedAt string
+}
+
+// Connection represents a network connection.
+// gqlgen should detect this type via autobind and NOT regenerate it.
+type Connection struct {
+	ID       string
+	SourceIP string
+	DestIP   string
+	Port     int
+}
+
+// Session contains multiple connections
+type Session struct {
+	ID          string
+	Connections []*Connection
+	Active      bool
+}
+

--- a/api/testdata/perf_options/graph/schema.graphqls
+++ b/api/testdata/perf_options/graph/schema.graphqls
@@ -1,0 +1,56 @@
+# Test schema for performance options validation
+# This schema tests that fast_validation, skip_import_grouping, and use_buffer_pooling
+# work correctly with autobind and @goModel mappings.
+
+directive @goModel(model: String, models: [String!]) on OBJECT | INPUT_OBJECT | SCALAR | ENUM | INTERFACE | UNION
+
+# LocationInfo is mapped to an external package via @goModel
+# This tests that type mapping works correctly with optimization options
+type LocationInfo @goModel(model: "github.com/99designs/gqlgen/api/testdata/perf_options/external.LocationInfo") {
+  country: String!
+  city: String!
+  latitude: Float!
+  longitude: Float!
+}
+
+# Metadata is in the autobind package
+type Metadata {
+  version: String!
+  createdAt: String!
+}
+
+# Connection is in the autobind package
+# gqlgen should use the autobind version, not generate a new one
+type Connection {
+  id: ID!
+  sourceIP: String!
+  destIP: String!
+  port: Int!
+}
+
+# Session contains connections - tests nested autobind types
+type Session {
+  id: ID!
+  connections: [Connection!]!
+  active: Boolean!
+}
+
+# Query type for the schema
+type Query {
+  connection(id: ID!): Connection
+  session(id: ID!): Session
+  locationInfo(country: String!): LocationInfo
+  activeConnections: [Connection!]!
+}
+
+# Mutation to test input handling with optimization options
+input NewConnectionInput {
+  sourceIP: String!
+  destIP: String!
+  port: Int!
+}
+
+type Mutation {
+  createConnection(input: NewConnectionInput!): Connection!
+}
+

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -71,10 +71,6 @@ type Config struct {
 	// formatting generated code. This is faster but doesn't group imports
 	// (stdlib/external/internal). Default: false (uses imports.Process)
 	SkipImportGrouping *bool `yaml:"skip_import_grouping,omitempty"`
-	// UseLightModePrefetch uses NeedName|NeedFiles|NeedModule instead of full
-	// NeedTypes for initial package loading. This avoids triggering compilation
-	// until types are actually needed. Default: false
-	UseLightModePrefetch *bool `yaml:"use_light_mode_prefetch,omitempty"`
 	// UseBufferPooling reuses byte buffers via sync.Pool during code formatting
 	// to reduce GC pressure. Default: false
 	UseBufferPooling *bool          `yaml:"use_buffer_pooling,omitempty"`
@@ -96,11 +92,6 @@ func (c *Config) GetFastValidation() bool {
 // GetSkipImportGrouping returns the value of SkipImportGrouping with default false.
 func (c *Config) GetSkipImportGrouping() bool {
 	return boolOrFalse(c.SkipImportGrouping)
-}
-
-// GetUseLightModePrefetch returns the value of UseLightModePrefetch with default false.
-func (c *Config) GetUseLightModePrefetch() bool {
-	return boolOrFalse(c.UseLightModePrefetch)
 }
 
 // GetUseBufferPooling returns the value of UseBufferPooling with default false.
@@ -348,7 +339,6 @@ func (c *Config) Init() error {
 			code.WithBuildTags(c.GoBuildTags...),
 			code.PackagePrefixToCache("github.com/99designs/gqlgen/graphql"),
 			code.WithPreloadNames(templatePackageNames...),
-			code.WithLightModePrefetch(c.GetUseLightModePrefetch()),
 		)
 	}
 
@@ -363,9 +353,7 @@ func (c *Config) Init() error {
 		return err
 	}
 
-	// prefetch all packages with light mode (no type checking, fast)
-	// Type info will be loaded on-demand only for packages that need it (e.g., autobind)
-	c.Packages.LoadAllLight(c.packageList()...)
+	c.Packages.LoadAll(c.packageList()...)
 
 	err = c.autobind()
 	if err != nil {
@@ -1097,7 +1085,6 @@ func (c *Config) LoadSchema() error {
 			code.WithBuildTags(c.GoBuildTags...),
 			code.PackagePrefixToCache("github.com/99designs/gqlgen/graphql"),
 			code.WithPreloadNames(templatePackageNames...),
-			code.WithLightModePrefetch(c.GetUseLightModePrefetch()),
 		)
 	}
 

--- a/codegen/config/config_test.go
+++ b/codegen/config/config_test.go
@@ -492,17 +492,6 @@ func TestPerformanceOptions(t *testing.T) {
 		require.True(t, cfg.GetSkipImportGrouping())
 	})
 
-	t.Run("GetUseLightModePrefetch defaults to false", func(t *testing.T) {
-		cfg := &Config{}
-		require.False(t, cfg.GetUseLightModePrefetch())
-	})
-
-	t.Run("GetUseLightModePrefetch returns true when set", func(t *testing.T) {
-		val := true
-		cfg := &Config{UseLightModePrefetch: &val}
-		require.True(t, cfg.GetUseLightModePrefetch())
-	})
-
 	t.Run("GetUseBufferPooling defaults to false", func(t *testing.T) {
 		cfg := &Config{}
 		require.False(t, cfg.GetUseBufferPooling())

--- a/internal/code/packages.go
+++ b/internal/code/packages.go
@@ -12,21 +12,12 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
-// lightMode is used for operations that don't need full type info (fast)
-var lightMode = packages.NeedName |
-	packages.NeedFiles |
-	packages.NeedModule
-
-// fullMode is used when type information is required (slow - triggers compilation)
-var fullMode = packages.NeedName |
+var mode = packages.NeedName |
 	packages.NeedFiles |
 	packages.NeedTypes |
 	packages.NeedSyntax |
 	packages.NeedTypesInfo |
 	packages.NeedModule
-
-// mode is the default mode for backwards compatibility
-var mode = fullMode
 
 type (
 	// Packages is a wrapper around x/tools/go/packages that maintains a (hopefully prewarmed) cache
@@ -38,7 +29,6 @@ type (
 		loadErrors            []error
 		buildFlags            []string
 		packagesToCachePrefix string
-		useLightModePrefetch  bool // Use lightMode instead of fullMode for LoadAll
 
 		numLoadCalls int // stupid test steam. ignore.
 		numNameCalls int // stupid test steam. ignore.
@@ -68,21 +58,11 @@ func PackagePrefixToCache(prefixPath string) func(p *Packages) {
 	}
 }
 
-// WithLightModePrefetch option for NewPackages uses lightMode (NeedName|NeedFiles|NeedModule)
-// instead of fullMode for LoadAll, avoiding compilation until types are needed.
-func WithLightModePrefetch(enabled bool) func(p *Packages) {
-	return func(p *Packages) {
-		p.useLightModePrefetch = enabled
-	}
-}
-
 // NewPackages creates a new packages cache
 // It will load all packages in the current module, and any packages that are passed to Load or
 // LoadAll
 func NewPackages(opts ...Option) *Packages {
-	p := &Packages{
-		useLightModePrefetch: false, // Default to full mode for backwards compatibility
-	}
+	p := &Packages{}
 	for _, opt := range opts {
 		opt(p)
 	}
@@ -135,42 +115,14 @@ func (p *Packages) ReloadAll(importPaths ...string) []*packages.Package {
 
 // LoadAll will call packages.Load and return the package data for the given packages,
 // but if the package already have been loaded it will return cached values instead.
-// If useLightModePrefetch is true, uses lightMode (faster, no type info).
-// Otherwise uses fullMode (slower but includes type information).
 func (p *Packages) LoadAll(importPaths ...string) []*packages.Package {
-	if p.useLightModePrefetch {
-		return p.loadAllWithMode(lightMode, importPaths...)
-	}
-	return p.loadAllWithMode(fullMode, importPaths...)
-}
-
-// LoadAllLight loads packages with minimal info (no type checking).
-// This is ~200x faster than LoadAll because it doesn't trigger compilation.
-// Use this when you only need package names/files, not type information.
-func (p *Packages) LoadAllLight(importPaths ...string) []*packages.Package {
-	return p.loadAllWithMode(lightMode, importPaths...)
-}
-
-// loadAllWithMode is the internal implementation that supports different modes.
-func (p *Packages) loadAllWithMode(
-	loadMode packages.LoadMode,
-	importPaths ...string,
-) []*packages.Package {
 	if p.packages == nil {
 		p.packages = map[string]*packages.Package{}
 	}
 
-	needsTypes := loadMode&packages.NeedTypes != 0
-
 	missing := make([]string, 0, len(importPaths))
 	for _, path := range importPaths {
-		cached, ok := p.packages[path]
-		if !ok {
-			missing = append(missing, path)
-			continue
-		}
-		// If we need types but cached package doesn't have them, reload
-		if needsTypes && cached.Types == nil {
+		if _, ok := p.packages[path]; !ok {
 			missing = append(missing, path)
 		}
 	}
@@ -178,7 +130,7 @@ func (p *Packages) loadAllWithMode(
 	if len(missing) > 0 {
 		p.numLoadCalls++
 		pkgs, err := packages.Load(&packages.Config{
-			Mode:       loadMode,
+			Mode:       mode,
 			BuildFlags: p.buildFlags,
 		}, missing...)
 		if err != nil {

--- a/internal/code/packages_test.go
+++ b/internal/code/packages_test.go
@@ -111,39 +111,6 @@ func TestLoadAllNames(t *testing.T) {
 	assert.Equal(t, "github_com", p.importToName["github.com"])
 }
 
-func TestWithLightModePrefetch(t *testing.T) {
-	t.Run("default is false", func(t *testing.T) {
-		p := NewPackages()
-		require.False(t, p.useLightModePrefetch)
-	})
-
-	t.Run("can be enabled", func(t *testing.T) {
-		p := NewPackages(WithLightModePrefetch(true))
-		require.True(t, p.useLightModePrefetch)
-	})
-
-	t.Run("can be disabled", func(t *testing.T) {
-		p := NewPackages(WithLightModePrefetch(false))
-		require.False(t, p.useLightModePrefetch)
-	})
-
-	t.Run("LoadAll uses full mode when disabled", func(t *testing.T) {
-		p := NewPackages(WithLightModePrefetch(false))
-		pkgs := p.LoadAll("github.com/99designs/gqlgen/internal/code/testdata/a")
-		require.NotEmpty(t, pkgs)
-		// Full mode includes type info
-		require.NotNil(t, pkgs[0].Types)
-	})
-
-	t.Run("LoadAll uses light mode when enabled", func(t *testing.T) {
-		p := NewPackages(WithLightModePrefetch(true))
-		pkgs := p.LoadAll("github.com/99designs/gqlgen/internal/code/testdata/a")
-		require.NotEmpty(t, pkgs)
-		// Light mode does not include type info
-		require.Nil(t, pkgs[0].Types)
-	})
-}
-
 func initialState(t *testing.T, opts ...Option) *Packages {
 	t.Helper()
 	p := NewPackages(opts...)


### PR DESCRIPTION
### Follow-up from #4070 : Feature/optimize packages load validation

This option was intended to speed up package loading by using light mode `(NeedName|NeedFiles|NeedModule)` instead of full mode `(NeedTypes|NeedSyntax|...)`.

However, the option doesn't work well with:
- Autobind packages (need full type info to match Go types)
- `@goModel` mappings (need full type info to resolve types)

For projects that use these features (most real-world projects), the option either causes incorrect code generation or provides no benefit, since the types need to be loaded anyway.

Keeping the 3 other performance options that do work:
- `fast_validation`: Uses `-gcflags="-N -l"` for faster validation
- `skip_import_grouping`: Uses format.Source instead of imports.Process
- `use_buffer_pooling`: Reuses byte buffers via sync.Pool

Also adds tests for the remaining performance options.

Describe your PR and link to any relevant issues. 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
