### PR TITLE
fix(federation): return a positioned validation error for @key referencing an undeclared field

### DIFF
--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 
 	"github.com/99designs/gqlgen/codegen"
 	"github.com/99designs/gqlgen/codegen/config"
@@ -205,7 +206,11 @@ func (f *Federation) InjectSourcesEarly() ([]*ast.Source, error) {
 // InjectSourcesLate creates a GraphQL Entity type with all
 // the fields that had the @key directive
 func (f *Federation) InjectSourcesLate(schema *ast.Schema) ([]*ast.Source, error) {
-	f.Entities = f.buildEntities(schema, f.version)
+	builtEntities, err := f.buildEntities(schema, f.version)
+	if err != nil {
+		return nil, err
+	}
+	f.Entities = builtEntities
 
 	entities := make([]string, 0)
 	resolvers := make([]string, 0)
@@ -451,10 +456,13 @@ func populateKeyFieldTypes(
 	}
 }
 
-func (f *Federation) buildEntities(schema *ast.Schema, version int) []*Entity {
+func (f *Federation) buildEntities(schema *ast.Schema, version int) ([]*Entity, error) {
 	entities := make([]*Entity, 0)
 	for _, schemaType := range schema.Types {
-		entity := f.buildEntity(schemaType, schema, version)
+		entity, err := f.buildEntity(schemaType, schema, version)
+		if err != nil {
+			return nil, err
+		}
 		if entity != nil {
 			entities = append(entities, entity)
 		}
@@ -465,17 +473,17 @@ func (f *Federation) buildEntities(schema *ast.Schema, version int) []*Entity {
 		return entities[i].Name < entities[j].Name
 	})
 
-	return entities
+	return entities, nil
 }
 
 func (f *Federation) buildEntity(
 	schemaType *ast.Definition,
 	schema *ast.Schema,
 	version int,
-) *Entity {
+) (*Entity, error) {
 	keys, ok := isFederatedEntity(schemaType)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	if (schemaType.Kind == ast.Interface) && (len(schema.GetPossibleTypes(schemaType)) == 0) {
@@ -483,7 +491,7 @@ func (f *Federation) buildEntity(
 			"@key directive found on unused \"interface %s\". Will be ignored.\n",
 			schemaType.Name,
 		)
-		return nil
+		return nil, nil
 	}
 
 	entity := &Entity{
@@ -513,16 +521,20 @@ func (f *Federation) buildEntity(
 	//       id: ID @external
 	//    }
 	if entity.allFieldsAreExternal(version) {
-		return entity
+		return entity, nil
 	}
 
-	entity.Resolvers = buildResolvers(schemaType, schema, keys, entity.Multi)
+	resolvers, err := buildResolvers(schemaType, schema, keys, entity.Multi)
+	if err != nil {
+		return nil, err
+	}
+	entity.Resolvers = resolvers
 	entity.Requires = buildRequires(schemaType)
 	if len(entity.Requires) > 0 {
 		f.usesRequires = true
 	}
 
-	return entity
+	return entity, nil
 }
 
 // isMultiEntity returns @entityResolver(multi) value, if directive is not defined,
@@ -547,17 +559,24 @@ func buildResolvers(
 	schema *ast.Schema,
 	keys []*ast.Directive,
 	multi bool,
-) []*EntityResolver {
+) ([]*EntityResolver, error) {
 	resolvers := make([]*EntityResolver, 0)
 	for _, dir := range keys {
 		if len(dir.Arguments) > 2 {
-			panic("More than two arguments provided for @key declaration.")
+			return nil, gqlerror.ErrorPosf(
+				dir.Position,
+				`@key on %q accepts only the "fields" and "resolvable" arguments`,
+				schemaType.Name,
+			)
 		}
-		keyFields, resolverFields := buildKeyFields(
+		keyFields, resolverFields, err := buildKeyFields(
 			schemaType,
 			schema,
 			dir,
 		)
+		if err != nil {
+			return nil, err
+		}
 
 		resolverFieldsToGo := schemaType.Name + "By" + strings.Join(resolverFields, "And")
 		var resolverName string
@@ -576,7 +595,7 @@ func buildResolvers(
 		})
 	}
 
-	return resolvers
+	return resolvers, nil
 }
 
 func extractFields(
@@ -602,10 +621,12 @@ func buildKeyFields(
 	schemaType *ast.Definition,
 	schema *ast.Schema,
 	dir *ast.Directive,
-) ([]*KeyField, []string) {
+) ([]*KeyField, []string, error) {
 	fieldsRaw, err := extractFields(dir)
 	if err != nil {
-		panic("More than one `fields` argument provided for declaration.")
+		// api.generate prefixes plugin errors with "federation: ", so the
+		// messages here omit that prefix to avoid duplicating it.
+		return nil, nil, gqlerror.ErrorPosf(dir.Position, "@key on %q: %s", schemaType.Name, err)
 	}
 
 	keyFieldSet := fieldset.New(fieldsRaw, nil)
@@ -616,7 +637,13 @@ func buildKeyFields(
 		def := field.FieldDefinition(schemaType, schema)
 
 		if def == nil {
-			panic(fmt.Sprintf("no field for %v", field))
+			return nil, nil, gqlerror.ErrorPosf(
+				dir.Position,
+				"@key(fields: %q): field %q is not defined on %q",
+				fieldsRaw,
+				field.Join("."),
+				schemaType.Name,
+			)
 		}
 
 		keyFields[i] = &KeyField{Definition: def, Field: field}
@@ -625,7 +652,7 @@ func buildKeyFields(
 
 	assignKeyFieldGoNames(keyFields)
 
-	return keyFields, resolverFields
+	return keyFields, resolverFields, nil
 }
 
 // assignKeyFieldGoNames sets each key field's GoName to a Go identifier that is

--- a/plugin/federation/federation_test.go
+++ b/plugin/federation/federation_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 
 	"github.com/99designs/gqlgen/codegen"
 	"github.com/99designs/gqlgen/codegen/config"
@@ -445,4 +446,35 @@ func load(t *testing.T, name string) (*Federation, *config.Config) {
 
 	require.NoError(t, cfg.Init())
 	return f, cfg
+}
+
+func TestKeyFieldUndeclared(t *testing.T) {
+	// A @key that references an undeclared (here, nested) field must produce a
+	// clear validation error during InjectSourcesLate, not a nil pointer
+	// dereference panic. See the "id order { id }" key where "order" is not
+	// declared on TestEnt.
+	cfg, err := config.LoadConfig("testdata/keyfieldundeclared/keyfieldundeclared.yml")
+	require.NoError(t, err)
+	if cfg.Federation.Version == 0 {
+		cfg.Federation.Version = 1
+	}
+
+	f := &Federation{version: cfg.Federation.Version}
+	early, err := f.InjectSourcesEarly()
+	require.NoError(t, err)
+	cfg.Sources = append(cfg.Sources, early...)
+	require.NoError(t, cfg.LoadSchema())
+
+	_, err = f.InjectSourcesLate(cfg.Schema)
+	require.Error(t, err)
+
+	// A structured, positioned error — not a panic — naming the entity, the
+	// offending field path, and the original @key(fields:) string.
+	var gerr *gqlerror.Error
+	require.ErrorAs(t, err, &gerr)
+	require.Contains(t, gerr.Message, "TestEnt")
+	require.Contains(t, gerr.Message, "order.id")
+	require.Contains(t, gerr.Message, "id order { id }")
+	require.NotEmpty(t, gerr.Locations)
+	require.Positive(t, gerr.Locations[0].Line)
 }

--- a/plugin/federation/fieldset/fieldset.go
+++ b/plugin/federation/fieldset/fieldset.go
@@ -54,6 +54,12 @@ func (f Field) FieldDefinition(
 	def := objType.Fields.ForName(f[0])
 
 	for _, part := range f[1:] {
+		// A missing first or intermediate segment leaves def nil; return nil
+		// (the "field not found" contract) rather than dereferencing it below.
+		// The caller turns this into an actionable error.
+		if def == nil {
+			return nil
+		}
 		if objType.Kind != ast.Object {
 			panic(fmt.Sprintf(`invalid sub-field reference "%s" in %v: `, objType.Name, f))
 		}

--- a/plugin/federation/fieldset/fieldset_test.go
+++ b/plugin/federation/fieldset/fieldset_test.go
@@ -124,3 +124,36 @@ func TestToGoPrivate(t *testing.T) {
 	require.Equal(t, "fooBar", Field{"foo", "bar"}.ToGoPrivate())
 	require.Equal(t, "barID", Field{"bar", "id"}.ToGoPrivate())
 }
+
+func TestFieldDefinitionMissingField(t *testing.T) {
+	inner := &ast.Definition{
+		Kind:   ast.Object,
+		Name:   "I",
+		Fields: ast.FieldList{{Name: "d", Type: ast.NamedType("ID", nil)}},
+	}
+	testEnt := &ast.Definition{
+		Kind: ast.Object,
+		Name: "TestEnt",
+		Fields: ast.FieldList{
+			{Name: "id", Type: ast.NamedType("ID", nil)},
+			{Name: "i", Type: ast.NamedType("I", nil)},
+		},
+	}
+	schema := &ast.Schema{Types: map[string]*ast.Definition{"TestEnt": testEnt, "I": inner}}
+
+	// A missing segment must return nil (the "not found" contract) rather than
+	// panicking with a nil pointer dereference. The caller turns nil into a
+	// clear validation error.
+	cases := map[string]Field{
+		"missing first segment":        {"order", "id"},  // "order" is not on TestEnt
+		"missing intermediate segment": {"i", "missing"}, // "i" exists; "missing" is not on I
+	}
+	for name, f := range cases {
+		t.Run(name, func(t *testing.T) {
+			require.Nil(t, f.FieldDefinition(testEnt, schema))
+		})
+	}
+
+	// A valid nested path still resolves.
+	require.NotNil(t, Field{"i", "d"}.FieldDefinition(testEnt, schema))
+}

--- a/plugin/federation/testdata/keyfieldundeclared/keyfieldundeclared.graphqls
+++ b/plugin/federation/testdata/keyfieldundeclared/keyfieldundeclared.graphqls
@@ -1,0 +1,10 @@
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.7",
+        import: ["@key"])
+
+# TestEnt's @key references the nested path "order { id }", but "order" is not
+# declared on the type. The federation plugin must surface this as a clear
+# validation error during InjectSourcesLate, not a nil pointer dereference.
+type TestEnt @key(fields: "id order { id }") {
+    id: ID!
+}

--- a/plugin/federation/testdata/keyfieldundeclared/keyfieldundeclared.yml
+++ b/plugin/federation/testdata/keyfieldundeclared/keyfieldundeclared.yml
@@ -1,0 +1,7 @@
+schema:
+  - "testdata/keyfieldundeclared/keyfieldundeclared.graphqls"
+exec:
+  filename: testdata/keyfieldundeclared/generated/exec.go
+federation:
+  version: 2
+  filename: testdata/keyfieldundeclared/generated/federation.go


### PR DESCRIPTION
Fix https://github.com/99designs/gqlgen/issues/4243

A `@key` directive that references a field path whose (possibly nested) parent
is not declared on the entity — e.g. `@key(fields: "id order { id }")` where
"order" is not a field of the type — caused a nil pointer dereference in
`fieldset.Field.FieldDefinition` during code generation.

FieldDefinition now honors its "not found" contract, returning nil when a key
path segment is missing instead of dereferencing nil. buildKeyFields,
buildResolvers, buildEntity, and buildEntities thread that up as a returned
error through InjectSourcesLate (which already returns error), so generation
fails cleanly instead of panicking. No public API change: the only exported
members in the chain (FieldDefinition, InjectSourcesLate) keep their signatures.

The @key validation errors are positioned gqlerror values that name the
directive's source location, the original fields string, the offending field
path, and the entity, e.g.:
```
  federation: schema.graphql:8:15: @key(fields: "id order { id }"): field "order.id" is not defined on "TestEnt"
```
The too-many-arguments error additionally names the allowed arguments
("fields", "resolvable"), and the in-message `"federation:"` prefix is dropped
since `api.generate` already prepends the plugin name.

### Tests: 
a fieldset unit test (missing first/intermediate key segment returns
nil, no panic) and a federation regression test asserting the structured,
positioned error and its source location.
