### PR TITLE
Add global batch resolver config under resolver.batch (issue #4044)

### DIFF
--- a/_examples/batchresolver/batchresolver_test.go
+++ b/_examples/batchresolver/batchresolver_test.go
@@ -425,22 +425,22 @@ func TestBatchDirectiveConfig(t *testing.T) {
 	userFields := cfg.Models["User"].Fields
 
 	// YAML-configured fields
-	require.True(t, userFields["nullableBatch"].Batch)
-	require.True(t, userFields["nullableBatchWithArg"].Batch)
-	require.True(t, userFields["nonNullableBatch"].Batch)
+	require.True(t, *userFields["nullableBatch"].Batch)
+	require.True(t, *userFields["nullableBatchWithArg"].Batch)
+	require.True(t, *userFields["nonNullableBatch"].Batch)
 
-	require.False(t, userFields["nullableNonBatch"].Batch)
-	require.False(t, userFields["nullableNonBatchWithArg"].Batch)
-	require.False(t, userFields["nonNullableNonBatch"].Batch)
+	require.False(t, *userFields["nullableNonBatch"].Batch)
+	require.False(t, *userFields["nullableNonBatchWithArg"].Batch)
+	require.False(t, *userFields["nonNullableNonBatch"].Batch)
 
 	// Directive-configured fields
-	require.True(t, userFields["directiveNullableBatch"].Batch)
-	require.True(t, userFields["directiveNullableBatchWithArg"].Batch)
-	require.True(t, userFields["directiveNonNullableBatch"].Batch)
+	require.True(t, *userFields["directiveNullableBatch"].Batch)
+	require.True(t, *userFields["directiveNullableBatchWithArg"].Batch)
+	require.True(t, *userFields["directiveNonNullableBatch"].Batch)
 
-	require.False(t, userFields["directiveNullableNonBatch"].Batch)
-	require.False(t, userFields["directiveNullableNonBatchWithArg"].Batch)
-	require.False(t, userFields["directiveNonNullableNonBatch"].Batch)
+	require.Nil(t, userFields["directiveNullableNonBatch"].Batch)
+	require.Nil(t, userFields["directiveNullableNonBatchWithArg"].Batch)
+	require.Nil(t, userFields["directiveNonNullableNonBatch"].Batch)
 }
 
 func TestBatchResolver_BatchErrors_ListPerIndex_AddsMultipleErrors(t *testing.T) {

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -330,6 +330,8 @@ func CompleteConfig(config *Config) error {
 
 	config.GoInitialisms.setInitialisms()
 
+	config.resolveModelBatchDefaults()
+
 	return nil
 }
 
@@ -503,7 +505,7 @@ func (c *Config) injectGoFieldDirectives(schemaType *ast.Definition) error {
 		if arg := fd.Arguments.ForName(DirArgBatch); arg != nil {
 			if k, err := arg.Value.Value(nil); err == nil {
 				if val, ok := k.(bool); ok {
-					typeMapFieldEntry.Batch = val
+					typeMapFieldEntry.Batch = &val
 				}
 			}
 		}
@@ -536,6 +538,20 @@ func (c *Config) injectGoFieldDirectives(schemaType *ast.Definition) error {
 	}
 
 	return nil
+}
+
+func (c *Config) resolveModelBatchDefaults() {
+	for typeName, entry := range c.Models {
+		for fieldName, field := range entry.Fields {
+			if field.Batch != nil {
+				continue
+			}
+			batch := c.Resolver.Batch.Enabled
+			field.Batch = &batch
+			entry.Fields[fieldName] = field
+		}
+		c.Models[typeName] = entry
+	}
 }
 
 func (c *Config) injectGoExtraFieldDirectives(schemaType *ast.Definition) error {
@@ -674,7 +690,7 @@ type TypeMapField struct {
 	// that accepts multiple parent objects and returns ([]T, error) for all of them
 	// in a single call, reducing N+1 query problems. For partial failures, return
 	// a graphql.BatchErrors implementation as the error.
-	Batch bool `yaml:"batch,omitempty"`
+	Batch *bool `yaml:"batch,omitempty"`
 	// ForceGenerate forces the field to be generated in the model struct
 	// even when OmitResolverFields is enabled and the field has forceResolver: true.
 	ForceGenerate bool `yaml:"forceGenerate"`

--- a/codegen/config/config_directive_test.go
+++ b/codegen/config/config_directive_test.go
@@ -66,9 +66,79 @@ func TestDirectiveParsing(t *testing.T) {
 		require.NoError(t, err)
 
 		m := cfg.Models["MyType"]
-		require.False(t, m.Fields["batchNull"].Batch)
-		require.True(t, m.Fields["batchTrue"].Batch)
-		require.False(t, m.Fields["batchFalse"].Batch)
-		require.False(t, m.Fields["noBatch"].Batch)
+		require.Nil(t, m.Fields["batchNull"].Batch)
+		require.NotNil(t, m.Fields["batchTrue"].Batch)
+		require.True(t, *m.Fields["batchTrue"].Batch)
+		require.NotNil(t, m.Fields["batchFalse"].Batch)
+		require.False(t, *m.Fields["batchFalse"].Batch)
+		_, ok := m.Fields["noBatch"]
+		require.False(t, ok)
+	})
+
+	t.Run("resolver.batch config enables batch for all fields", func(t *testing.T) {
+		cfg := Config{
+			Models:     TypeMap{},
+			Directives: map[string]DirectiveConfig{},
+			Resolver: ResolverConfig{
+				Batch: ResolverBatchConfig{Enabled: true},
+			},
+		}
+
+		cfg.Schema = gqlparser.MustLoadSchema(&ast.Source{Name: "schema.graphql", Input: `
+			directive @goField(batch: Boolean) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+
+			type MyType {
+				batchTrue: String @goField(batch: true)
+				batchFalse: String @goField(batch: false)
+				noBatch: String
+			}
+		`})
+
+		err := cfg.injectTypesFromSchema()
+		require.NoError(t, err)
+
+		m := cfg.Models["MyType"]
+		require.True(t, *m.Fields["batchTrue"].Batch)
+		require.False(t, *m.Fields["batchFalse"].Batch)
+		_, ok := m.Fields["noBatch"]
+		require.False(t, ok)
+	})
+
+	t.Run("batch priority: config, models yaml, goField directive", func(t *testing.T) {
+		falseVal := false
+		trueVal := true
+		cfg := Config{
+			Resolver: ResolverConfig{
+				Batch: ResolverBatchConfig{Enabled: true},
+			},
+			Models: TypeMap{
+				"MyType": {
+					Fields: map[string]TypeMapField{
+						"fromYaml":             {Batch: &falseVal},
+						"fromYamlAndDirective": {Batch: &trueVal},
+					},
+				},
+			},
+			Directives: map[string]DirectiveConfig{},
+		}
+
+		cfg.Schema = gqlparser.MustLoadSchema(&ast.Source{Name: "schema.graphql", Input: `
+			directive @goField(batch: Boolean) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+
+			type MyType {
+				fromYaml: String
+				fromYamlAndDirective: String @goField(batch: false)
+				fromConfigOnly: String
+			}
+		`})
+
+		err := cfg.injectTypesFromSchema()
+		require.NoError(t, err)
+
+		m := cfg.Models["MyType"]
+		require.False(t, *m.Fields["fromYaml"].Batch)
+		require.False(t, *m.Fields["fromYamlAndDirective"].Batch)
+		_, ok := m.Fields["fromConfigOnly"]
+		require.False(t, ok)
 	})
 }

--- a/codegen/config/config_test.go
+++ b/codegen/config/config_test.go
@@ -186,12 +186,14 @@ models:
         resolver: false
 `))
 		require.NoError(t, err)
-		require.True(t, cfg.Models["User"].Fields["posts"].Batch)
+		require.NotNil(t, cfg.Models["User"].Fields["posts"].Batch)
+		require.True(t, *cfg.Models["User"].Fields["posts"].Batch)
 		require.True(t, cfg.Models["User"].Fields["posts"].Resolver)
-		require.False(t, cfg.Models["User"].Fields["name"].Batch)
+		require.NotNil(t, cfg.Models["User"].Fields["name"].Batch)
+		require.False(t, *cfg.Models["User"].Fields["name"].Batch)
 	})
 
-	t.Run("batch flag defaults to false when not specified", func(t *testing.T) {
+	t.Run("batch flag defaults to resolver.batch when not specified", func(t *testing.T) {
 		cfg, err := ReadConfig(strings.NewReader(`
 schema: schema.graphql
 exec:
@@ -203,7 +205,45 @@ models:
         resolver: true
 `))
 		require.NoError(t, err)
-		require.False(t, cfg.Models["User"].Fields["posts"].Batch)
+		require.NotNil(t, cfg.Models["User"].Fields["posts"].Batch)
+		require.False(t, *cfg.Models["User"].Fields["posts"].Batch)
+	})
+
+	t.Run("batch defaults to resolver.batch when omitted in models yaml", func(t *testing.T) {
+		cfg, err := ReadConfig(strings.NewReader(`
+schema: schema.graphql
+resolver:
+  batch: true
+exec:
+  filename: generated.go
+models:
+  User:
+    fields:
+      posts:
+        resolver: true
+`))
+		require.NoError(t, err)
+		require.NotNil(t, cfg.Models["User"].Fields["posts"].Batch)
+		require.True(t, *cfg.Models["User"].Fields["posts"].Batch)
+	})
+
+	t.Run("batch defaults to resolver.batch.enabled when omitted in models yaml", func(t *testing.T) {
+		cfg, err := ReadConfig(strings.NewReader(`
+schema: schema.graphql
+resolver:
+  batch:
+    enabled: true
+exec:
+  filename: generated.go
+models:
+  User:
+    fields:
+      posts:
+        resolver: true
+`))
+		require.NoError(t, err)
+		require.NotNil(t, cfg.Models["User"].Fields["posts"].Batch)
+		require.True(t, *cfg.Models["User"].Fields["posts"].Batch)
 	})
 }
 

--- a/codegen/config/config_test.go
+++ b/codegen/config/config_test.go
@@ -227,8 +227,10 @@ models:
 		require.True(t, *cfg.Models["User"].Fields["posts"].Batch)
 	})
 
-	t.Run("batch defaults to resolver.batch.enabled when omitted in models yaml", func(t *testing.T) {
-		cfg, err := ReadConfig(strings.NewReader(`
+	t.Run(
+		"batch defaults to resolver.batch.enabled when omitted in models yaml",
+		func(t *testing.T) {
+			cfg, err := ReadConfig(strings.NewReader(`
 schema: schema.graphql
 resolver:
   batch:
@@ -241,10 +243,10 @@ models:
       posts:
         resolver: true
 `))
-		require.NoError(t, err)
-		require.NotNil(t, cfg.Models["User"].Fields["posts"].Batch)
-		require.True(t, *cfg.Models["User"].Fields["posts"].Batch)
-	})
+			require.NoError(t, err)
+			require.NotNil(t, cfg.Models["User"].Fields["posts"].Batch)
+			require.True(t, *cfg.Models["User"].Fields["posts"].Batch)
+		})
 }
 
 func TestConfigCheck(t *testing.T) {

--- a/codegen/config/resolver.go
+++ b/codegen/config/resolver.go
@@ -11,15 +11,40 @@ import (
 )
 
 type ResolverConfig struct {
-	Filename            string         `yaml:"filename,omitempty"`
-	FilenameTemplate    string         `yaml:"filename_template,omitempty"`
-	Package             string         `yaml:"package,omitempty"`
-	Type                string         `yaml:"type,omitempty"`
-	Layout              ResolverLayout `yaml:"layout,omitempty"`
-	DirName             string         `yaml:"dir"`
-	OmitTemplateComment bool           `yaml:"omit_template_comment,omitempty"`
-	ResolverTemplate    string         `yaml:"resolver_template,omitempty"`
-	PreserveResolver    bool           `yaml:"preserve_resolver,omitempty"`
+	Filename            string              `yaml:"filename,omitempty"`
+	FilenameTemplate    string              `yaml:"filename_template,omitempty"`
+	Package             string              `yaml:"package,omitempty"`
+	Type                string              `yaml:"type,omitempty"`
+	Layout              ResolverLayout      `yaml:"layout,omitempty"`
+	DirName             string              `yaml:"dir"`
+	Batch               ResolverBatchConfig `yaml:"batch,omitempty"`
+	OmitTemplateComment bool                `yaml:"omit_template_comment,omitempty"`
+	ResolverTemplate    string              `yaml:"resolver_template,omitempty"`
+	PreserveResolver    bool                `yaml:"preserve_resolver,omitempty"`
+}
+
+// ResolverBatchConfig enables batch resolver generation for all fields as if they
+// had @goField(batch: true). Individual fields can opt out with @goField(batch: false).
+type ResolverBatchConfig struct {
+	Enabled bool
+}
+
+func (b *ResolverBatchConfig) UnmarshalYAML(unmarshal func(any) error) error {
+	var enabled bool
+	if err := unmarshal(&enabled); err == nil {
+		b.Enabled = enabled
+		return nil
+	}
+
+	var long struct {
+		Enabled bool `yaml:"enabled"`
+	}
+	if err := unmarshal(&long); err != nil {
+		return err
+	}
+
+	b.Enabled = long.Enabled
+	return nil
 }
 
 type ResolverLayout string

--- a/codegen/field.go
+++ b/codegen/field.go
@@ -83,21 +83,22 @@ func (b *builder) buildField(obj *Object, field *ast.FieldDefinition) (*Field, e
 	}
 
 	// Set Batch flag from config (independent of resolver setting)
+	f.Batch = b.Config.Resolver.Batch.Enabled
 	if fieldCfg, ok := b.Config.Models[obj.Name]; ok {
-		if fieldEntry, ok := fieldCfg.Fields[field.Name]; ok {
-			f.Batch = fieldEntry.Batch
-			if f.Batch {
-				if f.Object.Root {
-					return nil, fmt.Errorf(
-						"batch resolver is not supported for root field %s.%s",
-						obj.Name,
-						field.Name,
-					)
-				}
-				// batch resolvers are always user-provided
-				f.IsResolver = true
-			}
+		if fieldEntry, ok := fieldCfg.Fields[field.Name]; ok && fieldEntry.Batch != nil {
+			f.Batch = *fieldEntry.Batch
 		}
+	}
+	if f.Batch {
+		if f.Object.Root {
+			return nil, fmt.Errorf(
+				"batch resolver is not supported for root field %s.%s",
+				obj.Name,
+				field.Name,
+			)
+		}
+		// batch resolvers are always user-provided
+		f.IsResolver = true
 	}
 
 	if f.IsResolver && b.Config.ResolversAlwaysReturnPointers && !f.TypeReference.IsPtr() &&

--- a/codegen/field_test.go
+++ b/codegen/field_test.go
@@ -149,17 +149,15 @@ func TestField_Batch(t *testing.T) {
 
 func TestField_BatchRootFieldUnsupported(t *testing.T) {
 	cfg := &config.Config{
+		Resolver: config.ResolverConfig{
+			Batch: config.ResolverBatchConfig{Enabled: true},
+		},
 		Exec: config.ExecConfig{
 			Layout:   config.ExecLayoutSingleFile,
 			Filename: "generated.go",
 			Package:  "generated",
 		},
 		Models: config.TypeMap{
-			"Query": {
-				Fields: map[string]config.TypeMapField{
-					"version": {Batch: true},
-				},
-			},
 			"Boolean": {
 				Model: config.StringList{"github.com/99designs/gqlgen/graphql.Boolean"},
 			},

--- a/gqlgen.schema.json
+++ b/gqlgen.schema.json
@@ -107,6 +107,18 @@
         "omit_template_comment": { "type": "boolean" },
         "resolver_template": { "type": "string" },
         "preserve_resolver": { "type": "boolean" },
+        "batch": {
+          "description": "Enable batch resolver generation for all fields as if they had @goField(batch: true). Individual fields can opt out with @goField(batch: false).",
+          "oneOf": [
+            { "type": "boolean" },
+            {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean", "default": false }
+              }
+            }
+          ]
+        },
         "type": {
           "type": "string",
           "description": "The name of the resolver struct type",


### PR DESCRIPTION
Closes #4044

## Summary

Adds a global batch resolver setting in `gqlgen.yml` so projects can enable batch resolver generation for all applicable fields by default, with per-field opt-out.

The option lives under the existing `resolver` section (as discussed in #4044), with support for both short and long YAML syntax:

```yaml
resolver:
  batch: true
```

```yaml
resolver:
  batch:
    enabled: true
```

### Priority chain

1. `resolver.batch` — global default
2. `models.*.fields.*.batch` in `gqlgen.yml`
3. `@goField(batch: ...)` — only when the argument is explicitly set

Fields without an explicit `@goField(batch: ...)` directive are not added to `models` config; they inherit the global default at codegen time via `buildField`.

### Other changes

- `TypeMapField.Batch` is now `*bool` to distinguish unset from explicit `false`
- `resolveModelBatchDefaults()` applies the global default to fields listed in `models` without an explicit `batch` value
- `@goField(batch:)` only overrides batch when the argument is present (e.g. `@goField(forceResolver: true)` no longer implicitly sets `batch: false`)
- JSON schema updated: `batch` added under `resolver`

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
