### PR TITLE
Fix follow-schema layout not generating location directive middleware for directive-only files

### DIFF
--- a/codegen/data.go
+++ b/codegen/data.go
@@ -37,6 +37,11 @@ type Data struct {
 	SubscriptionRoot *Object
 	AugmentedSources []AugmentedSource
 	Plugins          []any
+
+	// SkipLocationDirectives suppresses generation of location directive middleware
+	// (_fieldMiddleware, _queryMiddleware, etc.) in per-schema builds.
+	// In follow-schema layout these are generated in the root file instead.
+	SkipLocationDirectives bool
 }
 
 func (d *Data) HasEmbeddableSources() bool {
@@ -116,6 +121,46 @@ func (d *Data) Directives() DirectiveList {
 		}
 	}
 	return res
+}
+
+// DirectiveArgs returns directive argument parser functions that are not generated
+// by any per-schema build. A directive's args are orphaned when its source file
+// contains no type definitions (Objects, Inputs, Interfaces, ReferencedTypes),
+// meaning no per-schema build exists for that file.
+func (d *Data) DirectiveArgs() map[string][]*FieldArgument {
+	sourcesWithTypes := map[string]bool{}
+	for _, o := range d.Objects {
+		if o.Position != nil && o.Position.Src != nil {
+			sourcesWithTypes[o.Position.Src.Name] = true
+		}
+	}
+	for _, in := range d.Inputs {
+		if in.Position != nil && in.Position.Src != nil {
+			sourcesWithTypes[in.Position.Src.Name] = true
+		}
+	}
+	for _, inf := range d.Interfaces {
+		if inf.Position != nil && inf.Position.Src != nil {
+			sourcesWithTypes[inf.Position.Src.Name] = true
+		}
+	}
+	for _, rt := range d.ReferencedTypes {
+		if rt.Definition != nil && rt.Definition.Position != nil && rt.Definition.Position.Src != nil {
+			sourcesWithTypes[rt.Definition.Position.Src.Name] = true
+		}
+	}
+
+	ret := map[string][]*FieldArgument{}
+	for _, directive := range d.AllDirectives {
+		if len(directive.Args) == 0 {
+			continue
+		}
+		if directive.Position != nil && directive.Position.Src != nil &&
+			!sourcesWithTypes[directive.Position.Src.Name] {
+			ret[directive.ArgsFunc()] = directive.Args
+		}
+	}
+	return ret
 }
 
 func BuildData(cfg *config.Config, plugins ...any) (*Data, error) {

--- a/codegen/data.go
+++ b/codegen/data.go
@@ -145,7 +145,9 @@ func (d *Data) DirectiveArgs() map[string][]*FieldArgument {
 		}
 	}
 	for _, rt := range d.ReferencedTypes {
-		if rt.Definition != nil && rt.Definition.Position != nil && rt.Definition.Position.Src != nil {
+		if rt.Definition != nil &&
+			rt.Definition.Position != nil &&
+			rt.Definition.Position.Src != nil {
 			sourcesWithTypes[rt.Definition.Position.Src.Name] = true
 		}
 	}

--- a/codegen/directives.gotpl
+++ b/codegen/directives.gotpl
@@ -86,7 +86,7 @@
 	return {{.CallPath}}({{.CallArgs}})
 {{end}}
 
-{{ if .Directives.LocationDirectives "QUERY" }}
+{{ if and (.Directives.LocationDirectives "QUERY") (not .SkipLocationDirectives) }}
 {{ if $useFunctionSyntaxForExecutionContext -}}
 func _queryMiddleware(ctx context.Context, ec *executionContext, obj *ast.OperationDefinition, next func(ctx context.Context) (any, error)) graphql.Marshaler {
 {{- else -}}
@@ -96,7 +96,7 @@ func (ec *executionContext) _queryMiddleware(ctx context.Context, obj *ast.Opera
 }
 {{ end }}
 
-{{ if .Directives.LocationDirectives "MUTATION" }}
+{{ if and (.Directives.LocationDirectives "MUTATION") (not .SkipLocationDirectives) }}
 {{ if $useFunctionSyntaxForExecutionContext -}}
 func _mutationMiddleware(ctx context.Context, ec *executionContext, obj *ast.OperationDefinition, next func(ctx context.Context) (any, error)) graphql.Marshaler {
 {{- else -}}
@@ -106,7 +106,7 @@ func (ec *executionContext) _mutationMiddleware(ctx context.Context, obj *ast.Op
 }
 {{ end }}
 
-{{ if .Directives.LocationDirectives "SUBSCRIPTION" }}
+{{ if and (.Directives.LocationDirectives "SUBSCRIPTION") (not .SkipLocationDirectives) }}
 {{ if $useFunctionSyntaxForExecutionContext -}}
 func _subscriptionMiddleware(ctx context.Context, ec *executionContext, obj *ast.OperationDefinition, next func(ctx context.Context) (any, error)) func(ctx context.Context) graphql.Marshaler {
 {{- else -}}
@@ -154,7 +154,7 @@ func (ec *executionContext) _subscriptionMiddleware(ctx context.Context, obj *as
 }
 {{ end }}
 
-{{ if .Directives.LocationDirectives "FIELD" }}
+{{ if and (.Directives.LocationDirectives "FIELD") (not .SkipLocationDirectives) }}
 	{{ if $useFunctionSyntaxForExecutionContext -}}
 	func _fieldMiddleware(ctx context.Context, ec *executionContext, obj any, next graphql.Resolver) graphql.Resolver {
 	{{- else -}}

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -121,26 +121,32 @@ func addBuild(filename string, p *ast.Position, data *Data, builds *map[string]*
 	}
 
 	(*builds)[filename] = &Data{
-		Config:           &buildConfig,
-		QueryRoot:        data.QueryRoot,
-		MutationRoot:     data.MutationRoot,
-		SubscriptionRoot: data.SubscriptionRoot,
-		AllDirectives:    data.AllDirectives,
+		Config:                 &buildConfig,
+		QueryRoot:              data.QueryRoot,
+		MutationRoot:           data.MutationRoot,
+		SubscriptionRoot:       data.SubscriptionRoot,
+		AllDirectives:          data.AllDirectives,
+		SkipLocationDirectives: true,
 	}
 }
 
 //go:embed root_.gotpl
 var rootTemplate string
 
+//go:embed directives.gotpl
+var directivesTemplate string
+
 // Root file contains top-level definitions that should not be duplicated across the generated
 // files for each schema file.
+// In follow-schema layout, location directive middleware (_fieldMiddleware etc.)
+// and orphan directive args are generated here instead of per-schema files.
 func generateRootFile(data *Data) error {
 	dir := data.Config.Exec.DirName
 	path := filepath.Join(dir, "root_.generated.go")
 
 	return templates.Render(templates.Options{
 		PackageName:     data.Config.Exec.Package,
-		Template:        rootTemplate,
+		Template:        rootTemplate + "\n" + directivesTemplate,
 		Filename:        path,
 		Data:            data,
 		RegionTags:      false,

--- a/codegen/root_.gotpl
+++ b/codegen/root_.gotpl
@@ -1,5 +1,6 @@
 {{/* Context object: codegen.Data */}}
 {{ reserveImport "context"  }}
+{{ reserveImport "errors"  }}
 {{ reserveImport "fmt"  }}
 {{ reserveImport "io"  }}
 {{ reserveImport "strconv"  }}
@@ -282,3 +283,106 @@ var sources = []*ast.Source{
 {{- end }}
 }
 var parsedSchema = gqlparser.MustLoadSchema(sources...)
+
+{{/* Generate args functions for directives whose source file has no type definitions.
+     In follow-schema layout, per-schema builds only exist for files with types,
+     so these directive args would otherwise never be generated. */}}
+{{ range $name, $args := .DirectiveArgs }}
+{{ if $useFunctionSyntaxForExecutionContext -}}
+func {{ $name }}(ctx context.Context, ec *executionContext, rawArgs map[string]any) (map[string]any, error) {
+{{- else -}}
+func (ec *executionContext) {{ $name }}(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+{{- end }}
+	var err error
+	args := map[string]any{}
+
+	{{- range $i, $arg := . }}
+		{{ if $arg.ImplDirectives }}
+			{{ if $useFunctionSyntaxForExecutionContext -}}
+			arg{{$i}}, err := {{ $name }}{{$arg.Name | go}}(ctx, ec, rawArgs)
+			{{- else -}}
+			arg{{$i}}, err := ec.{{ $name }}{{$arg.Name | go}}(ctx, rawArgs)
+			{{- end }}
+		{{- else -}}
+			{{ if $useFunctionSyntaxForExecutionContext -}}
+			arg{{$i}}, err := graphql.ProcessArgFieldWithEC(ctx, ec, rawArgs, {{$arg.Name|quote}}, {{ $arg.TypeReference.UnmarshalFunc }})
+			{{- else -}}
+			arg{{$i}}, err := graphql.ProcessArgField(ctx, rawArgs, {{$arg.Name|quote}}, ec.{{ $arg.TypeReference.UnmarshalFunc }})
+			{{- end }}
+		{{- end }}
+		if err != nil {
+			return nil, err
+		}
+		args[{{$arg.Name|quote}}] = arg{{$i}}
+	{{- end }}
+	return args, nil
+}
+
+	{{- range $i, $arg := . }}
+		{{ if not $arg.ImplDirectives -}}
+			{{- continue -}}
+		{{- end }}
+		{{ if $useFunctionSyntaxForExecutionContext -}}
+		func {{ $name }}{{$arg.Name | go}}(
+			ctx context.Context,
+			ec *executionContext,
+			rawArgs map[string]any,
+		) ({{ $arg.TypeReference.GO | ref}}, error) {
+		{{- else -}}
+		func (ec *executionContext) {{ $name }}{{$arg.Name | go}}(
+			ctx context.Context,
+			rawArgs map[string]any,
+		) ({{ $arg.TypeReference.GO | ref}}, error) {
+		{{- end }}
+			{{- if not .CallArgumentDirectivesWithNull}}
+				if _, ok := rawArgs[{{$arg.Name|quote}}]; !ok {
+					var zeroVal {{ $arg.TypeReference.GO | ref}}
+					return zeroVal, nil
+				}
+			{{end}}
+			ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField({{$arg.Name|quote}}))
+			{{- if $arg.ImplDirectives }}
+				directive0 := func(ctx context.Context) (any, error) {
+					tmp, ok := rawArgs[{{$arg.Name|quote}}]
+					if !ok {
+						var zeroVal {{ $arg.TypeReference.GO | ref}}
+						return zeroVal, nil
+					}
+					{{ if $useFunctionSyntaxForExecutionContext -}}
+					return {{ $arg.TypeReference.UnmarshalFunc }}(ctx, ec, tmp)
+					{{- else -}}
+					return ec.{{ $arg.TypeReference.UnmarshalFunc }}(ctx, tmp)
+					{{- end }}
+				}
+				{{ template "implDirectives" (dict "Field" $arg "UseFunctionSyntaxForExecutionContext" $useFunctionSyntaxForExecutionContext) }}
+				tmp, err := directive{{$arg.ImplDirectives|len}}(ctx)
+				if err != nil {
+					var zeroVal {{ $arg.TypeReference.GO | ref}}
+					return zeroVal, graphql.ErrorOnPath(ctx, err)
+				}
+				if data, ok := tmp.({{ $arg.TypeReference.GO | ref }}) ; ok {
+					return data, nil
+				{{- if $arg.TypeReference.IsNilable }}
+					} else if tmp == nil {
+						var zeroVal {{ $arg.TypeReference.GO | ref}}
+						return zeroVal, nil
+				{{- end }}
+				} else {
+					var zeroVal {{ $arg.TypeReference.GO | ref}}
+					return zeroVal, graphql.ErrorOnPath(ctx, fmt.Errorf(`unexpected type %T from directive, should be {{ $arg.TypeReference.GO }}`, tmp))
+				}
+			{{- else }}
+				if tmp, ok := rawArgs[{{$arg.Name|quote}}]; ok {
+					{{ if $useFunctionSyntaxForExecutionContext -}}
+					return {{ $arg.TypeReference.UnmarshalFunc }}(ctx, ec, tmp)
+					{{- else -}}
+					return ec.{{ $arg.TypeReference.UnmarshalFunc }}(ctx, tmp)
+					{{- end }}
+				}
+
+				var zeroVal {{ $arg.TypeReference.GO | ref}}
+				return zeroVal, nil
+			{{- end }}
+		}
+	{{end}}
+{{ end }}

--- a/codegen/testserver/followschema/directive.generated.go
+++ b/codegen/testserver/followschema/directive.generated.go
@@ -115,29 +115,6 @@ func (ec *executionContext) dir_range_args(ctx context.Context, rawArgs map[stri
 
 // region    ************************** directives.gotpl **************************
 
-func (ec *executionContext) _fieldMiddleware(ctx context.Context, obj any, next graphql.Resolver) graphql.Resolver {
-	fc := graphql.GetFieldContext(ctx)
-	for _, d := range fc.Field.Directives {
-		switch d.Name {
-		case "logged":
-			rawArgs := d.ArgumentMap(ec.Variables)
-			args, err := ec.dir_logged_args(ctx, rawArgs)
-			if err != nil {
-				ec.Error(ctx, err)
-				return nil
-			}
-			n := next
-			next = func(ctx context.Context) (any, error) {
-				if ec.Directives.Logged == nil {
-					return nil, errors.New("directive logged is not implemented")
-				}
-				return ec.Directives.Logged(ctx, obj, n, args["id"].(string))
-			}
-		}
-	}
-	return next
-}
-
 // endregion ************************** directives.gotpl **************************
 
 // region    **************************** field.gotpl *****************************

--- a/codegen/testserver/followschema/directive_test.go
+++ b/codegen/testserver/followschema/directive_test.go
@@ -232,8 +232,20 @@ func TestDirectives(t *testing.T) {
 			Custom: func(ctx context.Context, obj any, next graphql.Resolver) (any, error) {
 				return next(ctx)
 			},
+			FieldOnly: func(ctx context.Context, obj any, next graphql.Resolver, reason string) (any, error) {
+				return next(context.WithValue(ctx, ckey("request_id"), &reason))
+			},
 			Logged: func(ctx context.Context, obj any, next graphql.Resolver, id string) (any, error) {
 				return next(context.WithValue(ctx, ckey("request_id"), &id))
+			},
+			MutationOnly: func(ctx context.Context, obj any, next graphql.Resolver, reason string) (any, error) {
+				return next(context.WithValue(ctx, ckey("request_id"), &reason))
+			},
+			QueryOnly: func(ctx context.Context, obj any, next graphql.Resolver, reason string) (any, error) {
+				return next(context.WithValue(ctx, ckey("request_id"), &reason))
+			},
+			SubscriptionOnly: func(ctx context.Context, obj any, next graphql.Resolver, reason string) (any, error) {
+				return next(context.WithValue(ctx, ckey("request_id"), &reason))
 			},
 			ToNull: func(ctx context.Context, obj any, next graphql.Resolver) (any, error) {
 				return nil, nil
@@ -457,6 +469,15 @@ func TestDirectives(t *testing.T) {
 
 			require.Nil(t, resp.DirectiveField)
 		})
+		t.Run("directive defined in a separate file with no type definitions", func(t *testing.T) {
+			var resp struct {
+				DirectiveField string
+			}
+
+			c.MustPost(`query { directiveField@fieldOnly(reason:"test_reason") }`, &resp)
+
+			require.Equal(t, "test_reason", resp.DirectiveField)
+		})
 	})
 	t.Run("input field directives", func(t *testing.T) {
 		t.Run("when function errors on directives", func(t *testing.T) {
@@ -618,6 +639,44 @@ func TestDirectives(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Nil(t, resp.DirectiveObjectWithCustomGoModel.NullableText)
+		})
+	})
+
+	t.Run("operation directives from separate file with no type definitions", func(t *testing.T) {
+		t.Run("query directive", func(t *testing.T) {
+			var resp struct {
+				DirectiveField string
+			}
+
+			c.MustPost(`query @queryOnly(reason:"query_test") { directiveField@logged(id:"id1") }`, &resp)
+
+			require.Equal(t, "id1", resp.DirectiveField)
+		})
+		t.Run("mutation directive", func(t *testing.T) {
+			resolvers.MutationResolver.UpdateSomething = func(ctx context.Context, input SpecialInput) (string, error) {
+				if s, ok := ctx.Value(ckey("request_id")).(*string); ok {
+					return *s, nil
+				}
+				return "no directive", nil
+			}
+
+			var resp struct {
+				UpdateSomething string
+			}
+
+			c.MustPost(`mutation @mutationOnly(reason:"mutation_test") { updateSomething(input:{nesting:{field:"a@b.c"}}) }`, &resp)
+
+			require.Equal(t, "mutation_test", resp.UpdateSomething)
+		})
+		t.Run("subscription directive", func(t *testing.T) {
+			var resp struct {
+				DirectiveArg *string
+			}
+
+			err := c.WebsocketOnce(`subscription @subscriptionOnly(reason:"sub_test") { directiveArg(arg: "test") }`, &resp)
+
+			require.NoError(t, err)
+			require.Equal(t, "Ok", *resp.DirectiveArg)
 		})
 	})
 

--- a/codegen/testserver/followschema/directive_test.go
+++ b/codegen/testserver/followschema/directive_test.go
@@ -648,7 +648,10 @@ func TestDirectives(t *testing.T) {
 				DirectiveField string
 			}
 
-			c.MustPost(`query @queryOnly(reason:"query_test") { directiveField@logged(id:"id1") }`, &resp)
+			c.MustPost(
+				`query @queryOnly(reason:"query_test") { directiveField@logged(id:"id1") }`,
+				&resp,
+			)
 
 			require.Equal(t, "id1", resp.DirectiveField)
 		})
@@ -664,7 +667,10 @@ func TestDirectives(t *testing.T) {
 				UpdateSomething string
 			}
 
-			c.MustPost(`mutation @mutationOnly(reason:"mutation_test") { updateSomething(input:{nesting:{field:"a@b.c"}}) }`, &resp)
+			c.MustPost(
+				`mutation @mutationOnly(reason:"mutation_test") { updateSomething(input:{nesting:{field:"a@b.c"}}) }`,
+				&resp,
+			)
 
 			require.Equal(t, "mutation_test", resp.UpdateSomething)
 		})
@@ -673,7 +679,10 @@ func TestDirectives(t *testing.T) {
 				DirectiveArg *string
 			}
 
-			err := c.WebsocketOnce(`subscription @subscriptionOnly(reason:"sub_test") { directiveArg(arg: "test") }`, &resp)
+			err := c.WebsocketOnce(
+				`subscription @subscriptionOnly(reason:"sub_test") { directiveArg(arg: "test") }`,
+				&resp,
+			)
 
 			require.NoError(t, err)
 			require.Equal(t, "Ok", *resp.DirectiveArg)

--- a/codegen/testserver/followschema/root_.generated.go
+++ b/codegen/testserver/followschema/root_.generated.go
@@ -5,6 +5,7 @@ package followschema
 import (
 	"bytes"
 	"context"
+	"errors"
 	"sync/atomic"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -46,15 +47,19 @@ type DirectiveRoot struct {
 	Directive2        func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error)
 	Directive3        func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error)
 	Directive3WithArg func(ctx context.Context, obj any, next graphql.Resolver, inputNamespace string) (res any, err error)
+	FieldOnly         func(ctx context.Context, obj any, next graphql.Resolver, reason string) (res any, err error)
 	Length            func(ctx context.Context, obj any, next graphql.Resolver, min int, max *int, message *string) (res any, err error)
 	Logged            func(ctx context.Context, obj any, next graphql.Resolver, id string) (res any, err error)
 	MakeNil           func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error)
 	MakeTypedNil      func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error)
+	MutationOnly      func(ctx context.Context, obj any, next graphql.Resolver, reason string) (res any, err error)
 	Noop              func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error)
 	Order1            func(ctx context.Context, obj any, next graphql.Resolver, location string) (res any, err error)
 	Order2            func(ctx context.Context, obj any, next graphql.Resolver, location string) (res any, err error)
 	Populate          func(ctx context.Context, obj any, next graphql.Resolver, value string) (res any, err error)
+	QueryOnly         func(ctx context.Context, obj any, next graphql.Resolver, reason string) (res any, err error)
 	Range             func(ctx context.Context, obj any, next graphql.Resolver, min *int, max *int) (res any, err error)
+	SubscriptionOnly  func(ctx context.Context, obj any, next graphql.Resolver, reason string) (res any, err error)
 	ToNull            func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error)
 	Unimplemented     func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error)
 }
@@ -2389,7 +2394,9 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 			if first {
 				first = false
 				ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
-				data = ec._Query(ctx, opCtx.Operation.SelectionSet)
+				data = ec._queryMiddleware(ctx, opCtx.Operation, func(ctx context.Context) (any, error) {
+					return ec._Query(ctx, opCtx.Operation.SelectionSet), nil
+				})
 			} else {
 				if atomic.LoadInt32(&ec.PendingDeferred) > 0 {
 					result := <-ec.DeferredResults
@@ -2419,7 +2426,9 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 			}
 			first = false
 			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
-			data := ec._Mutation(ctx, opCtx.Operation.SelectionSet)
+			data := ec._mutationMiddleware(ctx, opCtx.Operation, func(ctx context.Context) (any, error) {
+				return ec._Mutation(ctx, opCtx.Operation.SelectionSet), nil
+			})
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)
 
@@ -2428,7 +2437,9 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 			}
 		}
 	case ast.Subscription:
-		next := ec._Subscription(ctx, opCtx.Operation.SelectionSet)
+		next := ec._subscriptionMiddleware(ctx, opCtx.Operation, func(ctx context.Context) (any, error) {
+			return ec._Subscription(ctx, opCtx.Operation.SelectionSet), nil
+		})
 
 		var buf bytes.Buffer
 		return func(ctx context.Context) *graphql.Response {
@@ -2476,6 +2487,7 @@ directive @directive1 on FIELD_DEFINITION
 directive @directive2 on FIELD_DEFINITION
 directive @directive3 on INPUT_OBJECT
 directive @directive3WithArg(inputNamespace: String!) on INPUT_OBJECT
+directive @fieldOnly(reason: String!) on FIELD
 directive @goField(forceResolver: Boolean, name: String, omittable: Boolean, type: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 directive @goModel(model: String, models: [String!]) on OBJECT | INPUT_OBJECT | SCALAR | ENUM | INTERFACE | UNION
 directive @inlineArguments on ARGUMENT_DEFINITION
@@ -2483,11 +2495,14 @@ directive @length(min: Int!, max: Int, message: String) on ARGUMENT_DEFINITION |
 directive @logged(id: UUID!) on FIELD
 directive @makeNil on FIELD_DEFINITION
 directive @makeTypedNil on FIELD_DEFINITION
+directive @mutationOnly(reason: String!) on MUTATION
 directive @noop on ARGUMENT_DEFINITION
 directive @order1(location: String!) repeatable on FIELD_DEFINITION | OBJECT
 directive @order2(location: String!) on OBJECT
 directive @populate(value: String!) on ARGUMENT_DEFINITION
+directive @queryOnly(reason: String!) on QUERY
 directive @range(min: Int = 0, max: Int) on ARGUMENT_DEFINITION
+directive @subscriptionOnly(reason: String!) on SUBSCRIPTION
 directive @toNull on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 directive @unimplemented on FIELD_DEFINITION
 type A {
@@ -3052,3 +3067,187 @@ type iIt {
 `, BuiltIn: true},
 }
 var parsedSchema = gqlparser.MustLoadSchema(sources...)
+
+func (ec *executionContext) dir_fieldOnly_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "reason", ec.unmarshalNString2string)
+	if err != nil {
+		return nil, err
+	}
+	args["reason"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) dir_mutationOnly_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "reason", ec.unmarshalNString2string)
+	if err != nil {
+		return nil, err
+	}
+	args["reason"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) dir_queryOnly_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "reason", ec.unmarshalNString2string)
+	if err != nil {
+		return nil, err
+	}
+	args["reason"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) dir_subscriptionOnly_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "reason", ec.unmarshalNString2string)
+	if err != nil {
+		return nil, err
+	}
+	args["reason"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) _queryMiddleware(ctx context.Context, obj *ast.OperationDefinition, next func(ctx context.Context) (any, error)) graphql.Marshaler {
+
+	for _, d := range obj.Directives {
+		switch d.Name {
+		case "queryOnly":
+			rawArgs := d.ArgumentMap(ec.Variables)
+			args, err := ec.dir_queryOnly_args(ctx, rawArgs)
+			if err != nil {
+				ec.Error(ctx, err)
+				return graphql.Null
+			}
+			n := next
+			next = func(ctx context.Context) (any, error) {
+				if ec.Directives.QueryOnly == nil {
+					return nil, errors.New("directive queryOnly is not implemented")
+				}
+				return ec.Directives.QueryOnly(ctx, obj, n, args["reason"].(string))
+			}
+		}
+	}
+	tmp, err := next(ctx)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if data, ok := tmp.(graphql.Marshaler); ok {
+		return data
+	}
+	graphql.AddErrorf(ctx, `unexpected type %T from directive, should be graphql.Marshaler`, tmp)
+	return graphql.Null
+
+}
+
+func (ec *executionContext) _mutationMiddleware(ctx context.Context, obj *ast.OperationDefinition, next func(ctx context.Context) (any, error)) graphql.Marshaler {
+
+	for _, d := range obj.Directives {
+		switch d.Name {
+		case "mutationOnly":
+			rawArgs := d.ArgumentMap(ec.Variables)
+			args, err := ec.dir_mutationOnly_args(ctx, rawArgs)
+			if err != nil {
+				ec.Error(ctx, err)
+				return graphql.Null
+			}
+			n := next
+			next = func(ctx context.Context) (any, error) {
+				if ec.Directives.MutationOnly == nil {
+					return nil, errors.New("directive mutationOnly is not implemented")
+				}
+				return ec.Directives.MutationOnly(ctx, obj, n, args["reason"].(string))
+			}
+		}
+	}
+	tmp, err := next(ctx)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if data, ok := tmp.(graphql.Marshaler); ok {
+		return data
+	}
+	graphql.AddErrorf(ctx, `unexpected type %T from directive, should be graphql.Marshaler`, tmp)
+	return graphql.Null
+
+}
+
+func (ec *executionContext) _subscriptionMiddleware(ctx context.Context, obj *ast.OperationDefinition, next func(ctx context.Context) (any, error)) func(ctx context.Context) graphql.Marshaler {
+	for _, d := range obj.Directives {
+		switch d.Name {
+		case "subscriptionOnly":
+			rawArgs := d.ArgumentMap(ec.Variables)
+			args, err := ec.dir_subscriptionOnly_args(ctx, rawArgs)
+			if err != nil {
+				ec.Error(ctx, err)
+				return func(ctx context.Context) graphql.Marshaler {
+					return graphql.Null
+				}
+			}
+			n := next
+			next = func(ctx context.Context) (any, error) {
+				if ec.Directives.SubscriptionOnly == nil {
+					return nil, errors.New("directive subscriptionOnly is not implemented")
+				}
+				return ec.Directives.SubscriptionOnly(ctx, obj, n, args["reason"].(string))
+			}
+		}
+	}
+	tmp, err := next(ctx)
+	if err != nil {
+		ec.Error(ctx, err)
+		return func(ctx context.Context) graphql.Marshaler {
+			return graphql.Null
+		}
+	}
+	if data, ok := tmp.(func(ctx context.Context) graphql.Marshaler); ok {
+		return data
+	}
+	graphql.AddErrorf(ctx, `unexpected type %T from directive, should be graphql.Marshaler`, tmp)
+	return func(ctx context.Context) graphql.Marshaler {
+		return graphql.Null
+	}
+}
+
+func (ec *executionContext) _fieldMiddleware(ctx context.Context, obj any, next graphql.Resolver) graphql.Resolver {
+	fc := graphql.GetFieldContext(ctx)
+	for _, d := range fc.Field.Directives {
+		switch d.Name {
+		case "fieldOnly":
+			rawArgs := d.ArgumentMap(ec.Variables)
+			args, err := ec.dir_fieldOnly_args(ctx, rawArgs)
+			if err != nil {
+				ec.Error(ctx, err)
+				return nil
+			}
+			n := next
+			next = func(ctx context.Context) (any, error) {
+				if ec.Directives.FieldOnly == nil {
+					return nil, errors.New("directive fieldOnly is not implemented")
+				}
+				return ec.Directives.FieldOnly(ctx, obj, n, args["reason"].(string))
+			}
+		case "logged":
+			rawArgs := d.ArgumentMap(ec.Variables)
+			args, err := ec.dir_logged_args(ctx, rawArgs)
+			if err != nil {
+				ec.Error(ctx, err)
+				return nil
+			}
+			n := next
+			next = func(ctx context.Context) (any, error) {
+				if ec.Directives.Logged == nil {
+					return nil, errors.New("directive logged is not implemented")
+				}
+				return ec.Directives.Logged(ctx, obj, n, args["id"].(string))
+			}
+		}
+	}
+	return next
+}

--- a/codegen/testserver/followschema/separate_directive.graphql
+++ b/codegen/testserver/followschema/separate_directive.graphql
@@ -1,0 +1,4 @@
+directive @fieldOnly(reason: String!) on FIELD
+directive @queryOnly(reason: String!) on QUERY
+directive @mutationOnly(reason: String!) on MUTATION
+directive @subscriptionOnly(reason: String!) on SUBSCRIPTION

--- a/codegen/testserver/singlefile/generated.go
+++ b/codegen/testserver/singlefile/generated.go
@@ -56,15 +56,19 @@ type DirectiveRoot struct {
 	Directive2        func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error)
 	Directive3        func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error)
 	Directive3WithArg func(ctx context.Context, obj any, next graphql.Resolver, inputNamespace string) (res any, err error)
+	FieldOnly         func(ctx context.Context, obj any, next graphql.Resolver, reason string) (res any, err error)
 	Length            func(ctx context.Context, obj any, next graphql.Resolver, min int, max *int, message *string) (res any, err error)
 	Logged            func(ctx context.Context, obj any, next graphql.Resolver, id string) (res any, err error)
 	MakeNil           func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error)
 	MakeTypedNil      func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error)
+	MutationOnly      func(ctx context.Context, obj any, next graphql.Resolver, reason string) (res any, err error)
 	Noop              func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error)
 	Order1            func(ctx context.Context, obj any, next graphql.Resolver, location string) (res any, err error)
 	Order2            func(ctx context.Context, obj any, next graphql.Resolver, location string) (res any, err error)
 	Populate          func(ctx context.Context, obj any, next graphql.Resolver, value string) (res any, err error)
+	QueryOnly         func(ctx context.Context, obj any, next graphql.Resolver, reason string) (res any, err error)
 	Range             func(ctx context.Context, obj any, next graphql.Resolver, min *int, max *int) (res any, err error)
+	SubscriptionOnly  func(ctx context.Context, obj any, next graphql.Resolver, reason string) (res any, err error)
 	ToNull            func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error)
 	Unimplemented     func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error)
 }
@@ -2399,7 +2403,9 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 			if first {
 				first = false
 				ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
-				data = ec._Query(ctx, opCtx.Operation.SelectionSet)
+				data = ec._queryMiddleware(ctx, opCtx.Operation, func(ctx context.Context) (any, error) {
+					return ec._Query(ctx, opCtx.Operation.SelectionSet), nil
+				})
 			} else {
 				if atomic.LoadInt32(&ec.PendingDeferred) > 0 {
 					result := <-ec.DeferredResults
@@ -2429,7 +2435,9 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 			}
 			first = false
 			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
-			data := ec._Mutation(ctx, opCtx.Operation.SelectionSet)
+			data := ec._mutationMiddleware(ctx, opCtx.Operation, func(ctx context.Context) (any, error) {
+				return ec._Mutation(ctx, opCtx.Operation.SelectionSet), nil
+			})
 			var buf bytes.Buffer
 			data.MarshalGQL(&buf)
 
@@ -2438,7 +2446,9 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 			}
 		}
 	case ast.Subscription:
-		next := ec._Subscription(ctx, opCtx.Operation.SelectionSet)
+		next := ec._subscriptionMiddleware(ctx, opCtx.Operation, func(ctx context.Context) (any, error) {
+			return ec._Subscription(ctx, opCtx.Operation.SelectionSet), nil
+		})
 
 		var buf bytes.Buffer
 		return func(ctx context.Context) *graphql.Response {
@@ -2486,6 +2496,7 @@ directive @directive1 on FIELD_DEFINITION
 directive @directive2 on FIELD_DEFINITION
 directive @directive3 on INPUT_OBJECT
 directive @directive3WithArg(inputNamespace: String!) on INPUT_OBJECT
+directive @fieldOnly(reason: String!) on FIELD
 directive @goField(forceResolver: Boolean, name: String, omittable: Boolean, type: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 directive @goModel(model: String, models: [String!]) on OBJECT | INPUT_OBJECT | SCALAR | ENUM | INTERFACE | UNION
 directive @inlineArguments on ARGUMENT_DEFINITION
@@ -2493,11 +2504,14 @@ directive @length(min: Int!, max: Int, message: String) on ARGUMENT_DEFINITION |
 directive @logged(id: UUID!) on FIELD
 directive @makeNil on FIELD_DEFINITION
 directive @makeTypedNil on FIELD_DEFINITION
+directive @mutationOnly(reason: String!) on MUTATION
 directive @noop on ARGUMENT_DEFINITION
 directive @order1(location: String!) repeatable on FIELD_DEFINITION | OBJECT
 directive @order2(location: String!) on OBJECT
 directive @populate(value: String!) on ARGUMENT_DEFINITION
+directive @queryOnly(reason: String!) on QUERY
 directive @range(min: Int = 0, max: Int) on ARGUMENT_DEFINITION
+directive @subscriptionOnly(reason: String!) on SUBSCRIPTION
 directive @toNull on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 directive @unimplemented on FIELD_DEFINITION
 type A {
@@ -3094,6 +3108,17 @@ func (ec *executionContext) dir_directive3WithArg_args(ctx context.Context, rawA
 	return args, nil
 }
 
+func (ec *executionContext) dir_fieldOnly_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "reason", ec.unmarshalNString2string)
+	if err != nil {
+		return nil, err
+	}
+	args["reason"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) dir_length_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -3123,6 +3148,17 @@ func (ec *executionContext) dir_logged_args(ctx context.Context, rawArgs map[str
 		return nil, err
 	}
 	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) dir_mutationOnly_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "reason", ec.unmarshalNString2string)
+	if err != nil {
+		return nil, err
+	}
+	args["reason"] = arg0
 	return args, nil
 }
 
@@ -3159,6 +3195,17 @@ func (ec *executionContext) dir_populate_args(ctx context.Context, rawArgs map[s
 	return args, nil
 }
 
+func (ec *executionContext) dir_queryOnly_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "reason", ec.unmarshalNString2string)
+	if err != nil {
+		return nil, err
+	}
+	args["reason"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) dir_range_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -3172,6 +3219,17 @@ func (ec *executionContext) dir_range_args(ctx context.Context, rawArgs map[stri
 		return nil, err
 	}
 	args["max"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) dir_subscriptionOnly_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "reason", ec.unmarshalNString2string)
+	if err != nil {
+		return nil, err
+	}
+	args["reason"] = arg0
 	return args, nil
 }
 
@@ -4517,10 +4575,127 @@ func (ec *executionContext) field___Type_fields_args(ctx context.Context, rawArg
 
 // region    ************************** directives.gotpl **************************
 
+func (ec *executionContext) _queryMiddleware(ctx context.Context, obj *ast.OperationDefinition, next func(ctx context.Context) (any, error)) graphql.Marshaler {
+
+	for _, d := range obj.Directives {
+		switch d.Name {
+		case "queryOnly":
+			rawArgs := d.ArgumentMap(ec.Variables)
+			args, err := ec.dir_queryOnly_args(ctx, rawArgs)
+			if err != nil {
+				ec.Error(ctx, err)
+				return graphql.Null
+			}
+			n := next
+			next = func(ctx context.Context) (any, error) {
+				if ec.Directives.QueryOnly == nil {
+					return nil, errors.New("directive queryOnly is not implemented")
+				}
+				return ec.Directives.QueryOnly(ctx, obj, n, args["reason"].(string))
+			}
+		}
+	}
+	tmp, err := next(ctx)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if data, ok := tmp.(graphql.Marshaler); ok {
+		return data
+	}
+	graphql.AddErrorf(ctx, `unexpected type %T from directive, should be graphql.Marshaler`, tmp)
+	return graphql.Null
+
+}
+
+func (ec *executionContext) _mutationMiddleware(ctx context.Context, obj *ast.OperationDefinition, next func(ctx context.Context) (any, error)) graphql.Marshaler {
+
+	for _, d := range obj.Directives {
+		switch d.Name {
+		case "mutationOnly":
+			rawArgs := d.ArgumentMap(ec.Variables)
+			args, err := ec.dir_mutationOnly_args(ctx, rawArgs)
+			if err != nil {
+				ec.Error(ctx, err)
+				return graphql.Null
+			}
+			n := next
+			next = func(ctx context.Context) (any, error) {
+				if ec.Directives.MutationOnly == nil {
+					return nil, errors.New("directive mutationOnly is not implemented")
+				}
+				return ec.Directives.MutationOnly(ctx, obj, n, args["reason"].(string))
+			}
+		}
+	}
+	tmp, err := next(ctx)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if data, ok := tmp.(graphql.Marshaler); ok {
+		return data
+	}
+	graphql.AddErrorf(ctx, `unexpected type %T from directive, should be graphql.Marshaler`, tmp)
+	return graphql.Null
+
+}
+
+func (ec *executionContext) _subscriptionMiddleware(ctx context.Context, obj *ast.OperationDefinition, next func(ctx context.Context) (any, error)) func(ctx context.Context) graphql.Marshaler {
+	for _, d := range obj.Directives {
+		switch d.Name {
+		case "subscriptionOnly":
+			rawArgs := d.ArgumentMap(ec.Variables)
+			args, err := ec.dir_subscriptionOnly_args(ctx, rawArgs)
+			if err != nil {
+				ec.Error(ctx, err)
+				return func(ctx context.Context) graphql.Marshaler {
+					return graphql.Null
+				}
+			}
+			n := next
+			next = func(ctx context.Context) (any, error) {
+				if ec.Directives.SubscriptionOnly == nil {
+					return nil, errors.New("directive subscriptionOnly is not implemented")
+				}
+				return ec.Directives.SubscriptionOnly(ctx, obj, n, args["reason"].(string))
+			}
+		}
+	}
+	tmp, err := next(ctx)
+	if err != nil {
+		ec.Error(ctx, err)
+		return func(ctx context.Context) graphql.Marshaler {
+			return graphql.Null
+		}
+	}
+	if data, ok := tmp.(func(ctx context.Context) graphql.Marshaler); ok {
+		return data
+	}
+	graphql.AddErrorf(ctx, `unexpected type %T from directive, should be graphql.Marshaler`, tmp)
+	return func(ctx context.Context) graphql.Marshaler {
+		return graphql.Null
+	}
+}
+
 func (ec *executionContext) _fieldMiddleware(ctx context.Context, obj any, next graphql.Resolver) graphql.Resolver {
 	fc := graphql.GetFieldContext(ctx)
 	for _, d := range fc.Field.Directives {
 		switch d.Name {
+		case "fieldOnly":
+			rawArgs := d.ArgumentMap(ec.Variables)
+			args, err := ec.dir_fieldOnly_args(ctx, rawArgs)
+			if err != nil {
+				ec.Error(ctx, err)
+				return nil
+			}
+			n := next
+			next = func(ctx context.Context) (any, error) {
+				if ec.Directives.FieldOnly == nil {
+					return nil, errors.New("directive fieldOnly is not implemented")
+				}
+				return ec.Directives.FieldOnly(ctx, obj, n, args["reason"].(string))
+			}
 		case "logged":
 			rawArgs := d.ArgumentMap(ec.Variables)
 			args, err := ec.dir_logged_args(ctx, rawArgs)

--- a/codegen/testserver/singlefile/separate_directive.graphql
+++ b/codegen/testserver/singlefile/separate_directive.graphql
@@ -1,0 +1,4 @@
+directive @fieldOnly(reason: String!) on FIELD
+directive @queryOnly(reason: String!) on QUERY
+directive @mutationOnly(reason: String!) on MUTATION
+directive @subscriptionOnly(reason: String!) on SUBSCRIPTION


### PR DESCRIPTION
## Problem

When using the `follow-schema` layout, defining a location directive (e.g. `directive @myDirective(key: String!) on FIELD`) in a `.graphql` file that contains **no type definitions** causes a compilation error. The generated code calls `_fieldMiddleware` from every per-schema file, but the function definition is never generated because no per-schema build exists for the directive-only file.

This happens because:
- `field.gotpl` uses `AllDirectives.LocationDirectives "FIELD"` to generate **calls** to `_fieldMiddleware` in all per-schema files
- `directives.gotpl` uses `Directives().LocationDirectives "FIELD"` to generate the **definition**, but `Directives()` filters by `Config.Sources` (a single file in per-schema builds). If the directive's source file has no types, no per-schema build exists for it, so the definition is never generated

The same issue applies to `_queryMiddleware`, `_mutationMiddleware`, and `_subscriptionMiddleware`.

## Solution

Location directive middleware is a schema-global responsibility — `field.gotpl` calls `_fieldMiddleware` if *any* FIELD directive exists in the entire schema. This PR moves the middleware definition to the root file where all directives are visible.

- Add `SkipLocationDirectives` flag to `Data`; set it `true` for per-schema builds
- Guard the 4 middleware blocks in `directives.gotpl` with `not .SkipLocationDirectives`
- Concatenate `directives.gotpl` into the root file template so middleware is generated there
- Add `DirectiveArgs()` method to generate args functions for directives whose source file has no types (orphan directives)

The single-file layout is unaffected (`SkipLocationDirectives` defaults to `false`).

### Design notes

`generateRootFile` uses `Template:` (string), which causes `templates.Render` to ignore `TemplateFS`. This means the root file template cannot access `{{ define }}` blocks from other `.gotpl` files. To work around this, `directives.gotpl` is concatenated with `root_.gotpl` at the Go level via `rootTemplate + "\n" + directivesTemplate`.

We considered an alternative: deleting `directives.gotpl` and inlining its content into both `root_.gotpl` and `generated!.gotpl` (following the existing duplication pattern between these two files). However, `directives.gotpl` is not just root-level code — its `{{ define }}` blocks (`implDirectives`, `queryDirectives`, `callDirective`) are shared partials referenced by `field.gotpl`, `args.gotpl`, and `input.gotpl`. Duplicating these across files would be a heavier form of duplication than the existing pattern.

There are two known trade-offs with the current approach:
- **Go-level template concatenation has no precedent in this codebase.** If you'd prefer a different approach, happy to discuss.
- **`args.gotpl` logic is partially duplicated in `root_.gotpl`** for orphan directive args generation.

A cleaner long-term fix would be to restructure the templates so that root-level and per-schema templates are cleanly separated, with single-file mode combining both in one pass. This would eliminate the duplication between `root_.gotpl` and `generated!.gotpl`, the layout guards in `generated!.gotpl`, `SkipLocationDirectives`, and the template concatenation — but that is a larger refactor beyond the scope of this bug fix.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))