### PR TITLE
Fix panic when resolver returns a nil pointer to a slice or any

### DIFF
--- a/codegen/testserver/followschema/prelude.generated.go
+++ b/codegen/testserver/followschema/prelude.generated.go
@@ -2154,6 +2154,9 @@ func (ec *executionContext) unmarshalOString2ᚖᚕstringᚄ(ctx context.Context
 }
 
 func (ec *executionContext) marshalOString2ᚖᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v *[]string) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
 	return ec.marshalOString2ᚕstringᚄ(ctx, sel, *v)
 }
 

--- a/codegen/testserver/followschema/ptr_to_any.generated.go
+++ b/codegen/testserver/followschema/ptr_to_any.generated.go
@@ -173,6 +173,9 @@ func (ec *executionContext) unmarshalOAny2ᚖinterface(ctx context.Context, v an
 }
 
 func (ec *executionContext) marshalOAny2ᚖinterface(ctx context.Context, sel ast.SelectionSet, v *any) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
 	return ec.marshalOAny2interface(ctx, sel, *v)
 }
 

--- a/codegen/testserver/followschema/ptr_to_any_test.go
+++ b/codegen/testserver/followschema/ptr_to_any_test.go
@@ -39,3 +39,30 @@ func TestPtrToAny(t *testing.T) {
 		require.Equal(t, &a, resp.PtrToAnyContainer.Binding)
 	})
 }
+
+func TestPtrToAny_Null(t *testing.T) {
+	resolvers := &Stub{}
+
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	srv.SetRecoverFunc(nil)
+	c := client.New(srv)
+
+	resolvers.QueryResolver.PtrToAnyContainer = func(ctx context.Context) (wrappedStruct *PtrToAnyContainer, e error) {
+		return &PtrToAnyContainer{PtrToAny: nil}, nil
+	}
+
+	t.Run("nil pointer to any should return null without panic", func(t *testing.T) {
+		var resp struct {
+			PtrToAnyContainer struct {
+				Binding *any
+			}
+		}
+
+		require.NotPanics(t, func() {
+			err := c.Post(`query { ptrToAnyContainer { binding }}`, &resp)
+			require.NoError(t, err)
+			require.Nil(t, resp.PtrToAnyContainer.Binding)
+		})
+	})
+}

--- a/codegen/testserver/followschema/ptr_to_slice_test.go
+++ b/codegen/testserver/followschema/ptr_to_slice_test.go
@@ -38,3 +38,30 @@ func TestPtrToSlice(t *testing.T) {
 		require.Equal(t, []string{"hello"}, resp.PtrToSliceContainer.PtrToSlice)
 	})
 }
+
+func TestPtrToSlice_Null(t *testing.T) {
+	resolvers := &Stub{}
+
+	srv := handler.New(NewExecutableSchema(Config{Resolvers: resolvers}))
+	srv.AddTransport(transport.POST{})
+	srv.SetRecoverFunc(nil)
+	c := client.New(srv)
+
+	resolvers.QueryResolver.PtrToSliceContainer = func(ctx context.Context) (wrappedStruct *PtrToSliceContainer, e error) {
+		return &PtrToSliceContainer{PtrToSlice: nil}, nil
+	}
+
+	t.Run("nil pointer to slice should return null without panic", func(t *testing.T) {
+		var resp struct {
+			PtrToSliceContainer struct {
+				PtrToSlice []string
+			}
+		}
+
+		require.NotPanics(t, func() {
+			err := c.Post(`query { ptrToSliceContainer { ptrToSlice }}`, &resp)
+			require.NoError(t, err)
+			require.Nil(t, resp.PtrToSliceContainer.PtrToSlice)
+		})
+	})
+}

--- a/codegen/testserver/singlefile/generated.go
+++ b/codegen/testserver/singlefile/generated.go
@@ -23038,6 +23038,9 @@ func (ec *executionContext) unmarshalOAny2ᚖinterface(ctx context.Context, v an
 }
 
 func (ec *executionContext) marshalOAny2ᚖinterface(ctx context.Context, sel ast.SelectionSet, v *any) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
 	return ec.marshalOAny2interface(ctx, sel, *v)
 }
 
@@ -23819,6 +23822,9 @@ func (ec *executionContext) unmarshalOString2ᚖᚕstringᚄ(ctx context.Context
 }
 
 func (ec *executionContext) marshalOString2ᚖᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v *[]string) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
 	return ec.marshalOString2ᚕstringᚄ(ctx, sel, *v)
 }
 

--- a/codegen/type.gotpl
+++ b/codegen/type.gotpl
@@ -91,6 +91,9 @@
 		{{- $eventCtx := and (eq $type.Definition.Name "Subscription") $.Config.SubscriptionContextField -}}
 		func {{$.FuncReceiver}}{{ . }}(ctx context.Context, {{$.ECFuncParam}}sel ast.SelectionSet, v {{ $type.GO | ref }}) {{- if $eventCtx }}(context.Context, {{- end}}graphql.Marshaler{{- if $eventCtx }}){{- end}} {
 			{{- if or $type.IsPtrToSlice $type.IsPtrToIntf }}
+				if v == nil {
+					return {{- if $eventCtx }} ctx,{{- end}} graphql.Null
+				}
 				return {{$.ECDot}}{{ $type.Elem.MarshalFunc }}(ctx, {{$.ECArg}}sel, *v)
 			{{- else if $type.IsSlice }}
 				{{- if not $type.GQL.NonNull }}


### PR DESCRIPTION
Describe your PR and link to any relevant issues.

This PR resolves the runtime execution panics that occur when a resolver returns a nil pointer to either a slice or any (interface), as detailed in #4056. 

This issue stems from the shared code generation template, which did not have defensive nullability guard checks for these specific variations. This PR introduces a fix to the template engine to validate the underlying types during code generation and guarantee safe nullability handling at runtime.

Engine / Template Fixes: Updated code generation logic in codegen/type.gotpl to safely intercept nil pointers before executing downstream slice/interface resolution.
Regenerated Boilerplate: Ran the generator against the testserver suite (ptr_to_any.generated.go, prelude.generated.go)
Testing: Added comprehensive test cases to explicitly validate the fix across both variations (codegen/testserver/followschema/ptr_to_slice_test.go, codegen/testserver/followschema/ptr_to_any_test.go)

Fixes #4056 

I have:
 - [X] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [X] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
