### PR TITLE
Custom Omittable Type

### DIFF
--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"go/token"
 	"go/types"
-	"os"
 	"strings"
 
 	"github.com/vektah/gqlparser/v2/ast"
@@ -198,20 +197,21 @@ func (b *Binder) PointerTo(ref *TypeReference) *TypeReference {
 // TypeReference is used by args and field types. The Definition can refer to both input and output
 // types.
 type TypeReference struct {
-	Definition               *ast.Definition
-	GQL                      *ast.Type
-	GO                       types.Type  // Type of the field being bound. Could be a pointer or a value type of Target.
-	Target                   types.Type  // The actual type that we know how to bind to. May require pointer juggling when traversing to fields.
-	CastType                 types.Type  // Before calling marshalling functions cast from/to this base type
-	Marshaler                *types.Func // When using external marshalling functions this will point to the Marshal function
-	Unmarshaler              *types.Func // When using external marshalling functions this will point to the Unmarshal function
-	IsMarshaler              bool        // Does the type implement graphql.Marshaler and graphql.Unmarshaler
-	IsOmittable              bool        // Does the type support omittability via an unmarshaler function
-	OmittableUnmarshaler     *types.Func // If IsOmittable is true, this will point to the unmarshaler function that supports omittability
-	IsContext                bool        // Is the Marshaler/Unmarshaller the context version; applies to either the method or interface variety.
-	PointersInUnmarshalInput bool        // Inverse values and pointers in return.
-	IsRoot                   bool        // Is the type a root level definition such as Query, Mutation or Subscription
-	EnumValues               []EnumValueReference
+	Definition                   *ast.Definition
+	GQL                          *ast.Type
+	GO                           types.Type  // Type of the field being bound. Could be a pointer or a value type of Target.
+	Target                       types.Type  // The actual type that we know how to bind to. May require pointer juggling when traversing to fields.
+	CastType                     types.Type  // Before calling marshalling functions cast from/to this base type
+	Marshaler                    *types.Func // When using external marshalling functions this will point to the Marshal function
+	Unmarshaler                  *types.Func // When using external marshalling functions this will point to the Unmarshal function
+	IsMarshaler                  bool        // Does the type implement graphql.Marshaler and graphql.Unmarshaler
+	IsOmittable                  bool        // Does the type support omittability via an unmarshaler function
+	OmittableUnmarshaler         *types.Func // If IsOmittable is true, this will point to the unmarshaler function that supports omittability
+	OmittableUnmarshalerCanError bool        // If IsOmittable is true, indicates whether the unmarshaler function returns an error as a second return value
+	IsContext                    bool        // Is the Marshaler/Unmarshaller the context version; applies to either the method or interface variety.
+	PointersInUnmarshalInput     bool        // Inverse values and pointers in return.
+	IsRoot                       bool        // Is the type a root level definition such as Query, Mutation or Subscription
+	EnumValues                   []EnumValueReference
 }
 
 func (ref *TypeReference) Elem() *TypeReference {
@@ -367,7 +367,11 @@ func isIntf(t types.Type) bool {
 func (b *Binder) unwrapOmittable(
 	goType types.Type,
 	bindTarget types.Type,
-) (types.Type, *types.Func, bool) {
+) (
+	unwrappedType types.Type,
+	unmarshalOmittable *types.Func,
+	unmarshalerCanError bool,
+) {
 	if bindTarget == nil {
 		return nil, nil, false
 	}
@@ -375,49 +379,98 @@ func (b *Binder) unwrapOmittable(
 	if !ok {
 		return bindTarget, nil, false
 	}
-	for _, ot := range b.cfg.OmittableTypes {
-		pkgName, typeName := code.PkgAndType(ot)
+	for _, ot := range b.cfg.OmittableType {
+		pkgName, funName := code.PkgAndType(ot)
 
-		obj, err := b.FindObject(pkgName, "Unmarshal"+typeName)
+		obj, err := b.FindObject(pkgName, funName)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "unable to find Unmarshal function for Omittable type: %s.%s: %v\n", pkgName, typeName, err)
 			continue
 		}
 
 		fn, ok := obj.(*types.Func)
 		if !ok {
-			fmt.Fprintf(os.Stderr, "type for Omittable is not a function: %s.%s\n", pkgName, typeName)
 			continue
 		}
 
 		sig := obj.Type().(*types.Signature)
-		_ = sig
 		if named.Origin().String() == sig.Results().At(0).Type().(*types.Named).Origin().String() {
 			// If we instantiate the unmarshaler function with the type arg in the bindTarget, does it result in compatible types?
-			named.Origin().TypeParams().At(0)
 			typeArg := named.TypeArgs().At(0)
-			if ptr, isPtr := typeArg.(*types.Pointer); isPtr {
-				typeArg = ptr.Elem()
+
+			// There are four potential cases to check for compatibility:
+			// 1) The type arg and goType as-is
+			// 2) The type arg as a non-pointer (if it's a pointer), and the goType as-is
+			// 3) The type arg as-is, and the goType as a non-pointer (if it's a pointer)
+			// 4) Both the type arg and the goType as non-pointers (if they're pointers)
+			typeArgPtr, isTypeArgPtr := typeArg.(*types.Pointer)
+			goTypePtr, isGoTypePtr := goType.(*types.Pointer)
+
+			if canError, ok := b.instantiateAndCheckOmittable(fn, typeArg, goType, bindTarget); ok {
+				return goType, fn, canError
 			}
-			ifun, err := b.InstantiateType(obj.Type(), []types.Type{typeArg})
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "unable to instantiate Unmarshal function for Omittable type: %s.%s: %v\n", pkgName, typeName, err)
-				continue
+			if isTypeArgPtr {
+				if canError, ok := b.instantiateAndCheckOmittable(fn, typeArgPtr.Elem(), goType, bindTarget); ok {
+					return goType, fn, canError
+				}
 			}
-			isig := ifun.(*types.Signature)
-			fmt.Println(isig.String())
-			if goType.String() != isig.Params().At(0).Type().String() {
-				fmt.Fprintf(os.Stderr, "unmarshal function for Omittable type: %s.%s does not have a compatible parameter type. expected: %s, got: %s\n", pkgName, typeName, goType.String(), isig.Params().At(0).Type().String())
-				continue
+			if isGoTypePtr {
+				if canError, ok := b.instantiateAndCheckOmittable(fn, typeArg, goTypePtr.Elem(), bindTarget); ok {
+					return goTypePtr.Elem(), fn, canError
+				}
 			}
-			if bindTarget.String() != isig.Results().At(0).Type().String() {
-				fmt.Fprintf(os.Stderr, "unmarshal function for Omittable type: %s.%s does not have a compatible return type. expected: %s, got: %s\n", pkgName, typeName, bindTarget.String(), isig.Results().At(0).Type().String())
-				continue
+			if isTypeArgPtr && isGoTypePtr {
+				if canError, ok := b.instantiateAndCheckOmittable(fn, typeArgPtr.Elem(), goTypePtr.Elem(), bindTarget); ok {
+					return goTypePtr.Elem(), fn, canError
+				}
 			}
-			return goType, fn, true
 		}
 	}
 	return bindTarget, nil, false
+}
+
+// instantiateAndCheckOmittable attemps to instantiate the given function with the provided type
+// argument and checks if the resulting signature is compatible with the expected argument and
+// result types for an omittable unmarshaler function. It returns true if the function can be used
+// as an omittable unmarshaler for the given type, and false otherwise.
+func (b *Binder) instantiateAndCheckOmittable(fn *types.Func, typeArg, expectedArg, expectedResult types.Type) (canError, ok bool) {
+	ifun, err := b.InstantiateType(fn.Type(), []types.Type{typeArg})
+	if err != nil {
+		return false, false
+	}
+	isig := ifun.(*types.Signature)
+
+	// The signature of an omittable unmarshaler function can be one of:
+	// func[T any](T) U
+	// func[T any](T) (U, error)
+	// where U is the type we want to unmarshal into (the bindTarget) and T is the type argument in the function definition.
+
+	// Check the parameters. There should be exactly one parameter of the expected type (the type argument).
+	if isig.Params().Len() != 1 {
+		return false, false
+	}
+	if isig.Params().At(0).Type().String() != expectedArg.String() {
+		return false, false
+	}
+
+	// Check the results. We allow either a single result of the expected type, or a tuple of (expected type, error).
+	switch isig.Results().Len() {
+	case 1:
+		if isig.Results().At(0).Type().String() != expectedResult.String() {
+			return false, false
+		}
+	case 2:
+		if isig.Results().At(0).Type().String() != expectedResult.String() {
+			return false, false
+		}
+		if isig.Results().At(1).Type().String() != "error" {
+			return false, false
+		}
+		canError = true
+	default:
+		return false, false
+	}
+
+	return canError, true
 }
 
 func (b *Binder) TypeReference(
@@ -542,9 +595,10 @@ func (b *Binder) TypeReference(
 					ref.IsMarshaler = true
 					ref.Marshaler = nil
 					ref.Unmarshaler = nil
-				} else if newTarget, unmarshalFunc, isOmittable := b.unwrapOmittable(ref.GO, bindTarget); isOmittable {
+				} else if newTarget, unmarshalFunc, canError := b.unwrapOmittable(ref.GO, bindTarget); unmarshalFunc != nil {
 					ref.IsOmittable = true
 					ref.OmittableUnmarshaler = unmarshalFunc
+					ref.OmittableUnmarshalerCanError = canError
 					bindTarget = newTarget
 				} else {
 					continue

--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -377,28 +377,44 @@ func (b *Binder) unwrapOmittable(
 	}
 	for _, ot := range b.cfg.OmittableTypes {
 		pkgName, typeName := code.PkgAndType(ot)
+
 		obj, err := b.FindObject(pkgName, "Unmarshal"+typeName)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "unable to find Unmarshal function for Omittable type: %s.%s: %v\n", pkgName, typeName, err)
 			continue
 		}
 
-		t := code.Unalias(obj.Type())
 		fn, ok := obj.(*types.Func)
 		if !ok {
 			fmt.Fprintf(os.Stderr, "type for Omittable is not a function: %s.%s\n", pkgName, typeName)
 			continue
 		}
 
-		instantiated, err := b.InstantiateType(t, []types.Type{named})
-		if err == nil {
-			fmt.Printf("%s is an Omittable type\n", instantiated.String())
-		}
-
-		t.(*types.Signature).TypeParams()
-		fmt.Printf("%s\n", named.String())
-		if named.Origin().String() == t.(*types.Signature).Results().At(0).Type().(*types.Named).Origin().String() {
-			return named.TypeArgs().At(0), fn, true
+		sig := obj.Type().(*types.Signature)
+		_ = sig
+		if named.Origin().String() == sig.Results().At(0).Type().(*types.Named).Origin().String() {
+			// If we instantiate the unmarshaler function with the type arg in the bindTarget, does it result in compatible types?
+			named.Origin().TypeParams().At(0)
+			typeArg := named.TypeArgs().At(0)
+			if ptr, isPtr := typeArg.(*types.Pointer); isPtr {
+				typeArg = ptr.Elem()
+			}
+			ifun, err := b.InstantiateType(obj.Type(), []types.Type{typeArg})
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "unable to instantiate Unmarshal function for Omittable type: %s.%s: %v\n", pkgName, typeName, err)
+				continue
+			}
+			isig := ifun.(*types.Signature)
+			fmt.Println(isig.String())
+			if goType.String() != isig.Params().At(0).Type().String() {
+				fmt.Fprintf(os.Stderr, "unmarshal function for Omittable type: %s.%s does not have a compatible parameter type. expected: %s, got: %s\n", pkgName, typeName, goType.String(), isig.Params().At(0).Type().String())
+				continue
+			}
+			if bindTarget.String() != isig.Results().At(0).Type().String() {
+				fmt.Fprintf(os.Stderr, "unmarshal function for Omittable type: %s.%s does not have a compatible return type. expected: %s, got: %s\n", pkgName, typeName, bindTarget.String(), isig.Results().At(0).Type().String())
+				continue
+			}
+			return goType, fn, true
 		}
 	}
 	return bindTarget, nil, false
@@ -526,13 +542,12 @@ func (b *Binder) TypeReference(
 					ref.IsMarshaler = true
 					ref.Marshaler = nil
 					ref.Unmarshaler = nil
+				} else if newTarget, unmarshalFunc, isOmittable := b.unwrapOmittable(ref.GO, bindTarget); isOmittable {
+					ref.IsOmittable = true
+					ref.OmittableUnmarshaler = unmarshalFunc
+					bindTarget = newTarget
 				} else {
-					if newTarget, unmarshalFunc, isOmittable := b.unwrapOmittable(ref.GO, bindTarget); isOmittable {
-						ref.OmittableUnmarshaler = unmarshalFunc
-						ref.GO = newTarget
-					} else {
-						continue
-					}
+					continue
 				}
 			}
 			ref.GO = bindTarget

--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"go/token"
 	"go/types"
+	"os"
 	"strings"
 
 	"github.com/vektah/gqlparser/v2/ast"
@@ -205,7 +206,8 @@ type TypeReference struct {
 	Marshaler                *types.Func // When using external marshalling functions this will point to the Marshal function
 	Unmarshaler              *types.Func // When using external marshalling functions this will point to the Unmarshal function
 	IsMarshaler              bool        // Does the type implement graphql.Marshaler and graphql.Unmarshaler
-	IsOmittable              bool        // Is the type wrapped with Omittable
+	IsOmittable              bool        // Does the type support omittability via an unmarshaler function
+	OmittableUnmarshaler     *types.Func // If IsOmittable is true, this will point to the unmarshaler function that supports omittability
 	IsContext                bool        // Is the Marshaler/Unmarshaller the context version; applies to either the method or interface variety.
 	PointersInUnmarshalInput bool        // Inverse values and pointers in return.
 	IsRoot                   bool        // Is the type a root level definition such as Query, Mutation or Subscription
@@ -362,18 +364,44 @@ func isIntf(t types.Type) bool {
 	return ok
 }
 
-func unwrapOmittable(t types.Type) (types.Type, bool) {
-	if t == nil {
-		return nil, false
+func (b *Binder) unwrapOmittable(
+	goType types.Type,
+	bindTarget types.Type,
+) (types.Type, *types.Func, bool) {
+	if bindTarget == nil {
+		return nil, nil, false
 	}
-	named, ok := t.(*types.Named)
+	named, ok := bindTarget.(*types.Named)
 	if !ok {
-		return t, false
+		return bindTarget, nil, false
 	}
-	if named.Origin().String() != "github.com/99designs/gqlgen/graphql.Omittable[T any]" {
-		return t, false
+	for _, ot := range b.cfg.OmittableTypes {
+		pkgName, typeName := code.PkgAndType(ot)
+		obj, err := b.FindObject(pkgName, "Unmarshal"+typeName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "unable to find Unmarshal function for Omittable type: %s.%s: %v\n", pkgName, typeName, err)
+			continue
+		}
+
+		t := code.Unalias(obj.Type())
+		fn, ok := obj.(*types.Func)
+		if !ok {
+			fmt.Fprintf(os.Stderr, "type for Omittable is not a function: %s.%s\n", pkgName, typeName)
+			continue
+		}
+
+		instantiated, err := b.InstantiateType(t, []types.Type{named})
+		if err == nil {
+			fmt.Printf("%s is an Omittable type\n", instantiated.String())
+		}
+
+		t.(*types.Signature).TypeParams()
+		fmt.Printf("%s\n", named.String())
+		if named.Origin().String() == t.(*types.Signature).Results().At(0).Type().(*types.Named).Origin().String() {
+			return named.TypeArgs().At(0), fn, true
+		}
 	}
-	return named.TypeArgs().At(0), true
+	return bindTarget, nil, false
 }
 
 func (b *Binder) TypeReference(
@@ -382,19 +410,6 @@ func (b *Binder) TypeReference(
 ) (ret *TypeReference, err error) {
 	if bindTarget != nil {
 		bindTarget = code.Unalias(bindTarget)
-	}
-	if innerType, ok := unwrapOmittable(bindTarget); ok {
-		if schemaType.NonNull {
-			return nil, fmt.Errorf("%s is wrapped with Omittable but non-null", schemaType.Name())
-		}
-
-		ref, err := b.TypeReference(schemaType, innerType)
-		if err != nil {
-			return nil, err
-		}
-
-		ref.IsOmittable = true
-		return ref, err
 	}
 
 	if !isValid(bindTarget) {
@@ -512,7 +527,12 @@ func (b *Binder) TypeReference(
 					ref.Marshaler = nil
 					ref.Unmarshaler = nil
 				} else {
-					continue
+					if newTarget, unmarshalFunc, isOmittable := b.unwrapOmittable(ref.GO, bindTarget); isOmittable {
+						ref.OmittableUnmarshaler = unmarshalFunc
+						ref.GO = newTarget
+					} else {
+						continue
+					}
 				}
 			}
 			ref.GO = bindTarget

--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -581,15 +581,25 @@ func (b *Binder) TypeReference(
 
 		if bindTarget != nil {
 			if err = code.CompatibleTypes(ref.GO, bindTarget); err != nil {
-				// if the bind type implements the
-				// graphql.ContextMarshaler/graphql.ContextUnmarshaler/graphql.Marshaler/graphql.Unmarshaler
-				// interface, we can use it
+				// Attempt to unwrap omittable types if the provided bindTarget is not compatible
+				// with the initial GO type. This allows users to specify their own omittable types.
 				if newTarget, unmarshalFunc, canError := b.unwrapOmittable(ref.GO, bindTarget); unmarshalFunc != nil {
+					ref, err := b.TypeReference(schemaType, newTarget)
+					if err != nil {
+						return nil, err
+					}
+
 					ref.IsOmittable = true
 					ref.OmittableUnmarshaler = unmarshalFunc
 					ref.OmittableUnmarshalerCanError = canError
-					bindTarget = newTarget
-				} else if hasMethod(bindTarget, "MarshalGQLContext") &&
+
+					return ref, nil
+				}
+
+				// if the bind type implements the
+				// graphql.ContextMarshaler/graphql.ContextUnmarshaler/graphql.Marshaler/graphql.Unmarshaler
+				// interface, we can use it
+				if hasMethod(bindTarget, "MarshalGQLContext") &&
 					hasMethod(bindTarget, "UnmarshalGQLContext") {
 					ref.IsContext = true
 					ref.IsMarshaler = true

--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -584,7 +584,12 @@ func (b *Binder) TypeReference(
 				// if the bind type implements the
 				// graphql.ContextMarshaler/graphql.ContextUnmarshaler/graphql.Marshaler/graphql.Unmarshaler
 				// interface, we can use it
-				if hasMethod(bindTarget, "MarshalGQLContext") &&
+				if newTarget, unmarshalFunc, canError := b.unwrapOmittable(ref.GO, bindTarget); unmarshalFunc != nil {
+					ref.IsOmittable = true
+					ref.OmittableUnmarshaler = unmarshalFunc
+					ref.OmittableUnmarshalerCanError = canError
+					bindTarget = newTarget
+				} else if hasMethod(bindTarget, "MarshalGQLContext") &&
 					hasMethod(bindTarget, "UnmarshalGQLContext") {
 					ref.IsContext = true
 					ref.IsMarshaler = true
@@ -595,11 +600,6 @@ func (b *Binder) TypeReference(
 					ref.IsMarshaler = true
 					ref.Marshaler = nil
 					ref.Unmarshaler = nil
-				} else if newTarget, unmarshalFunc, canError := b.unwrapOmittable(ref.GO, bindTarget); unmarshalFunc != nil {
-					ref.IsOmittable = true
-					ref.OmittableUnmarshaler = unmarshalFunc
-					ref.OmittableUnmarshalerCanError = canError
-					bindTarget = newTarget
 				} else {
 					continue
 				}

--- a/codegen/config/binder_test.go
+++ b/codegen/config/binder_test.go
@@ -91,41 +91,6 @@ func TestOmittableBinding(t *testing.T) {
 		require.True(t, ta.IsOmittable)
 	})
 
-	t.Run("fail binding non-nullable string with Omittable[string]", func(t *testing.T) {
-		binder, schema := createBinder(Config{})
-
-		ot, err := binder.FindType("github.com/99designs/gqlgen/graphql", "Omittable")
-		require.NoError(t, err)
-
-		it, err := binder.InstantiateType(ot, []types.Type{types.Universe.Lookup("string").Type()})
-		require.NoError(t, err)
-
-		_, err = binder.TypeReference(
-			schema.Types["FooInput"].Fields.ForName("nonNullableString").Type,
-			it,
-		)
-		require.Error(t, err)
-	})
-
-	t.Run("fail binding non-nullable string with Omittable[*string]", func(t *testing.T) {
-		binder, schema := createBinder(Config{})
-
-		ot, err := binder.FindType("github.com/99designs/gqlgen/graphql", "Omittable")
-		require.NoError(t, err)
-
-		it, err := binder.InstantiateType(
-			ot,
-			[]types.Type{types.NewPointer(types.Universe.Lookup("string").Type())},
-		)
-		require.NoError(t, err)
-
-		_, err = binder.TypeReference(
-			schema.Types["FooInput"].Fields.ForName("nonNullableString").Type,
-			it,
-		)
-		require.Error(t, err)
-	})
-
 	t.Run("bind nullable object with Omittable[T]", func(t *testing.T) {
 		binder, schema := createBinder(Config{})
 
@@ -176,6 +141,7 @@ func TestOmittableBinding(t *testing.T) {
 }
 
 func createBinder(cfg Config) (*Binder, *ast.Schema) {
+	cfg.OmittableType = StringList{"github.com/99designs/gqlgen/graphql.OmittableOf"}
 	cfg.Models = TypeMap{
 		"Message": TypeMapEntry{
 			Model: []string{

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -31,7 +31,7 @@ type Config struct {
 	Resolver                             ResolverConfig             `yaml:"resolver,omitempty"`
 	AutoBind                             []string                   `yaml:"autobind"`
 	AutobindGetterHaser                  bool                       `yaml:"autobind_getter_haser,omitempty"`
-	OmittableTypes                       StringList                 `yaml:"omittable_types,omitempty"`
+	OmittableType                        StringList                 `yaml:"omittable_type,omitempty"`
 	Models                               TypeMap                    `yaml:"models,omitempty"`
 	StructTag                            string                     `yaml:"struct_tag,omitempty"`
 	EmbeddedStructsPrefix                string                     `yaml:"embedded_structs_prefix,omitempty"`

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -135,8 +135,6 @@ const (
 	DirArgOverrideTags        = "overrideTags"
 	DirArgDescription         = "description"
 	DirArgOmittable           = "omittable"
-	DirArgOmittableType       = "omittableType"
-	DirArgOmittableTypes      = "omittableTypes"
 	DirArgAutoBindGetterHaser = "autoBindGetterHaser"
 	DirArgBatch               = "batch"
 )
@@ -509,21 +507,6 @@ func (c *Config) injectGoFieldDirectives(schemaType *ast.Definition) error {
 			}
 		}
 
-		if ma := fd.Arguments.ForName(DirArgOmittableType); ma != nil {
-			if ot, err := ma.Value.Value(nil); err == nil {
-				typeMapFieldEntry.OmittableType = append(typeMapFieldEntry.OmittableType,
-					ot.(string))
-			}
-		}
-
-		if ma := fd.Arguments.ForName(DirArgOmittableTypes); ma != nil {
-			if ots, err := ma.Value.Value(nil); err == nil {
-				for _, ot := range ots.([]any) {
-					c.Models.Add(schemaType.Name, ot.(string))
-				}
-			}
-		}
-
 		if arg := fd.Arguments.ForName(DirArgAutoBindGetterHaser); arg != nil {
 			if k, err := arg.Value.Value(nil); err == nil {
 				val := k.(bool)
@@ -664,7 +647,6 @@ func (c *Config) injectGoEnumDirectives(schemaType *ast.Definition) {
 
 type TypeMapEntry struct {
 	Model         StringList              `yaml:"model,omitempty"`
-	OmittableType StringList              `yaml:"omittableType,omitempty"`
 	ForceGenerate bool                    `yaml:"forceGenerate,omitempty"`
 	Fields        map[string]TypeMapField `yaml:"fields,omitempty"`
 	EnumValues    map[string]EnumValue    `yaml:"enum_values,omitempty"`
@@ -693,12 +675,11 @@ type TypeMapField struct {
 	// restrictions.
 	Type string `yaml:"type"`
 
-	Resolver            bool       `yaml:"resolver"`
-	FieldName           string     `yaml:"fieldName"`
-	Omittable           *bool      `yaml:"omittable"`
-	OmittableType       StringList `yaml:"omittableType,omitempty"`
-	GeneratedMethod     string     `yaml:"-"`
-	AutoBindGetterHaser *bool      `yaml:"autoBindGetterHaser"`
+	Resolver            bool   `yaml:"resolver"`
+	FieldName           string `yaml:"fieldName"`
+	Omittable           *bool  `yaml:"omittable"`
+	GeneratedMethod     string `yaml:"-"`
+	AutoBindGetterHaser *bool  `yaml:"autoBindGetterHaser"`
 
 	// Batch enables batch resolver generation for this field.
 	// When true, a batch resolver method (e.g., PostsBatch) will be generated

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -172,6 +172,7 @@ func DefaultConfig() *Config {
 		SchemaFilename:                 StringList{"schema.graphql"},
 		Model:                          PackageConfig{Filename: "models_gen.go"},
 		Exec:                           ExecConfig{Filename: "generated.go"},
+		OmittableType:                  StringList{"github.com/99designs/gqlgen/graphql.OmittableOf"},
 		Directives:                     map[string]DirectiveConfig{},
 		Models:                         TypeMap{},
 		StructFieldsAlwaysPointers:     true,

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	Resolver                             ResolverConfig             `yaml:"resolver,omitempty"`
 	AutoBind                             []string                   `yaml:"autobind"`
 	AutobindGetterHaser                  bool                       `yaml:"autobind_getter_haser,omitempty"`
+	OmittableTypes                       StringList                 `yaml:"omittable_types,omitempty"`
 	Models                               TypeMap                    `yaml:"models,omitempty"`
 	StructTag                            string                     `yaml:"struct_tag,omitempty"`
 	EmbeddedStructsPrefix                string                     `yaml:"embedded_structs_prefix,omitempty"`
@@ -134,6 +135,8 @@ const (
 	DirArgOverrideTags        = "overrideTags"
 	DirArgDescription         = "description"
 	DirArgOmittable           = "omittable"
+	DirArgOmittableType       = "omittableType"
+	DirArgOmittableTypes      = "omittableTypes"
 	DirArgAutoBindGetterHaser = "autoBindGetterHaser"
 	DirArgBatch               = "batch"
 )
@@ -505,6 +508,21 @@ func (c *Config) injectGoFieldDirectives(schemaType *ast.Definition) error {
 			}
 		}
 
+		if ma := fd.Arguments.ForName(DirArgOmittableType); ma != nil {
+			if ot, err := ma.Value.Value(nil); err == nil {
+				typeMapFieldEntry.OmittableType = append(typeMapFieldEntry.OmittableType,
+					ot.(string))
+			}
+		}
+
+		if ma := fd.Arguments.ForName(DirArgOmittableTypes); ma != nil {
+			if ots, err := ma.Value.Value(nil); err == nil {
+				for _, ot := range ots.([]any) {
+					c.Models.Add(schemaType.Name, ot.(string))
+				}
+			}
+		}
+
 		if arg := fd.Arguments.ForName(DirArgAutoBindGetterHaser); arg != nil {
 			if k, err := arg.Value.Value(nil); err == nil {
 				val := k.(bool)
@@ -645,6 +663,7 @@ func (c *Config) injectGoEnumDirectives(schemaType *ast.Definition) {
 
 type TypeMapEntry struct {
 	Model         StringList              `yaml:"model,omitempty"`
+	OmittableType StringList              `yaml:"omittableType,omitempty"`
 	ForceGenerate bool                    `yaml:"forceGenerate,omitempty"`
 	Fields        map[string]TypeMapField `yaml:"fields,omitempty"`
 	EnumValues    map[string]EnumValue    `yaml:"enum_values,omitempty"`
@@ -673,11 +692,12 @@ type TypeMapField struct {
 	// restrictions.
 	Type string `yaml:"type"`
 
-	Resolver            bool   `yaml:"resolver"`
-	FieldName           string `yaml:"fieldName"`
-	Omittable           *bool  `yaml:"omittable"`
-	GeneratedMethod     string `yaml:"-"`
-	AutoBindGetterHaser *bool  `yaml:"autoBindGetterHaser"`
+	Resolver            bool       `yaml:"resolver"`
+	FieldName           string     `yaml:"fieldName"`
+	Omittable           *bool      `yaml:"omittable"`
+	OmittableType       StringList `yaml:"omittableType,omitempty"`
+	GeneratedMethod     string     `yaml:"-"`
+	AutoBindGetterHaser *bool      `yaml:"autoBindGetterHaser"`
 
 	// Batch enables batch resolver generation for this field.
 	// When true, a batch resolver method (e.g., PostsBatch) will be generated

--- a/codegen/field.go
+++ b/codegen/field.go
@@ -41,6 +41,29 @@ type Field struct {
 	Batch            bool   // Enable batch resolver for this field
 }
 
+func isFieldOmittable(field *ast.FieldDefinition) bool {
+	for _, dir := range field.Directives {
+		if dir.Name != "goField" {
+			continue
+		}
+		for _, arg := range dir.Arguments {
+			if arg.Name != "omittable" {
+				continue
+			}
+			v, err := arg.Value.Value(nil)
+			if err != nil {
+				continue
+			}
+			omittable, ok := v.(bool)
+			if !ok {
+				continue
+			}
+			return omittable
+		}
+	}
+	return false
+}
+
 func (b *builder) buildField(obj *Object, field *ast.FieldDefinition) (*Field, error) {
 	dirs, err := b.getDirectives(field.Directives)
 	if err != nil {
@@ -62,6 +85,10 @@ func (b *builder) buildField(obj *Object, field *ast.FieldDefinition) (*Field, e
 		if err != nil {
 			return nil, fmt.Errorf("default value %s is not valid: %w", field.Name, err)
 		}
+	}
+
+	if isFieldOmittable(field) && field.Type.NonNull {
+		return nil, fmt.Errorf("field %s.%s must be nullable if it is omittable", obj.Name, field.Name)
 	}
 
 	for _, arg := range field.Arguments {

--- a/codegen/input.gotpl
+++ b/codegen/input.gotpl
@@ -63,7 +63,7 @@
 							}
 						{{- else }}
 							{{- if $field.TypeReference.IsOmittable }}
-								{{ $lhs }} = graphql.OmittableOf(data)
+								{{ $lhs }} = {{ $field.TypeReference.OmittableUnmarshaler | call }}(data)
 							{{- else }}
 								{{ $lhs }} = data
 							{{- end }}
@@ -72,7 +72,7 @@
 						{{- if not $field.IsResolver }}
 						} else if tmp == nil {
 							{{- if $field.TypeReference.IsOmittable }}
-								{{ $lhs }} = graphql.OmittableOf[{{ $field.TypeReference.GO | ref }}](nil)
+								{{ $lhs }} = {{ $field.TypeReference.OmittableUnmarshaler | call }}(nil)
 							{{- else }}
 								{{ $lhs }} = nil
 							{{- end }}
@@ -105,7 +105,7 @@
 							return {{$it}}, err
 						}
 						{{- if $field.TypeReference.IsOmittable }}
-							{{ $lhs }} = graphql.OmittableOf(data)
+							{{ $lhs }} = {{ $field.TypeReference.OmittableUnmarshaler | call }}(data)
 						{{- else }}
 							{{ $lhs }} = data
 						{{- end }}

--- a/codegen/input.gotpl
+++ b/codegen/input.gotpl
@@ -63,7 +63,15 @@
 							}
 						{{- else }}
 							{{- if $field.TypeReference.IsOmittable }}
-								{{ $lhs }} = {{ $field.TypeReference.OmittableUnmarshaler | call }}(data)
+								{{- if $field.TypeReference.OmittableUnmarshalerCanError }}
+									odata, err := {{ $field.TypeReference.OmittableUnmarshaler | call }}(data)
+									if err != nil {
+										return {{$it}}, graphql.ErrorOnPath(ctx, err)
+									}
+									{{ $lhs }} = odata
+								{{- else }}
+									{{ $lhs }} = {{ $field.TypeReference.OmittableUnmarshaler | call }}(data)
+								{{- end }}
 							{{- else }}
 								{{ $lhs }} = data
 							{{- end }}
@@ -72,7 +80,15 @@
 						{{- if not $field.IsResolver }}
 						} else if tmp == nil {
 							{{- if $field.TypeReference.IsOmittable }}
-								{{ $lhs }} = {{ $field.TypeReference.OmittableUnmarshaler | call }}(nil)
+								{{- if $field.TypeReference.OmittableUnmarshalerCanError }}
+									odata, err := {{ $field.TypeReference.OmittableUnmarshaler | call }}(data)
+									if err != nil {
+										return {{$it}}, graphql.ErrorOnPath(ctx, err)
+									}
+									{{ $lhs }} = odata
+								{{- else }}
+									{{ $lhs }} = {{ $field.TypeReference.OmittableUnmarshaler | call }}(data)
+								{{- end }}
 							{{- else }}
 								{{ $lhs }} = nil
 							{{- end }}
@@ -105,7 +121,15 @@
 							return {{$it}}, err
 						}
 						{{- if $field.TypeReference.IsOmittable }}
-							{{ $lhs }} = {{ $field.TypeReference.OmittableUnmarshaler | call }}(data)
+							{{- if $field.TypeReference.OmittableUnmarshalerCanError }}
+								odata, err := {{ $field.TypeReference.OmittableUnmarshaler | call }}(data)
+								if err != nil {
+									return {{$it}}, graphql.ErrorOnPath(ctx, err)
+								}
+								{{ $lhs }} = odata
+							{{- else }}
+								{{ $lhs }} = {{ $field.TypeReference.OmittableUnmarshaler | call }}(data)
+							{{- end }}
 						{{- else }}
 							{{ $lhs }} = data
 						{{- end }}

--- a/gqlgen.schema.json
+++ b/gqlgen.schema.json
@@ -124,6 +124,11 @@
       "type": "boolean",
       "default": false
     },
+    "omittable_type": {
+      "type": "array",
+      "description": "Custom omittable type definitions to use instead of the default github.com/99designs/gqlgen/graphql.Omittable.",
+      "items": { "type": "string" }
+    },
     "models": {
       "description": "Type mapping between the GraphQL and go type systems",
       "type": "object",

--- a/graphql/omittable.go
+++ b/graphql/omittable.go
@@ -75,6 +75,14 @@ func (o *Omittable[T]) UnmarshalJSON(bytes []byte) error {
 }
 
 func (o Omittable[T]) MarshalGQL(w io.Writer) {
+	_ = o.MarshalGQLContext(context.Background(), w)
+}
+
+func (o *Omittable[T]) UnmarshalGQL(v any) error {
+	return o.UnmarshalGQLContext(context.Background(), v)
+}
+
+func (o Omittable[T]) MarshalGQLContext(ctx context.Context, w io.Writer) error {
 	var value any = o.value
 	if !o.set {
 		var zero T
@@ -82,68 +90,39 @@ func (o Omittable[T]) MarshalGQL(w io.Writer) {
 	}
 
 	switch marshaler := value.(type) {
+	case ContextMarshaler:
+		if err := marshaler.MarshalGQLContext(ctx, w); err != nil {
+			return err
+		}
 	case Marshaler:
 		marshaler.MarshalGQL(w)
-	case ContextMarshaler:
-		_ = marshaler.MarshalGQLContext(context.Background(), w)
 	default:
-		b, _ := json.Marshal(value)
+		b, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
 		w.Write(b)
-	}
-}
-
-func (o *Omittable[T]) UnmarshalGQL(bytes []byte) error {
-	switch unmarshaler := any(o.value).(type) {
-	case Unmarshaler:
-		if err := unmarshaler.UnmarshalGQL(bytes); err != nil {
-			return err
-		}
-		o.set = true
-	case ContextUnmarshaler:
-		if err := unmarshaler.UnmarshalGQLContext(context.Background(), bytes); err != nil {
-			return err
-		}
-		o.set = true
-	default:
-		if err := json.Unmarshal(bytes, &o.value); err != nil {
-			return err
-		}
-		o.set = true
 	}
 	return nil
 }
 
-func (o Omittable[T]) MarshalGQLContext(ctx context.Context, w io.Writer) {
-	var value any = o.value
-	if !o.set {
-		var zero T
-		value = zero
-	}
-
-	switch marshaler := value.(type) {
-	case ContextMarshaler:
-		_ = marshaler.MarshalGQLContext(ctx, w)
-	case Marshaler:
-		marshaler.MarshalGQL(w)
-	default:
-		b, _ := json.Marshal(value)
-		w.Write(b)
-	}
-}
-
-func (o *Omittable[T]) UnmarshalGQLContext(ctx context.Context, bytes []byte) error {
+func (o *Omittable[T]) UnmarshalGQLContext(ctx context.Context, v any) error {
 	switch unmarshaler := any(o.value).(type) {
 	case ContextUnmarshaler:
-		if err := unmarshaler.UnmarshalGQLContext(ctx, bytes); err != nil {
+		if err := unmarshaler.UnmarshalGQLContext(ctx, v); err != nil {
 			return err
 		}
 		o.set = true
 	case Unmarshaler:
-		if err := unmarshaler.UnmarshalGQL(bytes); err != nil {
+		if err := unmarshaler.UnmarshalGQL(v); err != nil {
 			return err
 		}
 		o.set = true
 	default:
+		bytes, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
 		if err := json.Unmarshal(bytes, &o.value); err != nil {
 			return err
 		}

--- a/init-templates/gqlgen.yml.gotmpl
+++ b/init-templates/gqlgen.yml.gotmpl
@@ -159,6 +159,11 @@ call_argument_directives_with_null: true
 autobind:
 #  - "{{.}}/graph/model"
 
+# Optional: can be used to specify custom omittable type unmarshallers for input fields. For example, if you wanted to use
+# github.com/samber/mo.Option[T] for omittable fields instead of the built-in graphql.Omittable[T]
+# omittable_type:
+# - github.com/99designs/gqlgen/graphql.OmittableOf
+
 # This section declares type mapping between the GraphQL and go type systems
 #
 # The first line in each type will be used as defaults for resolver arguments and

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/99designs/gqlgen/internal/code"
 	"github.com/vektah/gqlparser/v2/ast"
 
 	"github.com/99designs/gqlgen/codegen/config"
@@ -494,20 +495,65 @@ func (m *Plugin) generateField(
 			)
 		}
 
-		omittableType, err := binder.FindTypeFromName(
-			"github.com/99designs/gqlgen/graphql.Omittable",
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		f.Type, err = binder.InstantiateType(omittableType, []types.Type{f.Type})
+		omittableType, err := buildOmittableType(cfg, binder, f.Type)
 		if err != nil {
 			return nil, fmt.Errorf("generror: field %v.%v: %w", schemaType.Name, field.Name, err)
 		}
+
+		f.Type = omittableType
 	}
 
 	return f, nil
+}
+
+func buildOmittableType(cfg *config.Config, binder *config.Binder, typ types.Type) (types.Type, error) {
+	for _, ot := range cfg.OmittableType {
+		pkgName, funName := code.PkgAndType(ot)
+
+		obj, err := binder.FindObject(pkgName, funName)
+		if err != nil {
+			continue
+		}
+
+		fn, ok := obj.(*types.Func)
+		if !ok {
+			continue
+		}
+
+		if otype, ok := tryInstantiateOmittableType(binder, fn, typ, typ); ok {
+			return otype, nil
+		}
+
+		// Try and instantiate without pointer type
+		ptrTyp, ok := typ.(*types.Pointer)
+		if !ok {
+			continue
+		}
+
+		if otype, ok := tryInstantiateOmittableType(binder, fn, ptrTyp.Elem(), typ); ok {
+			return otype, nil
+		}
+	}
+
+	return nil, fmt.Errorf("generror: no suitable omittable type found for type %v", typ)
+}
+
+func tryInstantiateOmittableType(binder *config.Binder, fn *types.Func, instType, argType types.Type) (types.Type, bool) {
+	ifn, err := binder.InstantiateType(fn.Type(), []types.Type{instType})
+	if err != nil {
+		return nil, false
+	}
+
+	isig := ifn.(*types.Signature)
+	if isig.Params().Len() != 1 {
+		return nil, false
+	}
+
+	if isig.Params().At(0).Type().String() != argType.String() {
+		return nil, false
+	}
+
+	return isig.Results().At(0).Type(), true
 }
 
 func getExtraFields(cfg *config.Config, modelName string) []*Field {


### PR DESCRIPTION
This is an attempt to expand the existing omittable behaviour to allow a user-configurable omittable types, a solution for https://github.com/99designs/gqlgen/issues/3227#issuecomment-4060287904

It adds a new piece of config to gqlgen.yml:
```yaml
omittable_type: <omittable constructor function reference>
```

By default, this will continue to use the [graphql.Omittable](https://github.com/99designs/gqlgen/blob/v0.17.88/graphql/omittable.go#L11), but it can be overridden with a reference to a function which constructs an omittable of a different type. For example, to use Samber's [Option](https://github.com/samber/mo/blob/v1.16.0/option.go#L70) type, the config would look like:
```yaml
omittable_type: github.com/samber/mo.Some
```

The signature of the referenced function must be one of:
```
func [T any](v T) U
func [T any](v T) (U, error)
func [T any](v *T) U
func [T any](v *T) (U, error)
```
Where `U` is the type of the field being bound to.

To allow for multiple omittable implementations, say for the sake of binding to a type in an external package that uses the [omitnull](https://github.com/seambiz/opt) package, you can specify multiple omittable constructor functions, and gqlgen will find the most appropriate one to use on a case by case basis:
```yaml:
omittable_type:
- github.com/samber/mo.Some
- github.com/seambiz/opt/omitnull.From
```

A more complete example can be found [here](https://github.com/deitrix/gqlgen-custom-omittable)

## Model Generation 

Model generation works in a similar fashion to the existing `model` configuration, where it will choose the first specified type in the list of `omittable_type`, and use that for all generated models. For instance, with the following configuration, the corresponding models would be generated:

config:
```yaml
omittable_type:
- github.com/samber/mo.Some
- github.com/seambiz/opt/omitnull.From
```

schema:
```graphql
input MyInput {
  myField: String @goField(omittable: true)
}
```

generated go model
```go
type MyModel struct {
  MyField mo.Option[*string] `json:"myField"`
}
```

`github.com/seambiz/opt/omitnull.From` would still be available to gqlgen for the purpose of automatically mapping non-generated, bound types, but it would not be used for modelgen. The existing `graphql.Omittable` type would be the default fallback type, if no configuration is provided, meaning all existing projects using gqlgen would continue to work without issue.

## To-do:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
 - [x] Update modelgen to generate fields with the first defined omittable type