### PR TITLE
Add error unwrapping to WebsocketError

### DIFF
--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -94,6 +94,10 @@ func (e WebsocketError) Error() string {
 	return fmt.Sprintf("websocket write: %v", e.Err)
 }
 
+func (e WebsocketError) Unwrap() error {
+	return e.Err
+}
+
 var (
 	_ graphql.Transport = Websocket{}
 	_ error             = WebsocketError{}

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -455,7 +455,7 @@ func TestWebSocketErrorFunc(t *testing.T) {
 			ErrorFunc: func(_ context.Context, err error) {
 				require.EqualError(t, err, "websocket read: invalid message received")
 
-				var websocketError *transport.WebsocketError
+				var websocketError transport.WebsocketError
 				require.ErrorAs(t, err, &websocketError)
 				require.True(t, websocketError.IsReadError)
 				require.NotNil(t, websocketError.Unwrap())

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -458,7 +458,7 @@ func TestWebSocketErrorFunc(t *testing.T) {
 				var websocketError transport.WebsocketError
 				require.ErrorAs(t, err, &websocketError)
 				require.True(t, websocketError.IsReadError)
-				require.NotNil(t, websocketError.Unwrap())
+				require.Error(t, websocketError.Unwrap())
 
 				errFuncCalled <- true
 			},

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -454,7 +454,12 @@ func TestWebSocketErrorFunc(t *testing.T) {
 		h.AddTransport(transport.Websocket{
 			ErrorFunc: func(_ context.Context, err error) {
 				require.EqualError(t, err, "websocket read: invalid message received")
-				require.ErrorAs(t, err, &transport.WebsocketError{IsReadError: true})
+
+				var websocketError *transport.WebsocketError
+				require.ErrorAs(t, err, &websocketError)
+				require.True(t, websocketError.IsReadError)
+				require.NotNil(t, websocketError.Unwrap())
+
 				errFuncCalled <- true
 			},
 		})


### PR DESCRIPTION
The current `WebsocketError` does not implement `Unwrap()`. Consequently, we are unable to access the underlying error to understand how we should handle the error (e.g., we want to log errors due to abnormal socket closures as a non-error severity).

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
