### PR TITLE
Fix panic in transport on null body

### DIFF
--- a/graphql/handler/transport/http_form_urlencoded.go
+++ b/graphql/handler/transport/http_form_urlencoded.go
@@ -110,7 +110,7 @@ func (h UrlEncodedForm) parseJson(bodyString string) (*graphql.RawParams, error)
 	params := &graphql.RawParams{}
 	bodyReader := io.NopCloser(strings.NewReader(bodyString))
 
-	err := jsonDecode(bodyReader, &params)
+	err := jsonDecode(bodyReader, params)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/handler/transport/http_form_urlencoded_test.go
+++ b/graphql/handler/transport/http_form_urlencoded_test.go
@@ -56,6 +56,20 @@ func TestUrlEncodedForm(t *testing.T) {
 		assert.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 	})
 
+	t.Run("fail on no query", func(t *testing.T) {
+		resp := doRequest(
+			h,
+			http.MethodPost,
+			"/graphql",
+			`{"query": ""}`,
+			"",
+			"application/x-www-form-urlencoded",
+		)
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
+		assert.JSONEq(t, `{"errors":[{"message":"no operation provided","extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
+	})
+
 	t.Run("decode failure json", func(t *testing.T) {
 		resp := doRequest(
 			h,

--- a/graphql/handler/transport/http_form_urlencoded_test.go
+++ b/graphql/handler/transport/http_form_urlencoded_test.go
@@ -67,7 +67,11 @@ func TestUrlEncodedForm(t *testing.T) {
 		)
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-		assert.JSONEq(t, `{"errors":[{"message":"no operation provided","extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
+		assert.JSONEq(
+			t,
+			`{"errors":[{"message":"no operation provided","extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`,
+			resp.Body.String(),
+		)
 	})
 
 	t.Run("decode failure json", func(t *testing.T) {

--- a/graphql/handler/transport/http_get_test.go
+++ b/graphql/handler/transport/http_get_test.go
@@ -115,6 +115,24 @@ func TestGET(t *testing.T) {
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 	})
 
+	t.Run("no query params", func(t *testing.T) {
+		resp := doRequest(
+			h,
+			"GET",
+			`/graphql`,
+			"",
+			"",
+			"application/json",
+		)
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, resp.Body.String())
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
+		assert.JSONEq(
+			t,
+			`{"errors":[{"message":"no operation provided","extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`,
+			resp.Body.String(),
+		)
+	})
+
 	t.Run("decode failure", func(t *testing.T) {
 		resp := doRequest(
 			h,

--- a/graphql/handler/transport/http_multipart_mixed.go
+++ b/graphql/handler/transport/http_multipart_mixed.go
@@ -91,7 +91,7 @@ func (t MultipartMixed) Do(w http.ResponseWriter, r *http.Request, exec graphql.
 	}
 
 	bodyReader := io.NopCloser(strings.NewReader(bodyString))
-	if err = jsonDecode(bodyReader, &params); err != nil {
+	if err = jsonDecode(bodyReader, params); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		gqlErr := gqlerror.Errorf(
 			"json request body could not be decoded: %+v body:%s",

--- a/graphql/handler/transport/http_multipart_mixed_test.go
+++ b/graphql/handler/transport/http_multipart_mixed_test.go
@@ -52,7 +52,11 @@ func TestMultipartMixed(t *testing.T) {
 		resp := doRequest(handler, srv.URL, "null")
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-		assert.JSONEq(t, `{"errors":[{"message":"no operation provided","extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
+		assert.JSONEq(
+			t,
+			`{"errors":[{"message":"no operation provided","extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`,
+			resp.Body.String(),
+		)
 	})
 
 	t.Run("decode failure", func(t *testing.T) {

--- a/graphql/handler/transport/http_multipart_mixed_test.go
+++ b/graphql/handler/transport/http_multipart_mixed_test.go
@@ -47,6 +47,14 @@ func TestMultipartMixed(t *testing.T) {
 		return w
 	}
 
+	t.Run("fail on null body", func(t *testing.T) {
+		handler, srv := initializeWithServer()
+		resp := doRequest(handler, srv.URL, "null")
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
+		assert.JSONEq(t, `{"errors":[{"message":"no operation provided","extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
+	})
+
 	t.Run("decode failure", func(t *testing.T) {
 		handler, srv := initializeWithServer()
 		resp := doRequest(handler, srv.URL, "notjson")

--- a/graphql/handler/transport/http_post.go
+++ b/graphql/handler/transport/http_post.go
@@ -94,7 +94,7 @@ func (h POST) Do(w http.ResponseWriter, r *http.Request, exec graphql.GraphExecu
 	}
 
 	bodyReader := bytes.NewReader(bodyBytes)
-	if err := jsonDecode(bodyReader, &params); err != nil {
+	if err := jsonDecode(bodyReader, params); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		gqlErr := gqlerror.Errorf(
 			"json request body could not be decoded: %+v body:%s",

--- a/graphql/handler/transport/http_post_test.go
+++ b/graphql/handler/transport/http_post_test.go
@@ -114,7 +114,11 @@ func TestPOST(t *testing.T) {
 		)
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
 		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-		assert.JSONEq(t, `{"errors":[{"message":"no operation provided","extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
+		assert.JSONEq(
+			t,
+			`{"errors":[{"message":"no operation provided","extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`,
+			resp.Body.String(),
+		)
 	})
 
 	t.Run("decode failure", func(t *testing.T) {

--- a/graphql/handler/transport/http_post_test.go
+++ b/graphql/handler/transport/http_post_test.go
@@ -103,6 +103,20 @@ func TestPOST(t *testing.T) {
 		assert.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
 	})
 
+	t.Run("fail on null body", func(t *testing.T) {
+		resp := doRequest(
+			jsonH,
+			http.MethodPost,
+			"/graphql",
+			"null",
+			"",
+			"application/json",
+		)
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
+		assert.JSONEq(t, `{"errors":[{"message":"no operation provided","extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, resp.Body.String())
+	})
+
 	t.Run("decode failure", func(t *testing.T) {
 		resp := doRequest(
 			h,

--- a/graphql/handler/transport/sse.go
+++ b/graphql/handler/transport/sse.go
@@ -75,7 +75,7 @@ func (t SSE) Do(w http.ResponseWriter, r *http.Request, exec graphql.GraphExecut
 	}
 
 	bodyReader := io.NopCloser(strings.NewReader(bodyString))
-	if err = jsonDecode(bodyReader, &params); err != nil {
+	if err = jsonDecode(bodyReader, params); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		gqlErr := gqlerror.Errorf(
 			"json request body could not be decoded: %+v body:%s",

--- a/graphql/handler/transport/sse_test.go
+++ b/graphql/handler/transport/sse_test.go
@@ -78,6 +78,32 @@ func TestSSE(t *testing.T) {
 		)
 	})
 
+	t.Run("fail on null body", func(t *testing.T) {
+		h := initialize()
+		req := createHTTPTestRequest("null")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		assert.Equal(t, 200, w.Code, "Request return wrong status -> %d", w.Code)
+		assert.Equal(t, "text/event-stream", w.Header().Get("Content-Type"))
+
+		br := bufio.NewReader(w.Body)
+
+		assert.Equal(t, ":\n", readLine(br))
+		assert.Equal(t, "\n", readLine(br))
+		assert.Equal(t, "event: next\n", readLine(br))
+		assert.Equal(
+			t,
+			`data: {"errors":[{"message":"no operation provided","extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`+"\n",
+			readLine(br),
+		)
+		assert.Equal(t, "\n", readLine(br))
+		assert.Equal(t, "event: complete\n", readLine(br))
+		assert.Equal(t, "\n", readLine(br))
+
+		_, err := br.ReadByte()
+		assert.Equal(t, err, io.EOF)
+	})
+
 	t.Run("decode failure", func(t *testing.T) {
 		h := initialize()
 		req := createHTTPTestRequest("notjson")

--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -382,8 +382,8 @@ func (c *wsConnection) closeOnCancel(ctx context.Context) {
 
 func (c *wsConnection) subscribe(start time.Time, msg *message) {
 	ctx := graphql.StartOperationTrace(c.ctx)
-	var params *graphql.RawParams
-	if err := jsonDecode(bytes.NewReader(msg.payload), &params); err != nil {
+	params := &graphql.RawParams{}
+	if err := jsonDecode(bytes.NewReader(msg.payload), params); err != nil {
 		c.sendError(msg.id, &gqlerror.Error{Message: "invalid json"})
 		c.complete(msg.id)
 		return

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -732,7 +732,11 @@ func TestWebsocketGraphqltransportwsSubprotocol(t *testing.T) {
 		msg := readOp(c)
 		require.Equal(t, errorMsg, msg.Type, string(msg.Payload))
 		require.Equal(t, "test_1", msg.ID, string(msg.Payload))
-		require.JSONEq(t, `[{"message":"no operation provided","extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}]`, string(msg.Payload))
+		require.JSONEq(
+			t,
+			`[{"message":"no operation provided","extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}]`,
+			string(msg.Payload),
+		)
 		require.NoError(
 			t,
 			c.WriteJSON(&operationMessage{Type: graphqltransportwsCompleteMsg, ID: "test_1"}),

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -709,6 +709,40 @@ func TestWebsocketGraphqltransportwsSubprotocol(t *testing.T) {
 		require.Equal(t, "test_1", msg.ID)
 	})
 
+	t.Run("fail on null payload", func(t *testing.T) {
+		handler, srv := initialize(transport.Websocket{})
+		defer srv.Close()
+
+		c := wsConnectWithSubprotocol(srv.URL, graphqltransportwsSubprotocol)
+		defer c.Close()
+
+		require.NoError(
+			t,
+			c.WriteJSON(&operationMessage{Type: graphqltransportwsConnectionInitMsg}),
+		)
+		assert.Equal(t, graphqltransportwsConnectionAckMsg, readOp(c).Type)
+
+		require.NoError(t, c.WriteJSON(&operationMessage{
+			Type:    graphqltransportwsSubscribeMsg,
+			ID:      "test_1",
+			Payload: json.RawMessage(`null`),
+		}))
+
+		handler.SendNextSubscriptionMessage()
+		msg := readOp(c)
+		require.Equal(t, errorMsg, msg.Type, string(msg.Payload))
+		require.Equal(t, "test_1", msg.ID, string(msg.Payload))
+		require.JSONEq(t, `[{"message":"no operation provided","extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}]`, string(msg.Payload))
+		require.NoError(
+			t,
+			c.WriteJSON(&operationMessage{Type: graphqltransportwsCompleteMsg, ID: "test_1"}),
+		)
+
+		msg = readOp(c)
+		require.Equal(t, graphqltransportwsCompleteMsg, msg.Type)
+		require.Equal(t, "test_1", msg.ID)
+	})
+
 	t.Run("receives no graphql-ws keep alive messages", func(t *testing.T) {
 		_, srv := initialize(transport.Websocket{KeepAlivePingInterval: 5 * time.Millisecond})
 		defer srv.Close()


### PR DESCRIPTION
When a POST request was sent with the "null" value, the jsonDecode function succeeded but niled params. The calling code assumed params was non-nil, causing a panic.

Addressed all transports that were susceptible to "null" body.

Fixes https://github.com/99designs/gqlgen/issues/4114

Describe your PR and link to any relevant issues. 

I have:
 - [ x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
