### PR TITLE
fix: exit resolver when errors are in context

### DIFF
--- a/graphql/context_response.go
+++ b/graphql/context_response.go
@@ -134,6 +134,17 @@ func GetErrors(ctx context.Context) gqlerror.List {
 	return cpy
 }
 
+func HasErrors(ctx context.Context) bool {
+	resCtx, ok := ctx.Value(resultCtx).(*responseContext)
+	if !ok {
+		return false
+	}
+	resCtx.errorsMu.Lock()
+	defer resCtx.errorsMu.Unlock()
+
+	return len(resCtx.errors) > 0
+}
+
 // RegisterExtension allows you to add a new extension into the graphql response
 func RegisterExtension(ctx context.Context, key string, value any) {
 	c := getResponseContext(ctx)

--- a/graphql/context_response_test.go
+++ b/graphql/context_response_test.go
@@ -120,3 +120,15 @@ func TestGetErrorFromPresenter(t *testing.T) {
 	ctx = WithFieldContext(ctx, &FieldContext{})
 	AddError(ctx, errors.New("foo1"))
 }
+
+func TestHasErrors(t *testing.T) {
+	ctx := WithResponseContext(context.Background(), DefaultErrorPresenter, nil)
+
+	ctx = WithFieldContext(ctx, &FieldContext{})
+	assert.False(t, HasErrors(ctx))
+	AddError(ctx, errors.New("foo1"))
+	assert.True(t, HasErrors(ctx))
+}
+func TestHasErrorsWithoutResponseContext(t *testing.T) {
+	assert.False(t, HasErrors(context.Background()))
+}

--- a/graphql/resolve_field.go
+++ b/graphql/resolve_field.go
@@ -118,6 +118,10 @@ func resolveField[T, R any](
 		oc.Error(ctx, AddFieldLocationToError(ctx, err))
 		return defaultResult
 	}
+	// If all errors were added into ctx, and none returned directly, check the context and action accordingly.
+	if HasErrors(ctx) {
+		return defaultResult
+	}
 	if resTmp == nil {
 		if nonNull {
 			if !HasFieldError(ctx, fc) {

--- a/graphql/resolve_field_test.go
+++ b/graphql/resolve_field_test.go
@@ -18,6 +18,7 @@ type ResolveFieldTest struct {
 	initializeFieldContextErr error
 	panicMiddlewareChain      string
 	panicResolverMiddleware   string
+	resolverMiddlewareErr     error // error added to context by resolver middleware
 	panicFieldResolver        string
 	fieldResolverValue        any
 	fieldResolverErr          error
@@ -97,6 +98,14 @@ var commonResolveFieldTests = []ResolveFieldTest{
 		expected:         "null",
 		expectedErr:      "input: testField test field resolver error\n",
 		expectedCalls:    4,
+	},
+	{
+		name:                  "should return default when resolver middleware adds error to context",
+		resolverMiddlewareErr: errors.New("test resolver middleware context error"),
+		fieldResolverValue:    "test value",
+		expected:              "null",
+		expectedErr:           "input: testField test resolver middleware context error\n",
+		expectedCalls:         3,
 	},
 }
 
@@ -241,6 +250,10 @@ func testResolveField[R any](
 					)
 					if test.panicResolverMiddleware != "" {
 						panic(test.panicResolverMiddleware)
+					}
+					if test.resolverMiddlewareErr != nil {
+						AddError(ctx, test.resolverMiddlewareErr)
+						return nil, nil
 					}
 					return next(ctx)
 				},


### PR DESCRIPTION
Fixing #3510

When all errors are added to `ctx` and returned `nil` error, it failed further down the line.
This PR solves that by stopping resolve execution, if errors are in context.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
