### PR TITLE
Fix #4304: Go v1.27 any / interface{} adjustments

### DIFF
--- a/codegen/autobind_test.go
+++ b/codegen/autobind_test.go
@@ -32,18 +32,31 @@ func (m Model) HasName() bool {
 
 	tests := []struct {
 		Name                string
+		Model               types.Type
 		Field               string
 		AutoBindGetterHaser bool
 		Expected            string // Expected method/field name
 	}{
 		{
 			Name:                "Autobind enabled, should find GetName",
+			Model:               model,
 			Field:               "name",
 			AutoBindGetterHaser: true,
 			Expected:            "GetName",
 		},
 		{
 			Name:                "Autobind disabled, should find Name field",
+			Model:               model,
+			Field:               "name",
+			AutoBindGetterHaser: false,
+			Expected:            "Name",
+		},
+		{
+			Name: "Binding on an alias of the Model",
+			Model: types.NewAlias(
+				types.NewTypeName(0, nil, "AliasModel", nil),
+				model,
+			),
 			Field:               "name",
 			AutoBindGetterHaser: false,
 			Expected:            "Name",
@@ -53,7 +66,7 @@ func (m Model) HasName() bool {
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			b := builder{Config: &config.Config{}}
-			target, err := b.findBindTarget(model, tt.Field, tt.AutoBindGetterHaser)
+			target, err := b.findBindTarget(tt.Model, tt.Field, tt.AutoBindGetterHaser)
 			require.NoError(t, err)
 			require.NotNil(t, target)
 			require.Equal(t, tt.Expected, target.Name())

--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -564,7 +564,7 @@ func (b *Binder) CopyModifiersFromAst(t *ast.Type, base types.Type) types.Type {
 	}
 
 	var isInterface bool
-	if named, ok := base.(*types.Named); ok {
+	if named, ok := types.Unalias(base).(*types.Named); ok {
 		_, isInterface = named.Underlying().(*types.Interface)
 	}
 

--- a/codegen/config/binder.go
+++ b/codegen/config/binder.go
@@ -93,8 +93,8 @@ func (b *Binder) InstantiateType(orig types.Type, targs []types.Type) (types.Typ
 }
 
 var (
-	MapType       = types.NewMap(types.Typ[types.String], types.Universe.Lookup("any").Type())
-	InterfaceType = types.Universe.Lookup("any").Type()
+	MapType       = types.NewMap(types.Typ[types.String], templates.AnyType)
+	InterfaceType = templates.AnyType
 )
 
 func (b *Binder) DefaultUserObject(name string) (types.Type, error) {

--- a/codegen/field.go
+++ b/codegen/field.go
@@ -388,7 +388,7 @@ func (b *builder) findBindStructTagTarget(in types.Type, name string) (types.Obj
 }
 
 func (b *builder) findBindMethodTarget(in types.Type, name string) (types.Object, error) {
-	switch t := in.(type) {
+	switch t := types.Unalias(in).(type) {
 	case *types.Named:
 		if _, ok := t.Underlying().(*types.Interface); ok {
 			return b.findBindMethodTarget(t.Underlying(), name)
@@ -426,7 +426,7 @@ func (b *builder) findBindMethoderTarget(
 }
 
 func (b *builder) findBindFieldTarget(in types.Type, name string) (types.Object, error) {
-	switch t := in.(type) {
+	switch t := types.Unalias(in).(type) {
 	case *types.Named:
 		return b.findBindFieldTarget(t.Underlying(), name)
 	case *types.Struct:
@@ -454,7 +454,7 @@ func (b *builder) findBindEmbedsTarget(
 	name string,
 	autoBindGetterHaser bool,
 ) (types.Object, error) {
-	switch t := in.(type) {
+	switch t := types.Unalias(in).(type) {
 	case *types.Named:
 		return b.findBindEmbedsTarget(t.Underlying(), name, autoBindGetterHaser)
 	case *types.Struct:
@@ -528,7 +528,7 @@ func (b *builder) findBindInterfaceEmbedsTarget(
 func (b *builder) findBindHaserMethod(in types.Type, name string) (types.Object, error) {
 	haserName := "Has" + name
 
-	switch t := in.(type) {
+	switch t := types.Unalias(in).(type) {
 	case *types.Named:
 		if _, ok := t.Underlying().(*types.Interface); ok {
 			return b.findBindHaserMethod(t.Underlying(), name)
@@ -990,7 +990,7 @@ func (f *Field) fieldArgExpression(
 		arg.TypeReference.GO,
 	) + ")"
 
-	if iface, ok := arg.TypeReference.GO.(*types.Interface); ok && iface.Empty() {
+	if iface, ok := types.Unalias(arg.TypeReference.GO).(*types.Interface); ok && iface.Empty() {
 		tmp = fmt.Sprintf(`
 				func () any {
 					if fc.Args["%s"] == nil {

--- a/codegen/templates/import.go
+++ b/codegen/templates/import.go
@@ -118,6 +118,9 @@ func (s *Imports) Lookup(path string) string {
 }
 
 func (s *Imports) LookupType(t types.Type) string {
+	if iface, ok := types.Unalias(t).(*types.Interface); ok && iface.Empty() {
+		return "any"
+	}
 	return types.TypeString(t, func(i *types.Package) string {
 		return s.Lookup(i.Path())
 	})

--- a/codegen/templates/import.go
+++ b/codegen/templates/import.go
@@ -22,6 +22,8 @@ type Imports struct {
 	packages *code.Packages
 }
 
+var AnyType = types.Universe.Lookup("any").Type()
+
 func (i *Import) String() string {
 	if strings.HasSuffix(i.Path, i.Alias) && i.Alias == i.Name {
 		return strconv.Quote(i.Path)
@@ -119,7 +121,7 @@ func (s *Imports) Lookup(path string) string {
 
 func (s *Imports) LookupType(t types.Type) string {
 	if iface, ok := types.Unalias(t).(*types.Interface); ok && iface.Empty() {
-		return "any"
+		t = AnyType
 	}
 	return types.TypeString(t, func(i *types.Package) string {
 		return s.Lookup(i.Path())


### PR DESCRIPTION
Fix #4304
---

Running the same code under go1.26 (`any`) vs. go1.27 (`interface{}`) causes a difference with gqlgen that causes CI failures.

`schema.graphql`:
```
scalar Any

type Query {
  example: Foo
}

type Foo {
  bar: Any
}
```

go1.26:
```
$ go version
go version go1.26.7 darwin/arm64
$ go run --mod=mod github.com/99designs/gqlgen@v0.17.94 generate --verbose
Any is incompatible with map[string]string
```

go1.27:
```
$ /opt/homebrew/Cellar/go/1.27.0/bin/go version
go version go1.27.0 darwin/arm64
$ /opt/homebrew/Cellar/go/1.27.0/bin/go run --mod=mod github.com/99designs/gqlgen@v0.17.94 generate --verbose
Any is incompatible with map[string]string
```

Committed the output of go1.26 to a git repository and comparing the difference after running go1.27:
```
diff --git i/generated.go w/generated.go
index a3cec9d..0800297 100644
--- i/generated.go
+++ w/generated.go
@@ -50,7 +50,7 @@ type ComplexityRoot struct {
 // region    ************************** generated!.gotpl **************************
 
 type FooResolver interface {
-	Bar(ctx context.Context, obj *Foo) (any, error)
+	Bar(ctx context.Context, obj *Foo) (interface{}, error)
 }
 type QueryResolver interface {
 	Example(ctx context.Context) (*Foo, error)
diff --git i/schema.resolvers.go w/schema.resolvers.go
index f1c67d9..e08e9ba 100644
--- i/schema.resolvers.go
+++ w/schema.resolvers.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Bar is the resolver for the bar field.
-func (r *fooResolver) Bar(ctx context.Context, obj *Foo) (any, error) {
+func (r *fooResolver) Bar(ctx context.Context, obj *Foo) (interface{}, error) {
 	panic(fmt.Errorf("not implemented: Bar - bar"))
 }
```