### PR TITLE
playground: add optional URL state persistence for GraphiQL

### DIFF
--- a/graphql/playground/playground.go
+++ b/graphql/playground/playground.go
@@ -156,6 +156,48 @@ var page = template.Must(template.New("graphiql").Parse(`<!DOCTYPE html>
 {{- if .EnablePluginExplorer}}
       plugins.push(GraphiQLPluginExplorer.explorerPlugin());
 {{- end}}
+{{- if .PersistStateInURL }}
+      // Parse URL parameters.
+      const parameters = Object.fromEntries(
+        new URLSearchParams(window.location.search)
+      );
+
+      function updateURL() {
+        const searchParams = new URLSearchParams();
+
+        Object.entries(parameters).forEach(([key, value]) => {
+          if (value) {
+            searchParams.set(key, value);
+          }
+        });
+
+        history.replaceState(
+          null,
+          '',
+          '?' + searchParams.toString(),
+        );
+      }
+
+      function onEditQuery(query) {
+        parameters.query = query;
+        updateURL();
+      }
+
+      function onEditVariables(variables) {
+        parameters.variables = variables;
+        updateURL();
+      }
+
+      function onEditHeaders(headers) {
+        parameters.headers = headers;
+        updateURL();
+      }
+
+      function onEditOperationName(operationName) {
+        parameters.operationName = operationName;
+        updateURL();
+      }
+{{- end }}
 
       const fetcher = GraphiQL.createFetcher({ url, subscriptionUrl, headers: fetcherHeaders });
       ReactDOM.render(
@@ -163,8 +205,25 @@ var page = template.Must(template.New("graphiql").Parse(`<!DOCTYPE html>
           fetcher: fetcher,
           isHeadersEditorEnabled: true,
           shouldPersistHeaders: true,
-		  headers: JSON.stringify(uiHeaders, null, 2),
-		  plugins: plugins,
+{{- if .PersistStateInURL }}
+          query: parameters.query,
+          variables: parameters.variables,
+          operationName: parameters.operationName,
+
+          headers:
+            parameters.headers ??
+            (uiHeaders
+              ? JSON.stringify(uiHeaders, null, 2)
+              : undefined),
+
+          onEditQuery: onEditQuery,
+          onEditVariables: onEditVariables,
+          onEditHeaders: onEditHeaders,
+          onEditOperationName: onEditOperationName,
+{{- else }}
+          headers: JSON.stringify(uiHeaders, null, 2),
+{{- end }}
+          plugins: plugins,
           storage: new PrefixedStorage('{{.StoragePrefix}}'),
           inputValueDeprecation: true
         }),
@@ -183,6 +242,7 @@ type GraphiqlConfig struct {
 	UiHeaders            map[string]string
 	EndpointIsAbsolute   bool
 	SubscriptionEndpoint string
+	PersistStateInURL    bool
 	JsUrl                template.URL
 	JsSRI                string
 	CssUrl               template.URL
@@ -208,6 +268,15 @@ func WithGraphiqlFetcherHeaders(headers map[string]string) GraphiqlConfigOption 
 func WithGraphiqlUiHeaders(headers map[string]string) GraphiqlConfigOption {
 	return func(config *GraphiqlConfig) {
 		config.UiHeaders = headers
+	}
+}
+
+// WithGraphiqlPersistStateInURL enables loading GraphiQL state from URL
+// parameters and keeps the URL synchronized as the query, variables,
+// headers, and operation name change.
+func WithGraphiqlPersistStateInURL(enable bool) GraphiqlConfigOption {
+	return func(config *GraphiqlConfig) {
+		config.PersistStateInURL = enable
 	}
 }
 

--- a/graphql/playground/playground_test.go
+++ b/graphql/playground/playground_test.go
@@ -114,6 +114,24 @@ func TestWithGraphiqlUiHeaders(t *testing.T) {
 	})
 }
 
+func TestWithGraphiqlPersistStateInURL(t *testing.T) {
+	t.Run("should enable URL state persistence", func(t *testing.T) {
+		config := &GraphiqlConfig{}
+
+		WithGraphiqlPersistStateInURL(true)(config)
+
+		assert.True(t, config.PersistStateInURL)
+	})
+
+	t.Run("should disable URL state persistence", func(t *testing.T) {
+		config := &GraphiqlConfig{}
+
+		WithGraphiqlPersistStateInURL(false)(config)
+
+		assert.False(t, config.PersistStateInURL)
+	})
+}
+
 func TestWithGraphiqlVersion(t *testing.T) {
 	t.Run("should set graphiql version", func(t *testing.T) {
 		config := &GraphiqlConfig{}
@@ -235,6 +253,57 @@ func TestHandler_WithOptions(t *testing.T) {
 				assert.True(
 					t,
 					strings.Contains(body, `const uiHeaders = {"X-Custom-Header":"value"};`),
+				)
+			},
+		},
+		{
+			name: "WithGraphiqlPersistStateInURL",
+			options: []GraphiqlConfigOption{
+				WithGraphiqlPersistStateInURL(true),
+			},
+			assert: func(t *testing.T, body string) {
+				assert.True(
+					t,
+					strings.Contains(
+						body,
+						`new URLSearchParams(window.location.search)`,
+					),
+				)
+
+				assert.True(
+					t,
+					strings.Contains(
+						body,
+						`function onEditQuery(query)`,
+					),
+				)
+
+				assert.True(
+					t,
+					strings.Contains(
+						body,
+						`history.replaceState`,
+					),
+				)
+
+				assert.True(
+					t,
+					strings.Contains(body, `query: parameters.query`),
+				)
+
+				assert.True(
+					t,
+					strings.Contains(body, `variables: parameters.variables`),
+				)
+
+				assert.True(
+					t,
+					strings.Contains(body, `onEditQuery: onEditQuery`),
+				)
+
+				assert.True(
+					t,
+					strings.Contains(body, `onEditVariables: onEditVariables`),
 				)
 			},
 		},


### PR DESCRIPTION
Adds optional URL state persistence for the GraphiQL playground.

When enabled with:

`playground.WithGraphiqlPersistStateInURL(true)`

https://github.com/99designs/gqlgen/discussions/2044#discussioncomment-18217427

### Background

gqlgen's bundled GraphiQL handler currently doesn't provide a way to initialise or persist query state via URL parameters. GraphiQL itself supports this pattern and includes example implementations that read query, variables, headers, and operationName from the URL and keep them synchronised as the user edits. This allows gqlgen to expose this as an optional feature of the built-in GraphiQL handler so users can share GraphiQL URLs without maintaining a custom GraphiQL frontend per https://github.com/graphql/graphiql/discussions/3450

Example implementation: https://github.com/graphql/graphiql/blob/1f9335051fffc9e6a6f950b6f8060ed521b56789/packages/graphiql/resources/renderExample.js
