### PR TITLE
fix(transport): harden upload path and duplicate subscription handling

### DIFF
--- a/graphql/handler.go
+++ b/graphql/handler.go
@@ -152,16 +152,30 @@ func (p *RawParams) AddUpload(upload Upload, key, path string) *gqlerror.Error {
 			)
 		}
 		if index, parseNbrErr := strconv.Atoi(p); parseNbrErr == nil {
+			arr, ok := ptr.([]any)
+			if !ok || index < 0 || index >= len(arr) {
+				return gqlerror.Errorf(
+					"invalid upload path segment %q for key %s: expected array index within bounds",
+					p, key,
+				)
+			}
 			if last {
-				ptr.([]any)[index] = upload
+				arr[index] = upload
 			} else {
-				ptr = ptr.([]any)[index]
+				ptr = arr[index]
 			}
 		} else {
+			m, ok := ptr.(map[string]any)
+			if !ok {
+				return gqlerror.Errorf(
+					"invalid upload path segment %q for key %s: expected object",
+					p, key,
+				)
+			}
 			if last {
-				ptr.(map[string]any)[p] = upload
+				m[p] = upload
 			} else {
-				ptr = ptr.(map[string]any)[p]
+				ptr = m[p]
 			}
 		}
 	}

--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -468,6 +468,12 @@ func (c *wsConnection) subscribe(start time.Time, msg *message) {
 
 	ctx, cancel := context.WithCancel(ctx)
 	c.mu.Lock()
+	if _, exists := c.active[msg.id]; exists {
+		c.mu.Unlock()
+		cancel()
+		close(msg.data, websocket.CloseMessage)
+		return
+	}
 	c.active[msg.id] = cancel
 	c.mu.Unlock()
 


### PR DESCRIPTION
## Fix 1: Upload path panics (DoS)

`AddUpload` performed unvalidated type assertions and array indexing on client-controlled upload paths from the multipart `operations` field. A path like `variables.list.5` where `list` has 2 entries, or `variables.scalar.foo` where `scalar` is a string, caused an unrecovered panic in the HTTP handler — trivially scriptable DoS.

Now returns a `gqlerror` for out-of-bounds indices and wrong types.

## Fix 2: WebSocket duplicate operation ID

Per the graphql-transport-ws spec, a `subscribe` with an already-active id must be rejected. Instead, the map entry was silently overwritten: the first subscription's cancel was lost, making it unstoppable; when it eventually ended, its deferred `delete` removed the **second** subscription's cancel, making that one unstoppable too.

Now rejects duplicates before starting the goroutine.

## Testing

Both fixes are validation-only additions to existing error paths. No behavior change for valid inputs.