### PR TITLE
Add PayloadReadLimit to WebSocket transport

### DIFF
--- a/docs/content/recipes/subscriptions.md
+++ b/docs/content/recipes/subscriptions.md
@@ -116,6 +116,33 @@ srv.AddTransport(transport.Websocket{
 })
 ```
 
+### Limiting Payload Size
+
+By default, the WebSocket transport enforces a **1 MB read limit** per message. This protects
+your server against DoS/DDoS attacks where clients send very large payloads over many concurrent
+connections — even when compression makes those payloads tiny on the wire.
+
+You can tune this limit using `PayloadReadLimit`:
+
+```go
+// Tighten the limit to 512 KB for your use case.
+limit := int64(512 * 1024)
+srv.AddTransport(transport.Websocket{
+	PayloadReadLimit: &limit,
+})
+```
+
+```go
+// Relax the limit to 10 MB if your application sends large payloads.
+limit := int64(10 * 1024 * 1024)
+srv.AddTransport(transport.Websocket{
+	PayloadReadLimit: &limit,
+})
+```
+
+When a client sends a message that exceeds the limit, gorilla/websocket closes the connection
+immediately without processing the payload.
+
 [code]: https://github.com/99designs/gqlgen/blob/master/graphql/handler/transport/websocket.go
 [gorilla]: https://pkg.go.dev/github.com/gorilla/websocket
 [graphql-ws]: https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md

--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -39,6 +39,10 @@ type (
 		 */
 		MissingPongOk bool
 
+		// PayloadReadLimit is the maximum size in bytes of a WebSocket message read from the client.
+		// If nil, defaults to 1 MB. Set to a pointer of -1 to disable the limit entirely.
+		PayloadReadLimit *int64
+
 		didInjectSubprotocols bool
 	}
 	wsConnection struct {
@@ -65,6 +69,9 @@ type (
 	// Callback called when websocket is closed.
 	WebsocketCloseFunc func(ctx context.Context, closeCode int)
 )
+
+// defaultPayloadReadLimit is applied when PayloadReadLimit is 0.
+const defaultPayloadReadLimit = 1024 * 1024 // 1 MB
 
 var errReadTimeout = errors.New("read timeout")
 
@@ -116,6 +123,14 @@ func (t Websocket) Do(w http.ResponseWriter, r *http.Request, exec graphql.Graph
 		me = graphqlwsMessageExchanger{c: ws}
 	case graphqltransportwsSubprotocol:
 		me = graphqltransportwsMessageExchanger{c: ws}
+	}
+
+	readLimit := int64(defaultPayloadReadLimit)
+	if t.PayloadReadLimit != nil {
+		readLimit = *t.PayloadReadLimit
+	}
+	if readLimit > 0 {
+		ws.SetReadLimit(readLimit)
 	}
 
 	conn := wsConnection{

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -992,6 +992,28 @@ func readOp(conn *websocket.Conn) operationMessage {
 	return msg
 }
 
+func TestWebsocketWithPayloadReadLimit(t *testing.T) {
+	// Set a very small limit so we can trigger it easily in a test
+	limit := int64(100)
+	h := testserver.New()
+	h.AddTransport(transport.Websocket{PayloadReadLimit: &limit})
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	c := wsConnect(srv.URL)
+	defer c.Close()
+
+	// Send a payload that exceeds the 100-byte limit
+	oversized := strings.Repeat("x", 200)
+	err := c.WriteMessage(websocket.TextMessage, []byte(oversized))
+	require.NoError(t, err)
+
+	// Gorilla closes the connection when the read limit is exceeded
+	_, _, err = c.ReadMessage()
+	require.Error(t, err)
+}
+
 // copied out from websocket_graphqlws.go to keep these private
 
 const (


### PR DESCRIPTION
Fixes #3518 

The WebSocket transport had no cap on incoming message size. Gorilla/websocket's default read limit is effectively unlimited, making it trivial to DoS a server by opening many connections and sending large (but highly compressible) payloads in parallel.

If during development, a user wants to explicitly set it to the old **_unsafe_**, unlimited behavior, [they can explicitly set the limit to 0 based on the Gorilla websocket code](https://github.com/gorilla/websocket/blob/ac0789be11725ab2285233e9a3800c2312cff4fc/conn.go#L941) so this does not break backwards compatibility as users can opt-out of the new behavior.

  ## Changes                                                                                                                                                                                                        
                  
  - Added `PayloadReadLimit *int64` field to the `Websocket` struct
  - Default limit is **1 MB** when `PayloadReadLimit` is `nil`
  - Uses gorilla's `SetReadLimit` — oversized messages are rejected immediately without being processed, and the connection is closed                                                                                                                                                           
  - Added a test (`TestWebsocketWithPayloadReadLimit`) verifying the limit is enforced                                                                                                                              
  - Updated the subscriptions docs with usage examples                                                              
                                                                                                                                                                                                                    
  ## Usage                                                                                                                                                                                                          
                  
  ```go                                                                                                                                                                                                             
  // Use the 1 MB default (no config needed)
  srv.AddTransport(transport.Websocket{})
                                                                                                                                                                                                                    
  // Custom limit
  limit := int64(512 * 1024) // 512 KB
    srv.AddTransport(transport.Websocket{
      PayloadReadLimit: &limit,
  })
  
  // Explicitly Set to Prior *Unsafe* Unlimited
    limit := int64(0) // Unsafe Unlimited
    srv.AddTransport(transport.Websocket{
      PayloadReadLimit: &limit,
  })
```

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
