### PR TITLE
transport: allow setting custom response write fn in transport.POST

### DIFF
--- a/graphql/handler/transport/http_post.go
+++ b/graphql/handler/transport/http_post.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"mime"
@@ -24,7 +25,18 @@ type POST struct {
 	// as the response content type
 	// when the Accept header is empty or 'application/*' or '*/*'.
 	UseGrapQLResponseJsonByDefault bool
+
+	// WriteResponseFunc, if set, writes the response of an executed operation instead of
+	// the default JSON write. Use it to pick a different status code or body encoding.
+	// It is not called for requests that fail before execution (unreadable body,
+	// invalid JSON, parse, validation, complexity or APQ errors) - those keep the
+	// status code the transport picked for them.
+	WriteResponseFunc WriteResponseFunc
 }
+
+// WriteResponseFunc writes the response of an executed operation.
+// The implementation owns both the status code and the body.
+type WriteResponseFunc func(ctx context.Context, w http.ResponseWriter, resp *graphql.Response)
 
 var _ graphql.Transport = POST{}
 
@@ -126,5 +138,10 @@ func (h POST) Do(w http.ResponseWriter, r *http.Request, exec graphql.GraphExecu
 
 	var responses graphql.ResponseHandler
 	responses, ctx = exec.DispatchOperation(ctx, rc)
-	writeJson(w, responses(ctx))
+	resp := responses(ctx)
+	if h.WriteResponseFunc != nil {
+		h.WriteResponseFunc(ctx, w, resp)
+	} else {
+		writeJson(w, resp)
+	}
 }

--- a/graphql/handler/transport/http_post_test.go
+++ b/graphql/handler/transport/http_post_test.go
@@ -1,6 +1,7 @@
 package transport_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler/testserver"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 )
@@ -336,6 +338,29 @@ func TestPOST(t *testing.T) {
 		resp := doReq(h, http.MethodPost, "/graphql", `{"query":"{ name }"}`)
 		assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
 		assert.JSONEq(t, `{"data":{"name":"test"}}`, resp.Body.String())
+	})
+	t.Run("use custom write func", func(t *testing.T) {
+		srv := testserver.New()
+		called := false
+		srv.AddTransport(transport.POST{
+			WriteResponseFunc: func(ctx context.Context, w http.ResponseWriter, resp *graphql.Response) {
+				called = true
+				w.WriteHeader(123) // non-200 to test setting custom http status code
+				w.Write([]byte(`response`))
+			},
+		})
+
+		resp := doRequest(
+			srv,
+			http.MethodPost,
+			"/graphql",
+			`{"query":"{ name }"}`,
+			"application/json",
+			"application/json",
+		)
+		assert.Equal(t, 123, resp.Code)
+		assert.True(t, called)
+		assert.Equal(t, "resp", resp.Body.String())
 	})
 }
 


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

Allow setting custom write func in transport.POST so that we can set custom http status code.

Reason for this PR: I'd like to migrate an app in `$WORK` from (forked) graph-gophers/graphql into gqlgen, but currently we're setting HTTP 500 in some cases, which is not possible in gqlgen.

I can also add this feature to other transports (GET, GraphQL) for consistency, I'll leave it up to reviewer.

I'd love to hear that this PR is just not needed, but I've not found any way to set custom http status. My idea, validated in gqlgen's repo: I'll add an extension to the graphql.Error and check it in custom WriteResponseFunc, remove the extension so that it'll stay for internal usage only and run `w.WriteHeader` based on the content of it.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
