### PR TITLE
fix: batch resolver being called multiple times for interface implementations

### DIFF
--- a/_examples/batchresolver/batchresolver_test.go
+++ b/_examples/batchresolver/batchresolver_test.go
@@ -775,6 +775,44 @@ func TestBatchResolver_InterfaceSingleType_CallCount(t *testing.T) {
 	)
 }
 
+func TestBatchResolver_InterfaceSingleType_MixedPointerAndValue_CallCount(t *testing.T) {
+	resolver := &Resolver{
+		animals: []Animal{
+			Cat{ID: "cat1"},
+			&Cat{ID: "cat2"},
+			Cat{ID: "cat3"},
+		},
+	}
+
+	c := newTestClient(resolver)
+	var resp struct {
+		Animals []struct {
+			ID        string `json:"id"`
+			BatchProp string `json:"batchProp"`
+		} `json:"animals"`
+	}
+
+	err := c.Post(`query { animals { id batchProp } }`, &resp)
+	require.NoError(t, err)
+	require.Len(t, resp.Animals, 3)
+	require.JSONEq(
+		t,
+		`{"animals":[
+			{"id":"cat1","batchProp":"catBatchProp:cat1"},
+			{"id":"cat2","batchProp":"catBatchProp:cat2"},
+			{"id":"cat3","batchProp":"catBatchProp:cat3"}
+		]}`,
+		marshalJSON(t, resp),
+	)
+
+	require.Equal(
+		t,
+		int32(1),
+		resolver.catBatchPropCalls.Load(),
+		"Cat.BatchProp should be called once for cats regardless of pointer/value form",
+	)
+}
+
 func TestBatchResolver_InterfaceMixedTypes_CallCount(t *testing.T) {
 	resolver := &Resolver{
 		animals: []Animal{
@@ -869,6 +907,44 @@ func TestBatchResolver_MultipleInterfaces_CallCount(t *testing.T) {
 		int32(1),
 		resolver.domesticCatBatchNameCalls.Load(),
 		"DomesticCat.BatchName should be called once for all domestic cats",
+	)
+}
+
+func TestBatchResolver_MultipleInterfaces_MixedPointerAndValue_CallCount(t *testing.T) {
+	resolver := &Resolver{
+		pets: []Pet{
+			DomesticCat{ID: "dc1", Name: "Tama"},
+			&DomesticCat{ID: "dc2", Name: "Mii"},
+			DomesticCat{ID: "dc3", Name: "Kuro"},
+		},
+	}
+
+	c := newTestClient(resolver)
+	var resp struct {
+		Pets []struct {
+			Name      string `json:"name"`
+			BatchName string `json:"batchName"`
+		} `json:"pets"`
+	}
+
+	err := c.Post(`query { pets { name batchName } }`, &resp)
+	require.NoError(t, err)
+	require.Len(t, resp.Pets, 3)
+	require.JSONEq(
+		t,
+		`{"pets":[
+			{"name":"Tama","batchName":"domesticCatBatchName:Tama"},
+			{"name":"Mii","batchName":"domesticCatBatchName:Mii"},
+			{"name":"Kuro","batchName":"domesticCatBatchName:Kuro"}
+		]}`,
+		marshalJSON(t, resp),
+	)
+
+	require.Equal(
+		t,
+		int32(1),
+		resolver.domesticCatBatchNameCalls.Load(),
+		"DomesticCat.BatchName should be called once regardless of pointer/value form",
 	)
 }
 

--- a/_examples/batchresolver/batchresolver_test.go
+++ b/_examples/batchresolver/batchresolver_test.go
@@ -736,6 +736,187 @@ func BenchmarkBatchResolver_SingleLevel(b *testing.B) {
 	})
 }
 
+func TestBatchResolver_InterfaceSingleType_CallCount(t *testing.T) {
+	resolver := &Resolver{
+		animals: []Animal{
+			&Cat{ID: "cat1"},
+			&Cat{ID: "cat2"},
+			&Cat{ID: "cat3"},
+		},
+	}
+
+	c := newTestClient(resolver)
+	var resp struct {
+		Animals []struct {
+			ID        string `json:"id"`
+			BatchProp string `json:"batchProp"`
+		} `json:"animals"`
+	}
+
+	err := c.Post(`query { animals { id batchProp } }`, &resp)
+	require.NoError(t, err)
+	require.Len(t, resp.Animals, 3)
+	require.JSONEq(
+		t,
+		`{"animals":[
+			{"id":"cat1","batchProp":"catBatchProp:cat1"},
+			{"id":"cat2","batchProp":"catBatchProp:cat2"},
+			{"id":"cat3","batchProp":"catBatchProp:cat3"}
+		]}`,
+		marshalJSON(t, resp),
+	)
+
+	// The batch resolver should be called ONCE with all 3 cats, not 3 times with 1 cat each.
+	require.Equal(
+		t,
+		int32(1),
+		resolver.catBatchPropCalls.Load(),
+		"Cat.BatchProp should be called once for all cats (batch), not once per cat",
+	)
+}
+
+func TestBatchResolver_InterfaceMixedTypes_CallCount(t *testing.T) {
+	resolver := &Resolver{
+		animals: []Animal{
+			&Dog{ID: "dog1"},
+			&Cat{ID: "cat1"},
+			&Dog{ID: "dog2"},
+			&Pig{ID: "pig1"},
+			&Cat{ID: "cat2"},
+			&Pig{ID: "pig2"},
+		},
+	}
+
+	c := newTestClient(resolver)
+	var resp struct {
+		Animals []struct {
+			ID        string `json:"id"`
+			BatchProp string `json:"batchProp"`
+		} `json:"animals"`
+	}
+
+	err := c.Post(`query { animals { id batchProp } }`, &resp)
+	require.NoError(t, err)
+	require.Len(t, resp.Animals, 6)
+
+	// Verify data correctness
+	require.Equal(t, "dog1", resp.Animals[0].ID)
+	require.Equal(t, "dogBatchProp:dog1", resp.Animals[0].BatchProp)
+	require.Equal(t, "cat1", resp.Animals[1].ID)
+	require.Equal(t, "catBatchProp:cat1", resp.Animals[1].BatchProp)
+	require.Equal(t, "dog2", resp.Animals[2].ID)
+	require.Equal(t, "dogBatchProp:dog2", resp.Animals[2].BatchProp)
+	require.Equal(t, "pig1", resp.Animals[3].ID)
+	require.Equal(t, "pigBatchProp:pig1", resp.Animals[3].BatchProp)
+	require.Equal(t, "cat2", resp.Animals[4].ID)
+	require.Equal(t, "catBatchProp:cat2", resp.Animals[4].BatchProp)
+	require.Equal(t, "pig2", resp.Animals[5].ID)
+	require.Equal(t, "pigBatchProp:pig2", resp.Animals[5].BatchProp)
+
+	// Each concrete type's batch resolver should be called exactly once.
+	require.Equal(
+		t,
+		int32(1),
+		resolver.dogBatchPropCalls.Load(),
+		"Dog.BatchProp should be called once for all dogs",
+	)
+	require.Equal(
+		t,
+		int32(1),
+		resolver.catBatchPropCalls.Load(),
+		"Cat.BatchProp should be called once for all cats",
+	)
+	require.Equal(
+		t,
+		int32(1),
+		resolver.pigBatchPropCalls.Load(),
+		"Pig.BatchProp should be called once for all pigs",
+	)
+}
+
+func TestBatchResolver_MultipleInterfaces_CallCount(t *testing.T) {
+	resolver := &Resolver{
+		pets: []Pet{
+			&DomesticCat{ID: "dc1", Name: "Tama"},
+			&DomesticCat{ID: "dc2", Name: "Mii"},
+			&DomesticCat{ID: "dc3", Name: "Kuro"},
+		},
+	}
+
+	c := newTestClient(resolver)
+	var resp struct {
+		Pets []struct {
+			Name      string `json:"name"`
+			BatchName string `json:"batchName"`
+		} `json:"pets"`
+	}
+
+	err := c.Post(`query { pets { name batchName } }`, &resp)
+	require.NoError(t, err)
+	require.Len(t, resp.Pets, 3)
+	require.JSONEq(
+		t,
+		`{"pets":[
+			{"name":"Tama","batchName":"domesticCatBatchName:Tama"},
+			{"name":"Mii","batchName":"domesticCatBatchName:Mii"},
+			{"name":"Kuro","batchName":"domesticCatBatchName:Kuro"}
+		]}`,
+		marshalJSON(t, resp),
+	)
+
+	require.Equal(
+		t,
+		int32(1),
+		resolver.domesticCatBatchNameCalls.Load(),
+		"DomesticCat.BatchName should be called once for all domestic cats",
+	)
+}
+
+func TestBatchResolver_InterfaceMixed_WithMultipleInterfaces_CallCount(t *testing.T) {
+	resolver := &Resolver{
+		animals: []Animal{
+			&Cat{ID: "cat1"},
+			&DomesticCat{ID: "dc1", Name: "Tama"},
+			&Cat{ID: "cat2"},
+			&DomesticCat{ID: "dc2", Name: "Mii"},
+		},
+	}
+
+	c := newTestClient(resolver)
+	var resp struct {
+		Animals []struct {
+			ID        string `json:"id"`
+			BatchProp string `json:"batchProp"`
+		} `json:"animals"`
+	}
+
+	err := c.Post(`query { animals { id batchProp } }`, &resp)
+	require.NoError(t, err)
+	require.Len(t, resp.Animals, 4)
+
+	require.Equal(t, "cat1", resp.Animals[0].ID)
+	require.Equal(t, "catBatchProp:cat1", resp.Animals[0].BatchProp)
+	require.Equal(t, "dc1", resp.Animals[1].ID)
+	require.Equal(t, "domesticCatBatchProp:dc1", resp.Animals[1].BatchProp)
+	require.Equal(t, "cat2", resp.Animals[2].ID)
+	require.Equal(t, "catBatchProp:cat2", resp.Animals[2].BatchProp)
+	require.Equal(t, "dc2", resp.Animals[3].ID)
+	require.Equal(t, "domesticCatBatchProp:dc2", resp.Animals[3].BatchProp)
+
+	require.Equal(
+		t,
+		int32(1),
+		resolver.catBatchPropCalls.Load(),
+		"Cat.BatchProp should be called once for all cats",
+	)
+	require.Equal(
+		t,
+		int32(1),
+		resolver.domesticCatBatchPropCalls.Load(),
+		"DomesticCat.BatchProp should be called once for all domestic cats",
+	)
+}
+
 func BenchmarkBatchResolver_Nested(b *testing.B) {
 	const n = 100
 	users := make([]*User, n)

--- a/_examples/batchresolver/generated.go
+++ b/_examples/batchresolver/generated.go
@@ -27,6 +27,10 @@ func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 type ResolverRoot interface {
+	Cat() CatResolver
+	Dog() DogResolver
+	DomesticCat() DomesticCatResolver
+	Pig() PigResolver
 	Profile() ProfileResolver
 	Query() QueryResolver
 	User() UserResolver
@@ -36,8 +40,30 @@ type DirectiveRoot struct {
 }
 
 type ComplexityRoot struct {
+	Cat struct {
+		BatchProp func(childComplexity int) int
+		ID        func(childComplexity int) int
+	}
+
+	Dog struct {
+		BatchProp func(childComplexity int) int
+		ID        func(childComplexity int) int
+	}
+
+	DomesticCat struct {
+		BatchName func(childComplexity int) int
+		BatchProp func(childComplexity int) int
+		ID        func(childComplexity int) int
+		Name      func(childComplexity int) int
+	}
+
 	Image struct {
 		URL func(childComplexity int) int
+	}
+
+	Pig struct {
+		BatchProp func(childComplexity int) int
+		ID        func(childComplexity int) int
 	}
 
 	Profile struct {
@@ -57,7 +83,9 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		Users func(childComplexity int) int
+		Animals func(childComplexity int) int
+		Pets    func(childComplexity int) int
+		Users   func(childComplexity int) int
 	}
 
 	User struct {
@@ -80,12 +108,28 @@ type ComplexityRoot struct {
 	}
 }
 
+type CatResolver interface {
+	BatchProp(ctx context.Context, objs []*Cat) ([]string, error)
+}
+type DogResolver interface {
+	BatchProp(ctx context.Context, objs []*Dog) ([]string, error)
+}
+type DomesticCatResolver interface {
+	BatchProp(ctx context.Context, objs []*DomesticCat) ([]string, error)
+
+	BatchName(ctx context.Context, objs []*DomesticCat) ([]string, error)
+}
+type PigResolver interface {
+	BatchProp(ctx context.Context, objs []*Pig) ([]string, error)
+}
 type ProfileResolver interface {
 	CoverBatch(ctx context.Context, objs []*Profile) ([]*Image, error)
 	CoverNonBatch(ctx context.Context, obj *Profile) (*Image, error)
 }
 type QueryResolver interface {
 	Users(ctx context.Context) ([]*User, error)
+	Animals(ctx context.Context) ([]Animal, error)
+	Pets(ctx context.Context) ([]Pet, error)
 }
 type UserResolver interface {
 	NullableBatch(ctx context.Context, objs []*User) ([]*Profile, error)
@@ -120,12 +164,76 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	_ = ec
 	switch typeName + "." + field {
 
+	case "Cat.batchProp":
+		if e.ComplexityRoot.Cat.BatchProp == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Cat.BatchProp(childComplexity), true
+	case "Cat.id":
+		if e.ComplexityRoot.Cat.ID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Cat.ID(childComplexity), true
+
+	case "Dog.batchProp":
+		if e.ComplexityRoot.Dog.BatchProp == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Dog.BatchProp(childComplexity), true
+	case "Dog.id":
+		if e.ComplexityRoot.Dog.ID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Dog.ID(childComplexity), true
+
+	case "DomesticCat.batchName":
+		if e.ComplexityRoot.DomesticCat.BatchName == nil {
+			break
+		}
+
+		return e.ComplexityRoot.DomesticCat.BatchName(childComplexity), true
+	case "DomesticCat.batchProp":
+		if e.ComplexityRoot.DomesticCat.BatchProp == nil {
+			break
+		}
+
+		return e.ComplexityRoot.DomesticCat.BatchProp(childComplexity), true
+	case "DomesticCat.id":
+		if e.ComplexityRoot.DomesticCat.ID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.DomesticCat.ID(childComplexity), true
+	case "DomesticCat.name":
+		if e.ComplexityRoot.DomesticCat.Name == nil {
+			break
+		}
+
+		return e.ComplexityRoot.DomesticCat.Name(childComplexity), true
+
 	case "Image.url":
 		if e.ComplexityRoot.Image.URL == nil {
 			break
 		}
 
 		return e.ComplexityRoot.Image.URL(childComplexity), true
+
+	case "Pig.batchProp":
+		if e.ComplexityRoot.Pig.BatchProp == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Pig.BatchProp(childComplexity), true
+	case "Pig.id":
+		if e.ComplexityRoot.Pig.ID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Pig.ID(childComplexity), true
 
 	case "Profile.coverBatch":
 		if e.ComplexityRoot.Profile.CoverBatch == nil {
@@ -172,6 +280,19 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.ProfilesConnection.TotalCount(childComplexity), true
 
+	case "Query.animals":
+		if e.ComplexityRoot.Query.Animals == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Query.Animals(childComplexity), true
+
+	case "Query.pets":
+		if e.ComplexityRoot.Query.Pets == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Query.Pets(childComplexity), true
 	case "Query.users":
 		if e.ComplexityRoot.Query.Users == nil {
 			break
@@ -489,6 +610,378 @@ func (ec *executionContext) field___Type_fields_args(ctx context.Context, rawArg
 
 // region    **************************** field.gotpl *****************************
 
+func (ec *executionContext) _Cat_id(ctx context.Context, field graphql.CollectedField, obj *Cat) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Cat_id,
+		func(ctx context.Context) (any, error) {
+			return obj.ID, nil
+		},
+		nil,
+		ec.marshalNID2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Cat_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Cat",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Cat_batchProp(ctx context.Context, field graphql.CollectedField, obj *Cat) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Cat_batchProp,
+		func(ctx context.Context) (any, error) {
+			return ec.resolveBatch_Cat_batchProp(ctx, field, obj)
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Cat_batchProp(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Cat",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+func (ec *executionContext) resolveBatch_Cat_batchProp(ctx context.Context, field graphql.CollectedField, obj *Cat) (any, error) {
+	resolver := ec.Resolvers.Cat()
+	group := graphql.GetBatchParentGroup(ctx, "Cat")
+	if group != nil {
+		parents, ok := group.Parents.([]*Cat)
+		if ok {
+			idx, ok := graphql.BatchParentIndex(ctx)
+			if ok {
+				key := field.Alias
+				if key == "" {
+					key = field.Name
+				}
+				result := group.GetFieldResult(key, func() (any, error) {
+					return resolver.BatchProp(ctx, parents)
+				})
+				return graphql.ResolveBatchGroupResult[string](
+					ctx,
+					idx,
+					len(parents),
+					result,
+					"Cat.batchProp",
+					group.IndexMap,
+				)
+			}
+		}
+	}
+
+	results, err := resolver.BatchProp(ctx, []*Cat{obj})
+	return graphql.ResolveBatchSingleResult[string](
+		ctx,
+		results,
+		err,
+		"Cat.batchProp",
+	)
+}
+
+func (ec *executionContext) _Dog_id(ctx context.Context, field graphql.CollectedField, obj *Dog) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Dog_id,
+		func(ctx context.Context) (any, error) {
+			return obj.ID, nil
+		},
+		nil,
+		ec.marshalNID2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Dog_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Dog",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Dog_batchProp(ctx context.Context, field graphql.CollectedField, obj *Dog) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Dog_batchProp,
+		func(ctx context.Context) (any, error) {
+			return ec.resolveBatch_Dog_batchProp(ctx, field, obj)
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Dog_batchProp(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Dog",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+func (ec *executionContext) resolveBatch_Dog_batchProp(ctx context.Context, field graphql.CollectedField, obj *Dog) (any, error) {
+	resolver := ec.Resolvers.Dog()
+	group := graphql.GetBatchParentGroup(ctx, "Dog")
+	if group != nil {
+		parents, ok := group.Parents.([]*Dog)
+		if ok {
+			idx, ok := graphql.BatchParentIndex(ctx)
+			if ok {
+				key := field.Alias
+				if key == "" {
+					key = field.Name
+				}
+				result := group.GetFieldResult(key, func() (any, error) {
+					return resolver.BatchProp(ctx, parents)
+				})
+				return graphql.ResolveBatchGroupResult[string](
+					ctx,
+					idx,
+					len(parents),
+					result,
+					"Dog.batchProp",
+					group.IndexMap,
+				)
+			}
+		}
+	}
+
+	results, err := resolver.BatchProp(ctx, []*Dog{obj})
+	return graphql.ResolveBatchSingleResult[string](
+		ctx,
+		results,
+		err,
+		"Dog.batchProp",
+	)
+}
+
+func (ec *executionContext) _DomesticCat_id(ctx context.Context, field graphql.CollectedField, obj *DomesticCat) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_DomesticCat_id,
+		func(ctx context.Context) (any, error) {
+			return obj.ID, nil
+		},
+		nil,
+		ec.marshalNID2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_DomesticCat_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DomesticCat",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DomesticCat_batchProp(ctx context.Context, field graphql.CollectedField, obj *DomesticCat) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_DomesticCat_batchProp,
+		func(ctx context.Context) (any, error) {
+			return ec.resolveBatch_DomesticCat_batchProp(ctx, field, obj)
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_DomesticCat_batchProp(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DomesticCat",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+func (ec *executionContext) resolveBatch_DomesticCat_batchProp(ctx context.Context, field graphql.CollectedField, obj *DomesticCat) (any, error) {
+	resolver := ec.Resolvers.DomesticCat()
+	group := graphql.GetBatchParentGroup(ctx, "DomesticCat")
+	if group != nil {
+		parents, ok := group.Parents.([]*DomesticCat)
+		if ok {
+			idx, ok := graphql.BatchParentIndex(ctx)
+			if ok {
+				key := field.Alias
+				if key == "" {
+					key = field.Name
+				}
+				result := group.GetFieldResult(key, func() (any, error) {
+					return resolver.BatchProp(ctx, parents)
+				})
+				return graphql.ResolveBatchGroupResult[string](
+					ctx,
+					idx,
+					len(parents),
+					result,
+					"DomesticCat.batchProp",
+					group.IndexMap,
+				)
+			}
+		}
+	}
+
+	results, err := resolver.BatchProp(ctx, []*DomesticCat{obj})
+	return graphql.ResolveBatchSingleResult[string](
+		ctx,
+		results,
+		err,
+		"DomesticCat.batchProp",
+	)
+}
+
+func (ec *executionContext) _DomesticCat_name(ctx context.Context, field graphql.CollectedField, obj *DomesticCat) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_DomesticCat_name,
+		func(ctx context.Context) (any, error) {
+			return obj.Name, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_DomesticCat_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DomesticCat",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DomesticCat_batchName(ctx context.Context, field graphql.CollectedField, obj *DomesticCat) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_DomesticCat_batchName,
+		func(ctx context.Context) (any, error) {
+			return ec.resolveBatch_DomesticCat_batchName(ctx, field, obj)
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_DomesticCat_batchName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DomesticCat",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+func (ec *executionContext) resolveBatch_DomesticCat_batchName(ctx context.Context, field graphql.CollectedField, obj *DomesticCat) (any, error) {
+	resolver := ec.Resolvers.DomesticCat()
+	group := graphql.GetBatchParentGroup(ctx, "DomesticCat")
+	if group != nil {
+		parents, ok := group.Parents.([]*DomesticCat)
+		if ok {
+			idx, ok := graphql.BatchParentIndex(ctx)
+			if ok {
+				key := field.Alias
+				if key == "" {
+					key = field.Name
+				}
+				result := group.GetFieldResult(key, func() (any, error) {
+					return resolver.BatchName(ctx, parents)
+				})
+				return graphql.ResolveBatchGroupResult[string](
+					ctx,
+					idx,
+					len(parents),
+					result,
+					"DomesticCat.batchName",
+					group.IndexMap,
+				)
+			}
+		}
+	}
+
+	results, err := resolver.BatchName(ctx, []*DomesticCat{obj})
+	return graphql.ResolveBatchSingleResult[string](
+		ctx,
+		results,
+		err,
+		"DomesticCat.batchName",
+	)
+}
+
 func (ec *executionContext) _Image_url(ctx context.Context, field graphql.CollectedField, obj *Image) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -516,6 +1009,99 @@ func (ec *executionContext) fieldContext_Image_url(_ context.Context, field grap
 		},
 	}
 	return fc, nil
+}
+
+func (ec *executionContext) _Pig_id(ctx context.Context, field graphql.CollectedField, obj *Pig) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Pig_id,
+		func(ctx context.Context) (any, error) {
+			return obj.ID, nil
+		},
+		nil,
+		ec.marshalNID2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Pig_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Pig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Pig_batchProp(ctx context.Context, field graphql.CollectedField, obj *Pig) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Pig_batchProp,
+		func(ctx context.Context) (any, error) {
+			return ec.resolveBatch_Pig_batchProp(ctx, field, obj)
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Pig_batchProp(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Pig",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+func (ec *executionContext) resolveBatch_Pig_batchProp(ctx context.Context, field graphql.CollectedField, obj *Pig) (any, error) {
+	resolver := ec.Resolvers.Pig()
+	group := graphql.GetBatchParentGroup(ctx, "Pig")
+	if group != nil {
+		parents, ok := group.Parents.([]*Pig)
+		if ok {
+			idx, ok := graphql.BatchParentIndex(ctx)
+			if ok {
+				key := field.Alias
+				if key == "" {
+					key = field.Name
+				}
+				result := group.GetFieldResult(key, func() (any, error) {
+					return resolver.BatchProp(ctx, parents)
+				})
+				return graphql.ResolveBatchGroupResult[string](
+					ctx,
+					idx,
+					len(parents),
+					result,
+					"Pig.batchProp",
+					group.IndexMap,
+				)
+			}
+		}
+	}
+
+	results, err := resolver.BatchProp(ctx, []*Pig{obj})
+	return graphql.ResolveBatchSingleResult[string](
+		ctx,
+		results,
+		err,
+		"Pig.batchProp",
+	)
 }
 
 func (ec *executionContext) _Profile_id(ctx context.Context, field graphql.CollectedField, obj *Profile) (ret graphql.Marshaler) {
@@ -600,6 +1186,7 @@ func (ec *executionContext) resolveBatch_Profile_coverBatch(ctx context.Context,
 					len(parents),
 					result,
 					"Profile.coverBatch",
+					group.IndexMap,
 				)
 			}
 		}
@@ -840,6 +1427,64 @@ func (ec *executionContext) fieldContext_Query_users(_ context.Context, field gr
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_animals(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_animals,
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.Query().Animals(ctx)
+		},
+		nil,
+		ec.marshalNAnimal2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐAnimalᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_animals(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("FieldContext.Child cannot be called on type INTERFACE")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_pets(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_pets,
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.Query().Pets(ctx)
+		},
+		nil,
+		ec.marshalNPet2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐPetᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_pets(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("FieldContext.Child cannot be called on type INTERFACE")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -1005,6 +1650,7 @@ func (ec *executionContext) resolveBatch_User_nullableBatch(ctx context.Context,
 					len(parents),
 					result,
 					"User.nullableBatch",
+					group.IndexMap,
 				)
 			}
 		}
@@ -1125,6 +1771,7 @@ func (ec *executionContext) resolveBatch_User_nullableBatchWithArg(ctx context.C
 					len(parents),
 					result,
 					"User.nullableBatchWithArg",
+					group.IndexMap,
 				)
 			}
 		}
@@ -1245,6 +1892,7 @@ func (ec *executionContext) resolveBatch_User_nonNullableBatch(ctx context.Conte
 					len(parents),
 					result,
 					"User.nonNullableBatch",
+					group.IndexMap,
 				)
 			}
 		}
@@ -1353,6 +2001,7 @@ func (ec *executionContext) resolveBatch_User_directiveNullableBatch(ctx context
 					len(parents),
 					result,
 					"User.directiveNullableBatch",
+					group.IndexMap,
 				)
 			}
 		}
@@ -1473,6 +2122,7 @@ func (ec *executionContext) resolveBatch_User_directiveNullableBatchWithArg(ctx 
 					len(parents),
 					result,
 					"User.directiveNullableBatchWithArg",
+					group.IndexMap,
 				)
 			}
 		}
@@ -1593,6 +2243,7 @@ func (ec *executionContext) resolveBatch_User_directiveNonNullableBatch(ctx cont
 					len(parents),
 					result,
 					"User.directiveNonNullableBatch",
+					group.IndexMap,
 				)
 			}
 		}
@@ -1701,6 +2352,7 @@ func (ec *executionContext) resolveBatch_User_profileBatch(ctx context.Context, 
 					len(parents),
 					result,
 					"User.profileBatch",
+					group.IndexMap,
 				)
 			}
 		}
@@ -1807,6 +2459,7 @@ func (ec *executionContext) resolveBatch_User_profileConnectionBatch(ctx context
 					len(parents),
 					result,
 					"User.profileConnectionBatch",
+					group.IndexMap,
 				)
 			}
 		}
@@ -3306,9 +3959,336 @@ func (ec *executionContext) fieldContext___Type_isOneOf(_ context.Context, field
 
 // region    ************************** interface.gotpl ***************************
 
+func (ec *executionContext) _Animal(ctx context.Context, sel ast.SelectionSet, obj Animal) graphql.Marshaler {
+	switch obj := (obj).(type) {
+	case nil:
+		return graphql.Null
+	case DomesticCat:
+		return ec._DomesticCat(ctx, sel, &obj)
+	case *DomesticCat:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._DomesticCat(ctx, sel, obj)
+	case Pig:
+		return ec._Pig(ctx, sel, &obj)
+	case *Pig:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Pig(ctx, sel, obj)
+	case Dog:
+		return ec._Dog(ctx, sel, &obj)
+	case *Dog:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Dog(ctx, sel, obj)
+	case Cat:
+		return ec._Cat(ctx, sel, &obj)
+	case *Cat:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Cat(ctx, sel, obj)
+	default:
+		if typedObj, ok := obj.(graphql.Marshaler); ok {
+			return typedObj
+		} else {
+			panic(fmt.Errorf("unexpected type %T; non-generated variants of Animal must implement graphql.Marshaler", obj))
+		}
+	}
+}
+
+func (ec *executionContext) _Pet(ctx context.Context, sel ast.SelectionSet, obj Pet) graphql.Marshaler {
+	switch obj := (obj).(type) {
+	case nil:
+		return graphql.Null
+	case DomesticCat:
+		return ec._DomesticCat(ctx, sel, &obj)
+	case *DomesticCat:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._DomesticCat(ctx, sel, obj)
+	default:
+		if typedObj, ok := obj.(graphql.Marshaler); ok {
+			return typedObj
+		} else {
+			panic(fmt.Errorf("unexpected type %T; non-generated variants of Pet must implement graphql.Marshaler", obj))
+		}
+	}
+}
+
 // endregion ************************** interface.gotpl ***************************
 
 // region    **************************** object.gotpl ****************************
+
+var catImplementors = []string{"Cat", "Animal"}
+
+func (ec *executionContext) _Cat(ctx context.Context, sel ast.SelectionSet, obj *Cat) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, catImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Cat")
+		case "id":
+			out.Values[i] = ec._Cat_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "batchProp":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Cat_batchProp(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var dogImplementors = []string{"Dog", "Animal"}
+
+func (ec *executionContext) _Dog(ctx context.Context, sel ast.SelectionSet, obj *Dog) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, dogImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Dog")
+		case "id":
+			out.Values[i] = ec._Dog_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "batchProp":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Dog_batchProp(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var domesticCatImplementors = []string{"DomesticCat", "Animal", "Pet"}
+
+func (ec *executionContext) _DomesticCat(ctx context.Context, sel ast.SelectionSet, obj *DomesticCat) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, domesticCatImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DomesticCat")
+		case "id":
+			out.Values[i] = ec._DomesticCat_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "batchProp":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._DomesticCat_batchProp(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "name":
+			out.Values[i] = ec._DomesticCat_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "batchName":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._DomesticCat_batchName(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
 
 var imageImplementors = []string{"Image"}
 
@@ -3326,6 +4306,81 @@ func (ec *executionContext) _Image(ctx context.Context, sel ast.SelectionSet, ob
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var pigImplementors = []string{"Pig", "Animal"}
+
+func (ec *executionContext) _Pig(ctx context.Context, sel ast.SelectionSet, obj *Pig) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, pigImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Pig")
+		case "id":
+			out.Values[i] = ec._Pig_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "batchProp":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Pig_batchProp(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -3571,6 +4626,50 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_users(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "animals":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_animals(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "pets":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_pets(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -4523,6 +5622,70 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 
 // region    ***************************** type.gotpl *****************************
 
+func (ec *executionContext) marshalNAnimal2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐAnimal(ctx context.Context, sel ast.SelectionSet, v Animal) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Animal(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNAnimal2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐAnimalᚄ(ctx context.Context, sel ast.SelectionSet, v []Animal) graphql.Marshaler {
+	{
+		var batchItemsDomesticCat []*DomesticCat
+		batchIdxMapDomesticCat := map[int]int{}
+		var batchItemsPig []*Pig
+		batchIdxMapPig := map[int]int{}
+		var batchItemsDog []*Dog
+		batchIdxMapDog := map[int]int{}
+		var batchItemsCat []*Cat
+		batchIdxMapCat := map[int]int{}
+		for i, item := range v {
+			switch concrete := item.(type) {
+			case *DomesticCat:
+				batchIdxMapDomesticCat[i] = len(batchItemsDomesticCat)
+				batchItemsDomesticCat = append(batchItemsDomesticCat, concrete)
+			case *Pig:
+				batchIdxMapPig[i] = len(batchItemsPig)
+				batchItemsPig = append(batchItemsPig, concrete)
+			case *Dog:
+				batchIdxMapDog[i] = len(batchItemsDog)
+				batchItemsDog = append(batchItemsDog, concrete)
+			case *Cat:
+				batchIdxMapCat[i] = len(batchItemsCat)
+				batchItemsCat = append(batchItemsCat, concrete)
+			}
+		}
+		if len(batchItemsDomesticCat) > 0 {
+			ctx = graphql.WithBatchParents(ctx, "DomesticCat", batchItemsDomesticCat, batchIdxMapDomesticCat)
+		}
+		if len(batchItemsPig) > 0 {
+			ctx = graphql.WithBatchParents(ctx, "Pig", batchItemsPig, batchIdxMapPig)
+		}
+		if len(batchItemsDog) > 0 {
+			ctx = graphql.WithBatchParents(ctx, "Dog", batchItemsDog, batchIdxMapDog)
+		}
+		if len(batchItemsCat) > 0 {
+			ctx = graphql.WithBatchParents(ctx, "Cat", batchItemsCat, batchIdxMapCat)
+		}
+	}
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNAnimal2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐAnimal(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v any) (bool, error) {
 	res, err := graphql.UnmarshalBoolean(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -4571,6 +5734,46 @@ func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.Selecti
 	return res
 }
 
+func (ec *executionContext) marshalNPet2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐPet(ctx context.Context, sel ast.SelectionSet, v Pet) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Pet(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNPet2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐPetᚄ(ctx context.Context, sel ast.SelectionSet, v []Pet) graphql.Marshaler {
+	{
+		var batchItemsDomesticCat []*DomesticCat
+		batchIdxMapDomesticCat := map[int]int{}
+		for i, item := range v {
+			switch concrete := item.(type) {
+			case *DomesticCat:
+				batchIdxMapDomesticCat[i] = len(batchItemsDomesticCat)
+				batchItemsDomesticCat = append(batchItemsDomesticCat, concrete)
+			}
+		}
+		if len(batchItemsDomesticCat) > 0 {
+			ctx = graphql.WithBatchParents(ctx, "DomesticCat", batchItemsDomesticCat, batchIdxMapDomesticCat)
+		}
+	}
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNPet2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐPet(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) marshalNProfile2githubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfile(ctx context.Context, sel ast.SelectionSet, v Profile) graphql.Marshaler {
 	return ec._Profile(ctx, sel, &v)
 }
@@ -4586,7 +5789,7 @@ func (ec *executionContext) marshalNProfile2ᚖgithubᚗcomᚋ99designsᚋgqlgen
 }
 
 func (ec *executionContext) marshalNProfileEdge2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐProfileEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*ProfileEdge) graphql.Marshaler {
-	ctx = graphql.WithBatchParents(ctx, "ProfileEdge", v)
+	ctx = graphql.WithBatchParents(ctx, "ProfileEdge", v, nil)
 	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
 		fc := graphql.GetFieldContext(ctx)
 		fc.Result = &v[i]
@@ -4629,7 +5832,7 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 }
 
 func (ec *executionContext) marshalNUser2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋ_examplesᚋbatchresolverᚐUserᚄ(ctx context.Context, sel ast.SelectionSet, v []*User) graphql.Marshaler {
-	ctx = graphql.WithBatchParents(ctx, "User", v)
+	ctx = graphql.WithBatchParents(ctx, "User", v, nil)
 	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
 		fc := graphql.GetFieldContext(ctx)
 		fc.Result = &v[i]
@@ -4660,7 +5863,7 @@ func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlge
 }
 
 func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Directive) graphql.Marshaler {
-	ctx = graphql.WithBatchParents(ctx, "__Directive", v)
+	ctx = graphql.WithBatchParents(ctx, "__Directive", v, nil)
 	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
 		fc := graphql.GetFieldContext(ctx)
 		fc.Result = &v[i]
@@ -4736,7 +5939,7 @@ func (ec *executionContext) marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlg
 }
 
 func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
-	ctx = graphql.WithBatchParents(ctx, "__InputValue", v)
+	ctx = graphql.WithBatchParents(ctx, "__InputValue", v, nil)
 	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
 		fc := graphql.GetFieldContext(ctx)
 		fc.Result = &v[i]
@@ -4757,7 +5960,7 @@ func (ec *executionContext) marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋg
 }
 
 func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
-	ctx = graphql.WithBatchParents(ctx, "__Type", v)
+	ctx = graphql.WithBatchParents(ctx, "__Type", v, nil)
 	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
 		fc := graphql.GetFieldContext(ctx)
 		fc.Result = &v[i]
@@ -4872,7 +6075,7 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 	if v == nil {
 		return graphql.Null
 	}
-	ctx = graphql.WithBatchParents(ctx, "__EnumValue", v)
+	ctx = graphql.WithBatchParents(ctx, "__EnumValue", v, nil)
 	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
 		fc := graphql.GetFieldContext(ctx)
 		fc.Result = &v[i]
@@ -4892,7 +6095,7 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 	if v == nil {
 		return graphql.Null
 	}
-	ctx = graphql.WithBatchParents(ctx, "__Field", v)
+	ctx = graphql.WithBatchParents(ctx, "__Field", v, nil)
 	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
 		fc := graphql.GetFieldContext(ctx)
 		fc.Result = &v[i]
@@ -4912,7 +6115,7 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 	if v == nil {
 		return graphql.Null
 	}
-	ctx = graphql.WithBatchParents(ctx, "__InputValue", v)
+	ctx = graphql.WithBatchParents(ctx, "__InputValue", v, nil)
 	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
 		fc := graphql.GetFieldContext(ctx)
 		fc.Result = &v[i]
@@ -4939,7 +6142,7 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 	if v == nil {
 		return graphql.Null
 	}
-	ctx = graphql.WithBatchParents(ctx, "__Type", v)
+	ctx = graphql.WithBatchParents(ctx, "__Type", v, nil)
 	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
 		fc := graphql.GetFieldContext(ctx)
 		fc.Result = &v[i]

--- a/_examples/batchresolver/generated.go
+++ b/_examples/batchresolver/generated.go
@@ -5644,15 +5644,27 @@ func (ec *executionContext) marshalNAnimal2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 		batchIdxMapCat := map[int]int{}
 		for i, item := range v {
 			switch concrete := item.(type) {
+			case DomesticCat:
+				batchIdxMapDomesticCat[i] = len(batchItemsDomesticCat)
+				batchItemsDomesticCat = append(batchItemsDomesticCat, &concrete)
 			case *DomesticCat:
 				batchIdxMapDomesticCat[i] = len(batchItemsDomesticCat)
 				batchItemsDomesticCat = append(batchItemsDomesticCat, concrete)
+			case Pig:
+				batchIdxMapPig[i] = len(batchItemsPig)
+				batchItemsPig = append(batchItemsPig, &concrete)
 			case *Pig:
 				batchIdxMapPig[i] = len(batchItemsPig)
 				batchItemsPig = append(batchItemsPig, concrete)
+			case Dog:
+				batchIdxMapDog[i] = len(batchItemsDog)
+				batchItemsDog = append(batchItemsDog, &concrete)
 			case *Dog:
 				batchIdxMapDog[i] = len(batchItemsDog)
 				batchItemsDog = append(batchItemsDog, concrete)
+			case Cat:
+				batchIdxMapCat[i] = len(batchItemsCat)
+				batchItemsCat = append(batchItemsCat, &concrete)
 			case *Cat:
 				batchIdxMapCat[i] = len(batchItemsCat)
 				batchItemsCat = append(batchItemsCat, concrete)
@@ -5750,6 +5762,9 @@ func (ec *executionContext) marshalNPet2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋ_
 		batchIdxMapDomesticCat := map[int]int{}
 		for i, item := range v {
 			switch concrete := item.(type) {
+			case DomesticCat:
+				batchIdxMapDomesticCat[i] = len(batchItemsDomesticCat)
+				batchItemsDomesticCat = append(batchItemsDomesticCat, &concrete)
 			case *DomesticCat:
 				batchIdxMapDomesticCat[i] = len(batchItemsDomesticCat)
 				batchItemsDomesticCat = append(batchItemsDomesticCat, concrete)

--- a/_examples/batchresolver/models_gen.go
+++ b/_examples/batchresolver/models_gen.go
@@ -2,9 +2,63 @@
 
 package batchresolver
 
+type Animal interface {
+	IsAnimal()
+	GetID() string
+	GetBatchProp() string
+}
+
+type Pet interface {
+	IsPet()
+	GetName() string
+	GetBatchName() string
+}
+
+type Cat struct {
+	ID        string `json:"id"`
+	BatchProp string `json:"batchProp"`
+}
+
+func (Cat) IsAnimal()                 {}
+func (this Cat) GetID() string        { return this.ID }
+func (this Cat) GetBatchProp() string { return this.BatchProp }
+
+type Dog struct {
+	ID        string `json:"id"`
+	BatchProp string `json:"batchProp"`
+}
+
+func (Dog) IsAnimal()                 {}
+func (this Dog) GetID() string        { return this.ID }
+func (this Dog) GetBatchProp() string { return this.BatchProp }
+
+type DomesticCat struct {
+	ID        string `json:"id"`
+	BatchProp string `json:"batchProp"`
+	Name      string `json:"name"`
+	BatchName string `json:"batchName"`
+}
+
+func (DomesticCat) IsAnimal()                 {}
+func (this DomesticCat) GetID() string        { return this.ID }
+func (this DomesticCat) GetBatchProp() string { return this.BatchProp }
+
+func (DomesticCat) IsPet()                    {}
+func (this DomesticCat) GetName() string      { return this.Name }
+func (this DomesticCat) GetBatchName() string { return this.BatchName }
+
 type Image struct {
 	URL string `json:"url"`
 }
+
+type Pig struct {
+	ID        string `json:"id"`
+	BatchProp string `json:"batchProp"`
+}
+
+func (Pig) IsAnimal()                 {}
+func (this Pig) GetID() string        { return this.ID }
+func (this Pig) GetBatchProp() string { return this.BatchProp }
 
 type Profile struct {
 	ID            string `json:"id"`

--- a/_examples/batchresolver/resolver.go
+++ b/_examples/batchresolver/resolver.go
@@ -30,6 +30,17 @@ type Resolver struct {
 	coverNonBatchCalls             atomic.Int32
 	profileConnectionBatchCalls    atomic.Int32
 	profileConnectionNonBatchCalls atomic.Int32
+
+	// Animals for interface batch test
+	animals []Animal
+	pets    []Pet
+
+	// Call counters for interface batch resolvers
+	catBatchPropCalls         atomic.Int32
+	dogBatchPropCalls         atomic.Int32
+	pigBatchPropCalls         atomic.Int32
+	domesticCatBatchPropCalls atomic.Int32
+	domesticCatBatchNameCalls atomic.Int32
 }
 
 func (r *Resolver) userIndex(obj *User) int {

--- a/_examples/batchresolver/schema.graphql
+++ b/_examples/batchresolver/schema.graphql
@@ -7,6 +7,40 @@ directive @goField(
 
 type Query {
     users: [User!]!
+    animals: [Animal!]!
+    pets: [Pet!]!
+}
+
+interface Animal {
+    id: ID!
+    batchProp: String! @goField(batch: true)
+}
+
+interface Pet {
+    name: String!
+    batchName: String! @goField(batch: true)
+}
+
+type Dog implements Animal {
+    id: ID!
+    batchProp: String! @goField(batch: true)
+}
+
+type Cat implements Animal {
+    id: ID!
+    batchProp: String! @goField(batch: true)
+}
+
+type Pig implements Animal {
+    id: ID!
+    batchProp: String! @goField(batch: true)
+}
+
+type DomesticCat implements Animal & Pet {
+    id: ID!
+    batchProp: String! @goField(batch: true)
+    name: String!
+    batchName: String! @goField(batch: true)
 }
 
 type User {

--- a/_examples/batchresolver/schema.resolvers.go
+++ b/_examples/batchresolver/schema.resolvers.go
@@ -14,6 +14,56 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
+// BatchProp is the batch resolver for the batchProp field.
+func (r *catResolver) BatchProp(ctx context.Context, objs []*Cat) ([]string, error) {
+	r.catBatchPropCalls.Add(1)
+	results := make([]string, len(objs))
+	for i, obj := range objs {
+		results[i] = "catBatchProp:" + obj.ID
+	}
+	return results, nil
+}
+
+// BatchProp is the batch resolver for the batchProp field.
+func (r *dogResolver) BatchProp(ctx context.Context, objs []*Dog) ([]string, error) {
+	r.dogBatchPropCalls.Add(1)
+	results := make([]string, len(objs))
+	for i, obj := range objs {
+		results[i] = "dogBatchProp:" + obj.ID
+	}
+	return results, nil
+}
+
+// BatchProp is the batch resolver for the batchProp field.
+func (r *domesticCatResolver) BatchProp(ctx context.Context, objs []*DomesticCat) ([]string, error) {
+	r.domesticCatBatchPropCalls.Add(1)
+	results := make([]string, len(objs))
+	for i, obj := range objs {
+		results[i] = "domesticCatBatchProp:" + obj.ID
+	}
+	return results, nil
+}
+
+// BatchName is the batch resolver for the batchName field.
+func (r *domesticCatResolver) BatchName(ctx context.Context, objs []*DomesticCat) ([]string, error) {
+	r.domesticCatBatchNameCalls.Add(1)
+	results := make([]string, len(objs))
+	for i, obj := range objs {
+		results[i] = "domesticCatBatchName:" + obj.Name
+	}
+	return results, nil
+}
+
+// BatchProp is the batch resolver for the batchProp field.
+func (r *pigResolver) BatchProp(ctx context.Context, objs []*Pig) ([]string, error) {
+	r.pigBatchPropCalls.Add(1)
+	results := make([]string, len(objs))
+	for i, obj := range objs {
+		results[i] = "pigBatchProp:" + obj.ID
+	}
+	return results, nil
+}
+
 // CoverBatch is the batch resolver for the coverBatch field.
 func (r *profileResolver) CoverBatch(ctx context.Context, objs []*Profile) ([]*Image, error) {
 	r.coverBatchCalls.Add(1)
@@ -38,6 +88,22 @@ func (r *queryResolver) Users(ctx context.Context) ([]*User, error) {
 		return nil, errors.New("users not set")
 	}
 	return r.users, nil
+}
+
+// Animals is the resolver for the animals field.
+func (r *queryResolver) Animals(ctx context.Context) ([]Animal, error) {
+	if r.animals == nil {
+		return nil, errors.New("animals not set")
+	}
+	return r.animals, nil
+}
+
+// Pets is the resolver for the pets field.
+func (r *queryResolver) Pets(ctx context.Context) ([]Pet, error) {
+	if r.pets == nil {
+		return nil, errors.New("pets not set")
+	}
+	return r.pets, nil
 }
 
 // NullableBatch is the batch resolver for the nullableBatch field.
@@ -257,6 +323,18 @@ func (r *userResolver) ProfileConnectionNonBatch(ctx context.Context, obj *User)
 	}, nil
 }
 
+// Cat returns CatResolver implementation.
+func (r *Resolver) Cat() CatResolver { return &catResolver{r} }
+
+// Dog returns DogResolver implementation.
+func (r *Resolver) Dog() DogResolver { return &dogResolver{r} }
+
+// DomesticCat returns DomesticCatResolver implementation.
+func (r *Resolver) DomesticCat() DomesticCatResolver { return &domesticCatResolver{r} }
+
+// Pig returns PigResolver implementation.
+func (r *Resolver) Pig() PigResolver { return &pigResolver{r} }
+
 // Profile returns ProfileResolver implementation.
 func (r *Resolver) Profile() ProfileResolver { return &profileResolver{r} }
 
@@ -266,6 +344,10 @@ func (r *Resolver) Query() QueryResolver { return &queryResolver{r} }
 // User returns UserResolver implementation.
 func (r *Resolver) User() UserResolver { return &userResolver{r} }
 
+type catResolver struct{ *Resolver }
+type dogResolver struct{ *Resolver }
+type domesticCatResolver struct{ *Resolver }
+type pigResolver struct{ *Resolver }
 type profileResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
 type userResolver struct{ *Resolver }

--- a/codegen/field.gotpl
+++ b/codegen/field.gotpl
@@ -165,6 +165,7 @@ func (ec *executionContext) resolveBatch_{{$object.Name}}_{{$field.Name}}(ctx co
 					len(parents),
 					result,
 					{{ printf "%s.%s" $object.Name $field.Name | quote }},
+					group.IndexMap,
 				)
 			}
 		}

--- a/codegen/type.gotpl
+++ b/codegen/type.gotpl
@@ -130,7 +130,38 @@
 					}
 				{{- end }}
 				{{- if and $.HasBatchResolverFields (not $type.IsScalar) (eq $type.Elem.Definition.Kind "OBJECT") }}
-				ctx = graphql.WithBatchParents(ctx, {{ $type.Elem.Definition.Name | quote }}, v)
+				ctx = graphql.WithBatchParents(ctx, {{ $type.Elem.Definition.Name | quote }}, v, nil)
+				{{- end }}
+				{{- if and $.HasBatchResolverFields (not $type.IsScalar) (or (eq $type.Elem.Definition.Kind "INTERFACE") (eq $type.Elem.Definition.Kind "UNION")) }}
+				{{- $iface := index $.Interfaces $type.Elem.Definition.Name }}
+				{{- if $iface }}
+				{
+					{{- range $impl := $iface.Implementors }}
+					{{- if $impl.CanBeNil }}
+					var batchItems{{ $impl.Name }} []{{ $impl.Type | ref }}
+					batchIdxMap{{ $impl.Name }} := map[int]int{}
+					{{- end }}
+					{{- end }}
+					for i, item := range v {
+						switch concrete := item.(type) {
+						{{- range $impl := $iface.Implementors }}
+						{{- if $impl.CanBeNil }}
+						case {{ $impl.Type | ref }}:
+							batchIdxMap{{ $impl.Name }}[i] = len(batchItems{{ $impl.Name }})
+							batchItems{{ $impl.Name }} = append(batchItems{{ $impl.Name }}, concrete)
+						{{- end }}
+						{{- end }}
+						}
+					}
+					{{- range $impl := $iface.Implementors }}
+					{{- if $impl.CanBeNil }}
+					if len(batchItems{{ $impl.Name }}) > 0 {
+						ctx = graphql.WithBatchParents(ctx, {{ $impl.Name | quote }}, batchItems{{ $impl.Name }}, batchIdxMap{{ $impl.Name }})
+					}
+					{{- end }}
+					{{- end }}
+				}
+				{{- end }}
 				{{- end }}
 				{{- if not $type.IsScalar }}
 					ret := graphql.MarshalSliceConcurrently(ctx, len(v), {{ $.Config.Exec.WorkerLimit }}, {{ $.Config.OmitPanicHandler }}, func(ctx context.Context, i int) graphql.Marshaler {

--- a/codegen/type.gotpl
+++ b/codegen/type.gotpl
@@ -145,11 +145,15 @@
 					for i, item := range v {
 						switch concrete := item.(type) {
 						{{- range $impl := $iface.Implementors }}
-						{{- if $impl.CanBeNil }}
 						case {{ $impl.Type | ref }}:
 							batchIdxMap{{ $impl.Name }}[i] = len(batchItems{{ $impl.Name }})
+							{{- if $impl.CanBeNil }}
 							batchItems{{ $impl.Name }} = append(batchItems{{ $impl.Name }}, concrete)
-						{{- end }}
+							{{- else if $impl.TakeRef }}
+							batchItems{{ $impl.Name }} = append(batchItems{{ $impl.Name }}, &concrete)
+							{{- else }}
+							batchItems{{ $impl.Name }} = append(batchItems{{ $impl.Name }}, concrete)
+							{{- end }}
 						{{- end }}
 						}
 					}

--- a/graphql/batch.go
+++ b/graphql/batch.go
@@ -49,7 +49,10 @@ type BatchParentState struct {
 // BatchParentGroup represents a group of parent objects being resolved together.
 type BatchParentGroup struct {
 	Parents any
-	fields  sync.Map
+	// IndexMap is used to remap original array indices to group-specific indices,
+	// which is necessary when items are grouped by concrete type from an interface/union slice.
+	IndexMap map[int]int
+	fields   sync.Map
 }
 
 // BatchFieldResult represents the cached result of a batch field resolution.
@@ -61,7 +64,12 @@ type BatchFieldResult struct {
 }
 
 // WithBatchParents adds a batch parent group to the context.
-func WithBatchParents(ctx context.Context, typeName string, parents any) context.Context {
+func WithBatchParents(
+	ctx context.Context,
+	typeName string,
+	parents any,
+	indexMap map[int]int,
+) context.Context {
 	prev, _ := ctx.Value(batchContextKey{}).(*BatchParentState)
 	var groups map[string]*BatchParentGroup
 	if prev != nil {
@@ -70,7 +78,7 @@ func WithBatchParents(ctx context.Context, typeName string, parents any) context
 	} else {
 		groups = make(map[string]*BatchParentGroup, 1)
 	}
-	groups[typeName] = &BatchParentGroup{Parents: parents}
+	groups[typeName] = &BatchParentGroup{Parents: parents, IndexMap: indexMap}
 
 	return context.WithValue(ctx, batchContextKey{}, &BatchParentState{groups: groups})
 }
@@ -171,8 +179,23 @@ func ResolveBatchGroupResult[T any](
 	parentsLen int,
 	result *BatchFieldResult,
 	fieldName string,
+	indexMap map[int]int,
 ) (any, error) {
 	idxInt := int(idx)
+	resultIdx := idxInt
+	if indexMap != nil {
+		mapped, ok := indexMap[idxInt]
+		if !ok {
+			panic(
+				fmt.Sprintf(
+					"batch resolver %s: index %d not found in index map (this is a gqlgen bug)",
+					fieldName,
+					idx,
+				),
+			)
+		}
+		resultIdx = mapped
+	}
 	if result.Err != nil {
 		if batchErrs, ok := result.Err.(BatchErrors); ok {
 			results, ok := result.Results.([]T)
@@ -205,7 +228,7 @@ func ResolveBatchGroupResult[T any](
 				))
 				return nil, nil
 			}
-			if idxInt < 0 || idxInt >= len(results) {
+			if resultIdx < 0 || resultIdx >= len(results) {
 				AddBatchError(ctx, idxInt, fmt.Errorf(
 					"batch resolver %s could not resolve parent index %d",
 					fieldName,
@@ -213,11 +236,11 @@ func ResolveBatchGroupResult[T any](
 				))
 				return nil, nil
 			}
-			if err := errs[idxInt]; err != nil {
+			if err := errs[resultIdx]; err != nil {
 				AddBatchError(ctx, idxInt, err)
 				return nil, nil
 			}
-			return results[idxInt], nil
+			return results[resultIdx], nil
 		}
 		AddBatchError(ctx, idxInt, result.Err)
 		return nil, nil
@@ -242,7 +265,7 @@ func ResolveBatchGroupResult[T any](
 		))
 		return nil, nil
 	}
-	if idxInt < 0 || idxInt >= len(results) {
+	if resultIdx < 0 || resultIdx >= len(results) {
 		AddBatchError(ctx, idxInt, fmt.Errorf(
 			"batch resolver %s could not resolve parent index %d",
 			fieldName,
@@ -250,7 +273,7 @@ func ResolveBatchGroupResult[T any](
 		))
 		return nil, nil
 	}
-	return results[idxInt], nil
+	return results[resultIdx], nil
 }
 
 // ResolveBatchSingleResult handles batch resolver results for a single parent.

--- a/graphql/batch_test.go
+++ b/graphql/batch_test.go
@@ -60,6 +60,7 @@ func TestResolveBatchGroupResult_Success(t *testing.T) {
 		2,
 		result,
 		"User.profile",
+		nil,
 	)
 	require.NoError(t, err)
 	require.Equal(t, "b", got)
@@ -78,6 +79,7 @@ func TestResolveBatchGroupResult_ResultLenMismatch(t *testing.T) {
 		2,
 		result,
 		"User.profile",
+		nil,
 	)
 	require.NoError(t, err)
 	require.Nil(t, got)


### PR DESCRIPTION
## Summary

Closes #4081
I have resolved a bug in which the same batch resolver was being called multiple times for the same field when dealing with interface types.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
