### PR TITLE
Stop dispatch handler when request context is canceled

### DIFF
--- a/graphql/executor/executor.go
+++ b/graphql/executor/executor.go
@@ -131,6 +131,12 @@ func (e *Executor) DispatchOperation(
 		}
 
 		return func(ctx context.Context) *graphql.Response {
+			// nil is the end-of-stream signal for transports that iterate on
+			// this handler; honor context cancellation by emitting it instead
+			// of producing further responses no consumer will receive.
+			if ctx.Err() != nil {
+				return nil
+			}
 			ctx = graphql.WithResponseContext(ctx, e.errorPresenter, e.recoverFunc)
 			resp := e.ext.responseMiddleware(ctx, func(ctx context.Context) *graphql.Response {
 				resp := responses(ctx)

--- a/graphql/executor/executor_test.go
+++ b/graphql/executor/executor_test.go
@@ -183,6 +183,31 @@ func TestExecutor(t *testing.T) {
 	})
 }
 
+func TestDispatchOperationContextCancel(t *testing.T) {
+	exec := testexecutor.New()
+
+	ctx, cancel := context.WithCancel(graphql.StartOperationTrace(context.Background()))
+	now := graphql.Now()
+	rc, listErr := exec.CreateOperationContext(ctx, &graphql.RawParams{
+		Query: "{name}",
+		ReadTime: graphql.TraceTiming{
+			Start: now,
+			End:   now,
+		},
+	})
+	require.Nil(t, listErr)
+
+	responses, opCtx := exec.DispatchOperation(ctx, rc)
+	require.NotNil(t, responses(opCtx))
+
+	responses, opCtx = exec.DispatchOperation(ctx, rc)
+	require.NotNil(t, responses(opCtx))
+
+	cancel()
+	responses, opCtx = exec.DispatchOperation(ctx, rc)
+	assert.Nil(t, responses(opCtx))
+}
+
 func TestExecutorDisableSuggestion(t *testing.T) {
 	t.Run("by default, the error message will include suggestions", func(t *testing.T) {
 		exec := testexecutor.New()


### PR DESCRIPTION
## Summary

Add a `ctx.Err() != nil` guard at the top of the `*graphql.Response` closure returned by `(*Executor).DispatchOperation`, so the handler emits `nil` (= end-of-stream) once the request context is canceled or times out.

## Background

We hit this in production. A faulty operation interceptor in our service kept returning a non-nil `*graphql.Response` indefinitely (it should have returned `nil` after the first response). On a regular POST request this was harmless because the transport invokes the handler only once. But the moment a client sent `Accept: multipart/mixed` (Apollo Client with `@defer`), the multipart dispatch loop in `transport/http_multipart_mixed.go` had no way to terminate — the only exit condition was a `nil` response.

The result: a single request goroutine stayed alive on the server for **39+ hours**, emitting roughly 8,000 log lines per second the entire time. Neither HTTP timeouts nor context cancellation could break it out, because the loop never checks `ctx.Done()`.

The application bug was ours to fix, but a single misbehaving handler should not be able to leak goroutines forever. This PR adds a small safety net at the executor layer so the framework can defend against this class of issue across all transports.

## Why this layer

Putting the guard in `DispatchOperation` makes it a central safety net: every transport that loops on the handler — `multipart/mixed`, `sse`, `websocket` — benefits without changes, and conformant `ResponseHandler` implementations are unaffected (they should already return `nil` after their last response).

## Follow-up proposal (Go/No-go appreciated)

Even with this safety net in place, a canceled request still gets terminated by the transport's normal end-of-stream sequence — closing boundary for `multipart/mixed`, `event: complete` for SSE, `complete` message for websocket. The cancellation is invisible to clients, and is arguably a protocol violation when it appears right after a `hasNext: true` payload.

I'd like to address this in follow-up commits on this PR by adding per-protocol cancellation handling to the three transports that loop on `ResponseHandler`:

- `multipart/mixed` (`transport/http_multipart_mixed.go:148-156`): skip the closing boundary when the context is canceled
- `sse` (`transport/sse.go:118-127`): emit `event: error` instead of `event: complete`
- `websocket` (`transport/websocket.go:450-457`): emit an `error` message instead of `complete`

Let me know if you'd like me to proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)