### PR TITLE
Release SBOM hardening

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,9 @@ indent_size = 4
 
 [*.{go,gotpl}]
 indent_style = tab
+indent_size = 8
+[Dockerfile]
+indent_size = 4
 
 # Ignore yaml https://learn.microsoft.com/en-us/visualstudio/code-quality/use-roslyn-analyzers?view=vs-2022
 [*.{yaml,yml,yml.j2,yaml.j2}]
@@ -24,5 +27,14 @@ generated_code = true
 
 # These often end up with go code inside, so lets keep tabs
 [*.{html,md}]
-indent_size = 2
+indent_size = 4
 indent_style = tab
+
+[*.{sql,graphql}]
+generated_code = true
+# charset = unset
+# end_of_line = unset
+# insert_final_newline = unset
+# trim_trailing_whitespace = unset
+# indent_style = unset
+# indent_size = unset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+# Release workflow: on a pushed vX.Y.Z tag, goreleaser builds the source tarball,
+# its SBOM (syft), and a checksum, then cosign signs the checksum keylessly and a
+# build-provenance attestation is recorded. this is a library, so there are no
+# binaries or images — only the signed, attested source + SBOM.
+name: release
+
+# run only on tags
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write # create the GitHub release and upload assets
+  id-token: write # keyless cosign signing (OIDC)
+  attestations: write # build-provenance attestation
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # this is important, otherwise it won't checkout the full tree (i.e. no previous tags)
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-checksums: ./dist/checksums.txt

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,143 @@
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+#
+# This is also a CLI: this release publishes cross-platform binary archives, a
+# reproducible source tarball, an SBOM (syft) for each, a checksum file that
+# covers every artifact, and a keyless cosign signature over that checksum.
+#
+# Local test:  goreleaser release --snapshot --clean --skip=sign  (needs syft on
+#              PATH). --skip=sign is required, not optional: snapshot mode does
+#              NOT skip the signs block, and keyless cosign then blocks on an
+#              interactive OIDC device flow until it times out.
+# CI:          a release workflow must install syft + cosign and grant
+#              `id-token: write` for keyless signing.
+
+version: 2
+# Consider pinning your project name:
+# GoReleaser will attempt to resolve the project name with this precedence:
+#  1. explicit project_name — wins
+#  2. git remote / release repo name — beats go.mod
+#  3. go.mod module basename — used when there's no remote
+#  4. directory name — never observed; go.mod took precedence over it even with no remote
+# project_name: PIN_YOUR_PROJECT_HERE
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+
+builds:
+  - main: .
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - arm64
+      - amd64
+      - "386"
+    # `cmd/version.Version` defaults to "dev" and only falls back to build info
+    # when it is still "dev"/empty, so injecting it here is what makes a released
+    # binary report its real tag. Building through the proxy (below) strips the
+    # VCS stamps that fallback would otherwise read.
+    ldflags:
+      - -s -w
+      - -X {{ .ModulePath }}/cmd/version.Version={{ .Version }}
+    # Pin the binary mtime to the commit so repeated builds of one tag are
+    # byte-identical.
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+archives:
+  - formats: [tar.gz]
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+# Resolve modules through the Go proxy so the released binaries and source are
+# built from the verifiable, proxy-visible source of truth.
+gomod:
+  proxy: true
+
+# The source tarball ships beside the binaries so the release is auditable
+# without a clone.
+source:
+  enabled: true
+  name_template: "{{ .ProjectName }}_{{ .Version }}_source"
+
+# SBOMs via syft (goreleaser's default SBOM generator): one per binary archive,
+# capturing what each shipped artifact actually contains, plus one for the
+# source tree's full module dependency graph.
+sboms:
+  - id: archive
+    artifacts: archive
+  - id: source
+    artifacts: source
+
+# checksums.txt covers every artifact — archives, SBOMs and source tarball.
+checksum:
+  name_template: "checksums.txt"
+
+# Keyless cosign signature over the checksum. Because the checksum covers the
+# archives, SBOMs and the source tarball, this one signature makes all of them
+# verifiable. Runs only on real releases (skipped by --snapshot); needs cosign +
+# id-token.
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sigstore.json"
+    args:
+      - sign-blob
+      - "--bundle=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+    output: true
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  footer: |
+    ## Verifying this release
+
+    ```bash
+    # 1. cosign signature over the checksum file (identity = the release workflow).
+    cosign verify-blob \
+      --bundle checksums.txt.sigstore.json \
+      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+      --certificate-identity 'https://github.com/{{ .Env.GITHUB_REPOSITORY }}/.github/workflows/release.yml@refs/tags/{{ .Tag }}' \
+      checksums.txt
+
+    # 2. hash every downloaded artifact against the now-trusted checksums.
+    shasum -a 256 --ignore-missing -c checksums.txt
+
+    # 3. GitHub build provenance (repeat --repo for whichever archive you pulled).
+    gh attestation verify {{ .ProjectName }}_Darwin_arm64.tar.gz --repo {{ .Env.GITHUB_REPOSITORY }}
+    gh attestation verify {{ .ProjectName }}_{{ .Version }}_source.tar.gz --repo {{ .Env.GITHUB_REPOSITORY }}
+    ```
+
+    Each archive ships an SBOM alongside it (`<archive>.sbom.json`, SPDX-2.3); the
+    source tree's is `{{ .ProjectName }}_{{ .Version }}_source.tar.gz.sbom.json`.
+
+    ---
+    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).

--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -1,0 +1,141 @@
+# .mdformat.toml — mdformat configuration file
+# Read automatically by the mdformat-config plugin on every invocation when
+# this file is present at or above the directory being formatted.
+#
+# Corresponds to:
+#   mdformat --wrap keep --number
+#
+# With this file present the command line simplifies to:
+#   find . -type d -name node_modules -prune -o -name '*.md' -type f -print0 \
+#     | xargs -0 -n1 -P4 mdformat
+#
+# For check mode, --check still must be passed on the command line; it is a
+# run-mode switch (not a formatting option) and has no .mdformat.toml equivalent:
+#   find . -type d -name node_modules -prune -o -name '*.md' -type f -print0 \
+#     | xargs -0 -n1 -P4 mdformat --check
+
+# ── Paragraph wrapping ────────────────────────────────────────────────────────
+#
+# "keep" — preserve existing line breaks; never reflow paragraph text (default)
+# "no"   — collapse paragraph text to a single long line
+# N      — reflow to at most N characters per line (integer ≥ 2)
+#
+# "keep" is the default but is set explicitly here to make the project's intent
+# clear and to prevent a future mdformat default change from silently reflowing
+# all prose.
+wrap = "keep"
+
+# ── Ordered list numbering ────────────────────────────────────────────────────
+#
+# false — normalize all ordered list items to "1." regardless of source (default)
+# true  — apply consecutive numbering: 1. 2. 3. … (corresponds to --number)
+#
+# Must be true for the .rumdl.toml [MD029] style = "ordered" setting to stay
+# consistent: rumdl enforces sequential numbering and mdformat must produce it.
+number = true
+
+# ── Line endings ──────────────────────────────────────────────────────────────
+#
+# "lf"   — Unix line endings \n (default)
+# "crlf" — Windows line endings \r\n
+# "keep" — preserve each file's existing line ending type
+end_of_line = "lf"
+
+# ── HTML equivalence validation ───────────────────────────────────────────────
+#
+# true  — abort if formatting changes the rendered HTML of the document (default)
+# false — skip the check; required when a plugin intentionally alters rendered
+#         output. Corresponds to --no-validate on the command line.
+#
+# mdformat-toc sets CHANGES_AST = True, which causes mdformat to bypass HTML
+# equivalence validation entirely for any file the toc plugin touches. For
+# files not processed by toc, the other installed plugins (gfm, shfmt, gofmt,
+# config) do preserve rendered output, so validation is safe to leave enabled.
+validate = true
+
+# ── File exclusions (Python 3.13+) ────────────────────────────────────────────
+#
+# List of Unix-style glob patterns relative to the directory containing this
+# file. Files matching any pattern are skipped without formatting or error.
+# Equivalent to passing --exclude PATTERN multiple times on the command line.
+#
+# The project's format and check commands use `find -prune` to exclude
+# node_modules before handing paths to mdformat, so this list is empty.
+# Add patterns here when running `mdformat .` or `mdformat --check .` directly
+# against the directory tree without the find wrapper.
+#
+# Note: on Python < 3.13, the presence of this key in the TOML file causes
+# mdformat to print an error and exit 1 — even when set to an empty list.
+# Comment it out if you need to support Python < 3.13.
+# exclude = []
+
+# ── Extension plugins ─────────────────────────────────────────────────────────
+#
+# Key absent — all installed extension plugins are enabled (default); matches
+#              the invocation which omits --extensions.
+# List       — only the listed extensions are active AND required; mdformat
+#              exits 1 if a listed extension is not installed. Use this to turn
+#              a missing plugin from a silent no-op into a hard error.
+#
+# Installed extensions in this environment:
+#   "gfm"           — mdformat-gfm 1.0.0 (GFM: strikethrough, task lists, autolinks)
+#   "tables"        — mdformat-gfm 1.0.0 (padded/compact table rendering; built-in since 1.0.0,
+#                    replacing the deprecated and archived mdformat-tables package — do NOT
+#                    install mdformat-tables separately, it will conflict with mdformat-gfm 1.0.0)
+#   "front_matters" — mdformat-front-matters 2.0.0 (preserves YAML/TOML/JSON frontmatter blocks;
+#                    without this plugin, a leading --- block is mangled into a thematic break
+#                    and a heading; do NOT install mdformat-frontmatter (no trailing s, by butler54)
+#                    — it requires mdformat < 0.8.0 and is incompatible with mdformat 1.0.0)
+#   "toc"           — mdformat-toc 0.5.0 (TOC between <!-- mdformat-toc start/end --> markers;
+#                    0.5.0+ also inserts <a name="{slug}"></a> anchors after heading text by
+#                    default; use --no-anchors in the marker to suppress)
+#
+# Uncomment to pin explicitly and fail fast on a missing plugin.
+# Note: mdformat-gfm registers BOTH "gfm" and "tables" — both must be listed.
+# Note: mdformat-front-matters registers as "front_matters" (underscore, not hyphen):
+# extensions = ["gfm", "tables", "front_matters", "toc"]
+
+# ── Code formatter plugins ────────────────────────────────────────────────────
+#
+# Key absent — all installed code formatter plugins are enabled (default);
+#              matches the invocation which omits --codeformatters.
+# List       — only the listed language formatters are active AND required;
+#              mdformat exits 1 if a listed language is not available.
+#
+# Installed code formatters in this environment:
+#   "bash", "sh"             — mdformat-shfmt  (shells out to shfmt)
+#   "json", "toml", "yaml"   — mdformat-config (taplo for TOML, ruamel.yaml for YAML,
+#                                               json stdlib for JSON)
+#   "go"                     — mdformat-gofmt  (shells out to gofmt)
+#
+# Formatters that raise an exception (e.g. gofmt cannot parse an incomplete
+# snippet) emit a Warning: line on stderr and leave the block unchanged; they
+# do not cause --check to exit 1. Only "Error: File is not formatted" causes
+# a non-zero exit.
+#
+# Uncomment to pin explicitly and fail fast on a missing formatter:
+# codeformatters = ["bash", "sh", "json", "toml", "yaml", "go"]
+
+# ── Plugin-specific configuration ─────────────────────────────────────────────
+#
+# Plugin options are nested under [plugin.<plugin-id>] sub-tables and passed
+# into each plugin's mdit.options["mdformat"]["plugin"]["<plugin-id>"] namespace.
+#
+# mdformat-gfm 1.0.0 exposes one TOML-configurable option via [plugin.tables]:
+#
+#   compact_tables (bool, default false)
+#     false — pad all table cells to align column widths (default)
+#     true  — omit padding; each cell contains only its content
+#
+# The --compact-tables CLI flag is the command-line equivalent.
+# This project uses padded tables (the default) to match the rumdl MD060
+# aligned style, so compact_tables is left false here.
+#
+# Other installed plugins have no TOML-configurable options:
+#   mdformat-toc    — slug style is set per-file in the marker comment, not globally
+#   mdformat-shfmt  — shfmt flags are not exposed
+#   mdformat-config — taplo/ruamel.yaml defaults are used
+#   mdformat-gofmt  — gofmt has no configurable flags
+
+[plugin.tables]
+compact_tables = false  # true = no cell padding; false = columns aligned to widest cell

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,44 @@
+[tools]
+go = "latest"
+golangci-lint = "latest"
+goreleaser = "latest"
+"github:gotestyourself/gotestsum" = "latest"
+# supply-chain tooling: syft generates the SBOM, cosign signs the checksum.
+syft = "latest"
+cosign = "latest"
+
+[env]
+LOG_LEVEL = "debug"
+
+[tasks.sbom]
+description = "Build the source tarball + SBOM locally (goreleaser snapshot; signing skipped)"
+run = "goreleaser release --snapshot --clean --skip=sign"
+
+[tasks.check]
+description = "Validate the goreleaser configuration"
+run = "goreleaser check"
+
+[tasks.test]
+description = "Run all go tests using gotestsum"
+run = "gotestsum ./..."
+
+[tasks."test:watch"]
+description = "Run all go tests in watch mode"
+run = "gotestsum --watch -- -v ./..."
+
+[tasks.coverage]
+description = "Run tests with race detection and coverage"
+run = "go test -race -coverprofile=coverage.out -covermode=atomic ./... -v -cover"
+
+[tasks.tidy]
+description = "Run go mod tidy"
+run = "go mod tidy"
+
+[tasks.lint]
+description = "Run golangci-lint"
+run = "golangci-lint run ./..."
+
+[tasks.fmt]
+description = "Run golangci-lint fmt"
+run = "golangci-lint fmt"
+

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# Ignore all YAML files due to https://github.com/prettier/prettier/issues/9355
+*.yml
+*.yaml

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,0 +1,101 @@
+# rumdl configuration file
+
+# Inherit settings from another config file (relative to this file's directory)
+# extends = "../base.rumdl.toml"
+
+# Global configuration options
+[global]
+# List of rules to disable (uncomment and modify as needed)
+disable = ["MD013", "MD033", "MD024"]
+
+flavor = "gfm" # GitHub Flavored Markdown with security-sensitive HTML warnings and extended autolinks
+
+# List of rules to enable exclusively (replaces defaults; only these rules will run)
+# enable = ["MD001", "MD003", "MD004"]
+
+# Additional rules to enable on top of defaults (additive, does not replace)
+# Use this to activate opt-in rules like MD060, MD063, MD072, MD073, MD074
+extend-enable = ["MD060", "MD063", "MD073"]
+
+# Additional rules to disable on top of the disable list (additive)
+# extend-disable = ["MD041"]
+
+# List of file/directory patterns to include for linting (if provided, only these will be linted)
+# include = [
+#    "docs/*.md",
+#    "src/**/*.md",
+#    "README.md"
+# ]
+
+# List of file/directory patterns to exclude from linting
+exclude = [
+    # Common directories to exclude
+    ".git",
+    ".github",
+    "node_modules",
+    "vendor",
+    "dist",
+    "build",
+
+    # Specific files or patterns
+    "CHANGELOG.md",
+    "LICENSE.md",
+]
+
+# Respect .gitignore files when scanning directories (default: true)
+respect-gitignore = true
+
+# Markdown flavor/dialect (uncomment to enable)
+# Options: standard (default), gfm, commonmark, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops
+# flavor = "mkdocs"
+
+# Rule-specific configurations (uncomment and modify as needed)
+
+[MD003]
+style = "atx"  # mdformat always converts setext headings to ATX
+
+[MD004]
+style = "dash"  # mdformat normalizes all unordered list markers (* + -) to -
+
+[MD029]
+style = "ordered"  # matches mdformat --number (sequential numbering)
+
+# [MD007]
+# indent = 4  # Unordered list indentation
+
+# [MD013]
+# line-length = 100  # Line length
+# code-blocks = false  # Exclude code blocks from line length check
+# tables = false  # Exclude tables from line length check
+# headings = true  # Include headings in line length check
+
+[MD046]
+style = "fenced"  # mdformat converts indented code blocks to fenced
+
+[MD035]
+style = "______________________________________________________________________"  # matches mdformat's canonical thematic break rendering (70 underscores)
+
+[MD048]
+style = "backtick"  # mdformat defaults to backtick fences (tildes only as fallback)
+
+# [MD044]
+# names = ["rumdl", "Markdown", "GitHub"]  # Proper names that should be capitalized correctly
+# code-blocks = false  # Check code blocks for proper names (default: false, skips code blocks)
+
+[MD010]
+code-blocks = false  # Go code in fenced blocks uses tab indentation; gofmt keeps them
+
+[MD060]
+enabled = true              # Default: opt-in for conservative adoption
+style = "aligned"            # Options: "aligned", "aligned-no-space", "compact", "tight", "any"
+max-width = 0                # Default: inherit from MD013's line-length
+column-align = "auto"        # Options: "auto", "left", "center", "right"
+column-align-header = "auto" # Override alignment for header row only
+column-align-body = "auto"   # Override alignment for body rows only
+loose-last-column = false    # Cap last column at header width when true
+aligned-delimiter = true    # Pad delimiter dashes to header widths under compact/tight
+
+[MD063]
+enabled = true
+style = "title-case"
+preserve-cased-words = true

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,18 @@
+# Look for 'source'd files relative to the checked script
+source-path=SCRIPTDIR
+# source-path=/mnt/chroot
+
+# Since 0.9.0, values can be quoted with '' or "" to allow spaces
+# source-path="My Documents/scripts"
+
+# Allow opening any 'source'd file, even if not specified as input
+external-sources=true
+
+# Turn on warnings for unquoted variables with safe values
+# enable=quote-safe-variables
+
+# Turn on warnings for unassigned uppercase variables
+# enable=check-unassigned-uppercase
+
+# See https://www.shellcheck.net/wiki/SC2086 https://www.shellcheck.net/wiki/SC2129
+disable=SC2086,SC2129

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,18 @@
+StylesPath = .vale/styles
+MinAlertLevel = suggestion
+Vocab = ElasticTerms, TechJargon, ThirdPartyProducts
+
+Packages = write-good,alex,proselint,https://github.com/StevenACoffman/vale-ai-tells/releases/download/v1.26.0/ai-tells.zip, \
+  https://github.com/StevenACoffman/vale-ai-tells/releases/download/v1.26.0/ai-tells-commits.zip
+
+[*.md]
+BasedOnStyles = Readability,alex,proselint,write-good,Elastic,ai-tells
+
+; ai-tells: repo-local tuning for a Go errors library's docs.
+; These two heuristics over-flag ordinary software writing here:
+;   FormalRegister        flags implement/implementation/framework (correct Go terms)
+;   CataphoricForecasting flags back-references like "The two are ..."
+; Demoted to warning so an error-gated CI passes on correct technical prose while
+; the hints still surface locally. The token/regex fixes belong in the rule files.
+ai-tells.FormalRegister        = warning
+ai-tells.CataphoricForecasting = warning

--- a/bin/release
+++ b/bin/release
@@ -1,26 +1,66 @@
 #!/bin/bash
+set -euo pipefail
 
-set -eu
-
-if ! [ $# -eq 1 ] ; then
-    echo "usage: ./bin/release [version]"
+# Tag and publish a new release from master.
+#
+# Aborts unless ALL of these hold:
+#   - exactly one version argument, starting with "v"
+#   - the current branch is master
+#   - the working tree is clean (no staged, unstaged, or untracked changes)
+#   - local master is identical to origin/master (nothing unpushed, not behind,
+#     not diverged)
+#   - the tag does not already exist
+ORG="99designs"
+REPO="gqlgen"
+if [ $# -ne 1 ]; then
+    echo "usage: ./bin/release vX.Y.Z" >&2
     exit 1
 fi
 
 VERSION=$1
 
-if ! git diff-index --quiet HEAD -- ; then
-    echo "uncommitted changes on HEAD, aborting"
+if [[ ${VERSION} != v* ]]; then
+    echo "version must start with v (got: ${VERSION})" >&2
     exit 1
 fi
 
-if [[ ${VERSION:0:1} != "v" ]] ; then
-    echo "version strings must start with v"
+# Must be on master.
+branch=$(git branch --show-current)
+if [ "${branch}" != "master" ]; then
+    echo "must be on master to release (on: ${branch:-detached HEAD})" >&2
     exit 1
 fi
 
-git fetch origin
-git checkout origin/master
+# Working tree must be clean: modifications, staged changes, or untracked files
+# all count as dirty.
+if [ -n "$(git status --porcelain)" ]; then
+    echo "working tree is dirty, aborting" >&2
+    exit 1
+fi
+
+# Refuse to overwrite an existing tag.
+if git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null; then
+    echo "tag ${VERSION} already exists, aborting" >&2
+    exit 1
+fi
+
+# Local master must be exactly in sync with the remote.
+git fetch --quiet origin master
+local_sha=$(git rev-parse HEAD)
+remote_sha=$(git rev-parse origin/master)
+base_sha=$(git merge-base HEAD origin/master)
+if [ "${local_sha}" != "${remote_sha}" ]; then
+    if [ "${local_sha}" = "${base_sha}" ]; then
+        echo "local master is behind origin/master; pull first" >&2
+    elif [ "${remote_sha}" = "${base_sha}" ]; then
+        echo "local master has unpushed commits; push first" >&2
+    else
+        echo "local master and origin/master have diverged; reconcile first" >&2
+    fi
+    exit 1
+fi
+
+# All preconditions met: Re-generate, and update graphql/version.go, commit, push
 
 cat > graphql/version.go <<EOF
 package graphql
@@ -30,9 +70,15 @@ EOF
 go generate ./...
 git add .
 
-git commit -m "release $VERSION"
-git tag $VERSION
-git push origin $VERSION
+git commit -s -S -m "pre-release $VERSION"
+git push origin
+
+# All preparation done: tag the current commit and push only the tag.
+git tag -s "${VERSION}" -m "${VERSION}"
+git push origin "${VERSION}"
+
+
+# Post-Release version.go update
 git push origin HEAD:master
 
 cat > graphql/version.go <<EOF
@@ -47,5 +93,9 @@ git push origin HEAD:master
 git checkout master
 git pull
 
+echo "Tagged ${VERSION}. Now update release notes:"
+echo "  https://github.com/${ORG}/${REPO}/releases/tag/${VERSION}"
 
-echo "Now go write some release notes! https://github.com/99designs/gqlgen/releases"
+# Prime the Go module proxy so `go get` sees the new version promptly.
+curl -sS "https://proxy.golang.org/github.com/${ORG}/${REPO}/@v/${VERSION}.info"
+echo


### PR DESCRIPTION
I figured I would make efforts to defend against software supply chain attacks using GoReleaser. Because gqlparser is a library, rather than an executable, there's some differences from the [goreleaser supply chain example](https://github.com/goreleaser/example-supply-chain)

# goreleaser secure supply-chain attestation

GoReleaser + Go Mod proxying + Cosign keyless signing + Syft SBOM generation example.

## How it works

GoReleaser manages the entire thing, basically.

It will:

- build using the Go Mod Proxy as source of truth
- call `syft` to create the SBOMs
- create the checksum file
- sign it with `cosign`

## Verifying

Your users will need to know how to verify the artifacts, and this is what this
section is all about.

The first thing we need to do, is get the current latest version:

```bash
export VERSION="$(gh release list -L 1 -R goreleaser/example-supply-chain --json=tagName -q '.[] | .tagName')"
```

Then, we download the `checksums.txt` and the signature bundle
(`checksums.txt.sigstore.json`) files, and then verify them:

```bash
wget https://github.com/99designs/gqlgen/releases/download/$VERSION/checksums.txt
wget https://github.com/99designs/gqlgen/releases/download/$VERSION/checksums.txt.sigstore.json
cosign verify-blob \
    --certificate-identity "https://github.com/goreleaser/example-supply-chain/.github/workflows/release.yml@refs/tags/$VERSION" \
    --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
    --bundle "checksums.txt.sigstore.json" \
    ./checksums.txt
```

This should succeed - which means that we can from now on verify any artifact
from the release with this checksum file!

```bash
# assumes version set from above like VERSION=v2.5.36
export VERSION_NO_V_PREFIX="$(printf "$VERSION" | cut -c2-)"
wget "https://github.com/99designs/gqlgen/releases/download/$VERSION/gqlparser_${VERSION_NO_V_PREFIX}_source.tar.gz"
sha256sum --ignore-missing -c checksums.txt
```

Which should, ideally, say "OK".

You can then inspect the SBOM file to see the entire dependency tree of the
binary, check for vulnerable dependencies and whatnot.

To get the SBOM of an artifact, you can use the same download URL, adding
`.sbom.json` to the end of the URL, and we can then check it out with `grype`:

```bash
wget "https://github.com/99designs/gqlgen/archive/refs/tags/$VERSION.tar.gz.sbom.json"
sha256sum --ignore-missing -c checksums.txt
grype sbom:supply-chain-example_linux_amd64.tar.gz.sbom.json
```

Finally, we can also use the `gh` CLI to verify the attestations:

```bash
gh attestation verify \
  --owner goreleaser \
  *.tar.gz
```

**Release automation and supply chain security:**
- Introduced a GitHub Actions workflow (`.github/workflows/release.yml`) to automate releases on tag pushes. It builds a source tarball, generates an SBOM with syft, creates a checksum, and signs the checksum with cosign, including build provenance attestation. This ensures verifiable, secure releases for the library.
- Added a GoReleaser configuration (`.goreleaser.yaml`) to publish reproducible source tarballs, generate SBOMs, and sign artifacts in line with the automated release workflow.

**Development environment and tooling configuration:**
- Added `.mise.toml` to define tool versions (Go, golangci-lint, goreleaser, gotestsum, syft, cosign) and common development tasks (test, lint, coverage, formatting, SBOM generation), streamlining onboarding and setup.
- Updated `.go-version` to require Go 1.27.0, aligning with the latest toolchain.

**Code and documentation formatting standards:**
- Added `.editorconfig` to enforce consistent code style (indentation, charset, line endings, etc.) across editors and file types.
- Added `.mdformat.toml` to configure Markdown formatting (wrapping, ordered list numbering, line endings, plugin usage), ensuring uniform documentation style.
- Added `.rumdl.toml` to configure Markdown linting rules, aligning with project documentation standards and mdformat output.
- Added `.vale.ini` to set up prose linting for documentation, including custom heuristics for technical writing.

**Linting and formatting exclusions:**
- Added `.prettierignore` to exclude YAML files from Prettier formatting due to a known issue.
- Added `.shellcheckrc` to configure shell script linting, specifying source path handling and disabling specific warnings.