### PR TITLE
fix: explicitly ignore write result in generated enum MarshalGQL

### DIFF
--- a/_examples/multi-entity-tests/batchfieldcomputed/server.go
+++ b/_examples/multi-entity-tests/batchfieldcomputed/server.go
@@ -1,17 +1,18 @@
 package main
 
 import (
-	"batchfieldcomputed/graph"
 	"log"
 	"net/http"
 	"os"
+
+	"batchfieldcomputed/graph"
+	"github.com/vektah/gqlparser/v2/ast"
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/extension"
 	"github.com/99designs/gqlgen/graphql/handler/lru"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
-	"github.com/vektah/gqlparser/v2/ast"
 )
 
 const defaultPort = "8080"

--- a/_examples/multi-entity-tests/batchfieldexplicit/graph/federation.requires.go
+++ b/_examples/multi-entity-tests/batchfieldexplicit/graph/federation.requires.go
@@ -8,7 +8,11 @@ import (
 )
 
 // PopulateProductRequires is the requires populator for the Product entity.
-func (ec *executionContext) PopulateProductRequires(ctx context.Context, entity *model.Product, reps map[string]any) error {
+func (ec *executionContext) PopulateProductRequires(
+	ctx context.Context,
+	entity *model.Product,
+	reps map[string]any,
+) error {
 	b, _ := json.Marshal(reps)
 	println(string(b))
 	json.Unmarshal(b, entity)

--- a/_examples/multi-entity-tests/batchfieldexplicit/server.go
+++ b/_examples/multi-entity-tests/batchfieldexplicit/server.go
@@ -1,17 +1,18 @@
 package main
 
 import (
-	"batchfieldexplicit/graph"
 	"log"
 	"net/http"
 	"os"
+
+	"batchfieldexplicit/graph"
+	"github.com/vektah/gqlparser/v2/ast"
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/extension"
 	"github.com/99designs/gqlgen/graphql/handler/lru"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
-	"github.com/vektah/gqlparser/v2/ast"
 )
 
 const defaultPort = "8080"

--- a/_examples/multi-entity-tests/entityresolverexplicit/graph/federation.requires.go
+++ b/_examples/multi-entity-tests/entityresolverexplicit/graph/federation.requires.go
@@ -8,7 +8,11 @@ import (
 )
 
 // PopulateProductRequires is the requires populator for the Product entity.
-func (ec *executionContext) PopulateProductRequires(ctx context.Context, entity *model.Product, reps map[string]any) error {
+func (ec *executionContext) PopulateProductRequires(
+	ctx context.Context,
+	entity *model.Product,
+	reps map[string]any,
+) error {
 	b, _ := json.Marshal(reps)
 	println(string(b))
 	json.Unmarshal(b, entity)

--- a/_examples/multi-entity-tests/entityresolverexplicit/server.go
+++ b/_examples/multi-entity-tests/entityresolverexplicit/server.go
@@ -1,17 +1,18 @@
 package main
 
 import (
-	"entityresolverexplicit/graph"
 	"log"
 	"net/http"
 	"os"
+
+	"entityresolverexplicit/graph"
+	"github.com/vektah/gqlparser/v2/ast"
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/extension"
 	"github.com/99designs/gqlgen/graphql/handler/lru"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
-	"github.com/vektah/gqlparser/v2/ast"
 )
 
 const defaultPort = "8080"

--- a/_examples/multi-entity-tests/entityresolvermulti/server.go
+++ b/_examples/multi-entity-tests/entityresolvermulti/server.go
@@ -1,17 +1,18 @@
 package main
 
 import (
-	"entityresolvermulti/graph"
 	"log"
 	"net/http"
 	"os"
+
+	"entityresolvermulti/graph"
+	"github.com/vektah/gqlparser/v2/ast"
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/extension"
 	"github.com/99designs/gqlgen/graphql/handler/lru"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
-	"github.com/vektah/gqlparser/v2/ast"
 )
 
 const defaultPort = "8080"

--- a/_examples/multi-entity-tests/entityresolverpreloaded/server.go
+++ b/_examples/multi-entity-tests/entityresolverpreloaded/server.go
@@ -1,17 +1,18 @@
 package main
 
 import (
-	"entityresolverpreloaded/graph"
 	"log"
 	"net/http"
 	"os"
+
+	"entityresolverpreloaded/graph"
+	"github.com/vektah/gqlparser/v2/ast"
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/extension"
 	"github.com/99designs/gqlgen/graphql/handler/lru"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
-	"github.com/vektah/gqlparser/v2/ast"
 )
 
 const defaultPort = "8080"

--- a/_examples/scalars/model/model.go
+++ b/_examples/scalars/model/model.go
@@ -178,7 +178,7 @@ func (e *Tier) UnmarshalGQL(v any) error {
 }
 
 func (e Tier) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 type Prefs struct {

--- a/_examples/starwars/models/generated.go
+++ b/_examples/starwars/models/generated.go
@@ -88,7 +88,7 @@ func (e *Episode) UnmarshalGQL(v any) error {
 }
 
 func (e Episode) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *Episode) UnmarshalJSON(b []byte) error {
@@ -143,7 +143,7 @@ func (e *LengthUnit) UnmarshalGQL(v any) error {
 }
 
 func (e LengthUnit) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *LengthUnit) UnmarshalJSON(b []byte) error {

--- a/_examples/todo/models_gen.go
+++ b/_examples/todo/models_gen.go
@@ -62,7 +62,7 @@ func (e *Role) UnmarshalGQL(v any) error {
 }
 
 func (e Role) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *Role) UnmarshalJSON(b []byte) error {

--- a/_examples/type-system-extension/models_gen.go
+++ b/_examples/type-system-extension/models_gen.go
@@ -78,7 +78,7 @@ func (e *State) UnmarshalGQL(v any) error {
 }
 
 func (e State) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *State) UnmarshalJSON(b []byte) error {

--- a/_examples/websocket-initfunc/server/server.go
+++ b/_examples/websocket-initfunc/server/server.go
@@ -10,9 +10,8 @@ import (
 
 	"github.com/coder/websocket"
 	"github.com/go-chi/chi/v5"
-	"github.com/rs/cors"
-
 	"github.com/gqlgen/_examples/websocket-initfunc/server/graph"
+	"github.com/rs/cors"
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/extension"

--- a/codegen/testserver/benchmark/generated/models/models-gen.go
+++ b/codegen/testserver/benchmark/generated/models/models-gen.go
@@ -79,7 +79,7 @@ func (e *OrderDirection) UnmarshalGQL(v any) error {
 }
 
 func (e OrderDirection) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *OrderDirection) UnmarshalJSON(b []byte) error {
@@ -136,7 +136,7 @@ func (e *UserOrderField) UnmarshalGQL(v any) error {
 }
 
 func (e UserOrderField) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *UserOrderField) UnmarshalJSON(b []byte) error {

--- a/codegen/testserver/followschema/directive_test.go
+++ b/codegen/testserver/followschema/directive_test.go
@@ -275,7 +275,7 @@ func TestDirectives(t *testing.T) {
 				call := directiveCall{}
 				typedObj, err := next(ctx)
 				if typedObj != nil {
-					call.TypeName = (reflect.TypeOf(typedObj).String())
+					call.TypeName = reflect.TypeOf(typedObj).String()
 					call.Value = typedObj
 				}
 				callStore.addCall("Directive3", call)

--- a/codegen/testserver/followschema/maps_test.go
+++ b/codegen/testserver/followschema/maps_test.go
@@ -61,7 +61,7 @@ func TestMaps(t *testing.T) {
 		require.Equal(t, "42", resp.MapStringInterface["c"])
 		require.NotNil(t, resp.MapStringInterface["nested"])
 		require.IsType(t, map[string]any{}, resp.MapStringInterface["nested"])
-		require.Equal(t, "17", (resp.MapStringInterface["nested"].(map[string]any))["value"])
+		require.Equal(t, "17", resp.MapStringInterface["nested"].(map[string]any)["value"])
 	})
 
 	t.Run("nested", func(t *testing.T) {
@@ -78,7 +78,7 @@ func TestMaps(t *testing.T) {
 		require.Equal(t, "42", resp.MapNestedStringInterface["c"])
 		require.NotNil(t, resp.MapNestedStringInterface["nested"])
 		require.IsType(t, map[string]any{}, resp.MapNestedStringInterface["nested"])
-		require.Equal(t, "31", (resp.MapNestedStringInterface["nested"].(map[string]any))["value"])
+		require.Equal(t, "31", resp.MapNestedStringInterface["nested"].(map[string]any)["value"])
 	})
 
 	t.Run("nested nil", func(t *testing.T) {

--- a/codegen/testserver/followschema/models-gen.go
+++ b/codegen/testserver/followschema/models-gen.go
@@ -363,7 +363,7 @@ func (e *EnumTest) UnmarshalGQL(v any) error {
 }
 
 func (e EnumTest) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *EnumTest) UnmarshalJSON(b []byte) error {
@@ -418,7 +418,7 @@ func (e *Status) UnmarshalGQL(v any) error {
 }
 
 func (e Status) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *Status) UnmarshalJSON(b []byte) error {

--- a/codegen/testserver/singlefile/maps_test.go
+++ b/codegen/testserver/singlefile/maps_test.go
@@ -61,7 +61,7 @@ func TestMaps(t *testing.T) {
 		require.Equal(t, "42", resp.MapStringInterface["c"])
 		require.NotNil(t, resp.MapStringInterface["nested"])
 		require.IsType(t, map[string]any{}, resp.MapStringInterface["nested"])
-		require.Equal(t, "17", (resp.MapStringInterface["nested"].(map[string]any))["value"])
+		require.Equal(t, "17", resp.MapStringInterface["nested"].(map[string]any)["value"])
 	})
 
 	t.Run("nested", func(t *testing.T) {
@@ -78,7 +78,7 @@ func TestMaps(t *testing.T) {
 		require.Equal(t, "42", resp.MapNestedStringInterface["c"])
 		require.NotNil(t, resp.MapNestedStringInterface["nested"])
 		require.IsType(t, map[string]any{}, resp.MapNestedStringInterface["nested"])
-		require.Equal(t, "31", (resp.MapNestedStringInterface["nested"].(map[string]any))["value"])
+		require.Equal(t, "31", resp.MapNestedStringInterface["nested"].(map[string]any)["value"])
 	})
 
 	t.Run("nested nil", func(t *testing.T) {

--- a/codegen/testserver/singlefile/models-gen.go
+++ b/codegen/testserver/singlefile/models-gen.go
@@ -363,7 +363,7 @@ func (e *EnumTest) UnmarshalGQL(v any) error {
 }
 
 func (e EnumTest) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *EnumTest) UnmarshalJSON(b []byte) error {
@@ -418,7 +418,7 @@ func (e *Status) UnmarshalGQL(v any) error {
 }
 
 func (e Status) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *Status) UnmarshalJSON(b []byte) error {

--- a/integration/server/models-go/generated.go
+++ b/integration/server/models-go/generated.go
@@ -71,7 +71,7 @@ func (e *DateFilterOp) UnmarshalGQL(v any) error {
 }
 
 func (e DateFilterOp) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *DateFilterOp) UnmarshalJSON(b []byte) error {
@@ -126,7 +126,7 @@ func (e *ErrorType) UnmarshalGQL(v any) error {
 }
 
 func (e ErrorType) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *ErrorType) UnmarshalJSON(b []byte) error {

--- a/plugin/modelgen/models.gotpl
+++ b/plugin/modelgen/models.gotpl
@@ -98,7 +98,7 @@
 	}
 
 	func (e {{ goModelName .Name }}) MarshalGQL(w io.Writer) {
-		fmt.Fprint(w, strconv.Quote(e.String()))
+		_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 	}
 	{{- if not .OmitJSONMarshalers }}
 

--- a/plugin/modelgen/out/generated.go
+++ b/plugin/modelgen/out/generated.go
@@ -297,7 +297,7 @@ func (e *EnumWithDescription) UnmarshalGQL(v any) error {
 }
 
 func (e EnumWithDescription) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
@@ -352,7 +352,7 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 }
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *MissingEnum) UnmarshalJSON(b []byte) error {

--- a/plugin/modelgen/out/generated_omit_root_models.go
+++ b/plugin/modelgen/out/generated_omit_root_models.go
@@ -51,7 +51,7 @@ func (e *SomeContent) UnmarshalGQL(v any) error {
 }
 
 func (e SomeContent) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *SomeContent) UnmarshalJSON(b []byte) error {

--- a/plugin/modelgen/out_enable_model_json_omitempty_tag_false/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitempty_tag_false/generated.go
@@ -292,7 +292,7 @@ func (e *EnumWithDescription) UnmarshalGQL(v any) error {
 }
 
 func (e EnumWithDescription) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
@@ -347,7 +347,7 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 }
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *MissingEnum) UnmarshalJSON(b []byte) error {

--- a/plugin/modelgen/out_enable_model_json_omitempty_tag_false_omitempty_tag_false_omitzero_tag_nil/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitempty_tag_false_omitempty_tag_false_omitzero_tag_nil/generated.go
@@ -291,7 +291,7 @@ func (e *EnumWithDescription) UnmarshalGQL(v any) error {
 }
 
 func (e EnumWithDescription) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 type MissingEnum string
@@ -332,5 +332,5 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 }
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }

--- a/plugin/modelgen/out_enable_model_json_omitempty_tag_false_omitempty_tag_false_omitzero_tag_true/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitempty_tag_false_omitempty_tag_false_omitzero_tag_true/generated.go
@@ -291,7 +291,7 @@ func (e *EnumWithDescription) UnmarshalGQL(v any) error {
 }
 
 func (e EnumWithDescription) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 type MissingEnum string
@@ -332,5 +332,5 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 }
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }

--- a/plugin/modelgen/out_enable_model_json_omitempty_tag_false_omitzero_tag_false/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitempty_tag_false_omitzero_tag_false/generated.go
@@ -292,7 +292,7 @@ func (e *EnumWithDescription) UnmarshalGQL(v any) error {
 }
 
 func (e EnumWithDescription) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
@@ -347,7 +347,7 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 }
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *MissingEnum) UnmarshalJSON(b []byte) error {

--- a/plugin/modelgen/out_enable_model_json_omitempty_tag_false_omitzero_tag_nil/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitempty_tag_false_omitzero_tag_nil/generated.go
@@ -292,7 +292,7 @@ func (e *EnumWithDescription) UnmarshalGQL(v any) error {
 }
 
 func (e EnumWithDescription) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
@@ -347,7 +347,7 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 }
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *MissingEnum) UnmarshalJSON(b []byte) error {

--- a/plugin/modelgen/out_enable_model_json_omitempty_tag_false_omitzero_tag_true/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitempty_tag_false_omitzero_tag_true/generated.go
@@ -292,7 +292,7 @@ func (e *EnumWithDescription) UnmarshalGQL(v any) error {
 }
 
 func (e EnumWithDescription) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
@@ -347,7 +347,7 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 }
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *MissingEnum) UnmarshalJSON(b []byte) error {

--- a/plugin/modelgen/out_enable_model_json_omitempty_tag_nil/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitempty_tag_nil/generated.go
@@ -291,7 +291,7 @@ func (e *EnumWithDescription) UnmarshalGQL(v any) error {
 }
 
 func (e EnumWithDescription) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
@@ -346,7 +346,7 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 }
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *MissingEnum) UnmarshalJSON(b []byte) error {

--- a/plugin/modelgen/out_enable_model_json_omitempty_tag_true/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitempty_tag_true/generated.go
@@ -292,7 +292,7 @@ func (e *EnumWithDescription) UnmarshalGQL(v any) error {
 }
 
 func (e EnumWithDescription) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
@@ -347,7 +347,7 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 }
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *MissingEnum) UnmarshalJSON(b []byte) error {

--- a/plugin/modelgen/out_enable_model_json_omitzero_tag_false/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitzero_tag_false/generated.go
@@ -292,7 +292,7 @@ func (e *EnumWithDescription) UnmarshalGQL(v any) error {
 }
 
 func (e EnumWithDescription) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
@@ -347,7 +347,7 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 }
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *MissingEnum) UnmarshalJSON(b []byte) error {

--- a/plugin/modelgen/out_enable_model_json_omitzero_tag_nil/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitzero_tag_nil/generated.go
@@ -292,7 +292,7 @@ func (e *EnumWithDescription) UnmarshalGQL(v any) error {
 }
 
 func (e EnumWithDescription) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
@@ -347,7 +347,7 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 }
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *MissingEnum) UnmarshalJSON(b []byte) error {

--- a/plugin/modelgen/out_enable_model_json_omitzero_tag_true/generated.go
+++ b/plugin/modelgen/out_enable_model_json_omitzero_tag_true/generated.go
@@ -292,7 +292,7 @@ func (e *EnumWithDescription) UnmarshalGQL(v any) error {
 }
 
 func (e EnumWithDescription) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
@@ -347,7 +347,7 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 }
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *MissingEnum) UnmarshalJSON(b []byte) error {

--- a/plugin/modelgen/out_nullable_input_omittable/generated.go
+++ b/plugin/modelgen/out_nullable_input_omittable/generated.go
@@ -291,7 +291,7 @@ func (e *EnumWithDescription) UnmarshalGQL(v any) error {
 }
 
 func (e EnumWithDescription) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
@@ -346,7 +346,7 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 }
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *MissingEnum) UnmarshalJSON(b []byte) error {

--- a/plugin/modelgen/out_omit_json_enum_marshalers/generated.go
+++ b/plugin/modelgen/out_omit_json_enum_marshalers/generated.go
@@ -322,7 +322,7 @@ func (e *EnumWithDescription) UnmarshalGQL(v any) error {
 }
 
 func (e EnumWithDescription) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 type ExistingEnum string
@@ -363,7 +363,7 @@ func (e *ExistingEnum) UnmarshalGQL(v any) error {
 }
 
 func (e ExistingEnum) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 type MissingEnum string
@@ -404,5 +404,5 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 }
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }

--- a/plugin/modelgen/out_struct_pointers/generated.go
+++ b/plugin/modelgen/out_struct_pointers/generated.go
@@ -249,7 +249,7 @@ func (e *EnumWithDescription) UnmarshalGQL(v any) error {
 }
 
 func (e EnumWithDescription) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *EnumWithDescription) UnmarshalJSON(b []byte) error {
@@ -304,7 +304,7 @@ func (e *MissingEnum) UnmarshalGQL(v any) error {
 }
 
 func (e MissingEnum) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *MissingEnum) UnmarshalJSON(b []byte) error {


### PR DESCRIPTION
Closes #3946.

The generated enum `MarshalGQL` methods call `fmt.Fprint` without touching the returned values, and security scanners (SonarQube, OWASP dependency check) flag that as an unhandled error. Writing to the buffer here never actually fails, so I just changed the modelgen template to discard the result explicitly with `_, _ =`.

You mentioned in the issue you'd be happy with either the explicit ignore or a `graphql` helper wrapper. I went with the explicit `_, _ =` since it stays consistent with what's already in the tree (`graphql/handler/debug/tracer.go` uses the same form) and doesn't add any new exported API. Behavior is unchanged.

Regenerated the checked-in fixtures so `go generate ./...` stays clean.

I have:
 - [x] Added tests covering the bug / feature (the regenerated model fixtures exercise the new template output; existing modelgen tests build and run them)
 - [ ] Updated any relevant documentation (n/a)
