### PR TITLE
Disable scalar leaf suggestions when requested

### DIFF
--- a/graphql/executor/executor.go
+++ b/graphql/executor/executor.go
@@ -296,12 +296,20 @@ func (e *Executor) parseQuery(
 	// swap out the FieldsOnCorrectType rule with one that doesn't provide suggestions
 	if e.disableSuggestion {
 		currentRules.RemoveRule("FieldsOnCorrectType")
-		rule := rules.FieldsOnCorrectTypeRuleWithoutSuggestions
-		currentRules.AddRule(rule.Name, rule.RuleFunc)
+		fieldsOnCorrectTypeRule := rules.FieldsOnCorrectTypeRuleWithoutSuggestions
+		currentRules.AddRule(fieldsOnCorrectTypeRule.Name, fieldsOnCorrectTypeRule.RuleFunc)
+
+		currentRules.RemoveRule("ScalarLeafs")
+		scalarLeafsRule := rules.ScalarLeafsRuleWithoutSuggestions
+		currentRules.AddRule(scalarLeafsRule.Name, scalarLeafsRule.RuleFunc)
 	} else { // or vice versa
 		currentRules.RemoveRule("FieldsOnCorrectTypeWithoutSuggestions")
-		rule := rules.FieldsOnCorrectTypeRule
-		currentRules.AddRule(rule.Name, rule.RuleFunc)
+		fieldsOnCorrectTypeRule := rules.FieldsOnCorrectTypeRule
+		currentRules.AddRule(fieldsOnCorrectTypeRule.Name, fieldsOnCorrectTypeRule.RuleFunc)
+
+		currentRules.RemoveRule("ScalarLeafsWithoutSuggestions")
+		scalarLeafsRule := rules.ScalarLeafsRule
+		currentRules.AddRule(scalarLeafsRule.Name, scalarLeafsRule.RuleFunc)
 	}
 
 	listErr := validator.ValidateWithRules(e.es.Schema(), doc, currentRules)

--- a/graphql/executor/executor_test.go
+++ b/graphql/executor/executor_test.go
@@ -241,6 +241,15 @@ func TestExecutorDisableSuggestion(t *testing.T) {
 			"input:1:2: Cannot query field \"nam\" on type \"Query\".\n",
 			resp.Errors.Error(),
 		)
+
+		resp = query(exec, "", "{ user }")
+		assert.Empty(t, string(resp.Data))
+		assert.Len(t, resp.Errors, 1)
+		assert.Equal(
+			t,
+			"input:1:3: Field \"user\" of type \"User!\" must have a selection of subfields.\n",
+			resp.Errors.Error(),
+		)
 	})
 }
 

--- a/graphql/executor/testexecutor/testexecutor.go
+++ b/graphql/executor/testexecutor/testexecutor.go
@@ -46,6 +46,10 @@ func New() *TestExecutor {
     type Query {
       name: String!
       find(id: Int!): String!
+      user: User!
+    }
+    type User {
+      id: ID!
     }
     type Mutation {
       name: String!


### PR DESCRIPTION
When DisableSuggestion is enabled, gqlgen already swaps FieldsOnCorrectType for its no-suggestion variant. ScalarLeafs can also emit schema hints, for example suggesting `user { ... }` when an object field is queried without subfields.

Swap ScalarLeafs for ScalarLeafsRuleWithoutSuggestions as well, and add coverage to ensure invalid object-field queries still fail validation without exposing the suggested selection.

Describe your PR and link to any relevant issues. 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))

    The commit adds regression coverage in executor_test.go for `{ user }`, which specifically exercises `ScalarLeafsRuleWithoutSuggestions`.

 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

    No docs update is relevant for this change. This is internal validation behavior behind the existing `SetDisableSuggestion(true)` API, not a new config option, public API, or user-facing documented workflow.