### PR TITLE
Reduce Template Logic Part 2

### DIFF
--- a/_examples/type-system-extension/generated.go
+++ b/_examples/type-system-extension/generated.go
@@ -1892,12 +1892,14 @@ func (ec *executionContext) unmarshalInputTodoInput(ctx context.Context, obj any
 	// Execute INPUT_OBJECT level directives (e.g., @oneOf, @directive3)
 	// These run after all fields have been unmarshaled
 	directive0 := func(ctx context.Context) (any, error) { return it, nil }
+
 	directive1 := func(ctx context.Context) (any, error) {
 		if ec.Directives.InputLogging == nil {
-			return it, errors.New("directive inputLogging is not implemented")
+			return it, graphql.ErrorOnPath(ctx, errors.New("directive inputLogging is not implemented"))
 		}
 		return ec.Directives.InputLogging(ctx, asMap, directive0)
 	}
+
 	tmp, err := directive1(ctx)
 	if err != nil {
 		return it, graphql.ErrorOnPath(ctx, err)

--- a/codegen/args.go
+++ b/codegen/args.go
@@ -44,6 +44,12 @@ func (f *FieldArgument) DirectiveObjName() string {
 	return "rawArgs"
 }
 
+// ZeroVal returns the Go declaration for the typed zero value of this argument's
+// type, suitable for use as an error-path return value inside a directive closure.
+func (f *FieldArgument) ZeroVal() string {
+	return fmt.Sprintf("var zeroVal %s", templates.CurrentImports.LookupType(f.TypeReference.GO))
+}
+
 func (f *FieldArgument) Stream() bool {
 	return f.Object != nil && f.Object.Stream
 }

--- a/codegen/args.gotpl
+++ b/codegen/args.gotpl
@@ -36,7 +36,7 @@ func {{$.FuncReceiver}}{{ $name }}(ctx context.Context, {{$.ECFuncParam}}rawArgs
 				even if the argument is null.
 				*/ -}}
 				if _, ok := rawArgs[{{$arg.Name|quote}}]; !ok {
-					var zeroVal {{ $arg.TypeReference.GO | ref}}
+					{{ $arg.ZeroVal }}
 					return zeroVal, nil
 				}
 			{{end}}
@@ -45,26 +45,26 @@ func {{$.FuncReceiver}}{{ $name }}(ctx context.Context, {{$.ECFuncParam}}rawArgs
 				directive0 := func(ctx context.Context) (any, error) {
 					tmp, ok := rawArgs[{{$arg.Name|quote}}]
 					if !ok {
-						var zeroVal {{ $arg.TypeReference.GO | ref}}
+						{{ $arg.ZeroVal }}
 						return zeroVal, nil
 					}
 					return {{$.ECDot}}{{ $arg.TypeReference.UnmarshalFunc }}(ctx, {{$.ECArg}}tmp)
 				}
-				{{ template "implDirectives" (dict "Field" $arg "UseFunctionSyntaxForExecutionContext" $.Config.UseFunctionSyntaxForExecutionContext) }}
+				{{ template "implDirectives" ($.ImplDirectivesCtx $arg) }}
 				tmp, err := directive{{$arg.ImplDirectives|len}}(ctx)
 				if err != nil {
-					var zeroVal {{ $arg.TypeReference.GO | ref}}
+					{{ $arg.ZeroVal }}
 					return zeroVal, graphql.ErrorOnPath(ctx, err)
 				}
 				if data, ok := tmp.({{ $arg.TypeReference.GO | ref }}) ; ok {
 					return data, nil
 				{{- if $arg.TypeReference.IsNilable }}
 					} else if tmp == nil {
-						var zeroVal {{ $arg.TypeReference.GO | ref}}
+						{{ $arg.ZeroVal }}
 						return zeroVal, nil
 				{{- end }}
 				} else {
-					var zeroVal {{ $arg.TypeReference.GO | ref}}
+					{{ $arg.ZeroVal }}
 					return zeroVal, graphql.ErrorOnPath(ctx, fmt.Errorf(`unexpected type %T from directive, should be {{ $arg.TypeReference.GO }}`, tmp))
 				}
 			{{- else }}
@@ -72,7 +72,7 @@ func {{$.FuncReceiver}}{{ $name }}(ctx context.Context, {{$.ECFuncParam}}rawArgs
 					return {{$.ECDot}}{{ $arg.TypeReference.UnmarshalFunc }}(ctx, {{$.ECArg}}tmp)
 				}
 
-				var zeroVal {{ $arg.TypeReference.GO | ref}}
+				{{ $arg.ZeroVal }}
 				return zeroVal, nil
 			{{- end }}
 		}

--- a/codegen/data.go
+++ b/codegen/data.go
@@ -202,6 +202,79 @@ func (d *Data) ECArg() string {
 	return ""
 }
 
+// ImplDirectivesField is the subset of Field and FieldArgument needed by the
+// implDirectives template.
+type ImplDirectivesField interface {
+	DirectiveObjName() string
+	ImplDirectives() []*Directive
+	ZeroVal() string
+}
+
+// ImplDirectivesContext is the typed context passed to the implDirectives template.
+// ErrVal is the Go variable name to return on error ("zeroVal" for the standard
+// case, or the partially-built struct variable for INPUT_OBJECT directives).
+// ErrWrap controls whether the error is wrapped in graphql.ErrorOnPath(ctx, err).
+type ImplDirectivesContext struct {
+	Field   ImplDirectivesField
+	Data    *Data
+	ErrVal  string
+	ErrWrap bool
+}
+
+// QueryDirectivesContext is the typed context passed to the queryDirectives template.
+type QueryDirectivesContext struct {
+	DirectiveList DirectiveList
+	Data          *Data
+}
+
+// ImplDirectivesCtx returns a context for the implDirectives template suitable
+// for field and argument directive processing (ErrVal="zeroVal", ErrWrap=false).
+func (d *Data) ImplDirectivesCtx(f ImplDirectivesField) ImplDirectivesContext {
+	return ImplDirectivesContext{Field: f, Data: d, ErrVal: "zeroVal", ErrWrap: false}
+}
+
+// QueryDirectivesCtx returns a context for the queryDirectives template.
+func (d *Data) QueryDirectivesCtx(dl DirectiveList) QueryDirectivesContext {
+	return QueryDirectivesContext{DirectiveList: dl, Data: d}
+}
+
+// inputObjectImplDirectivesField adapts an *Object for use as an ImplDirectivesField
+// in INPUT_OBJECT-level directive processing, where the directive receiver is the
+// map representation of the input rather than a typed struct field.
+type inputObjectImplDirectivesField struct {
+	object *Object
+}
+
+func (f *inputObjectImplDirectivesField) DirectiveObjName() string { return "asMap" }
+func (f *inputObjectImplDirectivesField) ImplDirectives() []*Directive {
+	return f.object.InputObjectDirectives()
+}
+func (f *inputObjectImplDirectivesField) ZeroVal() string { return "" } // unused when ErrWrap=true
+
+// InputObjectImplDirectivesCtx returns a context for the implDirectives template
+// for INPUT_OBJECT-level directive processing. errVal is the Go variable name to
+// return on error (e.g., "it" or "&it").
+func (d *Data) InputObjectImplDirectivesCtx(obj *Object, errVal string) ImplDirectivesContext {
+	return ImplDirectivesContext{
+		Field:   &inputObjectImplDirectivesField{object: obj},
+		Data:    d,
+		ErrVal:  errVal,
+		ErrWrap: true,
+	}
+}
+
+// ErrReturn returns the Go statements for the error path inside a directive
+// closure. When ErrWrap is true the error is wrapped in
+// graphql.ErrorOnPath; when false the typed zero value is declared before
+// the plain error return. errExpr is the Go error expression to return
+// (e.g. "err" or `errors.New("not implemented")`).
+func (c ImplDirectivesContext) ErrReturn(errExpr string) string {
+	if c.ErrWrap {
+		return fmt.Sprintf("return %s, graphql.ErrorOnPath(ctx, %s)", c.ErrVal, errExpr)
+	}
+	return c.Field.ZeroVal() + "\nreturn " + c.ErrVal + ", " + errExpr
+}
+
 func BuildData(cfg *config.Config, plugins ...any) (*Data, error) {
 	cfg.ReloadAllPackages()
 

--- a/codegen/data_test.go
+++ b/codegen/data_test.go
@@ -128,3 +128,52 @@ func TestUniqueChildFieldTypes_Empty(t *testing.T) {
 	d := Data{}
 	assert.Empty(t, d.UniqueChildFieldTypes())
 }
+
+func TestDataECHelpers(t *testing.T) {
+	receiver := &Data{Config: &config.Config{UseFunctionSyntaxForExecutionContext: false}}
+	assert.Equal(t, "(ec *executionContext) ", receiver.FuncReceiver())
+	assert.Empty(t, receiver.ECFuncParam())
+	assert.Equal(t, "ec.", receiver.ECDot())
+	assert.Empty(t, receiver.ECArg())
+
+	function := &Data{Config: &config.Config{UseFunctionSyntaxForExecutionContext: true}}
+	assert.Empty(t, function.FuncReceiver())
+	assert.Equal(t, "ec *executionContext, ", function.ECFuncParam())
+	assert.Empty(t, function.ECDot())
+	assert.Equal(t, "ec, ", function.ECArg())
+}
+
+// implDirectivesFieldStub satisfies ImplDirectivesField for testing purposes.
+type implDirectivesFieldStub struct{ zeroVal string }
+
+func (s *implDirectivesFieldStub) DirectiveObjName() string     { return "obj" }
+func (s *implDirectivesFieldStub) ImplDirectives() []*Directive { return nil }
+func (s *implDirectivesFieldStub) ZeroVal() string              { return s.zeroVal }
+
+func TestImplDirectivesContext_ErrReturn(t *testing.T) {
+	// ErrWrap=false: declares the zero value then returns with plain error.
+	plain := ImplDirectivesContext{
+		ErrWrap: false,
+		ErrVal:  "zeroVal",
+		Field:   &implDirectivesFieldStub{zeroVal: "var zeroVal string"},
+		Data:    &Data{Config: &config.Config{}},
+	}
+	assert.Equal(t, "var zeroVal string\nreturn zeroVal, err", plain.ErrReturn("err"))
+	assert.Equal(t,
+		"var zeroVal string\nreturn zeroVal, errors.New(\"not found\")",
+		plain.ErrReturn(`errors.New("not found")`),
+	)
+
+	// ErrWrap=true: wraps error in graphql.ErrorOnPath, no zero-value declaration.
+	wrapped := ImplDirectivesContext{
+		ErrWrap: true,
+		ErrVal:  "it",
+		Field:   &inputObjectImplDirectivesField{},
+		Data:    &Data{Config: &config.Config{}},
+	}
+	assert.Equal(t, "return it, graphql.ErrorOnPath(ctx, err)", wrapped.ErrReturn("err"))
+	assert.Equal(t,
+		`return it, graphql.ErrorOnPath(ctx, errors.New("directive foo is not implemented"))`,
+		wrapped.ErrReturn(`errors.New("directive foo is not implemented")`),
+	)
+}

--- a/codegen/directives.gotpl
+++ b/codegen/directives.gotpl
@@ -1,37 +1,18 @@
 {{ define "implDirectives" }}
 	{{ $in := .Field.DirectiveObjName }}
-	{{ $useFunctionSyntaxForExecutionContext := .UseFunctionSyntaxForExecutionContext }}
-	{{ $zeroVal := .Field.TypeReference.GO | ref}}
 	{{- range $i, $directive := .Field.ImplDirectives -}}
 		directive{{add $i 1}} := func(ctx context.Context) (any, error) {
 			{{- range $arg := $directive.Args }}
 				{{- if notNil "Value" $arg }}
-						{{ if $useFunctionSyntaxForExecutionContext -}}
-						{{ $arg.VarName }}, err := {{ $arg.TypeReference.UnmarshalFunc }}(ctx, ec, {{ $arg.Value | dump }})
-						{{- else -}}
-						{{ $arg.VarName }}, err := ec.{{ $arg.TypeReference.UnmarshalFunc }}(ctx, {{ $arg.Value | dump }})
-						{{- end }}
-						if err != nil{
-							var zeroVal {{$zeroVal}}
-							return zeroVal, err
-						}
+						{{ $arg.VarName }}, err := {{$.Data.ECDot}}{{ $arg.TypeReference.UnmarshalFunc }}(ctx, {{$.Data.ECArg}}{{ $arg.Value | dump }})
+						if err != nil { {{ $.ErrReturn "err" }} }
 					{{- else if notNil "Default" $arg }}
-						{{ if $useFunctionSyntaxForExecutionContext -}}
-						{{ $arg.VarName }}, err := {{ $arg.TypeReference.UnmarshalFunc }}(ctx, ec, {{ $arg.Default | dump }})
-						{{- else -}}
-						{{ $arg.VarName }}, err := ec.{{ $arg.TypeReference.UnmarshalFunc }}(ctx, {{ $arg.Default | dump }})
-						{{- end }}
-						if err != nil{
-							var zeroVal {{$zeroVal}}
-							return zeroVal, err
-						}
+						{{ $arg.VarName }}, err := {{$.Data.ECDot}}{{ $arg.TypeReference.UnmarshalFunc }}(ctx, {{$.Data.ECArg}}{{ $arg.Default | dump }})
+						if err != nil { {{ $.ErrReturn "err" }} }
 					{{- end }}
 			{{- end }}
 			{{- if not $directive.IsBuiltIn}}
-				if {{$directive.CallPath}} == nil {
-					var zeroVal {{$zeroVal}}
-					return zeroVal, errors.New("directive {{$directive.Name}} is not implemented")
-				}
+				if {{$directive.CallPath}} == nil { {{ $.ErrReturn (printf "errors.New(%q)" (print "directive " $directive.Name " is not implemented")) }} }
 			{{- end}}
 			return {{$directive.CallPath}}({{$directive.ResolveArgs $in $i }})
 		}
@@ -39,18 +20,13 @@
 {{ end }}
 
 {{define "queryDirectives"}}
-	{{ $useFunctionSyntaxForExecutionContext := .UseFunctionSyntaxForExecutionContext }}
 	for _, d := range obj.Directives {
 		switch d.Name {
 		{{- range $directive := .DirectiveList }}
 		case "{{$directive.Name}}":
 			{{- if $directive.Args }}
 				rawArgs := d.ArgumentMap(ec.Variables)
-				{{ if $useFunctionSyntaxForExecutionContext -}}
-				args, err := {{ $directive.ArgsFunc }}(ctx,ec,rawArgs)
-				{{- else -}}
-				args, err := ec.{{ $directive.ArgsFunc }}(ctx,rawArgs)
-				{{- end }}
+				args, err := {{$.Data.ECDot}}{{ $directive.ArgsFunc }}(ctx,{{$.Data.ECArg}}rawArgs)
 				if err != nil {
 					ec.Error(ctx, err)
 					return graphql.Null
@@ -90,14 +66,14 @@
 {{ define "globalMiddleware" }}
 
 {{ if .AllDirectives.LocationDirectives "QUERY" }}
-func {{$.FuncReceiver}}_queryMiddleware(ctx context.Context, {{$.ECFuncParam}}obj *ast.OperationDefinition, next func(ctx context.Context) (any, error)) graphql.Marshaler {
-	{{ template "queryDirectives" (dict "DirectiveList" (.AllDirectives.LocationDirectives "QUERY") "UseFunctionSyntaxForExecutionContext" $.Config.UseFunctionSyntaxForExecutionContext) }}
+func {{.FuncReceiver}}_queryMiddleware(ctx context.Context, {{.ECFuncParam}}obj *ast.OperationDefinition, next func(ctx context.Context) (any, error)) graphql.Marshaler {
+	{{ template "queryDirectives" (.QueryDirectivesCtx (.AllDirectives.LocationDirectives "QUERY")) }}
 }
 {{ end }}
 
 {{ if .AllDirectives.LocationDirectives "MUTATION" }}
-func {{$.FuncReceiver}}_mutationMiddleware(ctx context.Context, {{$.ECFuncParam}}obj *ast.OperationDefinition, next func(ctx context.Context) (any, error)) graphql.Marshaler {
-	{{ template "queryDirectives" (dict "DirectiveList" (.AllDirectives.LocationDirectives "MUTATION") "UseFunctionSyntaxForExecutionContext" $.Config.UseFunctionSyntaxForExecutionContext) }}
+func {{.FuncReceiver}}_mutationMiddleware(ctx context.Context, {{.ECFuncParam}}obj *ast.OperationDefinition, next func(ctx context.Context) (any, error)) graphql.Marshaler {
+	{{ template "queryDirectives" (.QueryDirectivesCtx (.AllDirectives.LocationDirectives "MUTATION")) }}
 }
 {{ end }}
 

--- a/codegen/field.go
+++ b/codegen/field.go
@@ -713,6 +713,13 @@ func (f *Field) ResolverType() string {
 	return fmt.Sprintf("%s().%s(%s)", f.Object.Name, f.GoFieldName, f.CallArgs())
 }
 
+// ZeroVal returns the Go declaration for the typed zero value of this field's
+// return type, suitable for use as an error-path return value inside a
+// directive closure.
+func (f *Field) ZeroVal() string {
+	return fmt.Sprintf("var zeroVal %s", templates.CurrentImports.LookupType(f.TypeReference.GO))
+}
+
 func (f *Field) IsInputObject() bool {
 	return f.Object.Kind == ast.InputObject
 }

--- a/codegen/field.gotpl
+++ b/codegen/field.gotpl
@@ -41,7 +41,7 @@ func {{$.FuncReceiver}}_{{$object.Name}}_{{$field.Name}}(ctx context.Context, {{
 			func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 				{{- if $field.HasDirectives -}}
 				directive0 := next
-				{{ template "implDirectives" (dict "Field" $field "UseFunctionSyntaxForExecutionContext" $.Config.UseFunctionSyntaxForExecutionContext) }}
+				{{ template "implDirectives" ($.ImplDirectivesCtx $field) }}
 				next = directive{{$field.ImplDirectives|len}}
 				{{end}}
 				{{- if  $.AllDirectives.LocationDirectives "FIELD" -}}

--- a/codegen/input.gotpl
+++ b/codegen/input.gotpl
@@ -41,7 +41,7 @@
 				ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField({{$field.Name|quote}}))
 				{{- if $field.ImplDirectives }}
 					directive0 := func(ctx context.Context) (any, error) { return {{$.ECDot}}{{ $field.TypeReference.UnmarshalFunc }}(ctx, {{$.ECArg}}v) }
-					{{ template "implDirectives" (dict "Field" $field "UseFunctionSyntaxForExecutionContext" $.Config.UseFunctionSyntaxForExecutionContext) }}
+					{{ template "implDirectives" ($.ImplDirectivesCtx $field) }}
 					tmp, err := directive{{$field.ImplDirectives|len}}(ctx)
 					if err != nil {
 						return {{$it}}, graphql.ErrorOnPath(ctx, err)
@@ -101,29 +101,7 @@
 		// Execute INPUT_OBJECT level directives (e.g., @oneOf, @directive3)
 		// These run after all fields have been unmarshaled
 		directive0 := func(ctx context.Context) (any, error) { return {{$it}}, nil }
-		{{- range $i, $directive := $input.InputObjectDirectives }}
-		directive{{add $i 1}} := func(ctx context.Context) (any, error) {
-			{{- range $arg := $directive.Args }}
-				{{- if notNil "Value" $arg }}
-					{{ $arg.VarName }}, err := {{$.ECDot}}{{ $arg.TypeReference.UnmarshalFunc }}(ctx, {{$.ECArg}}{{ $arg.Value | dump }})
-					if err != nil {
-						return {{$it}}, graphql.ErrorOnPath(ctx, err)
-					}
-				{{- else if notNil "Default" $arg }}
-					{{ $arg.VarName }}, err := {{$.ECDot}}{{ $arg.TypeReference.UnmarshalFunc }}(ctx, {{$.ECArg}}{{ $arg.Default | dump }})
-					if err != nil {
-						return {{$it}}, graphql.ErrorOnPath(ctx, err)
-					}
-				{{- end }}
-			{{- end }}
-			{{- if not $directive.IsBuiltIn}}
-				if {{$directive.CallPath}} == nil {
-					return {{$it}}, errors.New("directive {{$directive.Name}} is not implemented")
-				}
-			{{- end}}
-			return {{$directive.CallPath}}({{$directive.ResolveArgs "asMap" $i}})
-		}
-		{{- end }}
+		{{ template "implDirectives" ($.InputObjectImplDirectivesCtx $input $it) }}
 		tmp, err := directive{{$input.InputObjectDirectives|len}}(ctx)
 		if err != nil {
 			return {{$it}}, graphql.ErrorOnPath(ctx, err)

--- a/codegen/object.go
+++ b/codegen/object.go
@@ -165,6 +165,16 @@ func (o *Object) IsConcurrent() bool {
 	return false
 }
 
+// InvalidsIncrement returns the Go statement that increments the invalids
+// counter for this object's field set. Concurrent objects require atomic
+// access; sequential objects use a plain increment.
+func (o *Object) InvalidsIncrement(fieldSetVar string) string {
+	if o.IsConcurrent() {
+		return fmt.Sprintf("atomic.AddUint32(&%s.Invalids, 1)", fieldSetVar)
+	}
+	return fieldSetVar + ".Invalids++"
+}
+
 func (o *Object) IsReserved() bool {
 	return strings.HasPrefix(o.Name, "__")
 }

--- a/codegen/object.gotpl
+++ b/codegen/object.gotpl
@@ -59,13 +59,7 @@ func {{$.FuncReceiver}}_{{$object.Name}}(ctx context.Context, {{$.ECFuncParam}}s
 					{{- end }}
 					res = {{$.ECDot}}_{{$object.Name}}_{{$field.Name}}(ctx, {{$.ECArg}}field{{if not $object.Root}}, obj{{end}})
 					{{- if $field.TypeReference.GQL.NonNull }}
-						if res == graphql.Null {
-							{{- if $object.IsConcurrent }}
-								atomic.AddUint32(&fs.Invalids, 1)
-							{{- else }}
-								fs.Invalids++
-							{{- end }}
-						}
+						if res == graphql.Null { {{ $object.InvalidsIncrement "fs" }} }
 					{{- end }}
 					return res
 				}
@@ -115,13 +109,7 @@ func {{$.FuncReceiver}}_{{$object.Name}}(ctx context.Context, {{$.ECFuncParam}}s
 				{{- end -}}
 
 				{{- if $field.TypeReference.GQL.NonNull }}
-					if out.Values[i] == graphql.Null {
-						{{- if $object.IsConcurrent }}
-							atomic.AddUint32(&out.Invalids, 1)
-						{{- else }}
-							out.Invalids++
-						{{- end }}
-					}
+					if out.Values[i] == graphql.Null { {{ $object.InvalidsIncrement "out" }} }
 				{{- end }}
 			{{- end }}
 		{{- end }}

--- a/codegen/object_test.go
+++ b/codegen/object_test.go
@@ -1,0 +1,46 @@
+package codegen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+func TestObjectInvalidsIncrement(t *testing.T) {
+	// non-concurrent: all fields are non-resolver, non-method-with-context
+	sequential := &Object{Definition: &ast.Definition{Name: "Query"}}
+	sequential.Fields = []*Field{
+		{FieldDefinition: &ast.FieldDefinition{Name: "foo"}, Object: sequential},
+	}
+	assert.Equal(t, "out.Invalids++", sequential.InvalidsIncrement("out"))
+	assert.Equal(t, "fs.Invalids++", sequential.InvalidsIncrement("fs"))
+
+	// concurrent: at least one resolver field
+	obj := &Object{Definition: &ast.Definition{Name: "User"}}
+	obj.Fields = []*Field{
+		{
+			FieldDefinition: &ast.FieldDefinition{Name: "name"},
+			IsResolver:      true,
+			Object:          obj,
+		},
+	}
+	assert.Equal(t, "atomic.AddUint32(&out.Invalids, 1)", obj.InvalidsIncrement("out"))
+	assert.Equal(t, "atomic.AddUint32(&fs.Invalids, 1)", obj.InvalidsIncrement("fs"))
+}
+
+func TestObjectInvalidsIncrement_DisableConcurrency(t *testing.T) {
+	// DisableConcurrency=true makes IsConcurrent() false even with resolver fields
+	obj := &Object{
+		Definition:         &ast.Definition{Name: "Mutation"},
+		DisableConcurrency: true,
+	}
+	obj.Fields = []*Field{
+		{
+			FieldDefinition: &ast.FieldDefinition{Name: "createUser"},
+			IsResolver:      true,
+			Object:          obj,
+		},
+	}
+	assert.Equal(t, "out.Invalids++", obj.InvalidsIncrement("out"))
+}

--- a/codegen/testserver/followschema/directive.generated.go
+++ b/codegen/testserver/followschema/directive.generated.go
@@ -461,12 +461,14 @@ func (ec *executionContext) unmarshalInputInputDirectives(ctx context.Context, o
 	// Execute INPUT_OBJECT level directives (e.g., @oneOf, @directive3)
 	// These run after all fields have been unmarshaled
 	directive0 := func(ctx context.Context) (any, error) { return it, nil }
+
 	directive1 := func(ctx context.Context) (any, error) {
 		if ec.Directives.Directive3 == nil {
-			return it, errors.New("directive directive3 is not implemented")
+			return it, graphql.ErrorOnPath(ctx, errors.New("directive directive3 is not implemented"))
 		}
 		return ec.Directives.Directive3(ctx, asMap, directive0)
 	}
+
 	tmp, err := directive1(ctx)
 	if err != nil {
 		return it, graphql.ErrorOnPath(ctx, err)
@@ -507,16 +509,18 @@ func (ec *executionContext) unmarshalInputInputDirectivesWithArgs(ctx context.Co
 	// Execute INPUT_OBJECT level directives (e.g., @oneOf, @directive3)
 	// These run after all fields have been unmarshaled
 	directive0 := func(ctx context.Context) (any, error) { return it, nil }
+
 	directive1 := func(ctx context.Context) (any, error) {
 		inputNamespace, err := ec.unmarshalNString2string(ctx, "InputDirectivesWithArgs")
 		if err != nil {
 			return it, graphql.ErrorOnPath(ctx, err)
 		}
 		if ec.Directives.Directive3WithArg == nil {
-			return it, errors.New("directive directive3WithArg is not implemented")
+			return it, graphql.ErrorOnPath(ctx, errors.New("directive directive3WithArg is not implemented"))
 		}
 		return ec.Directives.Directive3WithArg(ctx, asMap, directive0, inputNamespace)
 	}
+
 	tmp, err := directive1(ctx)
 	if err != nil {
 		return it, graphql.ErrorOnPath(ctx, err)

--- a/codegen/testserver/singlefile/generated.go
+++ b/codegen/testserver/singlefile/generated.go
@@ -14507,12 +14507,14 @@ func (ec *executionContext) unmarshalInputInputDirectives(ctx context.Context, o
 	// Execute INPUT_OBJECT level directives (e.g., @oneOf, @directive3)
 	// These run after all fields have been unmarshaled
 	directive0 := func(ctx context.Context) (any, error) { return it, nil }
+
 	directive1 := func(ctx context.Context) (any, error) {
 		if ec.Directives.Directive3 == nil {
-			return it, errors.New("directive directive3 is not implemented")
+			return it, graphql.ErrorOnPath(ctx, errors.New("directive directive3 is not implemented"))
 		}
 		return ec.Directives.Directive3(ctx, asMap, directive0)
 	}
+
 	tmp, err := directive1(ctx)
 	if err != nil {
 		return it, graphql.ErrorOnPath(ctx, err)
@@ -14553,16 +14555,18 @@ func (ec *executionContext) unmarshalInputInputDirectivesWithArgs(ctx context.Co
 	// Execute INPUT_OBJECT level directives (e.g., @oneOf, @directive3)
 	// These run after all fields have been unmarshaled
 	directive0 := func(ctx context.Context) (any, error) { return it, nil }
+
 	directive1 := func(ctx context.Context) (any, error) {
 		inputNamespace, err := ec.unmarshalNString2string(ctx, "InputDirectivesWithArgs")
 		if err != nil {
 			return it, graphql.ErrorOnPath(ctx, err)
 		}
 		if ec.Directives.Directive3WithArg == nil {
-			return it, errors.New("directive directive3WithArg is not implemented")
+			return it, graphql.ErrorOnPath(ctx, errors.New("directive directive3WithArg is not implemented"))
 		}
 		return ec.Directives.Directive3WithArg(ctx, asMap, directive0, inputNamespace)
 	}
+
 	tmp, err := directive1(ctx)
 	if err != nil {
 		return it, graphql.ErrorOnPath(ctx, err)

--- a/plugin/modelgen/out_conflicting_types/generated.go
+++ b/plugin/modelgen/out_conflicting_types/generated.go
@@ -3,18 +3,18 @@
 package out_conflicting_types
 
 type Baz struct {
-	WantWithoutUnderscore *FooBar0 `json:"want_without_underscore" database:"Bazwant_without_underscore"`
+	WantWithoutUnderscore *FooBar `json:"want_without_underscore" database:"Bazwant_without_underscore"`
 }
 
 type Bees struct {
-	WantWithUnderscore *FooBar `json:"want_with_underscore" database:"Beeswant_with_underscore"`
-}
-
-type FooBar0 struct {
-	WithoutUnderscore *bool `json:"without_underscore,omitempty" database:"FooBarwithout_underscore"`
+	WantWithUnderscore *FooBar0 `json:"want_with_underscore" database:"Beeswant_with_underscore"`
 }
 
 type FooBar struct {
+	WithoutUnderscore *bool `json:"without_underscore,omitempty" database:"FooBarwithout_underscore"`
+}
+
+type FooBar0 struct {
 	WithUnderscore *bool `json:"with_underscore,omitempty" database:"Foo_Barwith_underscore"`
 }
 


### PR DESCRIPTION
# gqlgen codegen template refactoring — typed contexts, extracted methods, shared templates

## Overview

Four related cleanups to the gqlgen code generation layer, all motivated by the same root cause: decision logic that belonged in Go was embedded in template syntax, making it hard to read, impossible to unit-test, and prone to drift across files. Each change moves a specific decision out of the templates and into a typed Go method.

---

## Replace ad-hoc `dict` template calls with typed context structs

**Files changed:** `codegen/data.go`, `codegen/directives.gotpl`, `codegen/field.gotpl`, `codegen/args.gotpl`, `codegen/input.gotpl`

Named templates in `directives.gotpl` (`implDirectives`, `queryDirectives`) are invoked from multiple call sites. Because Go templates accept only a single argument, `UseFunctionSyntaxForExecutionContext` was threaded to every call using an ad-hoc `dict`:

```
{{ template "implDirectives" (dict "Field" $field "UseFunctionSyntaxForExecutionContext" $.Config.UseFunctionSyntaxForExecutionContext) }}
{{ template "queryDirectives" (dict "DirectiveList" (...) "UseFunctionSyntaxForExecutionContext" ...) }}
```

This required every named template to re-read the bool from the map by name and branch on it explicitly. The bool was not a property of any individual field; it is a package-wide generation mode already exposed through the `ECDot`/`ECArg`/`FuncReceiver`/`ECFuncParam` methods added in a prior pass.

**Solution:** introduce two typed context structs in `data.go`:

```go
type ImplDirectivesContext struct {
    Field   ImplDirectivesField   // interface: DirectiveObjName, ImplDirectives, ZeroVal
    Data    *Data                 // provides ECDot, ECArg, FuncReceiver, ECFuncParam
    ErrVal  string                // Go variable name to return on error
    ErrWrap bool                  // when true, wrap error in graphql.ErrorOnPath
}

type QueryDirectivesContext struct {
    DirectiveList DirectiveList
    Data          *Data
}
```

Factory methods on `*Data` construct them:

```go
func (d *Data) ImplDirectivesCtx(f ImplDirectivesField) ImplDirectivesContext
func (d *Data) QueryDirectivesCtx(dl DirectiveList) QueryDirectivesContext
```

Call sites become:

```
{{ template "implDirectives" ($.ImplDirectivesCtx $field) }}
{{ template "queryDirectives" (.QueryDirectivesCtx (.AllDirectives.LocationDirectives "QUERY")) }}
```

Inside the named templates, execution-context helpers are accessed as `.Data.ECDot`, `.Data.ECArg`, etc. The manually forwarded bool and the `dict` calls are gone entirely.

The `ErrVal`/`ErrWrap` fields on `ImplDirectivesContext` are used by the INPUT_OBJECT directive path described below.

---

## Extract `Object.InvalidsIncrement()` to remove the atomic/non-atomic branch

**Files changed:** `codegen/object.go`, `codegen/object.gotpl`

`object.gotpl` contained this pattern twice — once in the concurrent `innerFunc` (using field set variable `fs`) and once in the non-concurrent path (using `out`):

```
{{- if $field.TypeReference.GQL.NonNull }}
    if res == graphql.Null {
        {{- if $object.IsConcurrent }}
            atomic.AddUint32(&fs.Invalids, 1)
        {{- else }}
            fs.Invalids++
        {{- end }}
    }
{{- end }}
```

Whether atomic access is required is a property of the object, not a decision for the template. Added to `object.go`:

```go
// InvalidsIncrement returns the Go statement that increments the invalids
// counter for this object's field set. Concurrent objects require atomic
// access; sequential objects use a plain increment.
func (o *Object) InvalidsIncrement(fieldSetVar string) string {
    if o.IsConcurrent() {
        return fmt.Sprintf("atomic.AddUint32(&%s.Invalids, 1)", fieldSetVar)
    }
    return fieldSetVar + ".Invalids++"
}
```

Both occurrences in the template collapse to a single line each:

```
{{- if $field.TypeReference.GQL.NonNull }}
    if res == graphql.Null { {{ $object.InvalidsIncrement "fs" }} }
{{- end }}
```

---

## Share `implDirectives` for INPUT_OBJECT-level directive processing

**Files changed:** `codegen/data.go`, `codegen/input.gotpl`

`input.gotpl` contained an inline directive chain loop (~20 lines) for INPUT_OBJECT-level directives that was structurally identical to the `implDirectives` named template, but duplicated inline because of two apparent differences:

1. **Directive receiver name.** `implDirectives` calls `$directive.ResolveArgs` with `.Field.DirectiveObjName` as the receiver. For INPUT_OBJECT directives the receiver is `"asMap"` (the map representation of the input), not a typed struct field.
2. **Error return form.** `implDirectives` returns a typed zero value on error (`var zeroVal T; return zeroVal, err`). The INPUT_OBJECT path returns the partially-built struct and wraps the error: `return it, graphql.ErrorOnPath(ctx, err)`.

Both differences are handled by extending `ImplDirectivesContext` with `ErrVal`/`ErrWrap` (described above) and adding an adapter type plus a factory method:

```go
// inputObjectImplDirectivesField adapts *Object for use as an ImplDirectivesField
// where the directive receiver is the map representation of the input.
type inputObjectImplDirectivesField struct{ object *Object }

func (f *inputObjectImplDirectivesField) DirectiveObjName() string    { return "asMap" }
func (f *inputObjectImplDirectivesField) ImplDirectives() []*Directive { return f.object.InputObjectDirectives() }
func (f *inputObjectImplDirectivesField) ZeroVal() string              { return "" } // unused when ErrWrap=true

func (d *Data) InputObjectImplDirectivesCtx(obj *Object, errVal string) ImplDirectivesContext {
    return ImplDirectivesContext{
        Field: &inputObjectImplDirectivesField{object: obj}, Data: d,
        ErrVal: errVal, ErrWrap: true,
    }
}
```

The inline loop in `input.gotpl` is replaced by:

```
directive0 := func(ctx context.Context) (any, error) { return {{$it}}, nil }
{{ template "implDirectives" ($.InputObjectImplDirectivesCtx $input $it) }}
tmp, err := directive{{$input.InputObjectDirectives|len}}(ctx)
```

---

## Add `ZeroVal()` to eliminate repeated zero-value construction

**Files changed:** `codegen/field.go`, `codegen/args.go`, `codegen/data.go`, `codegen/directives.gotpl`, `codegen/args.gotpl`

The zero-value-on-error pattern appeared throughout directive processing templates:

```
{{ $zeroVal := .Field.TypeReference.GO | ref }}
...
var zeroVal {{$zeroVal}}
return zeroVal, err
```

This required a setup variable at the top of each template block and was repeated at every error return point. Added to both `Field` and `FieldArgument`:

```go
func (f *Field) ZeroVal() string {
    return fmt.Sprintf("var zeroVal %s", templates.CurrentImports.LookupType(f.TypeReference.GO))
}
```

The `{{ $zeroVal := ... }}` setup line in `implDirectives` is deleted. Error returns that required it now use `.Field.ZeroVal` directly.

All six occurrences of `var zeroVal {{ $arg.TypeReference.GO | ref}}` in `args.gotpl` — in the null-check guard, the `directive0` closure, the post-invocation error path, the nilable `tmp==nil` branch, the unexpected-type branch, and the non-directive else path — are replaced with `{{ $arg.ZeroVal }}`.

A companion method on `ImplDirectivesContext` collapses the three repeated `if ErrWrap` branches inside `implDirectives` into single-line call sites:

```go
func (c ImplDirectivesContext) ErrReturn(errExpr string) string {
    if c.ErrWrap {
        return fmt.Sprintf("return %s, graphql.ErrorOnPath(ctx, %s)", c.ErrVal, errExpr)
    }
    return c.Field.ZeroVal() + "\nreturn " + c.ErrVal + ", " + errExpr
}
```

Template use:

```
{{ $arg.VarName }}, err := {{$.Data.ECDot}}{{ $arg.TypeReference.UnmarshalFunc }}(ctx, ...)
if err != nil { {{ $.ErrReturn "err" }} }
```

```
if {{$directive.CallPath}} == nil { {{ $.ErrReturn (printf "errors.New(%q)" (print "directive " $directive.Name " is not implemented")) }} }
```

---

## Unit tests

**Files changed:** `codegen/data_test.go`, `codegen/object_test.go` (new)

The methods added in this pass are pure functions on model types — they take no schema, produce no files, and call no external systems. They can be tested directly without running the code generator.

Added tests covering:

- `Data.FuncReceiver`, `Data.ECFuncParam`, `Data.ECDot`, `Data.ECArg` — both generation modes
- `ImplDirectivesContext.ErrReturn` — `ErrWrap=false` (zero-value declaration + plain error) and `ErrWrap=true` (wrapped error, no declaration)
- `Object.InvalidsIncrement` — sequential object (plain `++`), concurrent object (`atomic.AddUint32`), and `DisableConcurrency=true` (forces sequential even with resolver fields)
