### PR TITLE
Show deprecated input values in GraphiQL

### DIFF
--- a/graphql/playground/playground.go
+++ b/graphql/playground/playground.go
@@ -165,7 +165,8 @@ var page = template.Must(template.New("graphiql").Parse(`<!DOCTYPE html>
           shouldPersistHeaders: true,
 		  headers: JSON.stringify(uiHeaders, null, 2),
 		  plugins: plugins,
-          storage: new PrefixedStorage('{{.StoragePrefix}}')
+          storage: new PrefixedStorage('{{.StoragePrefix}}'),
+          inputValueDeprecation: true
         }),
         document.getElementById('graphiql'),
       );


### PR DESCRIPTION
This problem was mentioned at the end of the discussion in #1636. This change just makes GraphiQL show deprecation info for input values.

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
