### PR TITLE
Fix websocket flakytest

### DIFF
--- a/graphql/handler/transport/websocket_coderws_test.go
+++ b/graphql/handler/transport/websocket_coderws_test.go
@@ -72,9 +72,14 @@ func TestCoderWebsocketImplementationEnforcesReadDeadline(t *testing.T) {
 	closeFuncCalled := make(chan bool, 1)
 	h := testserver.New()
 	h.AddTransport(transport.Websocket{
-		Implementation:   transport.CoderWebsocketImplementation{},
-		MissingPongOk:    false,
-		PingPongInterval: 5 * time.Millisecond,
+		Implementation: transport.CoderWebsocketImplementation{},
+		MissingPongOk:  false,
+		// The server pings every PingPongInterval and closes the connection at
+		// 2*PingPongInterval when no pong arrives. Keep the interval well above OS
+		// timer granularity/jitter (notably ~10-15ms on Windows) so the client
+		// reliably reads the ping below before the deadline-close races ahead and
+		// the read returns EOF. See the read-deadline logic in websocket.go.
+		PingPongInterval: 100 * time.Millisecond,
 		CloseFunc: func(_ context.Context, _ int) {
 			closeFuncCalled <- true
 		},
@@ -94,7 +99,7 @@ func TestCoderWebsocketImplementationEnforcesReadDeadline(t *testing.T) {
 	select {
 	case res := <-closeFuncCalled:
 		assert.True(t, res)
-	case <-time.NewTimer(30 * time.Millisecond).C:
+	case <-time.NewTimer(time.Second).C:
 		assert.Fail(t, "The close handler was not called in time")
 	}
 }


### PR DESCRIPTION
It's a timer-granularity race, not a logic bug. From websocket.go: with `MissingPongOk: false`, the server sets a read deadline of 2 × PingPongInterval and closes the connection when no pong arrives. At PingPongInterval = 5ms, the ping is sent at ~5ms and the deadline-close fires at ~10ms — leaving the client only a ~5ms window to read the ping at line 92 of `graphql/handler/transport/websocket_coderws_test.go` (formerly: `assert.Equal(t, graphqltransportwsPingMsg, coderwsReadOperation(ctx, t, c).Type)`). On Windows, timer jitter (~10–15ms) is wider than that window, so the close often wins the race and the client's read returns EOF ("failed to read frame header") instead of the ping.

##  The fix

Raised PingPongInterval to 100ms (ping at ~100ms, deadline-close at ~200ms — a ~100ms margin that's comfortably above Windows timer jitter, so the ping reliably arrives first) and widened the close-observation timer from 30ms to 1s to match the larger deadline. Added a comment explaining the timing constraint so it doesn't get "optimized" back to 5ms.

##  Net effect
The test still verifies exactly the same behavior (ack → ping → CloseFunc invoked on missing pong); it just no longer depends on sub-granularity timing. The trade-off is that the test now takes ~200ms instead of ~10ms — a reasonable price for determinism on Windows.

##  Verification
- gofumpt-clean.
- Passed 20 consecutive runs locally and once under `-race`.

## Related notes:
- The reads in `coderwsReadOperation` use `context.Background()` (no deadline), so if a ping were never sent (a real bug), the test would hang until the overall `go test` timeout rather than failing fast. If we want belt-and-suspenders, those reads could take a bounded context — but it's orthogonal to this flake.
- The alternative could've been to make line 92 of `graphql/handler/transport/websocket_coderws_test.go` tolerant (accept a ping OR a close), relying solely on the `CloseFunc` channel as the authoritative check.

Signed-off-by: Steve Coffman <steve@khanacademy.org>
