### PR TITLE
Add SSE min event interval

### DIFF
--- a/graphql/handler/transport/sse.go
+++ b/graphql/handler/transport/sse.go
@@ -20,6 +20,8 @@ import (
 type (
 	SSE struct {
 		KeepAlivePingInterval time.Duration
+		// MinEventInterval optionally paces SSE event frames for high-throughput streams.
+		MinEventInterval time.Duration
 	}
 
 	sseConnection struct {
@@ -99,8 +101,21 @@ func (t SSE) Do(w http.ResponseWriter, r *http.Request, exec graphql.GraphExecut
 	c.ctx = ctx
 
 	w.Header().Set("Content-Type", "text/event-stream")
-	fmt.Fprint(w, ":\n\n")
-	c.flush()
+	c.writeAndFlush(w, func(w io.Writer) {
+		fmt.Fprint(w, ":\n\n")
+	})
+
+	lastEventSent := time.Time{}
+	eventCtx := ctx
+	writeEvent := func(ctx context.Context, write func(io.Writer)) bool {
+		if !waitForMinEventInterval(ctx, lastEventSent, t.MinEventInterval) {
+			return false
+		}
+
+		c.writeAndFlush(w, write)
+		lastEventSent = time.Now()
+		return true
+	}
 
 	if t.KeepAlivePingInterval > 0 {
 		c.mu.Lock()
@@ -112,22 +127,57 @@ func (t SSE) Do(w http.ResponseWriter, r *http.Request, exec graphql.GraphExecut
 
 	if opErr != nil {
 		resp := exec.DispatchError(ctx, opErr)
-		writeJsonWithSSE(w, resp)
+		if !writeEvent(ctx, func(w io.Writer) {
+			writeJsonWithSSE(w, resp)
+		}) {
+			return
+		}
 	} else {
-		responses, ctx := exec.DispatchOperation(ctx, rc)
+		responses, dispatchCtx := exec.DispatchOperation(ctx, rc)
+		eventCtx = dispatchCtx
 		for {
-			response := responses(ctx)
+			response := responses(dispatchCtx)
 			if response == nil {
 				break
 			}
-			writeJsonWithSSE(w, response)
-			c.flush()
+			if !writeEvent(dispatchCtx, func(w io.Writer) {
+				writeJsonWithSSE(w, response)
+			}) {
+				return
+			}
 
 			c.resetTicker(t.KeepAlivePingInterval)
 		}
 	}
 
-	fmt.Fprint(w, "event: complete\n\n")
+	writeEvent(eventCtx, func(w io.Writer) {
+		fmt.Fprint(w, "event: complete\n\n")
+	})
+}
+
+func waitForMinEventInterval(
+	ctx context.Context,
+	lastEventSent time.Time,
+	minInterval time.Duration,
+) bool {
+	if minInterval <= 0 || lastEventSent.IsZero() {
+		return true
+	}
+
+	wait := time.Until(lastEventSent.Add(minInterval))
+	if wait <= 0 {
+		return true
+	}
+
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }
 
 func (c *sseConnection) resetTicker(interval time.Duration) {
@@ -145,14 +195,22 @@ func (c *sseConnection) keepAlive(w io.Writer) {
 			c.keepAliveTicker.Stop()
 			return
 		case <-c.keepAliveTicker.C:
-			fmt.Fprintf(w, ": ping\n\n")
-			c.flush()
+			c.writeAndFlush(w, func(w io.Writer) {
+				fmt.Fprint(w, ": ping\n\n")
+			})
 		}
 	}
 }
 
 func (c *sseConnection) flush() {
 	c.mu.Lock()
+	c.f.Flush()
+	c.mu.Unlock()
+}
+
+func (c *sseConnection) writeAndFlush(w io.Writer, write func(io.Writer)) {
+	c.mu.Lock()
+	write(w)
 	c.f.Flush()
 	c.mu.Unlock()
 }

--- a/graphql/handler/transport/sse_test.go
+++ b/graphql/handler/transport/sse_test.go
@@ -2,6 +2,7 @@ package transport_test
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -12,7 +13,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 
+	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler/testserver"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 )
@@ -236,4 +239,66 @@ func TestSSE(t *testing.T) {
 
 		wg.Wait()
 	})
+
+	t.Run("min event interval paces rapid events", func(t *testing.T) {
+		interval := 10 * time.Millisecond
+		responses := []*graphql.Response{
+			{Data: []byte(`{"name":"test1"}`)},
+			{Data: []byte(`{"name":"test2"}`)},
+			{Data: []byte(`{"name":"test3"}`)},
+		}
+
+		req := createHTTPTestRequest(`{"query":"subscription { name }"}`)
+		w := httptest.NewRecorder()
+
+		start := time.Now()
+		transport.SSE{MinEventInterval: interval}.Do(
+			w,
+			req,
+			&sseGraphExecutor{responses: responses},
+		)
+		elapsed := time.Since(start)
+
+		assert.GreaterOrEqual(t, elapsed, interval*time.Duration(len(responses)))
+		assert.Equal(t, 200, w.Code, "Request return wrong status -> %d", w.Code)
+		assert.Equal(t, "text/event-stream", w.Header().Get("Content-Type"))
+
+		body := w.Body.String()
+		assert.Equal(t, len(responses), strings.Count(body, "event: next\n"))
+		assert.Contains(t, body, `data: {"data":{"name":"test1"}}`)
+		assert.Contains(t, body, `data: {"data":{"name":"test2"}}`)
+		assert.Contains(t, body, `data: {"data":{"name":"test3"}}`)
+		assert.Contains(t, body, "event: complete\n")
+	})
+}
+
+type sseGraphExecutor struct {
+	responses []*graphql.Response
+}
+
+func (e *sseGraphExecutor) CreateOperationContext(
+	context.Context,
+	*graphql.RawParams,
+) (*graphql.OperationContext, gqlerror.List) {
+	return &graphql.OperationContext{}, nil
+}
+
+func (e *sseGraphExecutor) DispatchOperation(
+	ctx context.Context,
+	_ *graphql.OperationContext,
+) (graphql.ResponseHandler, context.Context) {
+	index := 0
+	return func(context.Context) *graphql.Response {
+		if index >= len(e.responses) {
+			return nil
+		}
+
+		resp := e.responses[index]
+		index++
+		return resp
+	}, ctx
+}
+
+func (e *sseGraphExecutor) DispatchError(_ context.Context, errs gqlerror.List) *graphql.Response {
+	return &graphql.Response{Errors: errs}
 }


### PR DESCRIPTION
## Summary
- Add optional `SSE.MinEventInterval` pacing for high-throughput SSE streams.
- Write and flush SSE frames under the connection mutex so event and keep-alive frames are emitted atomically.
- Cover rapid event pacing in the SSE transport tests.

Refs #3960

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (not applicable; API field is documented inline)
