### PR TITLE
Fix potential panic in batch directive cast

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -502,7 +502,9 @@ func (c *Config) injectGoFieldDirectives(schemaType *ast.Definition) error {
 
 		if arg := fd.Arguments.ForName(DirArgBatch); arg != nil {
 			if k, err := arg.Value.Value(nil); err == nil {
-				typeMapFieldEntry.Batch = k.(bool)
+				if val, ok := k.(bool); ok {
+					typeMapFieldEntry.Batch = val
+				}
 			}
 		}
 

--- a/codegen/config/config_directive_test.go
+++ b/codegen/config/config_directive_test.go
@@ -44,4 +44,31 @@ func TestDirectiveParsing(t *testing.T) {
 		field3 := cfg.Models["MyType"].Fields["field3"]
 		require.Nil(t, field3.AutoBindGetterHaser)
 	})
+
+	t.Run("batch argument in goField", func(t *testing.T) {
+		cfg := Config{
+			Models:     TypeMap{},
+			Directives: map[string]DirectiveConfig{},
+		}
+
+		cfg.Schema = gqlparser.MustLoadSchema(&ast.Source{Name: "schema.graphql", Input: `
+			directive @goField(batch: Boolean) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+
+			type MyType {
+				batchNull: String @goField(batch: null)
+				batchTrue: String @goField(batch: true)
+				batchFalse: String @goField(batch: false)
+				noBatch: String
+			}
+		`})
+
+		err := cfg.injectTypesFromSchema()
+		require.NoError(t, err)
+
+		m := cfg.Models["MyType"]
+		require.False(t, m.Fields["batchNull"].Batch)
+		require.True(t, m.Fields["batchTrue"].Batch)
+		require.False(t, m.Fields["batchFalse"].Batch)
+		require.False(t, m.Fields["noBatch"].Batch)
+	})
 }


### PR DESCRIPTION
The batch directive could have null as the value which will cause a panic in Config.Init(). The code did a cast to bool without type check.

Solves number 5 in https://github.com/99designs/gqlgen/issues/4114

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
